### PR TITLE
fix(db): cascade soft-delete from definitions to runs and transcripts

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/definition.ts
+++ b/cloud/apps/api/src/graphql/mutations/definition.ts
@@ -461,16 +461,16 @@ builder.mutationField('deleteDefinition', (t) =>
 
       ctx.log.debug({ definitionId: id }, 'Deleting definition');
 
-      const deletedIds = await softDeleteDefinition(id);
+      const result = await softDeleteDefinition(id);
 
       ctx.log.info(
-        { definitionId: id, deletedCount: deletedIds.length },
+        { definitionId: id, deletedCount: result.deletedCount },
         'Definition deleted'
       );
 
       return {
-        deletedIds,
-        count: deletedIds.length,
+        deletedIds: result.definitionIds,
+        count: result.definitionIds.length,
       };
     },
   })

--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -100,15 +100,13 @@ builder.objectType(RunRef, {
       },
     }),
 
-    // Relation: definition
+    // Relation: definition (nullable if definition was deleted)
     definition: t.field({
       type: DefinitionRef,
+      nullable: true,
       resolve: async (run, _args, ctx) => {
         const definition = await ctx.loaders.definition.load(run.definitionId);
-        if (!definition) {
-          throw new Error(`Definition not found for run ${run.id}`);
-        }
-        return definition;
+        return definition ?? null;
       },
     }),
 

--- a/cloud/apps/api/src/mcp/tools/delete-definition.ts
+++ b/cloud/apps/api/src/mcp/tools/delete-definition.ts
@@ -105,13 +105,13 @@ function registerDeleteDefinitionTool(server: McpServer): void {
         }
 
         // Perform soft delete with cascading
-        const deletedIds = await softDeleteDefinition(args.definition_id);
+        const result = await softDeleteDefinition(args.definition_id);
 
         log.info({
           requestId,
           definitionId: args.definition_id,
           name: definitionName,
-          deletedCount: deletedIds.length,
+          deletedCount: result.deletedCount,
         }, 'Definition deleted');
 
         // Log audit event
@@ -124,7 +124,9 @@ function registerDeleteDefinitionTool(server: McpServer): void {
             requestId,
             deletedCount: {
               primary: 1,
-              scenarios: deletedIds.length - 1, // descendants
+              scenarios: result.deletedCount.scenarios,
+              runs: result.deletedCount.runs,
+              transcripts: result.deletedCount.transcripts,
             },
           })
         );
@@ -135,9 +137,7 @@ function registerDeleteDefinitionTool(server: McpServer): void {
           definition_id: args.definition_id,
           name: definitionName,
           deleted_at: new Date().toISOString(),
-          deleted_count: {
-            definitions: deletedIds.length,
-          },
+          deleted_count: result.deletedCount,
         });
       } catch (err) {
         log.error({ err, requestId }, 'delete_definition failed');

--- a/cloud/apps/api/src/services/mcp/audit.ts
+++ b/cloud/apps/api/src/services/mcp/audit.ts
@@ -227,6 +227,7 @@ export function createDeleteAudit(params: {
   deletedCount?: {
     primary: number;
     scenarios?: number;
+    runs?: number;
     transcripts?: number;
     analysisResults?: number;
   };


### PR DESCRIPTION
## Summary

- Fixed production GraphQL error when querying runs whose definitions were soft-deleted
- Extended `softDeleteDefinition` to properly cascade to runs, transcripts, and analysis results
- Made `Run.definition` nullable as defense-in-depth for any existing orphaned runs

## Changes

1. **`packages/db/src/queries/definitions.ts`**: Extended cascade to include runs, transcripts, and analysis results
2. **`apps/api/src/graphql/types/run.ts`**: Made `definition` field nullable to handle orphans gracefully
3. **`apps/api/src/mcp/tools/delete-definition.ts`**: Updated to use new return type with full counts
4. **`apps/api/src/graphql/mutations/definition.ts`**: Updated to use new return type

## Test plan

- [x] Added test for orphaned run scenario (definition soft-deleted, run still queryable)
- [x] Added test for cascade to runs/transcripts/analysis on definition delete
- [x] All existing tests pass (except pre-existing OAuth test failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)