### PR TITLE
feat(recovery): add automatic orphaned run recovery

### DIFF
--- a/cloud/apps/api/src/services/run/index.ts
+++ b/cloud/apps/api/src/services/run/index.ts
@@ -23,3 +23,19 @@ export {
   isRunPaused,
   isRunTerminal,
 } from './control.js';
+
+export {
+  detectOrphanedRuns,
+  recoverOrphanedRun,
+  recoverOrphanedRuns,
+  runStartupRecovery,
+  RECOVERY_INTERVAL_MS,
+} from './recovery.js';
+export type { OrphanedRunInfo, RecoveryResult } from './recovery.js';
+
+export {
+  startRecoveryScheduler,
+  stopRecoveryScheduler,
+  isRecoverySchedulerRunning,
+  triggerRecovery,
+} from './scheduler.js';

--- a/cloud/apps/api/src/services/run/recovery.ts
+++ b/cloud/apps/api/src/services/run/recovery.ts
@@ -1,0 +1,436 @@
+/**
+ * Run Recovery Service
+ *
+ * Detects and recovers orphaned runs - runs stuck in RUNNING/SUMMARIZING state
+ * with no active/pending jobs in the queue.
+ *
+ * This handles scenarios like:
+ * - API restart during job processing (jobs orphaned)
+ * - Power outage / pod eviction
+ * - Jobs that expired and exhausted retries without updating run progress
+ */
+
+import { db } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+import { getBoss } from '../../queue/boss.js';
+import { DEFAULT_JOB_OPTIONS } from '../../queue/types.js';
+import { getQueueNameForModel } from '../parallelism/index.js';
+
+const log = createLogger('services:run:recovery');
+
+// How long a run must be stuck before we consider it orphaned (5 minutes)
+const STUCK_THRESHOLD_MINUTES = 5;
+
+// How often to run recovery (set by scheduled job)
+export const RECOVERY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export type OrphanedRunInfo = {
+  runId: string;
+  status: string;
+  progress: { total: number; completed: number; failed: number };
+  pendingJobs: number;
+  activeJobs: number;
+  missingProbes: number;
+  stuckMinutes: number;
+};
+
+export type RecoveryResult = {
+  detected: OrphanedRunInfo[];
+  recovered: Array<{ runId: string; action: string; requeuedCount?: number }>;
+  errors: Array<{ runId: string; error: string }>;
+};
+
+/**
+ * Detects orphaned runs by comparing run progress with actual queue state.
+ *
+ * A run is considered orphaned if:
+ * 1. Status is RUNNING or SUMMARIZING
+ * 2. No pending or active jobs exist for this run
+ * 3. Progress shows incomplete (completed + failed < total)
+ * 4. Last update was > STUCK_THRESHOLD_MINUTES ago
+ */
+export async function detectOrphanedRuns(): Promise<OrphanedRunInfo[]> {
+  const orphaned: OrphanedRunInfo[] = [];
+
+  // Find runs that might be stuck
+  const stuckRuns = await db.run.findMany({
+    where: {
+      status: { in: ['RUNNING', 'SUMMARIZING'] },
+      updatedAt: {
+        lt: new Date(Date.now() - STUCK_THRESHOLD_MINUTES * 60 * 1000),
+      },
+      deletedAt: null,
+    },
+    select: {
+      id: true,
+      status: true,
+      progress: true,
+      updatedAt: true,
+      config: true,
+    },
+  });
+
+  if (stuckRuns.length === 0) {
+    return [];
+  }
+
+  log.debug({ stuckRunCount: stuckRuns.length }, 'Checking potentially stuck runs');
+
+  for (const run of stuckRuns) {
+    const progress = run.progress as { total: number; completed: number; failed: number };
+    const done = progress.completed + progress.failed;
+
+    // Check if run is actually incomplete
+    if (done >= progress.total) {
+      // Progress shows complete, but status not updated - different issue
+      // This might be a stuck summarization, handle separately
+      if (run.status === 'RUNNING') {
+        log.warn(
+          { runId: run.id, progress },
+          'Run progress complete but status still RUNNING - triggering summarization'
+        );
+        // This is an edge case - we'll handle it in recovery
+      }
+      continue;
+    }
+
+    // Count pending/active jobs for this run in PgBoss
+    const jobCounts = await countJobsForRun(run.id);
+
+    if (jobCounts.pending === 0 && jobCounts.active === 0) {
+      const stuckMinutes = Math.floor(
+        (Date.now() - run.updatedAt.getTime()) / (60 * 1000)
+      );
+
+      orphaned.push({
+        runId: run.id,
+        status: run.status,
+        progress,
+        pendingJobs: jobCounts.pending,
+        activeJobs: jobCounts.active,
+        missingProbes: progress.total - done,
+        stuckMinutes,
+      });
+
+      log.info(
+        {
+          runId: run.id,
+          status: run.status,
+          progress,
+          missingProbes: progress.total - done,
+          stuckMinutes,
+        },
+        'Detected orphaned run'
+      );
+    }
+  }
+
+  return orphaned;
+}
+
+/**
+ * Counts pending and active jobs for a specific run across all probe queues.
+ */
+async function countJobsForRun(runId: string): Promise<{ pending: number; active: number }> {
+  // Query PgBoss job table directly for accurate counts
+  const result = await db.$queryRaw<Array<{ state: string; count: bigint }>>`
+    SELECT state, COUNT(*) as count
+    FROM pgboss.job
+    WHERE (name = 'probe_scenario' OR name LIKE 'probe_scenario_%')
+      AND state IN ('created', 'retry', 'active')
+      AND data->>'runId' = ${runId}
+    GROUP BY state
+  `;
+
+  let pending = 0;
+  let active = 0;
+
+  for (const row of result) {
+    const count = Number(row.count);
+    if (row.state === 'active') {
+      active = count;
+    } else {
+      pending += count; // 'created' and 'retry' are both pending
+    }
+  }
+
+  return { pending, active };
+}
+
+/**
+ * Finds which scenario+model combinations are missing transcripts for a run.
+ */
+async function findMissingProbes(
+  runId: string
+): Promise<Array<{ scenarioId: string; modelId: string }>> {
+  // Get run config to know which models were requested
+  const run = await db.run.findUnique({
+    where: { id: runId },
+    select: {
+      config: true,
+      scenarioSelections: {
+        select: { scenarioId: true },
+      },
+    },
+  });
+
+  if (!run) {
+    return [];
+  }
+
+  const config = run.config as { models: string[] };
+  const models = config.models || [];
+  const scenarioIds = run.scenarioSelections.map((s) => s.scenarioId);
+
+  // Get existing transcripts for this run
+  const existingTranscripts = await db.transcript.findMany({
+    where: { runId },
+    select: { scenarioId: true, modelId: true },
+  });
+
+  // Build set of existing scenario+model pairs
+  const existingPairs = new Set(
+    existingTranscripts.map((t) => `${t.scenarioId}:${t.modelId}`)
+  );
+
+  // Find missing pairs
+  const missing: Array<{ scenarioId: string; modelId: string }> = [];
+
+  for (const modelId of models) {
+    for (const scenarioId of scenarioIds) {
+      const key = `${scenarioId}:${modelId}`;
+      if (!existingPairs.has(key)) {
+        missing.push({ scenarioId, modelId });
+      }
+    }
+  }
+
+  return missing;
+}
+
+/**
+ * Re-queues missing probe jobs for an orphaned run.
+ */
+async function requeueMissingProbes(
+  runId: string,
+  missingProbes: Array<{ scenarioId: string; modelId: string }>
+): Promise<number> {
+  const boss = getBoss();
+  if (!boss) {
+    throw new Error('PgBoss not initialized');
+  }
+
+  const jobOptions = DEFAULT_JOB_OPTIONS['probe_scenario'];
+  let queuedCount = 0;
+
+  for (const { scenarioId, modelId } of missingProbes) {
+    const queueName = await getQueueNameForModel(modelId);
+
+    await boss.send(
+      queueName,
+      {
+        runId,
+        scenarioId,
+        modelId,
+        config: {
+          temperature: 0.7,
+          maxTurns: 10,
+        },
+      },
+      jobOptions
+    );
+
+    queuedCount++;
+  }
+
+  log.info({ runId, queuedCount }, 'Re-queued missing probe jobs');
+  return queuedCount;
+}
+
+/**
+ * Queues summarize jobs for all transcripts in a run.
+ * Duplicated from progress.ts since that function is private.
+ */
+async function queueSummarizeJobsForRecovery(runId: string): Promise<number> {
+  const boss = getBoss();
+  if (!boss) {
+    throw new Error('PgBoss not initialized for summarization');
+  }
+
+  // Get all transcripts for this run that haven't been summarized
+  const transcripts = await db.transcript.findMany({
+    where: { runId, summarizedAt: null },
+    select: { id: true },
+  });
+
+  if (transcripts.length === 0) {
+    return 0;
+  }
+
+  const jobOptions = DEFAULT_JOB_OPTIONS['summarize_transcript'];
+
+  for (const transcript of transcripts) {
+    await boss.send('summarize_transcript', {
+      runId,
+      transcriptId: transcript.id,
+    }, jobOptions);
+  }
+
+  log.info({ runId, jobCount: transcripts.length }, 'Queued summarize jobs for recovery');
+  return transcripts.length;
+}
+
+/**
+ * Recovers a single orphaned run by re-queuing missing probes.
+ */
+export async function recoverOrphanedRun(
+  runId: string
+): Promise<{ action: string; requeuedCount?: number }> {
+  const missingProbes = await findMissingProbes(runId);
+
+  if (missingProbes.length === 0) {
+    // No missing probes - check if we need to trigger summarization
+    const run = await db.run.findUnique({
+      where: { id: runId },
+      select: { status: true, progress: true },
+    });
+
+    if (run?.status === 'RUNNING') {
+      const progress = run.progress as { total: number; completed: number; failed: number };
+      if (progress.completed + progress.failed >= progress.total) {
+        // Progress complete, trigger summarization
+        log.info({ runId }, 'Triggering summarization for completed run');
+        await db.run.update({
+          where: { id: runId },
+          data: { status: 'SUMMARIZING' },
+        });
+
+        // Queue summarize jobs for unsummarized transcripts
+        const queuedCount = await queueSummarizeJobsForRecovery(runId);
+        return { action: 'triggered_summarization', requeuedCount: queuedCount };
+      }
+    }
+
+    // Check if run is in SUMMARIZING but has no pending summarize jobs
+    if (run?.status === 'SUMMARIZING') {
+      const pendingSummarizeJobs = await db.$queryRaw<Array<{ count: bigint }>>`
+        SELECT COUNT(*) as count
+        FROM pgboss.job
+        WHERE name = 'summarize_transcript'
+          AND state IN ('created', 'retry', 'active')
+          AND data->>'runId' = ${runId}
+      `;
+
+      const pendingCount = Number(pendingSummarizeJobs[0]?.count ?? 0);
+
+      if (pendingCount === 0) {
+        // Check if there are unsummarized transcripts
+        const unsummarizedCount = await db.transcript.count({
+          where: { runId, summarizedAt: null },
+        });
+
+        if (unsummarizedCount > 0) {
+          // Re-queue summarize jobs
+          const queuedCount = await queueSummarizeJobsForRecovery(runId);
+          log.info({ runId, queuedCount }, 'Re-queued orphaned summarize jobs');
+          return { action: 'requeued_summarize_jobs', requeuedCount: queuedCount };
+        } else {
+          // All transcripts summarized, mark as complete
+          log.info({ runId }, 'All transcripts summarized, completing run');
+          await db.run.update({
+            where: { id: runId },
+            data: { status: 'COMPLETED', completedAt: new Date() },
+          });
+          return { action: 'completed_run' };
+        }
+      }
+    }
+
+    return { action: 'no_missing_probes' };
+  }
+
+  // Re-queue missing probes
+  const requeuedCount = await requeueMissingProbes(runId, missingProbes);
+
+  // Update run status back to RUNNING if it was stuck
+  await db.run.update({
+    where: { id: runId },
+    data: { updatedAt: new Date() },
+  });
+
+  log.info(
+    { runId, requeuedCount, missingProbes: missingProbes.length },
+    'Recovered orphaned run'
+  );
+
+  return { action: 'requeued_probes', requeuedCount };
+}
+
+/**
+ * Detects and recovers all orphaned runs.
+ * This is the main entry point for scheduled recovery.
+ */
+export async function recoverOrphanedRuns(): Promise<RecoveryResult> {
+  const result: RecoveryResult = {
+    detected: [],
+    recovered: [],
+    errors: [],
+  };
+
+  try {
+    // Detect orphaned runs
+    result.detected = await detectOrphanedRuns();
+
+    if (result.detected.length === 0) {
+      log.debug('No orphaned runs detected');
+      return result;
+    }
+
+    log.info(
+      { orphanedCount: result.detected.length },
+      'Recovering orphaned runs'
+    );
+
+    // Recover each orphaned run
+    for (const orphaned of result.detected) {
+      try {
+        const recovery = await recoverOrphanedRun(orphaned.runId);
+        result.recovered.push({
+          runId: orphaned.runId,
+          ...recovery,
+        });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        log.error({ runId: orphaned.runId, error: errorMessage }, 'Failed to recover run');
+        result.errors.push({
+          runId: orphaned.runId,
+          error: errorMessage,
+        });
+      }
+    }
+
+    log.info(
+      {
+        detected: result.detected.length,
+        recovered: result.recovered.length,
+        errors: result.errors.length,
+      },
+      'Orphaned run recovery complete'
+    );
+  } catch (error) {
+    log.error({ error }, 'Failed to run orphaned run recovery');
+    throw error;
+  }
+
+  return result;
+}
+
+/**
+ * Runs recovery immediately on startup.
+ * Called once when the API server starts to recover any runs
+ * that were orphaned during the previous shutdown.
+ */
+export async function runStartupRecovery(): Promise<RecoveryResult> {
+  log.info('Running startup recovery for orphaned runs');
+  return recoverOrphanedRuns();
+}

