### PR TITLE
feat(probe): capture provider metadata in transcripts

### DIFF
--- a/cloud/apps/api/src/services/transcript/create.ts
+++ b/cloud/apps/api/src/services/transcript/create.ts
@@ -10,6 +10,16 @@ import { createLogger } from '@valuerank/shared';
 const log = createLogger('services:transcript');
 
 /**
+ * Provider metadata captured from LLM API response.
+ * Contains normalized finish reason and raw provider-specific data.
+ */
+export type ProviderMetadata = {
+  provider: string;
+  finishReason: string;
+  raw: Record<string, unknown>;
+};
+
+/**
  * Turn structure from Python probe worker.
  */
 export type TranscriptTurn = {
@@ -19,6 +29,7 @@ export type TranscriptTurn = {
   targetResponse: string;
   inputTokens?: number | null;
   outputTokens?: number | null;
+  providerMetadata?: ProviderMetadata | null;
 };
 
 /**

--- a/cloud/workers/probe.py
+++ b/cloud/workers/probe.py
@@ -99,10 +99,11 @@ class Turn:
     target_response: str
     input_tokens: Optional[int] = None
     output_tokens: Optional[int] = None
+    provider_metadata: Optional[dict[str, Any]] = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON output."""
-        return {
+        result = {
             "turnNumber": self.turn_number,
             "promptLabel": self.prompt_label,
             "probePrompt": self.probe_prompt,
@@ -110,6 +111,9 @@ class Turn:
             "inputTokens": self.input_tokens,
             "outputTokens": self.output_tokens,
         }
+        if self.provider_metadata is not None:
+            result["providerMetadata"] = self.provider_metadata
+        return result
 
 
 @dataclass
@@ -243,6 +247,7 @@ def run_probe(data: dict[str, Any]) -> dict[str, Any]:
             target_response=response.content,
             input_tokens=response.input_tokens,
             output_tokens=response.output_tokens,
+            provider_metadata=response.provider_metadata,
         )
         transcript.turns.append(turn)
 
@@ -286,6 +291,7 @@ def run_probe(data: dict[str, Any]) -> dict[str, Any]:
                 target_response=response.content,
                 input_tokens=response.input_tokens,
                 output_tokens=response.output_tokens,
+                provider_metadata=response.provider_metadata,
             )
             transcript.turns.append(turn)
 


### PR DESCRIPTION
## Summary

- Add `provider_metadata` field to capture LLM API response details for all 6 providers
- Normalize finish reasons across providers (stop, max_tokens, content_filter, safety, etc.)
- Preserve raw provider-specific data (safetyRatings, promptFeedback) for debugging

## Motivation

While investigating run `cmj0sp2j5001m1kkejtt6v6nu` in production, we found that Gemini 2.5 Pro returned empty responses for all 125 scenarios due to safety filtering on a sensitive topic. Previously, these appeared as empty transcripts with no indication of why the responses were blocked.

With this change, blocked responses now include:
- Normalized `finishReason` (e.g., "safety", "content_filter")
- Raw provider data including `safetyRatings` and `promptFeedback` for diagnosis

## Changes

| File | Change |
|------|--------|
| `workers/common/llm_adapters.py` | Add `FINISH_REASON_MAP` for normalizing finish reasons across all providers; update all 6 adapters to populate `provider_metadata` |
| `workers/probe.py` | Pass `provider_metadata` through `Turn` dataclass |
| `apps/api/src/services/transcript/create.ts` | Add `ProviderMetadata` TypeScript type |

## Provider Metadata Structure

```json
{
  "provider": "google",
  "finishReason": "safety",
  "raw": {
    "promptFeedback": {
      "blockReason": "SAFETY",
      "safetyRatings": [...]
    },
    "candidates": []
  }
}
```

## Test plan

- [x] All TypeScript tests pass (1212 tests)
- [x] All Python tests pass (192 tests)
- [x] Verified metadata capture in local Docker database for run with Anthropic and DeepSeek providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)