### PR TITLE
feat(mcp): add OAuth 2.1 support for Claude.ai integration

### DIFF
--- a/cloud/apps/api/package.json
+++ b/cloud/apps/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tsx watch --env-file=../../.env src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "prisma migrate deploy --schema ../db/prisma/schema.prisma && node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/cloud/apps/api/src/auth/types.ts
+++ b/cloud/apps/api/src/auth/types.ts
@@ -30,7 +30,7 @@ export type AuthUser = {
 /**
  * Authentication method used for the current request
  */
-export type AuthMethod = 'jwt' | 'api_key';
+export type AuthMethod = 'jwt' | 'api_key' | 'oauth';
 
 /**
  * Authentication context added to Express request

--- a/cloud/apps/api/src/mcp/auth.ts
+++ b/cloud/apps/api/src/mcp/auth.ts
@@ -1,57 +1,95 @@
 /**
  * MCP Authentication Middleware
  *
- * Ensures MCP requests are authenticated via API key.
- * Reuses existing API key validation from auth middleware.
+ * Supports two authentication methods:
+ * 1. OAuth 2.1 Bearer tokens (for Claude.ai and other OAuth clients)
+ * 2. API keys (legacy, for backwards compatibility)
  */
 
 import type { Request, Response, NextFunction } from 'express';
 import { createLogger, AuthenticationError } from '@valuerank/shared';
+import { validateAccessToken, buildWwwAuthenticateHeader, getBaseUrl } from './oauth/index.js';
 
 const log = createLogger('mcp:auth');
 
 /**
  * MCP Auth Middleware
  *
- * Requires valid API key authentication for all MCP requests.
- * Uses the auth state populated by the global authMiddleware.
+ * Authenticates MCP requests via:
+ * 1. OAuth 2.1 Bearer token in Authorization header
+ * 2. API key in X-API-Key header (legacy support)
  *
  * Returns:
- * - 401 if X-API-Key header is missing
- * - 401 if API key is invalid (already handled by authMiddleware)
- * - Continues if valid API key authentication
+ * - 401 with WWW-Authenticate if no valid credentials
+ * - Continues if valid authentication
  */
 export function mcpAuthMiddleware(
   req: Request,
-  _res: Response,
+  res: Response,
   next: NextFunction
 ): void {
-  // Check if request has API key header
-  const apiKey = req.headers['x-api-key'];
+  // Try OAuth Bearer token first
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.slice(7);
+    const baseUrl = getBaseUrl(req);
+    const resourceUri = `${baseUrl}/mcp`;
 
-  if (!apiKey || typeof apiKey !== 'string' || apiKey.length === 0) {
-    log.debug({ path: req.path }, 'MCP request missing API key');
-    next(new AuthenticationError('API key required in X-API-Key header'));
+    const payload = validateAccessToken(token, resourceUri);
+    if (payload) {
+      // Set user info from token
+      req.user = { id: payload.sub, email: '' }; // Email not in token, but ID is sufficient
+      req.authMethod = 'oauth';
+      log.debug({ userId: payload.sub, clientId: payload.client_id, path: req.path }, 'MCP OAuth authenticated');
+      next();
+      return;
+    }
+
+    // Invalid Bearer token
+    log.debug({ path: req.path }, 'Invalid OAuth Bearer token');
+    res.setHeader('WWW-Authenticate', buildWwwAuthenticateHeader(req, 'invalid_token', 'Token is invalid or expired'));
+    next(new AuthenticationError('Invalid or expired access token'));
     return;
   }
 
-  // Check if user was authenticated (populated by global authMiddleware)
-  if (!req.user) {
-    log.debug({ path: req.path }, 'MCP request has invalid API key');
+  // Try legacy API key authentication
+  const apiKey = req.headers['x-api-key'];
+  if (apiKey && typeof apiKey === 'string' && apiKey.length > 0) {
+    // Check if user was authenticated by global authMiddleware
+    if (req.user && req.authMethod === 'api_key') {
+      log.debug({ userId: req.user.id, path: req.path }, 'MCP API key authenticated');
+      next();
+      return;
+    }
+
+    // API key present but not validated
+    log.debug({ path: req.path }, 'Invalid API key');
+    res.setHeader('WWW-Authenticate', buildWwwAuthenticateHeader(req, 'invalid_token', 'API key is invalid'));
     next(new AuthenticationError('Invalid or expired API key'));
     return;
   }
 
-  // Check if auth method is API key (not JWT)
-  if (req.authMethod !== 'api_key') {
-    log.debug(
-      { path: req.path, authMethod: req.authMethod },
-      'MCP requires API key authentication'
-    );
-    next(new AuthenticationError('MCP requires API key authentication'));
+  // No authentication provided - return 401 with OAuth challenge
+  log.debug({ path: req.path }, 'MCP request missing authentication');
+  res.setHeader('WWW-Authenticate', buildWwwAuthenticateHeader(req));
+  next(new AuthenticationError('Authentication required. Use OAuth Bearer token or X-API-Key header.'));
+}
+
+/**
+ * MCP Auth Middleware that allows unauthenticated requests
+ * Used for HEAD requests to check MCP-Protocol-Version
+ */
+export function mcpAuthOptional(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  // For HEAD requests, allow through without auth (metadata check)
+  if (req.method === 'HEAD') {
+    next();
     return;
   }
 
-  log.debug({ userId: req.user.id, path: req.path }, 'MCP request authenticated');
-  next();
+  // For all other requests, require auth
+  mcpAuthMiddleware(req, res, next);
 }

--- a/cloud/apps/api/src/mcp/oauth/constants.ts
+++ b/cloud/apps/api/src/mcp/oauth/constants.ts
@@ -1,0 +1,39 @@
+/**
+ * OAuth 2.1 Constants for MCP Authentication
+ */
+
+/** Default scopes supported by the MCP server */
+export const SUPPORTED_SCOPES = ['mcp:read', 'mcp:write'] as const;
+
+/** Default scope granted to clients */
+export const DEFAULT_SCOPE = 'mcp:read mcp:write';
+
+/** Authorization code expiration (10 minutes) */
+export const AUTH_CODE_EXPIRY_MS = 10 * 60 * 1000;
+
+/** Access token expiration (1 hour) */
+export const ACCESS_TOKEN_EXPIRY_SECONDS = 3600;
+
+/** Refresh token expiration (30 days) */
+export const REFRESH_TOKEN_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Client secret expiration (never - 0 means no expiry) */
+export const CLIENT_SECRET_EXPIRY_SECONDS = 0;
+
+/** Maximum number of stored auth codes (memory limit) */
+export const MAX_AUTH_CODES = 10000;
+
+/** Auth code cleanup interval (5 minutes) */
+export const AUTH_CODE_CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Allowed redirect URI schemes */
+export const ALLOWED_REDIRECT_SCHEMES = ['https', 'http'] as const;
+
+/** Localhost hosts allowed for http:// redirects */
+export const LOCALHOST_HOSTS = ['localhost', '127.0.0.1', '[::1]'] as const;
+
+/** Claude.ai callback URLs to allowlist */
+export const CLAUDE_CALLBACK_URLS = [
+  'https://claude.ai/api/mcp/auth_callback',
+  'https://claude.com/api/mcp/auth_callback',
+] as const;

--- a/cloud/apps/api/src/mcp/oauth/index.ts
+++ b/cloud/apps/api/src/mcp/oauth/index.ts
@@ -1,0 +1,27 @@
+/**
+ * OAuth 2.1 Module for MCP Authentication
+ *
+ * Exports:
+ * - Router for OAuth endpoints
+ * - Metadata handlers
+ * - Token validation utilities
+ * - Storage management
+ */
+
+export { createOAuthRouter } from './router.js';
+export {
+  authorizationServerMetadata,
+  protectedResourceMetadata,
+  buildWwwAuthenticateHeader,
+  getBaseUrl,
+} from './metadata.js';
+export { validateAccessToken, decodeAccessToken, generateAccessToken } from './tokens.js';
+export {
+  startAuthCodeCleanup,
+  stopAuthCodeCleanup,
+  cleanupExpiredRefreshTokens,
+  getUserByApiKey,
+} from './storage.js';
+export { generateCodeVerifier, generateCodeChallenge } from './pkce.js';
+export * from './types.js';
+export * from './constants.js';

--- a/cloud/apps/api/src/mcp/oauth/metadata.ts
+++ b/cloud/apps/api/src/mcp/oauth/metadata.ts
@@ -1,0 +1,92 @@
+/**
+ * OAuth 2.1 Metadata Endpoints
+ *
+ * Implements:
+ * - RFC 8414: Authorization Server Metadata
+ * - RFC 9728: Protected Resource Metadata
+ */
+
+import type { Request, Response } from 'express';
+import { createLogger } from '@valuerank/shared';
+import type { AuthorizationServerMetadata, ProtectedResourceMetadata } from './types.js';
+import { DEFAULT_SCOPE, SUPPORTED_SCOPES } from './constants.js';
+
+const log = createLogger('mcp:oauth:metadata');
+
+/**
+ * Get the base URL from request, handling proxies
+ */
+export function getBaseUrl(req: Request): string {
+  const protocol = req.headers['x-forwarded-proto'] || req.protocol;
+  const host = req.headers['x-forwarded-host'] || req.headers.host;
+  return `${protocol}://${host}`;
+}
+
+/**
+ * GET /.well-known/oauth-authorization-server
+ *
+ * Returns OAuth 2.0 Authorization Server Metadata (RFC 8414)
+ */
+export function authorizationServerMetadata(req: Request, res: Response): void {
+  const baseUrl = getBaseUrl(req);
+
+  log.debug({ baseUrl }, 'Authorization server metadata requested');
+
+  const metadata: AuthorizationServerMetadata = {
+    issuer: baseUrl,
+    authorization_endpoint: `${baseUrl}/oauth/authorize`,
+    token_endpoint: `${baseUrl}/oauth/token`,
+    registration_endpoint: `${baseUrl}/oauth/register`,
+    scopes_supported: [...SUPPORTED_SCOPES],
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    token_endpoint_auth_methods_supported: ['client_secret_post', 'client_secret_basic', 'none'],
+    code_challenge_methods_supported: ['S256'],
+    service_documentation: `${baseUrl}/docs/oauth`,
+  };
+
+  res.json(metadata);
+}
+
+/**
+ * GET /.well-known/resource.json (at MCP server path)
+ *
+ * Returns Protected Resource Metadata (RFC 9728)
+ * This tells clients which authorization server to use
+ */
+export function protectedResourceMetadata(req: Request, res: Response): void {
+  const baseUrl = getBaseUrl(req);
+  const resourceUri = `${baseUrl}/mcp`;
+
+  log.debug({ baseUrl, resourceUri }, 'Protected resource metadata requested');
+
+  const metadata: ProtectedResourceMetadata = {
+    resource: resourceUri,
+    authorization_servers: [baseUrl],
+    scopes_supported: [...SUPPORTED_SCOPES],
+    bearer_methods_supported: ['header'],
+    resource_documentation: `${baseUrl}/docs/mcp`,
+  };
+
+  res.json(metadata);
+}
+
+/**
+ * Build WWW-Authenticate header for 401 responses
+ */
+export function buildWwwAuthenticateHeader(req: Request, error?: string, errorDescription?: string): string {
+  const baseUrl = getBaseUrl(req);
+  const resourceUri = `${baseUrl}/mcp`;
+
+  let header = `Bearer resource="${resourceUri}"`;
+
+  if (error) {
+    header += `, error="${error}"`;
+  }
+
+  if (errorDescription) {
+    header += `, error_description="${errorDescription}"`;
+  }
+
+  return header;
+}

--- a/cloud/apps/api/src/mcp/oauth/pkce.ts
+++ b/cloud/apps/api/src/mcp/oauth/pkce.ts
@@ -1,0 +1,81 @@
+/**
+ * PKCE (Proof Key for Code Exchange) Implementation
+ *
+ * Implements RFC 7636 for OAuth 2.1 PKCE validation
+ */
+
+import crypto from 'crypto';
+
+/**
+ * Validate a PKCE code verifier against a code challenge
+ *
+ * @param codeVerifier - The code_verifier from the token request
+ * @param codeChallenge - The code_challenge from the authorization request
+ * @param method - The code_challenge_method (only 'S256' supported)
+ * @returns true if the verifier matches the challenge
+ */
+export function validatePkce(
+  codeVerifier: string,
+  codeChallenge: string,
+  method: string
+): boolean {
+  if (method !== 'S256') {
+    return false;
+  }
+
+  // Validate code_verifier format (43-128 chars, URL-safe)
+  if (!isValidCodeVerifier(codeVerifier)) {
+    return false;
+  }
+
+  // S256: BASE64URL(SHA256(code_verifier)) === code_challenge
+  const hash = crypto.createHash('sha256').update(codeVerifier).digest();
+  const computed = hash.toString('base64url');
+
+  return computed === codeChallenge;
+}
+
+/**
+ * Check if a code verifier has valid format
+ *
+ * Must be 43-128 characters, using only [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~"
+ */
+export function isValidCodeVerifier(verifier: string): boolean {
+  if (verifier.length < 43 || verifier.length > 128) {
+    return false;
+  }
+
+  // RFC 7636 character set: unreserved characters
+  return /^[A-Za-z0-9\-._~]+$/.test(verifier);
+}
+
+/**
+ * Check if a code challenge has valid format
+ *
+ * Must be BASE64URL encoded (no padding)
+ */
+export function isValidCodeChallenge(challenge: string): boolean {
+  // S256 produces 43 characters (256 bits / 6 bits per char = 43 chars)
+  if (challenge.length !== 43) {
+    return false;
+  }
+
+  // BASE64URL character set (no padding)
+  return /^[A-Za-z0-9\-_]+$/.test(challenge);
+}
+
+/**
+ * Generate a code verifier (for testing)
+ */
+export function generateCodeVerifier(): string {
+  // Generate 32 random bytes = 43 base64url characters
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+/**
+ * Generate a code challenge from a verifier (for testing)
+ */
+export function generateCodeChallenge(verifier: string): string {
+  const hash = crypto.createHash('sha256').update(verifier).digest();
+  return hash.toString('base64url');
+}

--- a/cloud/apps/api/src/mcp/oauth/router.ts
+++ b/cloud/apps/api/src/mcp/oauth/router.ts
@@ -1,0 +1,496 @@
+/**
+ * OAuth 2.1 Router for MCP Authentication
+ *
+ * Implements:
+ * - Dynamic Client Registration (RFC 7591)
+ * - Authorization Endpoint
+ * - Token Endpoint
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { createLogger } from '@valuerank/shared';
+import {
+  validateAuthorizationRequest,
+  validateTokenRequest,
+  validateClientRegistrationRequest,
+  validateScope,
+} from './validation.js';
+import {
+  createOAuthClient,
+  getOAuthClient,
+  validateClientCredentials,
+  storeAuthCode,
+  consumeAuthCode,
+  createRefreshToken,
+  consumeRefreshToken,
+  getUserByApiKey,
+  hashSecret,
+} from './storage.js';
+import { validatePkce } from './pkce.js';
+import { generateAccessToken } from './tokens.js';
+import { getBaseUrl } from './metadata.js';
+import { DEFAULT_SCOPE, ACCESS_TOKEN_EXPIRY_SECONDS, CLIENT_SECRET_EXPIRY_SECONDS } from './constants.js';
+import type { ClientRegistrationResponse, TokenResponse, TokenErrorResponse } from './types.js';
+
+const log = createLogger('mcp:oauth:router');
+
+export function createOAuthRouter(): Router {
+  const router = Router();
+
+  /**
+   * POST /oauth/register - Dynamic Client Registration (RFC 7591)
+   */
+  router.post('/register', async (req: Request, res: Response) => {
+    log.debug({ body: req.body }, 'Client registration request');
+
+    const validation = validateClientRegistrationRequest(req.body || {});
+    if (!validation.valid || !validation.data) {
+      res.status(400).json({
+        error: validation.error,
+        error_description: validation.errorDescription,
+      });
+      return;
+    }
+
+    const data = validation.data;
+
+    try {
+      const { client, clientSecret } = await createOAuthClient({
+        clientName: data.client_name,
+        redirectUris: data.redirect_uris,
+        tokenEndpointAuthMethod: data.token_endpoint_auth_method || 'client_secret_post',
+        grantTypes: data.grant_types || ['authorization_code', 'refresh_token'],
+        responseTypes: data.response_types || ['code'],
+        scope: validateScope(data.scope),
+      });
+
+      const response: ClientRegistrationResponse = {
+        client_id: client.clientId,
+        client_secret: clientSecret,
+        client_id_issued_at: Math.floor(client.createdAt.getTime() / 1000),
+        client_secret_expires_at: CLIENT_SECRET_EXPIRY_SECONDS,
+        redirect_uris: client.redirectUris,
+        client_name: client.clientName,
+        token_endpoint_auth_method: client.tokenEndpointAuthMethod,
+        grant_types: client.grantTypes,
+        response_types: client.responseTypes,
+        scope: client.scope,
+      };
+
+      log.info({ clientId: client.clientId, clientName: client.clientName }, 'Client registered');
+      res.status(201).json(response);
+    } catch (err) {
+      log.error({ err }, 'Client registration failed');
+      res.status(500).json({
+        error: 'server_error',
+        error_description: 'Failed to register client',
+      });
+    }
+  });
+
+  /**
+   * GET /oauth/authorize - Authorization Endpoint
+   *
+   * This endpoint requires the user to authenticate with their API key.
+   * In a browser flow, this would show a login page.
+   * For Claude.ai, we check for an API key in the X-API-Key header.
+   */
+  router.get('/authorize', async (req: Request, res: Response) => {
+    log.debug({ query: req.query }, 'Authorization request');
+
+    const validation = validateAuthorizationRequest(req.query);
+    if (!validation.valid || !validation.data) {
+      // For authorization errors, we redirect with error if redirect_uri is valid
+      const redirectUri = req.query.redirect_uri as string;
+      const state = req.query.state as string;
+
+      if (redirectUri && typeof redirectUri === 'string') {
+        try {
+          const errorUrl = new URL(redirectUri);
+          errorUrl.searchParams.set('error', validation.error || 'invalid_request');
+          if (validation.errorDescription) {
+            errorUrl.searchParams.set('error_description', validation.errorDescription);
+          }
+          if (state) {
+            errorUrl.searchParams.set('state', state);
+          }
+          res.redirect(errorUrl.toString());
+          return;
+        } catch {
+          // Invalid redirect_uri, return error directly
+        }
+      }
+
+      res.status(400).json({
+        error: validation.error,
+        error_description: validation.errorDescription,
+      });
+      return;
+    }
+
+    const authReq = validation.data;
+
+    // Validate client exists and redirect_uri matches
+    const client = await getOAuthClient(authReq.client_id);
+    if (!client) {
+      log.debug({ clientId: authReq.client_id }, 'Unknown client');
+      res.status(400).json({
+        error: 'invalid_client',
+        error_description: 'Unknown client_id',
+      });
+      return;
+    }
+
+    if (!client.redirectUris.includes(authReq.redirect_uri)) {
+      log.debug({ clientId: authReq.client_id, redirectUri: authReq.redirect_uri }, 'Redirect URI mismatch');
+      res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'redirect_uri does not match registered URIs',
+      });
+      return;
+    }
+
+    // Check for API key authentication
+    const apiKey = req.headers['x-api-key'] as string;
+    if (!apiKey) {
+      // No API key - return an HTML page for user to enter API key
+      // For Claude.ai, this shouldn't happen as they send credentials
+      const baseUrl = getBaseUrl(req);
+      res.status(401).send(`
+<!DOCTYPE html>
+<html>
+<head>
+  <title>ValueRank MCP Authorization</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 500px; margin: 50px auto; padding: 20px; }
+    h1 { color: #333; }
+    form { margin-top: 20px; }
+    label { display: block; margin-bottom: 5px; font-weight: bold; }
+    input[type="text"] { width: 100%; padding: 10px; margin-bottom: 15px; border: 1px solid #ccc; border-radius: 4px; }
+    button { background: #007bff; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; }
+    button:hover { background: #0056b3; }
+    .info { background: #f0f0f0; padding: 15px; border-radius: 4px; margin-bottom: 20px; }
+  </style>
+</head>
+<body>
+  <h1>Authorize ValueRank MCP</h1>
+  <div class="info">
+    <p><strong>Client:</strong> ${client.clientName || authReq.client_id}</p>
+    <p><strong>Scope:</strong> ${authReq.scope || DEFAULT_SCOPE}</p>
+  </div>
+  <form method="POST" action="${baseUrl}/oauth/authorize">
+    <input type="hidden" name="response_type" value="${authReq.response_type}">
+    <input type="hidden" name="client_id" value="${authReq.client_id}">
+    <input type="hidden" name="redirect_uri" value="${authReq.redirect_uri}">
+    <input type="hidden" name="scope" value="${authReq.scope || ''}">
+    <input type="hidden" name="state" value="${authReq.state || ''}">
+    <input type="hidden" name="code_challenge" value="${authReq.code_challenge}">
+    <input type="hidden" name="code_challenge_method" value="${authReq.code_challenge_method}">
+    <input type="hidden" name="resource" value="${authReq.resource}">
+    <label for="api_key">API Key:</label>
+    <input type="text" id="api_key" name="api_key" placeholder="vr_..." required>
+    <button type="submit">Authorize</button>
+  </form>
+</body>
+</html>
+      `);
+      return;
+    }
+
+    // Validate API key
+    const user = await getUserByApiKey(apiKey);
+    if (!user) {
+      log.debug({ clientId: authReq.client_id }, 'Invalid API key');
+      res.status(401).json({
+        error: 'access_denied',
+        error_description: 'Invalid API key',
+      });
+      return;
+    }
+
+    // Generate authorization code
+    const scope = validateScope(authReq.scope);
+    const code = storeAuthCode({
+      clientId: authReq.client_id,
+      userId: user.id,
+      redirectUri: authReq.redirect_uri,
+      scope,
+      codeChallenge: authReq.code_challenge,
+      codeChallengeMethod: authReq.code_challenge_method,
+      resource: authReq.resource,
+    });
+
+    // Redirect with code
+    const redirectUrl = new URL(authReq.redirect_uri);
+    redirectUrl.searchParams.set('code', code);
+    if (authReq.state) {
+      redirectUrl.searchParams.set('state', authReq.state);
+    }
+
+    log.info({ clientId: authReq.client_id, userId: user.id }, 'Authorization code issued');
+    res.redirect(redirectUrl.toString());
+  });
+
+  /**
+   * POST /oauth/authorize - Authorization Endpoint (form submission)
+   */
+  router.post('/authorize', async (req: Request, res: Response) => {
+    const body = req.body || {};
+    log.debug({ body: { ...body, api_key: '[redacted]' } }, 'Authorization POST request');
+
+    // Reconstruct auth request from form data
+    const validation = validateAuthorizationRequest({
+      response_type: body.response_type,
+      client_id: body.client_id,
+      redirect_uri: body.redirect_uri,
+      scope: body.scope,
+      state: body.state,
+      code_challenge: body.code_challenge,
+      code_challenge_method: body.code_challenge_method,
+      resource: body.resource,
+    });
+
+    if (!validation.valid || !validation.data) {
+      res.status(400).json({
+        error: validation.error,
+        error_description: validation.errorDescription,
+      });
+      return;
+    }
+
+    const authReq = validation.data;
+
+    // Validate client
+    const client = await getOAuthClient(authReq.client_id);
+    if (!client || !client.redirectUris.includes(authReq.redirect_uri)) {
+      res.status(400).json({
+        error: 'invalid_client',
+        error_description: 'Invalid client or redirect_uri',
+      });
+      return;
+    }
+
+    // Validate API key from form
+    const apiKey = body.api_key;
+    if (!apiKey) {
+      res.status(400).json({
+        error: 'access_denied',
+        error_description: 'API key required',
+      });
+      return;
+    }
+
+    const user = await getUserByApiKey(apiKey);
+    if (!user) {
+      res.status(401).json({
+        error: 'access_denied',
+        error_description: 'Invalid API key',
+      });
+      return;
+    }
+
+    // Generate authorization code
+    const scope = validateScope(authReq.scope);
+    const code = storeAuthCode({
+      clientId: authReq.client_id,
+      userId: user.id,
+      redirectUri: authReq.redirect_uri,
+      scope,
+      codeChallenge: authReq.code_challenge,
+      codeChallengeMethod: authReq.code_challenge_method,
+      resource: authReq.resource,
+    });
+
+    // Redirect with code
+    const redirectUrl = new URL(authReq.redirect_uri);
+    redirectUrl.searchParams.set('code', code);
+    if (authReq.state) {
+      redirectUrl.searchParams.set('state', authReq.state);
+    }
+
+    log.info({ clientId: authReq.client_id, userId: user.id }, 'Authorization code issued via form');
+    res.redirect(redirectUrl.toString());
+  });
+
+  /**
+   * POST /oauth/token - Token Endpoint
+   */
+  router.post('/token', async (req: Request, res: Response) => {
+    // Parse body - support both JSON and form-urlencoded
+    const body = req.body || {};
+    log.debug({ grantType: body.grant_type, clientId: body.client_id }, 'Token request');
+
+    const validation = validateTokenRequest(body);
+    if (!validation.valid || !validation.data) {
+      const errorResponse: TokenErrorResponse = {
+        error: validation.error || 'invalid_request',
+        error_description: validation.errorDescription,
+      };
+      res.status(400).json(errorResponse);
+      return;
+    }
+
+    const tokenReq = validation.data;
+
+    // Get client - might need credentials depending on auth method
+    let client = await getOAuthClient(tokenReq.client_id);
+    if (!client) {
+      res.status(401).json({
+        error: 'invalid_client',
+        error_description: 'Unknown client',
+      });
+      return;
+    }
+
+    // Validate client credentials if required
+    if (client.tokenEndpointAuthMethod !== 'none') {
+      // Check for client_secret in body or Basic auth header
+      let clientSecret = tokenReq.client_secret;
+
+      // Check Basic auth header
+      const authHeader = req.headers.authorization;
+      if (authHeader?.startsWith('Basic ')) {
+        const encoded = authHeader.slice(6);
+        const decoded = Buffer.from(encoded, 'base64').toString();
+        const [basicClientId, basicSecret] = decoded.split(':');
+        if (basicClientId === tokenReq.client_id) {
+          clientSecret = basicSecret;
+        }
+      }
+
+      if (!clientSecret) {
+        res.status(401).json({
+          error: 'invalid_client',
+          error_description: 'Client authentication required',
+        });
+        return;
+      }
+
+      const validatedClient = await validateClientCredentials(tokenReq.client_id, clientSecret);
+      if (!validatedClient) {
+        res.status(401).json({
+          error: 'invalid_client',
+          error_description: 'Invalid client credentials',
+        });
+        return;
+      }
+      client = validatedClient;
+    }
+
+    // Handle authorization_code grant
+    if (tokenReq.grant_type === 'authorization_code') {
+      const authCode = consumeAuthCode(tokenReq.code!);
+      if (!authCode) {
+        res.status(400).json({
+          error: 'invalid_grant',
+          error_description: 'Invalid or expired authorization code',
+        });
+        return;
+      }
+
+      // Validate client matches
+      if (authCode.clientId !== tokenReq.client_id) {
+        res.status(400).json({
+          error: 'invalid_grant',
+          error_description: 'Authorization code was not issued to this client',
+        });
+        return;
+      }
+
+      // Validate redirect_uri matches
+      if (authCode.redirectUri !== tokenReq.redirect_uri) {
+        res.status(400).json({
+          error: 'invalid_grant',
+          error_description: 'redirect_uri does not match',
+        });
+        return;
+      }
+
+      // Validate PKCE
+      if (!validatePkce(tokenReq.code_verifier!, authCode.codeChallenge, authCode.codeChallengeMethod)) {
+        res.status(400).json({
+          error: 'invalid_grant',
+          error_description: 'Invalid code_verifier (PKCE validation failed)',
+        });
+        return;
+      }
+
+      // Generate tokens
+      const accessToken = generateAccessToken(
+        req,
+        authCode.userId,
+        authCode.clientId,
+        authCode.scope,
+        authCode.resource
+      );
+
+      const refreshToken = await createRefreshToken({
+        clientId: authCode.clientId,
+        userId: authCode.userId,
+        scope: authCode.scope,
+        resource: authCode.resource,
+      });
+
+      const response: TokenResponse = {
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: ACCESS_TOKEN_EXPIRY_SECONDS,
+        refresh_token: refreshToken,
+        scope: authCode.scope,
+      };
+
+      log.info({ clientId: authCode.clientId, userId: authCode.userId }, 'Access token issued');
+      res.json(response);
+      return;
+    }
+
+    // Handle refresh_token grant
+    if (tokenReq.grant_type === 'refresh_token') {
+      const storedToken = await consumeRefreshToken(tokenReq.refresh_token!, tokenReq.client_id);
+      if (!storedToken) {
+        res.status(400).json({
+          error: 'invalid_grant',
+          error_description: 'Invalid or expired refresh token',
+        });
+        return;
+      }
+
+      // Generate new tokens (rotation)
+      const accessToken = generateAccessToken(
+        req,
+        storedToken.userId,
+        storedToken.clientId,
+        storedToken.scope,
+        storedToken.resource
+      );
+
+      const newRefreshToken = await createRefreshToken({
+        clientId: storedToken.clientId,
+        userId: storedToken.userId,
+        scope: storedToken.scope,
+        resource: storedToken.resource,
+      });
+
+      const response: TokenResponse = {
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: ACCESS_TOKEN_EXPIRY_SECONDS,
+        refresh_token: newRefreshToken,
+        scope: storedToken.scope,
+      };
+
+      log.info({ clientId: storedToken.clientId, userId: storedToken.userId }, 'Access token refreshed');
+      res.json(response);
+      return;
+    }
+
+    // Unknown grant type (shouldn't reach here due to validation)
+    res.status(400).json({
+      error: 'unsupported_grant_type',
+      error_description: 'Unknown grant type',
+    });
+  });
+
+  return router;
+}

--- a/cloud/apps/api/src/mcp/oauth/storage.ts
+++ b/cloud/apps/api/src/mcp/oauth/storage.ts
@@ -1,0 +1,387 @@
+/**
+ * OAuth Storage Layer
+ *
+ * Manages storage for:
+ * - Authorization codes (in-memory, short-lived)
+ * - OAuth clients (database)
+ * - Refresh tokens (database)
+ */
+
+import crypto from 'crypto';
+import { db } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+import type {
+  StoredAuthCode,
+  StoredOAuthClient,
+  StoredRefreshToken,
+  CodeChallengeMethod,
+  GrantType,
+  ResponseType,
+  TokenEndpointAuthMethod,
+} from './types.js';
+import {
+  AUTH_CODE_EXPIRY_MS,
+  AUTH_CODE_CLEANUP_INTERVAL_MS,
+  MAX_AUTH_CODES,
+  REFRESH_TOKEN_EXPIRY_MS,
+} from './constants.js';
+
+const log = createLogger('mcp:oauth:storage');
+
+// In-memory store for authorization codes (short-lived)
+const authCodes = new Map<string, StoredAuthCode>();
+
+// Cleanup interval reference
+let cleanupInterval: NodeJS.Timeout | null = null;
+
+/**
+ * Hash a secret using SHA-256
+ */
+export function hashSecret(secret: string): string {
+  return crypto.createHash('sha256').update(secret).digest('hex');
+}
+
+/**
+ * Generate a cryptographically secure random string
+ */
+export function generateSecureToken(length: number = 32): string {
+  return crypto.randomBytes(length).toString('base64url');
+}
+
+/**
+ * Start the auth code cleanup interval
+ */
+export function startAuthCodeCleanup(): void {
+  if (cleanupInterval) return;
+
+  cleanupInterval = setInterval(() => {
+    const now = new Date();
+    let cleaned = 0;
+
+    for (const [code, stored] of authCodes) {
+      if (stored.expiresAt < now) {
+        authCodes.delete(code);
+        cleaned++;
+      }
+    }
+
+    if (cleaned > 0) {
+      log.debug({ cleaned }, 'Cleaned expired auth codes');
+    }
+  }, AUTH_CODE_CLEANUP_INTERVAL_MS);
+
+  log.info('Auth code cleanup started');
+}
+
+/**
+ * Stop the auth code cleanup interval
+ */
+export function stopAuthCodeCleanup(): void {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = null;
+    log.info('Auth code cleanup stopped');
+  }
+}
+
+// ============================================================================
+// Authorization Code Storage (In-Memory)
+// ============================================================================
+
+/**
+ * Store an authorization code
+ */
+export function storeAuthCode(data: Omit<StoredAuthCode, 'code' | 'expiresAt' | 'createdAt'>): string {
+  // Enforce memory limit
+  if (authCodes.size >= MAX_AUTH_CODES) {
+    // Remove oldest entries
+    const entries = Array.from(authCodes.entries());
+    entries.sort((a, b) => a[1].createdAt.getTime() - b[1].createdAt.getTime());
+    const toRemove = entries.slice(0, Math.floor(MAX_AUTH_CODES * 0.1));
+    for (const [code] of toRemove) {
+      authCodes.delete(code);
+    }
+    log.warn({ removed: toRemove.length }, 'Auth code limit reached, removed oldest');
+  }
+
+  const code = generateSecureToken(32);
+  const now = new Date();
+
+  authCodes.set(code, {
+    ...data,
+    code,
+    expiresAt: new Date(now.getTime() + AUTH_CODE_EXPIRY_MS),
+    createdAt: now,
+  });
+
+  log.debug({ clientId: data.clientId }, 'Auth code stored');
+  return code;
+}
+
+/**
+ * Retrieve and consume an authorization code (one-time use)
+ */
+export function consumeAuthCode(code: string): StoredAuthCode | null {
+  const stored = authCodes.get(code);
+
+  if (!stored) {
+    log.debug('Auth code not found');
+    return null;
+  }
+
+  // Always delete - codes are single use
+  authCodes.delete(code);
+
+  // Check expiration
+  if (stored.expiresAt < new Date()) {
+    log.debug({ clientId: stored.clientId }, 'Auth code expired');
+    return null;
+  }
+
+  log.debug({ clientId: stored.clientId }, 'Auth code consumed');
+  return stored;
+}
+
+// ============================================================================
+// OAuth Client Storage (Database)
+// ============================================================================
+
+/**
+ * Create a new OAuth client via Dynamic Client Registration
+ */
+export async function createOAuthClient(
+  data: Omit<StoredOAuthClient, 'clientId' | 'clientSecretHash' | 'createdAt'>
+): Promise<{ client: StoredOAuthClient; clientSecret: string }> {
+  const clientId = generateSecureToken(16);
+  const clientSecret = generateSecureToken(32);
+  const clientSecretHash = hashSecret(clientSecret);
+
+  const client = await db.oAuthClient.create({
+    data: {
+      clientId,
+      clientSecretHash,
+      clientName: data.clientName,
+      redirectUris: data.redirectUris,
+      tokenEndpointAuthMethod: data.tokenEndpointAuthMethod,
+      grantTypes: data.grantTypes,
+      responseTypes: data.responseTypes,
+      scope: data.scope,
+    },
+  });
+
+  log.info({ clientId, clientName: data.clientName }, 'OAuth client created');
+
+  return {
+    client: {
+      clientId: client.clientId,
+      clientSecretHash: client.clientSecretHash,
+      clientName: client.clientName ?? undefined,
+      redirectUris: client.redirectUris as string[],
+      tokenEndpointAuthMethod: client.tokenEndpointAuthMethod as TokenEndpointAuthMethod,
+      grantTypes: client.grantTypes as GrantType[],
+      responseTypes: client.responseTypes as ResponseType[],
+      scope: client.scope,
+      createdAt: client.createdAt,
+    },
+    clientSecret,
+  };
+}
+
+/**
+ * Get an OAuth client by ID
+ */
+export async function getOAuthClient(clientId: string): Promise<StoredOAuthClient | null> {
+  const client = await db.oAuthClient.findUnique({
+    where: { clientId },
+  });
+
+  if (!client) return null;
+
+  return {
+    clientId: client.clientId,
+    clientSecretHash: client.clientSecretHash,
+    clientName: client.clientName ?? undefined,
+    redirectUris: client.redirectUris as string[],
+    tokenEndpointAuthMethod: client.tokenEndpointAuthMethod as TokenEndpointAuthMethod,
+    grantTypes: client.grantTypes as GrantType[],
+    responseTypes: client.responseTypes as ResponseType[],
+    scope: client.scope,
+    createdAt: client.createdAt,
+  };
+}
+
+/**
+ * Validate client credentials
+ */
+export async function validateClientCredentials(
+  clientId: string,
+  clientSecret: string
+): Promise<StoredOAuthClient | null> {
+  const client = await getOAuthClient(clientId);
+
+  if (!client || !client.clientSecretHash) {
+    return null;
+  }
+
+  const secretHash = hashSecret(clientSecret);
+  if (secretHash !== client.clientSecretHash) {
+    log.debug({ clientId }, 'Invalid client secret');
+    return null;
+  }
+
+  return client;
+}
+
+/**
+ * Delete an OAuth client
+ */
+export async function deleteOAuthClient(clientId: string): Promise<boolean> {
+  try {
+    await db.oAuthClient.delete({ where: { clientId } });
+    log.info({ clientId }, 'OAuth client deleted');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ============================================================================
+// Refresh Token Storage (Database)
+// ============================================================================
+
+/**
+ * Create a refresh token
+ */
+export async function createRefreshToken(
+  data: Omit<StoredRefreshToken, 'token' | 'tokenHash' | 'expiresAt' | 'createdAt'>
+): Promise<string> {
+  const token = generateSecureToken(32);
+  const tokenHash = hashSecret(token);
+  const now = new Date();
+
+  await db.oAuthRefreshToken.create({
+    data: {
+      tokenHash,
+      clientId: data.clientId,
+      userId: data.userId,
+      scope: data.scope,
+      resource: data.resource,
+      expiresAt: new Date(now.getTime() + REFRESH_TOKEN_EXPIRY_MS),
+    },
+  });
+
+  log.debug({ clientId: data.clientId, userId: data.userId }, 'Refresh token created');
+  return token;
+}
+
+/**
+ * Validate and consume a refresh token (rotation)
+ * Returns the token data if valid, null otherwise
+ */
+export async function consumeRefreshToken(
+  token: string,
+  clientId: string
+): Promise<Omit<StoredRefreshToken, 'token' | 'tokenHash'> | null> {
+  const tokenHash = hashSecret(token);
+
+  const stored = await db.oAuthRefreshToken.findUnique({
+    where: { tokenHash },
+  });
+
+  if (!stored) {
+    log.debug('Refresh token not found');
+    return null;
+  }
+
+  // Validate client
+  if (stored.clientId !== clientId) {
+    log.warn({ clientId, storedClientId: stored.clientId }, 'Refresh token client mismatch');
+    return null;
+  }
+
+  // Delete the token (rotation - each token is single use)
+  await db.oAuthRefreshToken.delete({ where: { tokenHash } });
+
+  // Check expiration
+  if (stored.expiresAt < new Date()) {
+    log.debug({ clientId }, 'Refresh token expired');
+    return null;
+  }
+
+  log.debug({ clientId, userId: stored.userId }, 'Refresh token consumed');
+  return {
+    clientId: stored.clientId,
+    userId: stored.userId,
+    scope: stored.scope,
+    resource: stored.resource,
+    expiresAt: stored.expiresAt,
+    createdAt: stored.createdAt,
+  };
+}
+
+/**
+ * Revoke all refresh tokens for a user/client combination
+ */
+export async function revokeRefreshTokens(userId: string, clientId?: string): Promise<number> {
+  const result = await db.oAuthRefreshToken.deleteMany({
+    where: {
+      userId,
+      ...(clientId && { clientId }),
+    },
+  });
+
+  log.info({ userId, clientId, count: result.count }, 'Refresh tokens revoked');
+  return result.count;
+}
+
+/**
+ * Clean up expired refresh tokens
+ */
+export async function cleanupExpiredRefreshTokens(): Promise<number> {
+  const result = await db.oAuthRefreshToken.deleteMany({
+    where: {
+      expiresAt: { lt: new Date() },
+    },
+  });
+
+  if (result.count > 0) {
+    log.info({ count: result.count }, 'Expired refresh tokens cleaned up');
+  }
+
+  return result.count;
+}
+
+// ============================================================================
+// User Lookup (for API key to user mapping)
+// ============================================================================
+
+/**
+ * Get user by API key (for authorization)
+ * This maps API keys to users for OAuth token issuance
+ */
+export async function getUserByApiKey(apiKey: string): Promise<{ id: string; email: string } | null> {
+  const keyHash = hashSecret(apiKey);
+
+  const apiKeyRecord = await db.apiKey.findUnique({
+    where: { keyHash },
+    include: { user: true },
+  });
+
+  if (!apiKeyRecord) return null;
+
+  // Check expiration
+  if (apiKeyRecord.expiresAt && apiKeyRecord.expiresAt < new Date()) {
+    return null;
+  }
+
+  // Update last used
+  await db.apiKey.update({
+    where: { id: apiKeyRecord.id },
+    data: { lastUsed: new Date() },
+  });
+
+  return {
+    id: apiKeyRecord.user.id,
+    email: apiKeyRecord.user.email,
+  };
+}

--- a/cloud/apps/api/src/mcp/oauth/tokens.ts
+++ b/cloud/apps/api/src/mcp/oauth/tokens.ts
@@ -1,0 +1,92 @@
+/**
+ * OAuth Token Generation and Validation
+ *
+ * Handles JWT access token creation and validation
+ */
+
+import jwt from 'jsonwebtoken';
+import { createLogger } from '@valuerank/shared';
+import type { AccessTokenPayload } from './types.js';
+import { ACCESS_TOKEN_EXPIRY_SECONDS } from './constants.js';
+import { getBaseUrl } from './metadata.js';
+import type { Request } from 'express';
+
+const log = createLogger('mcp:oauth:tokens');
+
+/**
+ * Get JWT secret from environment
+ */
+function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is required');
+  }
+  return secret;
+}
+
+/**
+ * Generate an access token (JWT)
+ */
+export function generateAccessToken(
+  req: Request,
+  userId: string,
+  clientId: string,
+  scope: string,
+  resource: string
+): string {
+  const baseUrl = getBaseUrl(req);
+  const now = Math.floor(Date.now() / 1000);
+
+  const payload: AccessTokenPayload = {
+    sub: userId,
+    aud: resource,
+    iss: baseUrl,
+    exp: now + ACCESS_TOKEN_EXPIRY_SECONDS,
+    iat: now,
+    scope,
+    client_id: clientId,
+  };
+
+  const token = jwt.sign(payload, getJwtSecret(), { algorithm: 'HS256' });
+
+  log.debug({ userId, clientId, scope, resource }, 'Access token generated');
+  return token;
+}
+
+/**
+ * Validate and decode an access token
+ */
+export function validateAccessToken(
+  token: string,
+  expectedAudience: string
+): AccessTokenPayload | null {
+  try {
+    const payload = jwt.verify(token, getJwtSecret(), {
+      algorithms: ['HS256'],
+      audience: expectedAudience,
+    }) as AccessTokenPayload;
+
+    return payload;
+  } catch (err) {
+    if (err instanceof jwt.TokenExpiredError) {
+      log.debug('Access token expired');
+    } else if (err instanceof jwt.JsonWebTokenError) {
+      log.debug({ error: err.message }, 'Invalid access token');
+    } else {
+      log.error({ err }, 'Token validation error');
+    }
+    return null;
+  }
+}
+
+/**
+ * Decode an access token without validation (for debugging)
+ */
+export function decodeAccessToken(token: string): AccessTokenPayload | null {
+  try {
+    const decoded = jwt.decode(token);
+    return decoded as AccessTokenPayload | null;
+  } catch {
+    return null;
+  }
+}

