### PR TITLE
chore: trigger redeploy after health check fix

### DIFF
--- a/cloud/railway.toml
+++ b/cloud/railway.toml
@@ -1,5 +1,6 @@
 # Railway deployment configuration
 # See: https://docs.railway.com/reference/config-as-code
+# Last updated: 2024-12-08 - Trigger redeploy after health check fix
 #
 # NOTE: This file applies to ALL services in the monorepo.
 # Service-specific settings (like health checks) should be configured


### PR DESCRIPTION
## Summary
- Add timestamp comment to railway.toml to trigger Railway redeploy
- Previous fix removed shared healthcheckPath that was breaking web service

## Test plan
- [ ] Merge PR to main
- [ ] Sync fork from upstream
- [ ] Verify Railway triggers redeploy
- [ ] Test web service responds at https://web-production-e8494.up.railway.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)