### PR TITLE
feat(mcp): add get_transcript tool for full transcript data

### DIFF
--- a/cloud/apps/api/src/mcp/tools/get-transcript.ts
+++ b/cloud/apps/api/src/mcp/tools/get-transcript.ts
@@ -1,0 +1,269 @@
+/**
+ * get_transcript MCP Tool
+ *
+ * Returns the full transcript data including all turns and provider metadata.
+ * Use this when you need the complete conversation and API response details.
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { db } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+import { buildMcpResponse } from '../../services/mcp/index.js';
+import { addToolRegistrar } from './registry.js';
+
+const log = createLogger('mcp:tools:get-transcript');
+
+/**
+ * Input schema for get_transcript tool
+ */
+const GetTranscriptInputSchema = {
+  run_id: z.string().describe('Run ID (required)'),
+  scenario_id: z.string().describe('Scenario ID (required)'),
+  model: z.string().describe('Model ID (required)'),
+};
+
+/**
+ * Provider metadata from LLM API response
+ */
+type ProviderMetadata = {
+  provider: string;
+  finishReason: string;
+  raw: Record<string, unknown>;
+};
+
+/**
+ * Turn structure in transcript content
+ */
+type TranscriptTurn = {
+  turnNumber: number;
+  promptLabel: string;
+  probePrompt: string;
+  targetResponse: string;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  providerMetadata?: ProviderMetadata | null;
+};
+
+/**
+ * Full transcript output
+ */
+type TranscriptOutput = {
+  runId: string;
+  scenarioId: string;
+  model: string;
+  status: 'found' | 'not_found';
+  transcript?: {
+    id: string;
+    modelVersion: string | null;
+    turnCount: number;
+    tokenCount: number;
+    durationMs: number;
+    estimatedCost: number | null;
+    createdAt: string;
+    turns: TranscriptTurn[];
+    costSnapshot?: {
+      inputTokens: number;
+      outputTokens: number;
+      estimatedCost: number;
+      costInputPerMillion: number;
+      costOutputPerMillion: number;
+    };
+  };
+};
+
+/**
+ * Extracts turns from transcript content
+ */
+function extractTurns(content: unknown): TranscriptTurn[] {
+  if (!content || typeof content !== 'object') return [];
+
+  const obj = content as Record<string, unknown>;
+  const turns = obj.turns;
+
+  if (!Array.isArray(turns)) return [];
+
+  return turns.map((turn) => {
+    if (!turn || typeof turn !== 'object') {
+      return {
+        turnNumber: 0,
+        promptLabel: '',
+        probePrompt: '',
+        targetResponse: '',
+      };
+    }
+
+    const t = turn as Record<string, unknown>;
+    return {
+      turnNumber: typeof t.turnNumber === 'number' ? t.turnNumber : 0,
+      promptLabel: typeof t.promptLabel === 'string' ? t.promptLabel : '',
+      probePrompt: typeof t.probePrompt === 'string' ? t.probePrompt : '',
+      targetResponse: typeof t.targetResponse === 'string' ? t.targetResponse : '',
+      inputTokens: typeof t.inputTokens === 'number' ? t.inputTokens : null,
+      outputTokens: typeof t.outputTokens === 'number' ? t.outputTokens : null,
+      providerMetadata: t.providerMetadata as ProviderMetadata | null | undefined,
+    };
+  });
+}
+
+/**
+ * Cost snapshot type
+ */
+type CostSnapshot = {
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+  costInputPerMillion: number;
+  costOutputPerMillion: number;
+};
+
+/**
+ * Extracts cost snapshot from transcript content
+ */
+function extractCostSnapshot(content: unknown): CostSnapshot | undefined {
+  if (!content || typeof content !== 'object') return undefined;
+
+  const obj = content as Record<string, unknown>;
+  const costSnapshot = obj.costSnapshot;
+
+  if (!costSnapshot || typeof costSnapshot !== 'object') return undefined;
+
+  const cs = costSnapshot as Record<string, unknown>;
+  return {
+    inputTokens: typeof cs.inputTokens === 'number' ? cs.inputTokens : 0,
+    outputTokens: typeof cs.outputTokens === 'number' ? cs.outputTokens : 0,
+    estimatedCost: typeof cs.estimatedCost === 'number' ? cs.estimatedCost : 0,
+    costInputPerMillion: typeof cs.costInputPerMillion === 'number' ? cs.costInputPerMillion : 0,
+    costOutputPerMillion: typeof cs.costOutputPerMillion === 'number' ? cs.costOutputPerMillion : 0,
+  };
+}
+
+/**
+ * Registers the get_transcript tool on the MCP server
+ */
+function registerGetTranscriptTool(server: McpServer): void {
+  log.info('Registering get_transcript tool');
+
+  server.registerTool(
+    'get_transcript',
+    {
+      description: `Get the full transcript data including all conversation turns and provider metadata.
+Returns complete transcript with:
+- All turns (prompt, response, token counts)
+- Provider metadata per turn (provider name, finish reason, raw API data)
+- Cost snapshot with token usage and pricing
+- Model version and timing information
+
+Use get_transcript_summary for a lighter-weight overview without full content.
+Limited to 10KB token budget.`,
+      inputSchema: GetTranscriptInputSchema,
+    },
+    async (args, extra) => {
+      const startTime = Date.now();
+      const requestId = String(extra.requestId ?? 'unknown');
+
+      log.debug(
+        { requestId, runId: args.run_id, scenarioId: args.scenario_id, model: args.model },
+        'get_transcript called'
+      );
+
+      try {
+        // Query transcript with all fields
+        const transcript = await db.transcript.findFirst({
+          where: {
+            runId: args.run_id,
+            scenarioId: args.scenario_id,
+            modelId: args.model,
+            deletedAt: null,
+          },
+        });
+
+        let data: TranscriptOutput;
+
+        if (!transcript) {
+          data = {
+            runId: args.run_id,
+            scenarioId: args.scenario_id,
+            model: args.model,
+            status: 'not_found',
+          };
+        } else {
+          const turns = extractTurns(transcript.content);
+          const costSnapshot = extractCostSnapshot(transcript.content);
+
+          data = {
+            runId: args.run_id,
+            scenarioId: args.scenario_id,
+            model: args.model,
+            status: 'found',
+            transcript: {
+              id: transcript.id,
+              modelVersion: transcript.modelVersion,
+              turnCount: transcript.turnCount,
+              tokenCount: transcript.tokenCount,
+              durationMs: transcript.durationMs,
+              estimatedCost: transcript.estimatedCost ? Number(transcript.estimatedCost) : null,
+              createdAt: transcript.createdAt.toISOString(),
+              turns,
+              ...(costSnapshot && { costSnapshot }),
+            },
+          };
+        }
+
+        // Build response
+        const response = buildMcpResponse({
+          toolName: 'get_transcript',
+          data,
+          requestId,
+          startTime,
+        });
+
+        log.info(
+          {
+            requestId,
+            runId: args.run_id,
+            scenarioId: args.scenario_id,
+            model: args.model,
+            found: data.status === 'found',
+            turnCount: data.transcript?.turnCount ?? 0,
+            bytes: response.metadata.bytes,
+            executionMs: response.metadata.executionMs,
+          },
+          'get_transcript completed'
+        );
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(response, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        log.error(
+          { err, requestId, runId: args.run_id, scenarioId: args.scenario_id },
+          'get_transcript failed'
+        );
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'INTERNAL_ERROR',
+                message: 'Failed to get transcript',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}
+
+// Register this tool with the tool registry
+addToolRegistrar(registerGetTranscriptTool);
+
+export { registerGetTranscriptTool };

--- a/cloud/apps/api/src/mcp/tools/index.ts
+++ b/cloud/apps/api/src/mcp/tools/index.ts
@@ -26,6 +26,7 @@ import './graphql-query.js';
 // P2 Tools - Read
 import './get-dimension-analysis.js';
 import './get-transcript-summary.js';
+import './get-transcript.js';
 // Stage 14 - Write Tools
 import './create-definition.js';
 import './fork-definition.js';

--- a/cloud/apps/api/src/services/mcp/response.ts
+++ b/cloud/apps/api/src/services/mcp/response.ts
@@ -35,6 +35,7 @@ export const TOKEN_BUDGETS = {
   get_run_summary: 5 * 1024, // 5KB
   get_dimension_analysis: 2 * 1024, // 2KB
   get_transcript_summary: 1 * 1024, // 1KB
+  get_transcript: 10 * 1024, // 10KB
   graphql_query: 10 * 1024, // 10KB
 } as const;
 

--- a/cloud/apps/api/tests/mcp/tools/get-transcript.test.ts
+++ b/cloud/apps/api/tests/mcp/tools/get-transcript.test.ts
@@ -1,0 +1,296 @@
+/**
+ * get_transcript Tool Tests
+ *
+ * Tests the full transcript retrieval including provider metadata.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// Mock db before importing the tool
+vi.mock('@valuerank/db', () => ({
+  db: {
+    transcript: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+// Import after mock
+import { db } from '@valuerank/db';
+
+describe('get_transcript tool', () => {
+  const testRunId = 'test-run-123';
+  const testScenarioId = 'test-scenario-456';
+  const testModel = 'openai:gpt-4';
+
+  // Mock server and capture the registered handler
+  let toolHandler: (args: Record<string, unknown>, extra: Record<string, unknown>) => Promise<unknown>;
+  const mockServer = {
+    registerTool: vi.fn((name, config, handler) => {
+      toolHandler = handler;
+    }),
+  } as unknown as McpServer;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Dynamically import to trigger registration
+    const { registerGetTranscriptTool } = await import(
+      '../../../src/mcp/tools/get-transcript.js'
+    );
+    registerGetTranscriptTool(mockServer);
+  });
+
+  it('registers the tool with correct name and schema', () => {
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'get_transcript',
+      expect.objectContaining({
+        description: expect.stringContaining('full transcript'),
+        inputSchema: expect.objectContaining({
+          run_id: expect.any(Object),
+          scenario_id: expect.any(Object),
+          model: expect.any(Object),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('returns full transcript with turns and provider metadata', async () => {
+    const mockTranscript = {
+      id: 'transcript-123',
+      runId: testRunId,
+      scenarioId: testScenarioId,
+      modelId: testModel,
+      modelVersion: 'gpt-4-0613',
+      turnCount: 2,
+      tokenCount: 500,
+      durationMs: 1500,
+      estimatedCost: 0.025,
+      createdAt: new Date('2024-01-15T10:00:00Z'),
+      content: {
+        schemaVersion: 1,
+        turns: [
+          {
+            turnNumber: 1,
+            promptLabel: 'scenario',
+            probePrompt: 'What would you do in this dilemma?',
+            targetResponse: 'I would prioritize safety.',
+            inputTokens: 100,
+            outputTokens: 150,
+            providerMetadata: {
+              provider: 'openai',
+              finishReason: 'stop',
+              raw: {
+                id: 'chatcmpl-123',
+                model: 'gpt-4-0613',
+                usage: { prompt_tokens: 100, completion_tokens: 150 },
+              },
+            },
+          },
+          {
+            turnNumber: 2,
+            promptLabel: 'followup',
+            probePrompt: 'Why did you make that choice?',
+            targetResponse: 'Because human life has inherent value.',
+            inputTokens: 80,
+            outputTokens: 170,
+            providerMetadata: {
+              provider: 'openai',
+              finishReason: 'stop',
+              raw: {
+                id: 'chatcmpl-124',
+                model: 'gpt-4-0613',
+              },
+            },
+          },
+        ],
+        costSnapshot: {
+          inputTokens: 180,
+          outputTokens: 320,
+          estimatedCost: 0.025,
+          costInputPerMillion: 30,
+          costOutputPerMillion: 60,
+        },
+      },
+    };
+
+    vi.mocked(db.transcript.findFirst).mockResolvedValue(mockTranscript);
+
+    const result = await toolHandler(
+      { run_id: testRunId, scenario_id: testScenarioId, model: testModel },
+      { requestId: 'req-1' }
+    );
+
+    expect(result).toHaveProperty('content');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.status).toBe('found');
+    expect(response.data.transcript.id).toBe('transcript-123');
+    expect(response.data.transcript.turnCount).toBe(2);
+    expect(response.data.transcript.turns).toHaveLength(2);
+
+    // Check provider metadata is included
+    const turn1 = response.data.transcript.turns[0];
+    expect(turn1.providerMetadata).toBeDefined();
+    expect(turn1.providerMetadata.provider).toBe('openai');
+    expect(turn1.providerMetadata.finishReason).toBe('stop');
+    expect(turn1.providerMetadata.raw).toHaveProperty('id', 'chatcmpl-123');
+
+    // Check cost snapshot
+    expect(response.data.transcript.costSnapshot).toBeDefined();
+    expect(response.data.transcript.costSnapshot.estimatedCost).toBe(0.025);
+  });
+
+  it('returns not_found when transcript does not exist', async () => {
+    vi.mocked(db.transcript.findFirst).mockResolvedValue(null);
+
+    const result = await toolHandler(
+      { run_id: testRunId, scenario_id: testScenarioId, model: testModel },
+      { requestId: 'req-2' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.status).toBe('not_found');
+    expect(response.data.transcript).toBeUndefined();
+  });
+
+  it('handles transcript without provider metadata', async () => {
+    const mockTranscript = {
+      id: 'transcript-456',
+      runId: testRunId,
+      scenarioId: testScenarioId,
+      modelId: testModel,
+      modelVersion: null,
+      turnCount: 1,
+      tokenCount: 200,
+      durationMs: 800,
+      estimatedCost: null,
+      createdAt: new Date('2024-01-15T10:00:00Z'),
+      content: {
+        schemaVersion: 1,
+        turns: [
+          {
+            turnNumber: 1,
+            promptLabel: 'scenario',
+            probePrompt: 'A simple question',
+            targetResponse: 'A simple answer',
+            // No providerMetadata
+          },
+        ],
+        // No costSnapshot
+      },
+    };
+
+    vi.mocked(db.transcript.findFirst).mockResolvedValue(mockTranscript);
+
+    const result = await toolHandler(
+      { run_id: testRunId, scenario_id: testScenarioId, model: testModel },
+      { requestId: 'req-3' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.status).toBe('found');
+    expect(response.data.transcript.turns[0].providerMetadata).toBeUndefined();
+    expect(response.data.transcript.costSnapshot).toBeUndefined();
+  });
+
+  it('handles empty turns array', async () => {
+    const mockTranscript = {
+      id: 'transcript-789',
+      runId: testRunId,
+      scenarioId: testScenarioId,
+      modelId: testModel,
+      modelVersion: null,
+      turnCount: 0,
+      tokenCount: 0,
+      durationMs: 0,
+      estimatedCost: null,
+      createdAt: new Date(),
+      content: {
+        schemaVersion: 1,
+        turns: [],
+      },
+    };
+
+    vi.mocked(db.transcript.findFirst).mockResolvedValue(mockTranscript);
+
+    const result = await toolHandler(
+      { run_id: testRunId, scenario_id: testScenarioId, model: testModel },
+      { requestId: 'req-4' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.status).toBe('found');
+    expect(response.data.transcript.turns).toEqual([]);
+  });
+
+  it('handles malformed content gracefully', async () => {
+    const mockTranscript = {
+      id: 'transcript-bad',
+      runId: testRunId,
+      scenarioId: testScenarioId,
+      modelId: testModel,
+      modelVersion: null,
+      turnCount: 0,
+      tokenCount: 0,
+      durationMs: 0,
+      estimatedCost: null,
+      createdAt: new Date(),
+      content: 'not an object', // Malformed
+    };
+
+    vi.mocked(db.transcript.findFirst).mockResolvedValue(mockTranscript);
+
+    const result = await toolHandler(
+      { run_id: testRunId, scenario_id: testScenarioId, model: testModel },
+      { requestId: 'req-5' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.status).toBe('found');
+    expect(response.data.transcript.turns).toEqual([]);
+  });
+
+  it('filters out soft-deleted transcripts', async () => {
+    vi.mocked(db.transcript.findFirst).mockResolvedValue(null);
+
+    await toolHandler(
+      { run_id: testRunId, scenario_id: testScenarioId, model: testModel },
+      { requestId: 'req-6' }
+    );
+
+    expect(db.transcript.findFirst).toHaveBeenCalledWith({
+      where: {
+        runId: testRunId,
+        scenarioId: testScenarioId,
+        modelId: testModel,
+        deletedAt: null,
+      },
+    });
+  });
+
+  it('returns error on database failure', async () => {
+    vi.mocked(db.transcript.findFirst).mockRejectedValue(new Error('DB connection failed'));
+
+    const result = await toolHandler(
+      { run_id: testRunId, scenario_id: testScenarioId, model: testModel },
+      { requestId: 'req-7' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+    expect(response.error).toBe('INTERNAL_ERROR');
+  });
+});


### PR DESCRIPTION
## Summary
- Add new MCP tool `get_transcript` that returns complete transcript data including provider metadata
- Exposes full conversation turns, API response details, cost snapshots, and timing information
- Complements existing `get_transcript_summary` for cases where full details are needed

## Test plan
- [x] Unit tests for the new tool covering all cases (8 tests)
- [x] Build passes with no TypeScript errors
- [x] Existing transcript summary tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)