--- a/cloud/apps/api/src/mcp/oauth/types.ts
+++ b/cloud/apps/api/src/mcp/oauth/types.ts
@@ -1,0 +1,202 @@
+/**
+ * OAuth 2.1 Types for MCP Authentication
+ *
+ * Implements types for:
+ * - RFC 8414: Authorization Server Metadata
+ * - RFC 9728: Protected Resource Metadata
+ * - RFC 7591: Dynamic Client Registration
+ * - RFC 8707: Resource Indicators
+ */
+
+/** OAuth 2.1 Grant Types */
+export type GrantType = 'authorization_code' | 'refresh_token';
+
+/** OAuth 2.1 Response Types */
+export type ResponseType = 'code';
+
+/** OAuth 2.1 Token Endpoint Auth Methods */
+export type TokenEndpointAuthMethod = 'none' | 'client_secret_post' | 'client_secret_basic';
+
+/** Code Challenge Methods (PKCE) */
+export type CodeChallengeMethod = 'S256';
+
+/**
+ * Authorization Server Metadata (RFC 8414)
+ */
+export interface AuthorizationServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint?: string;
+  scopes_supported: string[];
+  response_types_supported: ResponseType[];
+  grant_types_supported: GrantType[];
+  token_endpoint_auth_methods_supported: TokenEndpointAuthMethod[];
+  code_challenge_methods_supported: CodeChallengeMethod[];
+  service_documentation?: string;
+}
+
+/**
+ * Protected Resource Metadata (RFC 9728)
+ */
+export interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  scopes_supported?: string[];
+  bearer_methods_supported?: string[];
+  resource_documentation?: string;
+}
+
+/**
+ * Dynamic Client Registration Request (RFC 7591)
+ */
+export interface ClientRegistrationRequest {
+  redirect_uris: string[];
+  client_name?: string;
+  token_endpoint_auth_method?: TokenEndpointAuthMethod;
+  grant_types?: GrantType[];
+  response_types?: ResponseType[];
+  scope?: string;
+}
+
+/**
+ * Dynamic Client Registration Response (RFC 7591)
+ */
+export interface ClientRegistrationResponse {
+  client_id: string;
+  client_secret?: string;
+  client_id_issued_at: number;
+  client_secret_expires_at?: number;
+  redirect_uris: string[];
+  client_name?: string;
+  token_endpoint_auth_method: TokenEndpointAuthMethod;
+  grant_types: GrantType[];
+  response_types: ResponseType[];
+  scope?: string;
+}
+
+/**
+ * Authorization Request Parameters
+ */
+export interface AuthorizationRequest {
+  response_type: ResponseType;
+  client_id: string;
+  redirect_uri: string;
+  scope?: string;
+  state?: string;
+  code_challenge: string;
+  code_challenge_method: CodeChallengeMethod;
+  resource: string;
+}
+
+/**
+ * Token Request Parameters
+ */
+export interface TokenRequest {
+  grant_type: GrantType;
+  code?: string;
+  redirect_uri?: string;
+  client_id: string;
+  client_secret?: string;
+  code_verifier?: string;
+  refresh_token?: string;
+  resource?: string;
+}
+
+/**
+ * Token Response
+ */
+export interface TokenResponse {
+  access_token: string;
+  token_type: 'Bearer';
+  expires_in: number;
+  refresh_token?: string;
+  scope?: string;
+}
+
+/**
+ * Token Error Response (RFC 6749)
+ */
+export interface TokenErrorResponse {
+  error: OAuthError;
+  error_description?: string;
+  error_uri?: string;
+}
+
+/** OAuth Error Codes */
+export type OAuthError =
+  | 'invalid_request'
+  | 'invalid_client'
+  | 'invalid_grant'
+  | 'unauthorized_client'
+  | 'unsupported_grant_type'
+  | 'invalid_scope'
+  | 'access_denied'
+  | 'server_error';
+
+/**
+ * Stored Authorization Code
+ */
+export interface StoredAuthCode {
+  code: string;
+  clientId: string;
+  userId: string;
+  redirectUri: string;
+  scope: string;
+  codeChallenge: string;
+  codeChallengeMethod: CodeChallengeMethod;
+  resource: string;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+/**
+ * Stored OAuth Client (Dynamic Registration)
+ */
+export interface StoredOAuthClient {
+  clientId: string;
+  clientSecret?: string;
+  clientSecretHash?: string;
+  clientName?: string;
+  redirectUris: string[];
+  tokenEndpointAuthMethod: TokenEndpointAuthMethod;
+  grantTypes: GrantType[];
+  responseTypes: ResponseType[];
+  scope: string;
+  createdAt: Date;
+  clientSecretExpiresAt?: Date;
+}
+
+/**
+ * Stored Refresh Token
+ */
+export interface StoredRefreshToken {
+  token: string;
+  tokenHash: string;
+  clientId: string;
+  userId: string;
+  scope: string;
+  resource: string;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+/**
+ * JWT Access Token Payload
+ */
+export interface AccessTokenPayload {
+  /** Subject - user ID */
+  sub: string;
+  /** Audience - MCP server resource URI */
+  aud: string;
+  /** Issuer - authorization server */
+  iss: string;
+  /** Expiration time */
+  exp: number;
+  /** Issued at */
+  iat: number;
+  /** Scope */
+  scope: string;
+  /** Client ID */
+  client_id: string;
+}

--- a/cloud/apps/api/src/mcp/oauth/validation.ts
+++ b/cloud/apps/api/src/mcp/oauth/validation.ts
@@ -1,0 +1,336 @@
+/**
+ * OAuth Request Validation
+ *
+ * Validates OAuth requests according to RFC specs
+ */
+
+import { createLogger } from '@valuerank/shared';
+import type {
+  AuthorizationRequest,
+  TokenRequest,
+  ClientRegistrationRequest,
+  OAuthError,
+} from './types.js';
+import {
+  ALLOWED_REDIRECT_SCHEMES,
+  LOCALHOST_HOSTS,
+  CLAUDE_CALLBACK_URLS,
+  SUPPORTED_SCOPES,
+  DEFAULT_SCOPE,
+} from './constants.js';
+import { isValidCodeChallenge } from './pkce.js';
+
+const log = createLogger('mcp:oauth:validation');
+
+export interface ValidationResult<T> {
+  valid: boolean;
+  data?: T;
+  error?: OAuthError;
+  errorDescription?: string;
+}
+
+/**
+ * Validate a redirect URI
+ *
+ * - Must be HTTPS, or
+ * - HTTP only for localhost
+ * - Claude.ai callbacks are always allowed
+ */
+export function isValidRedirectUri(uri: string): boolean {
+  // Allow Claude.ai callbacks
+  if (CLAUDE_CALLBACK_URLS.includes(uri as typeof CLAUDE_CALLBACK_URLS[number])) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(uri);
+
+    // Check scheme
+    if (!ALLOWED_REDIRECT_SCHEMES.includes(parsed.protocol.replace(':', '') as typeof ALLOWED_REDIRECT_SCHEMES[number])) {
+      return false;
+    }
+
+    // HTTP only allowed for localhost
+    if (parsed.protocol === 'http:') {
+      const hostname = parsed.hostname.toLowerCase();
+      if (!LOCALHOST_HOSTS.includes(hostname as typeof LOCALHOST_HOSTS[number])) {
+        return false;
+      }
+    }
+
+    // No fragments allowed
+    if (parsed.hash) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate a resource URI (RFC 8707)
+ */
+export function isValidResourceUri(uri: string): boolean {
+  try {
+    const parsed = new URL(uri);
+
+    // Must have scheme
+    if (!parsed.protocol) {
+      return false;
+    }
+
+    // No fragments
+    if (parsed.hash) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate scope string
+ */
+export function validateScope(scope: string | undefined): string {
+  if (!scope) {
+    return DEFAULT_SCOPE;
+  }
+
+  const requestedScopes = scope.split(' ').filter(Boolean);
+  const validScopes = requestedScopes.filter((s) =>
+    SUPPORTED_SCOPES.includes(s as typeof SUPPORTED_SCOPES[number])
+  );
+
+  return validScopes.length > 0 ? validScopes.join(' ') : DEFAULT_SCOPE;
+}
+
+/**
+ * Validate authorization request parameters
+ */
+export function validateAuthorizationRequest(
+  params: Record<string, unknown>
+): ValidationResult<AuthorizationRequest> {
+  // Required: response_type
+  if (params.response_type !== 'code') {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'response_type must be "code"',
+    };
+  }
+
+  // Required: client_id
+  if (!params.client_id || typeof params.client_id !== 'string') {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'client_id is required',
+    };
+  }
+
+  // Required: redirect_uri
+  if (!params.redirect_uri || typeof params.redirect_uri !== 'string') {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'redirect_uri is required',
+    };
+  }
+
+  if (!isValidRedirectUri(params.redirect_uri)) {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'redirect_uri must be HTTPS or localhost',
+    };
+  }
+
+  // Required: code_challenge (PKCE)
+  if (!params.code_challenge || typeof params.code_challenge !== 'string') {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'code_challenge is required (PKCE)',
+    };
+  }
+
+  if (!isValidCodeChallenge(params.code_challenge)) {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'code_challenge must be valid BASE64URL (43 chars for S256)',
+    };
+  }
+
+  // Required: code_challenge_method
+  if (params.code_challenge_method !== 'S256') {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'code_challenge_method must be "S256"',
+    };
+  }
+
+  // Required: resource (RFC 8707)
+  if (!params.resource || typeof params.resource !== 'string') {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'resource parameter is required (RFC 8707)',
+    };
+  }
+
+  if (!isValidResourceUri(params.resource)) {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'resource must be a valid URI without fragments',
+    };
+  }
+
+  return {
+    valid: true,
+    data: {
+      response_type: 'code',
+      client_id: params.client_id,
+      redirect_uri: params.redirect_uri,
+      scope: typeof params.scope === 'string' ? params.scope : undefined,
+      state: typeof params.state === 'string' ? params.state : undefined,
+      code_challenge: params.code_challenge,
+      code_challenge_method: 'S256',
+      resource: params.resource,
+    },
+  };
+}
+
+/**
+ * Validate token request parameters
+ */
+export function validateTokenRequest(
+  params: Record<string, unknown>
+): ValidationResult<TokenRequest> {
+  // Required: grant_type
+  const grantType = params.grant_type;
+  if (grantType !== 'authorization_code' && grantType !== 'refresh_token') {
+    return {
+      valid: false,
+      error: 'unsupported_grant_type',
+      errorDescription: 'grant_type must be "authorization_code" or "refresh_token"',
+    };
+  }
+
+  // Required: client_id
+  if (!params.client_id || typeof params.client_id !== 'string') {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'client_id is required',
+    };
+  }
+
+  if (grantType === 'authorization_code') {
+    // Required: code
+    if (!params.code || typeof params.code !== 'string') {
+      return {
+        valid: false,
+        error: 'invalid_request',
+        errorDescription: 'code is required for authorization_code grant',
+      };
+    }
+
+    // Required: redirect_uri
+    if (!params.redirect_uri || typeof params.redirect_uri !== 'string') {
+      return {
+        valid: false,
+        error: 'invalid_request',
+        errorDescription: 'redirect_uri is required for authorization_code grant',
+      };
+    }
+
+    // Required: code_verifier (PKCE)
+    if (!params.code_verifier || typeof params.code_verifier !== 'string') {
+      return {
+        valid: false,
+        error: 'invalid_request',
+        errorDescription: 'code_verifier is required (PKCE)',
+      };
+    }
+  }
+
+  if (grantType === 'refresh_token') {
+    // Required: refresh_token
+    if (!params.refresh_token || typeof params.refresh_token !== 'string') {
+      return {
+        valid: false,
+        error: 'invalid_request',
+        errorDescription: 'refresh_token is required for refresh_token grant',
+      };
+    }
+  }
+
+  return {
+    valid: true,
+    data: {
+      grant_type: grantType,
+      client_id: params.client_id,
+      client_secret: typeof params.client_secret === 'string' ? params.client_secret : undefined,
+      code: typeof params.code === 'string' ? params.code : undefined,
+      redirect_uri: typeof params.redirect_uri === 'string' ? params.redirect_uri : undefined,
+      code_verifier: typeof params.code_verifier === 'string' ? params.code_verifier : undefined,
+      refresh_token: typeof params.refresh_token === 'string' ? params.refresh_token : undefined,
+      resource: typeof params.resource === 'string' ? params.resource : undefined,
+    },
+  };
+}
+
+/**
+ * Validate client registration request
+ */
+export function validateClientRegistrationRequest(
+  body: Record<string, unknown>
+): ValidationResult<ClientRegistrationRequest> {
+  // Required: redirect_uris
+  if (!Array.isArray(body.redirect_uris) || body.redirect_uris.length === 0) {
+    return {
+      valid: false,
+      error: 'invalid_request',
+      errorDescription: 'redirect_uris array is required',
+    };
+  }
+
+  // Validate each redirect URI
+  for (const uri of body.redirect_uris) {
+    if (typeof uri !== 'string' || !isValidRedirectUri(uri)) {
+      return {
+        valid: false,
+        error: 'invalid_request',
+        errorDescription: `Invalid redirect_uri: ${uri}`,
+      };
+    }
+  }
+
+  return {
+    valid: true,
+    data: {
+      redirect_uris: body.redirect_uris as string[],
+      client_name: typeof body.client_name === 'string' ? body.client_name : undefined,
+      token_endpoint_auth_method:
+        body.token_endpoint_auth_method === 'none' ||
+        body.token_endpoint_auth_method === 'client_secret_post' ||
+        body.token_endpoint_auth_method === 'client_secret_basic'
+          ? body.token_endpoint_auth_method
+          : undefined,
+      grant_types: Array.isArray(body.grant_types) ? (body.grant_types as string[]).filter(
+        (g) => g === 'authorization_code' || g === 'refresh_token'
+      ) as ('authorization_code' | 'refresh_token')[] : undefined,
+      response_types: Array.isArray(body.response_types) ? (body.response_types as string[]).filter(
+        (r) => r === 'code'
+      ) as ('code')[] : undefined,
+      scope: typeof body.scope === 'string' ? body.scope : undefined,
+    },
+  };
+}