--- a/cloud/apps/api/src/services/run/scheduler.ts
+++ b/cloud/apps/api/src/services/run/scheduler.ts
@@ -1,0 +1,118 @@
+/**
+ * Run Recovery Scheduler
+ *
+ * Manages the periodic recovery job that detects and recovers orphaned runs.
+ * Uses setInterval for simplicity - PgBoss schedule() is for distributed cron,
+ * but we only need one instance running recovery.
+ */
+
+import { createLogger } from '@valuerank/shared';
+import { recoverOrphanedRuns, RECOVERY_INTERVAL_MS, runStartupRecovery } from './recovery.js';
+
+const log = createLogger('services:run:scheduler');
+
+let recoveryInterval: NodeJS.Timeout | null = null;
+let isRecovering = false;
+
+/**
+ * Runs the recovery job, preventing concurrent executions.
+ */
+async function runRecoveryJob(): Promise<void> {
+  if (isRecovering) {
+    log.debug('Recovery already in progress, skipping');
+    return;
+  }
+
+  isRecovering = true;
+  try {
+    const result = await recoverOrphanedRuns();
+
+    if (result.detected.length > 0 || result.errors.length > 0) {
+      log.info(
+        {
+          detected: result.detected.length,
+          recovered: result.recovered.length,
+          errors: result.errors.length,
+        },
+        'Recovery job completed'
+      );
+    }
+  } catch (error) {
+    log.error({ error }, 'Recovery job failed');
+  } finally {
+    isRecovering = false;
+  }
+}
+
+/**
+ * Starts the recovery scheduler.
+ * Runs recovery immediately on startup, then every RECOVERY_INTERVAL_MS.
+ */
+export async function startRecoveryScheduler(): Promise<void> {
+  if (recoveryInterval) {
+    log.warn('Recovery scheduler already running');
+    return;
+  }
+
+  log.info(
+    { intervalMs: RECOVERY_INTERVAL_MS },
+    'Starting recovery scheduler'
+  );
+
+  // Run startup recovery first
+  try {
+    const startupResult = await runStartupRecovery();
+    if (startupResult.detected.length > 0) {
+      log.info(
+        {
+          detected: startupResult.detected.length,
+          recovered: startupResult.recovered.length,
+          errors: startupResult.errors.length,
+        },
+        'Startup recovery completed'
+      );
+    }
+  } catch (error) {
+    log.error({ error }, 'Startup recovery failed');
+    // Don't throw - we still want to start the scheduled job
+  }
+
+  // Schedule periodic recovery
+  recoveryInterval = setInterval(runRecoveryJob, RECOVERY_INTERVAL_MS);
+
+  log.info('Recovery scheduler started');
+}
+
+/**
+ * Stops the recovery scheduler.
+ */
+export function stopRecoveryScheduler(): void {
+  if (recoveryInterval) {
+    clearInterval(recoveryInterval);
+    recoveryInterval = null;
+    log.info('Recovery scheduler stopped');
+  }
+}
+
+/**
+ * Checks if the recovery scheduler is running.
+ */
+export function isRecoverySchedulerRunning(): boolean {
+  return recoveryInterval !== null;
+}
+
+/**
+ * Manually triggers a recovery run (for debugging/admin).
+ */
+export async function triggerRecovery(): Promise<{
+  detected: number;
+  recovered: number;
+  errors: number;
+}> {
+  const result = await recoverOrphanedRuns();
+  return {
+    detected: result.detected.length,
+    recovered: result.recovered.length,
+    errors: result.errors.length,
+  };
+}


