### PR TITLE
fix(scenario): omit preamble from generated scenarios when empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 *.venv
 venv/
 .envrc
+.mcp.json
 
 # Output directories
 output/


### PR DESCRIPTION
## Summary
- When a scenario definition has an empty or whitespace-only preamble, generated scenarios now omit the preamble field entirely instead of including an empty string
- The LLM prompt no longer instructs the model to generate a preamble section when there's no preamble defined

## Changes
- Add `normalizePreamble()` helper function that returns `undefined` for empty/whitespace-only preambles
- Update `buildGenerationPrompt()` to conditionally include the preamble section in the LLM prompt
- Update all scenario content creation paths to use `normalizePreamble()`
- Add 3 new tests for empty preamble handling

## Test plan
- [x] All existing tests pass (18 total)
- [x] New tests verify empty preamble handling
- [x] New tests verify whitespace-only preamble handling
- [x] New tests verify LLM prompt doesn't include preamble section when empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)