--- a/cloud/apps/api/tests/mcp/auth.test.ts
+++ b/cloud/apps/api/tests/mcp/auth.test.ts
@@ -1,5 +1,7 @@
 /**
  * MCP Authentication Middleware Tests
+ *
+ * Tests both OAuth Bearer token and legacy API key authentication
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -7,41 +9,67 @@ import type { Request, Response, NextFunction } from 'express';
 import { mcpAuthMiddleware } from '../../src/mcp/auth.js';
 import { AuthenticationError } from '@valuerank/shared';
 
+// Mock the OAuth module
+vi.mock('../../src/mcp/oauth/index.js', () => ({
+  validateAccessToken: vi.fn(),
+  buildWwwAuthenticateHeader: vi.fn().mockReturnValue('Bearer resource="http://localhost/mcp"'),
+  getBaseUrl: vi.fn().mockReturnValue('http://localhost'),
+}));
+
+import { validateAccessToken } from '../../src/mcp/oauth/index.js';
+
 describe('MCP Auth Middleware', () => {
   let mockReq: Partial<Request>;
   let mockRes: Partial<Response>;
   let mockNext: NextFunction;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     mockReq = {
       headers: {},
       path: '/mcp',
+      protocol: 'http',
     };
-    mockRes = {};
+    mockRes = {
+      setHeader: vi.fn(),
+    };
     mockNext = vi.fn();
   });
 
-  describe('API key requirement', () => {
-    it('rejects request without X-API-Key header', () => {
-      mcpAuthMiddleware(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalledWith(expect.any(AuthenticationError));
-      const error = (mockNext as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      expect(error.message).toContain('API key required');
-    });
-
-    it('rejects request with empty X-API-Key header', () => {
-      mockReq.headers = { 'x-api-key': '' };
+  describe('OAuth Bearer token authentication', () => {
+    it('accepts valid Bearer token', () => {
+      mockReq.headers = { authorization: 'Bearer valid-token' };
+      (validateAccessToken as ReturnType<typeof vi.fn>).mockReturnValue({
+        sub: 'user-123',
+        client_id: 'client-456',
+        scope: 'mcp:read mcp:write',
+      });
 
       mcpAuthMiddleware(mockReq as Request, mockRes as Response, mockNext);
 
-      expect(mockNext).toHaveBeenCalledWith(expect.any(AuthenticationError));
-      const error = (mockNext as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      expect(error.message).toContain('API key required');
+      expect(mockNext).toHaveBeenCalledWith();
+      expect(mockReq.user).toEqual({ id: 'user-123', email: '' });
+      expect(mockReq.authMethod).toBe('oauth');
     });
 
-    it('rejects request when API key is not a string', () => {
-      mockReq.headers = { 'x-api-key': ['array', 'value'] as unknown as string };
+    it('rejects invalid Bearer token with 401', () => {
+      mockReq.headers = { authorization: 'Bearer invalid-token' };
+      (validateAccessToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+      mcpAuthMiddleware(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockRes.setHeader).toHaveBeenCalledWith(
+        'WWW-Authenticate',
+        expect.stringContaining('Bearer')
+      );
+      expect(mockNext).toHaveBeenCalledWith(expect.any(AuthenticationError));
+      const error = (mockNext as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(error.message).toContain('Invalid or expired access token');
+    });
+
+    it('rejects expired Bearer token', () => {
+      mockReq.headers = { authorization: 'Bearer expired-token' };
+      (validateAccessToken as ReturnType<typeof vi.fn>).mockReturnValue(null);
 
       mcpAuthMiddleware(mockReq as Request, mockRes as Response, mockNext);
 
@@ -49,8 +77,18 @@ describe('MCP Auth Middleware', () => {
     });
   });
 
-  describe('user validation', () => {
-    it('rejects request with API key but no user (invalid key)', () => {
+  describe('API key authentication (legacy)', () => {
+    it('accepts valid API key when user is pre-authenticated', () => {
+      mockReq.headers = { 'x-api-key': 'valid-key-123' };
+      mockReq.user = { id: 'user-1', email: 'test@test.com' };
+      mockReq.authMethod = 'api_key';
+
+      mcpAuthMiddleware(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
+    it('rejects API key without pre-authenticated user', () => {
       mockReq.headers = { 'x-api-key': 'invalid-key-123' };
       mockReq.user = undefined;
 
@@ -58,12 +96,10 @@ describe('MCP Auth Middleware', () => {
 
       expect(mockNext).toHaveBeenCalledWith(expect.any(AuthenticationError));
       const error = (mockNext as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      expect(error.message).toContain('Invalid');
+      expect(error.message).toContain('Invalid or expired API key');
     });
-  });
 
-  describe('auth method validation', () => {
-    it('rejects JWT authentication even with valid user', () => {
+    it('rejects JWT auth method even with valid user', () => {
       mockReq.headers = { 'x-api-key': 'valid-key-123' };
       mockReq.user = { id: 'user-1', email: 'test@test.com' };
       mockReq.authMethod = 'jwt';
@@ -71,31 +107,44 @@ describe('MCP Auth Middleware', () => {
       mcpAuthMiddleware(mockReq as Request, mockRes as Response, mockNext);
 
       expect(mockNext).toHaveBeenCalledWith(expect.any(AuthenticationError));
-      const error = (mockNext as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      expect(error.message).toContain('API key authentication');
-    });
-
-    it('accepts API key authentication with valid user', () => {
-      mockReq.headers = { 'x-api-key': 'valid-key-123' };
-      mockReq.user = { id: 'user-1', email: 'test@test.com' };
-      mockReq.authMethod = 'api_key';
-
-      mcpAuthMiddleware(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalledWith(); // Called with no arguments
     });
   });
 
-  describe('successful authentication', () => {
-    it('calls next without error for valid API key auth', () => {
-      mockReq.headers = { 'x-api-key': 'valid-api-key-12345' };
-      mockReq.user = { id: 'user-123', email: 'user@example.com' };
-      mockReq.authMethod = 'api_key';
+  describe('no authentication', () => {
+    it('returns 401 with WWW-Authenticate header when no credentials provided', () => {
+      mockReq.headers = {};
 
       mcpAuthMiddleware(mockReq as Request, mockRes as Response, mockNext);
 
-      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockRes.setHeader).toHaveBeenCalledWith(
+        'WWW-Authenticate',
+        expect.stringContaining('Bearer')
+      );
+      expect(mockNext).toHaveBeenCalledWith(expect.any(AuthenticationError));
+      const error = (mockNext as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(error.message).toContain('Authentication required');
+    });
+  });
+
+  describe('authentication priority', () => {
+    it('prefers OAuth Bearer over API key when both present', () => {
+      mockReq.headers = {
+        authorization: 'Bearer valid-token',
+        'x-api-key': 'also-valid-key',
+      };
+      mockReq.user = { id: 'api-key-user', email: 'api@test.com' };
+      mockReq.authMethod = 'api_key';
+      (validateAccessToken as ReturnType<typeof vi.fn>).mockReturnValue({
+        sub: 'oauth-user',
+        client_id: 'client-456',
+        scope: 'mcp:read',
+      });
+
+      mcpAuthMiddleware(mockReq as Request, mockRes as Response, mockNext);
+
       expect(mockNext).toHaveBeenCalledWith();
+      expect(mockReq.user?.id).toBe('oauth-user');
+      expect(mockReq.authMethod).toBe('oauth');
     });
   });
 });

--- a/cloud/apps/api/tests/mcp/oauth/endpoints.test.ts
+++ b/cloud/apps/api/tests/mcp/oauth/endpoints.test.ts
@@ -1,0 +1,480 @@
+/**
+ * OAuth Endpoint Integration Tests
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createServer } from '../../../src/server.js';
+import { db } from '@valuerank/db';
+import { hashApiKey, generateApiKey } from '../../../src/auth/api-keys.js';
+import { generateCodeVerifier, generateCodeChallenge } from '../../../src/mcp/oauth/pkce.js';
+import type { Express } from 'express';
+
+describe('OAuth Endpoints', () => {
+  let app: Express;
+  let testUser: { id: string; email: string };
+  let testApiKey: string;
+
+  beforeAll(async () => {
+    app = createServer();
+
+    // Create test user
+    testUser = await db.user.create({
+      data: {
+        email: `oauth-test-${Date.now()}@valuerank.ai`,
+        passwordHash: 'test-hash',
+      },
+    });
+
+    // Create test API key
+    testApiKey = generateApiKey();
+    await db.apiKey.create({
+      data: {
+        userId: testUser.id,
+        name: 'OAuth Test Key',
+        keyHash: hashApiKey(testApiKey),
+        keyPrefix: testApiKey.slice(0, 10),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    // Cleanup
+    await db.apiKey.deleteMany({ where: { userId: testUser.id } });
+    await db.oAuthRefreshToken.deleteMany({ where: { userId: testUser.id } });
+    await db.user.delete({ where: { id: testUser.id } });
+  });
+
+  describe('GET /.well-known/oauth-authorization-server', () => {
+    it('returns authorization server metadata', async () => {
+      const res = await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+
+      expect(res.body.issuer).toBeDefined();
+      expect(res.body.authorization_endpoint).toContain('/oauth/authorize');
+      expect(res.body.token_endpoint).toContain('/oauth/token');
+      expect(res.body.registration_endpoint).toContain('/oauth/register');
+      expect(res.body.scopes_supported).toContain('mcp:read');
+      expect(res.body.scopes_supported).toContain('mcp:write');
+      expect(res.body.response_types_supported).toContain('code');
+      expect(res.body.grant_types_supported).toContain('authorization_code');
+      expect(res.body.grant_types_supported).toContain('refresh_token');
+      expect(res.body.code_challenge_methods_supported).toContain('S256');
+    });
+  });
+
+  describe('GET /mcp/.well-known/resource.json', () => {
+    it('returns protected resource metadata', async () => {
+      const res = await request(app)
+        .get('/mcp/.well-known/resource.json')
+        .expect(200);
+
+      expect(res.body.resource).toContain('/mcp');
+      expect(res.body.authorization_servers).toBeInstanceOf(Array);
+      expect(res.body.authorization_servers.length).toBeGreaterThan(0);
+      expect(res.body.scopes_supported).toContain('mcp:read');
+      expect(res.body.bearer_methods_supported).toContain('header');
+    });
+  });
+
+  describe('HEAD /mcp', () => {
+    it('returns MCP protocol version header', async () => {
+      const res = await request(app)
+        .head('/mcp')
+        .expect(200);
+
+      expect(res.headers['mcp-protocol-version']).toBe('2025-06-18');
+    });
+  });
+
+  describe('POST /oauth/register', () => {
+    let createdClientId: string;
+
+    afterAll(async () => {
+      if (createdClientId) {
+        await db.oAuthClient.deleteMany({ where: { clientId: createdClientId } });
+      }
+    });
+
+    it('registers a new OAuth client', async () => {
+      const res = await request(app)
+        .post('/oauth/register')
+        .send({
+          redirect_uris: ['https://example.com/callback'],
+          client_name: 'Test Client',
+        })
+        .expect(201);
+
+      expect(res.body.client_id).toBeDefined();
+      expect(res.body.client_secret).toBeDefined();
+      expect(res.body.redirect_uris).toEqual(['https://example.com/callback']);
+      expect(res.body.client_name).toBe('Test Client');
+      expect(res.body.token_endpoint_auth_method).toBe('client_secret_post');
+      expect(res.body.grant_types).toContain('authorization_code');
+
+      createdClientId = res.body.client_id;
+    });
+
+    it('rejects registration without redirect_uris', async () => {
+      const res = await request(app)
+        .post('/oauth/register')
+        .send({
+          client_name: 'Invalid Client',
+        })
+        .expect(400);
+
+      expect(res.body.error).toBe('invalid_request');
+    });
+
+    it('rejects registration with invalid redirect_uri', async () => {
+      const res = await request(app)
+        .post('/oauth/register')
+        .send({
+          redirect_uris: ['http://external.com/callback'],
+        })
+        .expect(400);
+
+      expect(res.body.error).toBe('invalid_request');
+    });
+  });
+
+  describe('OAuth Authorization Flow', () => {
+    let clientId: string;
+    let clientSecret: string;
+    let codeVerifier: string;
+    let codeChallenge: string;
+
+    beforeAll(async () => {
+      // Register a test client
+      const res = await request(app)
+        .post('/oauth/register')
+        .send({
+          redirect_uris: ['https://example.com/callback', 'http://localhost:3000/callback'],
+          client_name: 'Flow Test Client',
+        });
+
+      clientId = res.body.client_id;
+      clientSecret = res.body.client_secret;
+    });
+
+    beforeEach(() => {
+      // Generate fresh PKCE values for each test
+      codeVerifier = generateCodeVerifier();
+      codeChallenge = generateCodeChallenge(codeVerifier);
+    });
+
+    afterAll(async () => {
+      await db.oAuthRefreshToken.deleteMany({ where: { clientId } });
+      await db.oAuthClient.deleteMany({ where: { clientId } });
+    });
+
+    describe('GET /oauth/authorize', () => {
+      it('returns HTML form when no API key provided', async () => {
+        const res = await request(app)
+          .get('/oauth/authorize')
+          .query({
+            response_type: 'code',
+            client_id: clientId,
+            redirect_uri: 'https://example.com/callback',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            resource: 'http://localhost/mcp',
+          })
+          .expect(401);
+
+        expect(res.text).toContain('Authorize ValueRank MCP');
+        expect(res.text).toContain('API Key');
+      });
+
+      it('redirects with code when API key is valid', async () => {
+        const res = await request(app)
+          .get('/oauth/authorize')
+          .set('X-API-Key', testApiKey)
+          .query({
+            response_type: 'code',
+            client_id: clientId,
+            redirect_uri: 'https://example.com/callback',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            resource: 'http://localhost/mcp',
+            state: 'test-state',
+          })
+          .expect(302);
+
+        const location = new URL(res.headers.location);
+        expect(location.origin).toBe('https://example.com');
+        expect(location.pathname).toBe('/callback');
+        expect(location.searchParams.get('code')).toBeDefined();
+        expect(location.searchParams.get('state')).toBe('test-state');
+      });
+
+      it('rejects invalid client_id', async () => {
+        const res = await request(app)
+          .get('/oauth/authorize')
+          .set('X-API-Key', testApiKey)
+          .query({
+            response_type: 'code',
+            client_id: 'invalid-client',
+            redirect_uri: 'https://example.com/callback',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            resource: 'http://localhost/mcp',
+          })
+          .expect(400);
+
+        expect(res.body.error).toBe('invalid_client');
+      });
+
+      it('rejects mismatched redirect_uri', async () => {
+        const res = await request(app)
+          .get('/oauth/authorize')
+          .set('X-API-Key', testApiKey)
+          .query({
+            response_type: 'code',
+            client_id: clientId,
+            redirect_uri: 'https://other.com/callback',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            resource: 'http://localhost/mcp',
+          })
+          .expect(400);
+
+        expect(res.body.error).toBe('invalid_request');
+      });
+
+      it('rejects invalid API key', async () => {
+        const res = await request(app)
+          .get('/oauth/authorize')
+          .set('X-API-Key', 'vr_invalid_api_key_12345678901234567890')
+          .query({
+            response_type: 'code',
+            client_id: clientId,
+            redirect_uri: 'https://example.com/callback',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            resource: 'http://localhost/mcp',
+          })
+          .expect(401);
+
+        expect(res.body.error).toBe('access_denied');
+      });
+    });
+
+    describe('POST /oauth/token', () => {
+      it('exchanges authorization code for tokens', async () => {
+        // First, get an authorization code
+        const authRes = await request(app)
+          .get('/oauth/authorize')
+          .set('X-API-Key', testApiKey)
+          .query({
+            response_type: 'code',
+            client_id: clientId,
+            redirect_uri: 'https://example.com/callback',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            resource: 'http://localhost/mcp',
+          });
+
+        const authCode = new URL(authRes.headers.location).searchParams.get('code');
+
+        // Exchange code for tokens
+        const tokenRes = await request(app)
+          .post('/oauth/token')
+          .send({
+            grant_type: 'authorization_code',
+            client_id: clientId,
+            client_secret: clientSecret,
+            code: authCode,
+            redirect_uri: 'https://example.com/callback',
+            code_verifier: codeVerifier,
+          })
+          .expect(200);
+
+        expect(tokenRes.body.access_token).toBeDefined();
+        expect(tokenRes.body.token_type).toBe('Bearer');
+        expect(tokenRes.body.expires_in).toBe(3600);
+        expect(tokenRes.body.refresh_token).toBeDefined();
+        expect(tokenRes.body.scope).toContain('mcp:read');
+      });
+
+      it('rejects reused authorization code', async () => {
+        // Get an authorization code
+        const authRes = await request(app)
+          .get('/oauth/authorize')
+          .set('X-API-Key', testApiKey)
+          .query({
+            response_type: 'code',
+            client_id: clientId,
+            redirect_uri: 'https://example.com/callback',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            resource: 'http://localhost/mcp',
+          });
+
+        const authCode = new URL(authRes.headers.location).searchParams.get('code');
+
+        // First exchange - should succeed
+        await request(app)
+          .post('/oauth/token')
+          .send({
+            grant_type: 'authorization_code',
+            client_id: clientId,
+            client_secret: clientSecret,
+            code: authCode,
+            redirect_uri: 'https://example.com/callback',
+            code_verifier: codeVerifier,
+          })
+          .expect(200);
+
+        // Second exchange - should fail (code is single-use)
+        const res = await request(app)
+          .post('/oauth/token')
+          .send({
+            grant_type: 'authorization_code',
+            client_id: clientId,
+            client_secret: clientSecret,
+            code: authCode,
+            redirect_uri: 'https://example.com/callback',
+            code_verifier: codeVerifier,
+          })
+          .expect(400);
+
+        expect(res.body.error).toBe('invalid_grant');
+      });
+
+      it('rejects invalid PKCE verifier', async () => {
+        // Get an authorization code
+        const authRes = await request(app)
+          .get('/oauth/authorize')
+          .set('X-API-Key', testApiKey)
+          .query({
+            response_type: 'code',
+            client_id: clientId,
+            redirect_uri: 'https://example.com/callback',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            resource: 'http://localhost/mcp',
+          });
+
+        const authCode = new URL(authRes.headers.location).searchParams.get('code');
+
+        // Try with wrong verifier
+        const res = await request(app)
+          .post('/oauth/token')
+          .send({
+            grant_type: 'authorization_code',
+            client_id: clientId,
+            client_secret: clientSecret,
+            code: authCode,
+            redirect_uri: 'https://example.com/callback',
+            code_verifier: generateCodeVerifier(), // Different verifier
+          })
+          .expect(400);
+
+        expect(res.body.error).toBe('invalid_grant');
+        expect(res.body.error_description).toContain('PKCE');
+      });
+
+      it('refreshes tokens with refresh_token grant', async () => {
+        // Get authorization code and exchange for tokens
+        const authRes = await request(app)
+          .get('/oauth/authorize')
+          .set('X-API-Key', testApiKey)
+          .query({
+            response_type: 'code',
+            client_id: clientId,
+            redirect_uri: 'https://example.com/callback',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            resource: 'http://localhost/mcp',
+          });
+
+        const authCode = new URL(authRes.headers.location).searchParams.get('code');
+
+        const tokenRes = await request(app)
+          .post('/oauth/token')
+          .send({
+            grant_type: 'authorization_code',
+            client_id: clientId,
+            client_secret: clientSecret,
+            code: authCode,
+            redirect_uri: 'https://example.com/callback',
+            code_verifier: codeVerifier,
+          });
+
+        const refreshToken = tokenRes.body.refresh_token;
+
+        // Use refresh token to get new access token
+        const refreshRes = await request(app)
+          .post('/oauth/token')
+          .send({
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            client_secret: clientSecret,
+            refresh_token: refreshToken,
+          })
+          .expect(200);
+
+        expect(refreshRes.body.access_token).toBeDefined();
+        expect(refreshRes.body.access_token).not.toBe(tokenRes.body.access_token);
+        expect(refreshRes.body.refresh_token).toBeDefined();
+        expect(refreshRes.body.refresh_token).not.toBe(refreshToken); // Rotation
+      });
+
+      it('rejects reused refresh token', async () => {
+        // Get tokens
+        const authRes = await request(app)
+          .get('/oauth/authorize')
+          .set('X-API-Key', testApiKey)
+          .query({
+            response_type: 'code',
+            client_id: clientId,
+            redirect_uri: 'https://example.com/callback',
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            resource: 'http://localhost/mcp',
+          });
+
+        const authCode = new URL(authRes.headers.location).searchParams.get('code');
+
+        const tokenRes = await request(app)
+          .post('/oauth/token')
+          .send({
+            grant_type: 'authorization_code',
+            client_id: clientId,
+            client_secret: clientSecret,
+            code: authCode,
+            redirect_uri: 'https://example.com/callback',
+            code_verifier: codeVerifier,
+          });
+
+        const refreshToken = tokenRes.body.refresh_token;
+
+        // First refresh - should succeed
+        await request(app)
+          .post('/oauth/token')
+          .send({
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            client_secret: clientSecret,
+            refresh_token: refreshToken,
+          })
+          .expect(200);
+
+        // Second refresh with same token - should fail (rotation)
+        const res = await request(app)
+          .post('/oauth/token')
+          .send({
+            grant_type: 'refresh_token',
+            client_id: clientId,
+            client_secret: clientSecret,
+            refresh_token: refreshToken,
+          })
+          .expect(400);
+
+        expect(res.body.error).toBe('invalid_grant');
+      });
+    });
+  });
+});

--- a/cloud/apps/api/tests/mcp/oauth/pkce.test.ts
+++ b/cloud/apps/api/tests/mcp/oauth/pkce.test.ts
@@ -1,0 +1,136 @@
+/**
+ * PKCE Validation Tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validatePkce,
+  isValidCodeVerifier,
+  isValidCodeChallenge,
+  generateCodeVerifier,
+  generateCodeChallenge,
+} from '../../../src/mcp/oauth/pkce.js';
+
+describe('PKCE', () => {
+  describe('generateCodeVerifier', () => {
+    it('generates a valid code verifier', () => {
+      const verifier = generateCodeVerifier();
+
+      expect(verifier.length).toBeGreaterThanOrEqual(43);
+      expect(verifier.length).toBeLessThanOrEqual(128);
+      expect(isValidCodeVerifier(verifier)).toBe(true);
+    });
+
+    it('generates unique verifiers', () => {
+      const verifiers = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        verifiers.add(generateCodeVerifier());
+      }
+      expect(verifiers.size).toBe(100);
+    });
+  });
+
+  describe('generateCodeChallenge', () => {
+    it('generates a valid S256 code challenge', () => {
+      const verifier = generateCodeVerifier();
+      const challenge = generateCodeChallenge(verifier);
+
+      expect(challenge.length).toBe(43);
+      expect(isValidCodeChallenge(challenge)).toBe(true);
+    });
+
+    it('generates consistent challenges for same verifier', () => {
+      const verifier = 'test-verifier-that-is-exactly-43-chars-long!';
+      const challenge1 = generateCodeChallenge(verifier);
+      const challenge2 = generateCodeChallenge(verifier);
+
+      expect(challenge1).toBe(challenge2);
+    });
+  });
+
+  describe('isValidCodeVerifier', () => {
+    it('accepts valid verifiers', () => {
+      expect(isValidCodeVerifier('a'.repeat(43))).toBe(true);
+      expect(isValidCodeVerifier('a'.repeat(128))).toBe(true);
+      expect(isValidCodeVerifier('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq')).toBe(true); // 43 chars
+      expect(isValidCodeVerifier('0123456789-._~'.repeat(4))).toBe(true); // 56 chars
+    });
+
+    it('rejects too short verifiers', () => {
+      expect(isValidCodeVerifier('a'.repeat(42))).toBe(false);
+      expect(isValidCodeVerifier('')).toBe(false);
+    });
+
+    it('rejects too long verifiers', () => {
+      expect(isValidCodeVerifier('a'.repeat(129))).toBe(false);
+    });
+
+    it('rejects invalid characters', () => {
+      expect(isValidCodeVerifier('a'.repeat(42) + '!')).toBe(false);
+      expect(isValidCodeVerifier('a'.repeat(42) + ' ')).toBe(false);
+      expect(isValidCodeVerifier('a'.repeat(42) + '+')).toBe(false);
+    });
+  });
+
+  describe('isValidCodeChallenge', () => {
+    it('accepts valid challenges', () => {
+      // S256 produces exactly 43 base64url characters
+      expect(isValidCodeChallenge('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM')).toBe(true);
+      expect(isValidCodeChallenge('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ')).toBe(true); // 43 chars
+    });
+
+    it('rejects wrong length challenges', () => {
+      expect(isValidCodeChallenge('a'.repeat(42))).toBe(false);
+      expect(isValidCodeChallenge('a'.repeat(44))).toBe(false);
+      expect(isValidCodeChallenge('')).toBe(false);
+    });
+
+    it('rejects invalid characters', () => {
+      expect(isValidCodeChallenge('a'.repeat(42) + '=')).toBe(false); // padding not allowed
+      expect(isValidCodeChallenge('a'.repeat(42) + '+')).toBe(false);
+      expect(isValidCodeChallenge('a'.repeat(42) + '/')).toBe(false);
+    });
+  });
+
+  describe('validatePkce', () => {
+    it('validates correct verifier against challenge', () => {
+      const verifier = generateCodeVerifier();
+      const challenge = generateCodeChallenge(verifier);
+
+      expect(validatePkce(verifier, challenge, 'S256')).toBe(true);
+    });
+
+    it('rejects incorrect verifier', () => {
+      const verifier = generateCodeVerifier();
+      const challenge = generateCodeChallenge(verifier);
+      const wrongVerifier = generateCodeVerifier();
+
+      expect(validatePkce(wrongVerifier, challenge, 'S256')).toBe(false);
+    });
+
+    it('rejects unsupported methods', () => {
+      const verifier = generateCodeVerifier();
+      const challenge = generateCodeChallenge(verifier);
+
+      expect(validatePkce(verifier, challenge, 'plain')).toBe(false);
+      expect(validatePkce(verifier, challenge, '')).toBe(false);
+    });
+
+    it('rejects invalid verifier format', () => {
+      const challenge = generateCodeChallenge('valid-verifier-that-is-at-least-43-chars!!');
+
+      expect(validatePkce('short', challenge, 'S256')).toBe(false);
+      expect(validatePkce('invalid chars +/', challenge, 'S256')).toBe(false);
+    });
+
+    it('works with known test vectors', () => {
+      // RFC 7636 Appendix B test vector
+      const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+      const expectedChallenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+      const computedChallenge = generateCodeChallenge(verifier);
+      expect(computedChallenge).toBe(expectedChallenge);
+      expect(validatePkce(verifier, expectedChallenge, 'S256')).toBe(true);
+    });
+  });
+});

--- a/cloud/apps/api/tests/mcp/oauth/validation.test.ts
+++ b/cloud/apps/api/tests/mcp/oauth/validation.test.ts
@@ -1,0 +1,305 @@
+/**
+ * OAuth Request Validation Tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isValidRedirectUri,
+  isValidResourceUri,
+  validateScope,
+  validateAuthorizationRequest,
+  validateTokenRequest,
+  validateClientRegistrationRequest,
+} from '../../../src/mcp/oauth/validation.js';
+
+describe('OAuth Validation', () => {
+  describe('isValidRedirectUri', () => {
+    it('accepts HTTPS URLs', () => {
+      expect(isValidRedirectUri('https://example.com/callback')).toBe(true);
+      expect(isValidRedirectUri('https://app.example.com:8443/oauth')).toBe(true);
+    });
+
+    it('accepts Claude.ai callbacks', () => {
+      expect(isValidRedirectUri('https://claude.ai/api/mcp/auth_callback')).toBe(true);
+      expect(isValidRedirectUri('https://claude.com/api/mcp/auth_callback')).toBe(true);
+    });
+
+    it('accepts localhost HTTP', () => {
+      expect(isValidRedirectUri('http://localhost/callback')).toBe(true);
+      expect(isValidRedirectUri('http://localhost:3000/oauth')).toBe(true);
+      expect(isValidRedirectUri('http://127.0.0.1/callback')).toBe(true);
+      expect(isValidRedirectUri('http://[::1]:8080/callback')).toBe(true);
+    });
+
+    it('rejects non-localhost HTTP', () => {
+      expect(isValidRedirectUri('http://example.com/callback')).toBe(false);
+      expect(isValidRedirectUri('http://192.168.1.1/callback')).toBe(false);
+    });
+
+    it('rejects URLs with fragments', () => {
+      expect(isValidRedirectUri('https://example.com/callback#fragment')).toBe(false);
+    });
+
+    it('rejects invalid URLs', () => {
+      expect(isValidRedirectUri('not-a-url')).toBe(false);
+      expect(isValidRedirectUri('')).toBe(false);
+    });
+
+    it('rejects unsupported schemes', () => {
+      expect(isValidRedirectUri('ftp://example.com/callback')).toBe(false);
+      expect(isValidRedirectUri('custom://callback')).toBe(false);
+    });
+  });
+
+  describe('isValidResourceUri', () => {
+    it('accepts valid resource URIs', () => {
+      expect(isValidResourceUri('https://mcp.example.com')).toBe(true);
+      expect(isValidResourceUri('https://mcp.example.com/mcp')).toBe(true);
+      expect(isValidResourceUri('https://mcp.example.com:8443')).toBe(true);
+    });
+
+    it('rejects URIs with fragments', () => {
+      expect(isValidResourceUri('https://mcp.example.com#fragment')).toBe(false);
+    });
+
+    it('rejects invalid URIs', () => {
+      expect(isValidResourceUri('mcp.example.com')).toBe(false);
+      expect(isValidResourceUri('')).toBe(false);
+    });
+  });
+
+  describe('validateScope', () => {
+    it('returns default scope for empty input', () => {
+      expect(validateScope(undefined)).toBe('mcp:read mcp:write');
+      expect(validateScope('')).toBe('mcp:read mcp:write');
+    });
+
+    it('filters to supported scopes', () => {
+      expect(validateScope('mcp:read')).toBe('mcp:read');
+      expect(validateScope('mcp:write')).toBe('mcp:write');
+      expect(validateScope('mcp:read mcp:write')).toBe('mcp:read mcp:write');
+    });
+
+    it('removes unsupported scopes', () => {
+      expect(validateScope('mcp:read invalid:scope')).toBe('mcp:read');
+      expect(validateScope('invalid:scope')).toBe('mcp:read mcp:write');
+    });
+  });
+
+  describe('validateAuthorizationRequest', () => {
+    const validRequest = {
+      response_type: 'code',
+      client_id: 'test-client',
+      redirect_uri: 'https://example.com/callback',
+      code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+      code_challenge_method: 'S256',
+      resource: 'https://mcp.example.com',
+    };
+
+    it('accepts valid request', () => {
+      const result = validateAuthorizationRequest(validRequest);
+
+      expect(result.valid).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data?.client_id).toBe('test-client');
+    });
+
+    it('accepts request with optional state', () => {
+      const result = validateAuthorizationRequest({
+        ...validRequest,
+        state: 'random-state',
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.data?.state).toBe('random-state');
+    });
+
+    it('rejects invalid response_type', () => {
+      const result = validateAuthorizationRequest({
+        ...validRequest,
+        response_type: 'token',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('invalid_request');
+    });
+
+    it('rejects missing client_id', () => {
+      const { client_id, ...noClientId } = validRequest;
+
+      const result = validateAuthorizationRequest(noClientId);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('invalid_request');
+    });
+
+    it('rejects invalid redirect_uri', () => {
+      const result = validateAuthorizationRequest({
+        ...validRequest,
+        redirect_uri: 'http://external.com/callback',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('invalid_request');
+    });
+
+    it('rejects missing code_challenge', () => {
+      const { code_challenge, ...noChallenge } = validRequest;
+
+      const result = validateAuthorizationRequest(noChallenge);
+
+      expect(result.valid).toBe(false);
+      expect(result.errorDescription).toContain('code_challenge');
+    });
+
+    it('rejects invalid code_challenge_method', () => {
+      const result = validateAuthorizationRequest({
+        ...validRequest,
+        code_challenge_method: 'plain',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errorDescription).toContain('S256');
+    });
+
+    it('rejects missing resource', () => {
+      const { resource, ...noResource } = validRequest;
+
+      const result = validateAuthorizationRequest(noResource);
+
+      expect(result.valid).toBe(false);
+      expect(result.errorDescription).toContain('resource');
+    });
+  });
+
+  describe('validateTokenRequest', () => {
+    describe('authorization_code grant', () => {
+      const validAuthCodeRequest = {
+        grant_type: 'authorization_code',
+        client_id: 'test-client',
+        code: 'auth-code-123',
+        redirect_uri: 'https://example.com/callback',
+        code_verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+      };
+
+      it('accepts valid request', () => {
+        const result = validateTokenRequest(validAuthCodeRequest);
+
+        expect(result.valid).toBe(true);
+        expect(result.data?.grant_type).toBe('authorization_code');
+      });
+
+      it('rejects missing code', () => {
+        const { code, ...noCode } = validAuthCodeRequest;
+
+        const result = validateTokenRequest(noCode);
+
+        expect(result.valid).toBe(false);
+        expect(result.errorDescription).toContain('code');
+      });
+
+      it('rejects missing redirect_uri', () => {
+        const { redirect_uri, ...noRedirect } = validAuthCodeRequest;
+
+        const result = validateTokenRequest(noRedirect);
+
+        expect(result.valid).toBe(false);
+        expect(result.errorDescription).toContain('redirect_uri');
+      });
+
+      it('rejects missing code_verifier', () => {
+        const { code_verifier, ...noVerifier } = validAuthCodeRequest;
+
+        const result = validateTokenRequest(noVerifier);
+
+        expect(result.valid).toBe(false);
+        expect(result.errorDescription).toContain('code_verifier');
+      });
+    });
+
+    describe('refresh_token grant', () => {
+      const validRefreshRequest = {
+        grant_type: 'refresh_token',
+        client_id: 'test-client',
+        refresh_token: 'refresh-token-123',
+      };
+
+      it('accepts valid request', () => {
+        const result = validateTokenRequest(validRefreshRequest);
+
+        expect(result.valid).toBe(true);
+        expect(result.data?.grant_type).toBe('refresh_token');
+      });
+
+      it('rejects missing refresh_token', () => {
+        const { refresh_token, ...noToken } = validRefreshRequest;
+
+        const result = validateTokenRequest(noToken);
+
+        expect(result.valid).toBe(false);
+        expect(result.errorDescription).toContain('refresh_token');
+      });
+    });
+
+    it('rejects unsupported grant_type', () => {
+      const result = validateTokenRequest({
+        grant_type: 'client_credentials',
+        client_id: 'test-client',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('unsupported_grant_type');
+    });
+  });
+
+  describe('validateClientRegistrationRequest', () => {
+    it('accepts valid request', () => {
+      const result = validateClientRegistrationRequest({
+        redirect_uris: ['https://example.com/callback'],
+        client_name: 'Test Client',
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.data?.redirect_uris).toEqual(['https://example.com/callback']);
+      expect(result.data?.client_name).toBe('Test Client');
+    });
+
+    it('accepts request with multiple redirect URIs', () => {
+      const result = validateClientRegistrationRequest({
+        redirect_uris: [
+          'https://example.com/callback',
+          'http://localhost:3000/callback',
+        ],
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.data?.redirect_uris).toHaveLength(2);
+    });
+
+    it('rejects empty redirect_uris', () => {
+      const result = validateClientRegistrationRequest({
+        redirect_uris: [],
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errorDescription).toContain('redirect_uris');
+    });
+
+    it('rejects invalid redirect_uri in array', () => {
+      const result = validateClientRegistrationRequest({
+        redirect_uris: ['https://valid.com/callback', 'http://invalid.com/callback'],
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errorDescription).toContain('Invalid redirect_uri');
+    });
+
+    it('rejects missing redirect_uris', () => {
+      const result = validateClientRegistrationRequest({
+        client_name: 'Test Client',
+      });
+
+      expect(result.valid).toBe(false);
+    });
+  });
+});

--- a/cloud/packages/db/prisma/migrations/20241209000000_add_oauth_tables/migration.sql
+++ b/cloud/packages/db/prisma/migrations/20241209000000_add_oauth_tables/migration.sql
@@ -1,0 +1,47 @@
+-- CreateTable
+CREATE TABLE "oauth_clients" (
+    "id" TEXT NOT NULL,
+    "client_id" TEXT NOT NULL,
+    "client_secret_hash" TEXT NOT NULL,
+    "client_name" TEXT,
+    "redirect_uris" TEXT[],
+    "token_endpoint_auth_method" TEXT NOT NULL DEFAULT 'client_secret_post',
+    "grant_types" TEXT[] DEFAULT ARRAY['authorization_code', 'refresh_token']::TEXT[],
+    "response_types" TEXT[] DEFAULT ARRAY['code']::TEXT[],
+    "scope" TEXT NOT NULL DEFAULT 'mcp:read mcp:write',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "oauth_clients_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "oauth_refresh_tokens" (
+    "id" TEXT NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "client_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "scope" TEXT NOT NULL,
+    "resource" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "oauth_refresh_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "oauth_clients_client_id_key" ON "oauth_clients"("client_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "oauth_refresh_tokens_token_hash_key" ON "oauth_refresh_tokens"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "oauth_refresh_tokens_client_id_idx" ON "oauth_refresh_tokens"("client_id");
+
+-- CreateIndex
+CREATE INDEX "oauth_refresh_tokens_user_id_idx" ON "oauth_refresh_tokens"("user_id");
+
+-- CreateIndex
+CREATE INDEX "oauth_refresh_tokens_expires_at_idx" ON "oauth_refresh_tokens"("expires_at");
+
+-- AddForeignKey
+ALTER TABLE "oauth_refresh_tokens" ADD CONSTRAINT "oauth_refresh_tokens_client_id_fkey" FOREIGN KEY ("client_id") REFERENCES "oauth_clients"("client_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/cloud/packages/db/prisma/schema.prisma
+++ b/cloud/packages/db/prisma/schema.prisma
@@ -43,6 +43,45 @@ model ApiKey {
 }
 
 // ============================================================================
+// OAUTH 2.1 (MCP Authentication)
+// ============================================================================
+
+model OAuthClient {
+  id                      String   @id @default(cuid())
+  clientId                String   @unique @map("client_id")
+  clientSecretHash        String   @map("client_secret_hash")
+  clientName              String?  @map("client_name")
+  redirectUris            String[] @map("redirect_uris")
+  tokenEndpointAuthMethod String   @default("client_secret_post") @map("token_endpoint_auth_method")
+  grantTypes              String[] @default(["authorization_code", "refresh_token"]) @map("grant_types")
+  responseTypes           String[] @default(["code"]) @map("response_types")
+  scope                   String   @default("mcp:read mcp:write")
+  createdAt               DateTime @default(now()) @map("created_at")
+
+  refreshTokens OAuthRefreshToken[]
+
+  @@map("oauth_clients")
+}
+
+model OAuthRefreshToken {
+  id        String   @id @default(cuid())
+  tokenHash String   @unique @map("token_hash")
+  clientId  String   @map("client_id")
+  userId    String   @map("user_id")
+  scope     String
+  resource  String
+  expiresAt DateTime @map("expires_at")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  client OAuthClient @relation(fields: [clientId], references: [clientId], onDelete: Cascade)
+
+  @@index([clientId])
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("oauth_refresh_tokens")
+}
+
+// ============================================================================
 // CORE DOMAIN
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Implements OAuth 2.1 authentication for the MCP server to enable Claude.ai custom connector integration
- Follows MCP specification (2025-06-18) with full RFC compliance
- Adds migration infrastructure with auto-deploy on Railway startup
- Updates CLAUDE.md with Prisma migration best practices

## What's New

### OAuth 2.1 Endpoints
| Endpoint | Purpose |
|----------|---------|
| `GET /.well-known/oauth-authorization-server` | Authorization Server Metadata (RFC 8414) |
| `GET /mcp/.well-known/resource.json` | Protected Resource Metadata (RFC 9728) |
| `HEAD /mcp` | Returns `MCP-Protocol-Version: 2025-06-18` |
| `POST /oauth/register` | Dynamic Client Registration (RFC 7591) |
| `GET/POST /oauth/authorize` | Authorization endpoint (with PKCE) |
| `POST /oauth/token` | Token endpoint with refresh support |

### Database Changes
- `oauth_clients` - Stores dynamically registered OAuth clients
- `oauth_refresh_tokens` - Stores refresh tokens with rotation support

### Backwards Compatibility
The MCP endpoint now accepts both:
- OAuth Bearer tokens (new, for Claude.ai)
- X-API-Key header (legacy, still works)

## How to Use with Claude.ai

1. Go to Claude.ai Settings → Connectors → Add Custom Integration
2. Enter URL: `https://api-production-8494.up.railway.app/mcp`
3. Claude.ai will auto-discover OAuth endpoints and register
4. Enter your ValueRank API key when prompted to authorize
5. Done! Claude can now use ValueRank MCP tools

## Test plan

- [x] All 1000+ existing tests pass
- [x] 73 new OAuth tests pass (PKCE, validation, full flow)
- [ ] Manual test with Claude.ai after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)