### PR DESCRIPTION
## Summary

Adds automatic recovery for runs that become orphaned due to API restarts, deploys, or power outages. This ensures the system continues where it left off after any interruption.

**Problem:** When the API restarts mid-run (e.g., during a deploy), jobs being processed are lost. The run stays in RUNNING state forever because no one updates the progress counter.

**Solution:** A scheduled recovery job that:
- Runs immediately on API startup
- Runs every 5 minutes thereafter
- Detects orphaned runs (RUNNING/SUMMARIZING with no active jobs + incomplete progress)
- Re-queues missing probe jobs by comparing existing transcripts to expected scenario+model pairs
- Handles stuck summarization phases

## Changes

### New Files
- `apps/api/src/services/run/recovery.ts` - Core detection and recovery logic
- `apps/api/src/services/run/scheduler.ts` - Scheduled job management (5-minute interval)

### Modified Files
- `apps/api/src/queue/orchestrator.ts` - Starts/stops recovery scheduler with queue lifecycle
- `apps/api/src/services/run/index.ts` - Exports recovery functions
- `apps/api/src/graphql/mutations/run.ts` - Manual recovery mutations

### New GraphQL Mutations
- `recoverRun(runId: ID!)` - Manually recover a specific run
- `triggerRecovery` - Manually trigger system-wide recovery scan

## Recovery Logic

| State | Condition | Action |
|-------|-----------|--------|
| RUNNING | Missing probes | Re-queue missing scenario+model probe jobs |
| RUNNING | Progress complete | Trigger transition to SUMMARIZING |
| SUMMARIZING | Unsummarized transcripts, no jobs | Re-queue summarize jobs |
| SUMMARIZING | All summarized, no jobs | Mark run COMPLETED |

## Test plan

- [x] Build passes (`npx turbo build`)
- [x] All 1102 tests pass
- [ ] Deploy to staging and verify startup recovery logs
- [ ] Simulate orphaned run by killing API mid-run, verify recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)