### PR TITLE
feat(recovery): add activity-based scheduling to reduce resource usage

### DIFF
--- a/cloud/apps/api/src/services/run/index.ts
+++ b/cloud/apps/api/src/services/run/index.ts
@@ -38,4 +38,6 @@ export {
   stopRecoveryScheduler,
   isRecoverySchedulerRunning,
   triggerRecovery,
+  signalRunActivity,
+  RECOVERY_ACTIVITY_WINDOW_MS,
 } from './scheduler.js';

--- a/cloud/apps/api/src/services/run/scheduler.ts
+++ b/cloud/apps/api/src/services/run/scheduler.ts
@@ -4,6 +4,11 @@
  * Manages the periodic recovery job that detects and recovers orphaned runs.
  * Uses setInterval for simplicity - PgBoss schedule() is for distributed cron,
  * but we only need one instance running recovery.
+ *
+ * Activity-based scheduling:
+ * - Recovery only runs for 1 hour after the last run was started
+ * - When a new run starts, the activity timeout is reset
+ * - This prevents wasting resources checking for orphaned runs when no runs are active
  */
 
 import { createLogger } from '@valuerank/shared';
@@ -12,7 +17,11 @@ import { recoverOrphanedRuns, RECOVERY_INTERVAL_MS, runStartupRecovery } from '.
 const log = createLogger('services:run:scheduler');
 
 let recoveryInterval: NodeJS.Timeout | null = null;
+let activityTimeout: NodeJS.Timeout | null = null;
 let isRecovering = false;
+
+// How long to keep recovery running after the last run was started (1 hour)
+export const RECOVERY_ACTIVITY_WINDOW_MS = 60 * 60 * 1000;
 
 /**
  * Runs the recovery job, preventing concurrent executions.
@@ -45,8 +54,71 @@ async function runRecoveryJob(): Promise<void> {
 }
 
 /**
+ * Clears the activity timeout if set.
+ */
+function clearActivityTimeout(): void {
+  if (activityTimeout) {
+    clearTimeout(activityTimeout);
+    activityTimeout = null;
+  }
+}
+
+/**
+ * Starts the activity timeout that will stop recovery after RECOVERY_ACTIVITY_WINDOW_MS.
+ */
+function startActivityTimeout(): void {
+  clearActivityTimeout();
+
+  activityTimeout = setTimeout(() => {
+    log.info(
+      { windowMs: RECOVERY_ACTIVITY_WINDOW_MS },
+      'Activity window expired, stopping recovery scheduler'
+    );
+    stopRecoveryInterval();
+  }, RECOVERY_ACTIVITY_WINDOW_MS);
+}
+
+/**
+ * Stops only the recovery interval (not the activity tracking).
+ */
+function stopRecoveryInterval(): void {
+  if (recoveryInterval) {
+    clearInterval(recoveryInterval);
+    recoveryInterval = null;
+    log.info('Recovery interval stopped');
+  }
+}
+
+/**
+ * Starts the recovery interval if not already running.
+ */
+function startRecoveryInterval(): void {
+  if (recoveryInterval) {
+    return; // Already running
+  }
+
+  recoveryInterval = setInterval(runRecoveryJob, RECOVERY_INTERVAL_MS);
+  log.info({ intervalMs: RECOVERY_INTERVAL_MS }, 'Recovery interval started');
+}
+
+/**
+ * Signals that a run has been started.
+ * This resets the activity window and ensures recovery is running.
+ */
+export function signalRunActivity(): void {
+  log.debug('Run activity signaled, resetting activity window');
+
+  // Ensure recovery is running
+  startRecoveryInterval();
+
+  // Reset the activity timeout
+  startActivityTimeout();
+}
+
+/**
  * Starts the recovery scheduler.
- * Runs recovery immediately on startup, then every RECOVERY_INTERVAL_MS.
+ * Runs recovery immediately on startup, then schedules periodic recovery
+ * only if there are active runs (detected during startup recovery).
  */
 export async function startRecoveryScheduler(): Promise<void> {
   if (recoveryInterval) {
@@ -55,11 +127,12 @@ export async function startRecoveryScheduler(): Promise<void> {
   }
 
   log.info(
-    { intervalMs: RECOVERY_INTERVAL_MS },
+    { intervalMs: RECOVERY_INTERVAL_MS, activityWindowMs: RECOVERY_ACTIVITY_WINDOW_MS },
     'Starting recovery scheduler'
   );
 
   // Run startup recovery first
+  let hasActiveRuns = false;
   try {
     const startupResult = await runStartupRecovery();
     if (startupResult.detected.length > 0) {
@@ -71,27 +144,31 @@ export async function startRecoveryScheduler(): Promise<void> {
         },
         'Startup recovery completed'
       );
+      // If we found orphaned runs, keep recovery running
+      hasActiveRuns = true;
     }
   } catch (error) {
     log.error({ error }, 'Startup recovery failed');
-    // Don't throw - we still want to start the scheduled job
+    // Don't throw - we still want to proceed
   }
 
-  // Schedule periodic recovery
-  recoveryInterval = setInterval(runRecoveryJob, RECOVERY_INTERVAL_MS);
-
-  log.info('Recovery scheduler started');
+  // Only start the interval if we found active runs during startup
+  if (hasActiveRuns) {
+    startRecoveryInterval();
+    startActivityTimeout();
+    log.info('Recovery scheduler started (active runs detected)');
+  } else {
+    log.info('Recovery scheduler initialized but not running (no active runs)');
+  }
 }
 
 /**
- * Stops the recovery scheduler.
+ * Stops the recovery scheduler completely (interval and activity timeout).
  */
 export function stopRecoveryScheduler(): void {
-  if (recoveryInterval) {
-    clearInterval(recoveryInterval);
-    recoveryInterval = null;
-    log.info('Recovery scheduler stopped');
-  }
+  stopRecoveryInterval();
+  clearActivityTimeout();
+  log.info('Recovery scheduler stopped');
 }
 
 /**

--- a/cloud/apps/api/src/services/run/start.ts
+++ b/cloud/apps/api/src/services/run/start.ts
@@ -12,6 +12,7 @@ import type { ProbeScenarioJobData, PriorityLevel } from '../../queue/types.js';
 import { PRIORITY_VALUES, DEFAULT_JOB_OPTIONS } from '../../queue/types.js';
 import { getQueueNameForModel } from '../parallelism/index.js';
 import { estimateCost, type CostEstimate } from '../cost/index.js';
+import { signalRunActivity } from './scheduler.js';
 
 const log = createLogger('services:run:start');
 
@@ -277,6 +278,9 @@ export async function startRun(input: StartRunInput): Promise<StartRunResult> {
     { runId: run.id, jobsCreated: jobIds.length, totalJobs },
     'Jobs queued successfully'
   );
+
+  // Signal run activity to ensure recovery scheduler is running
+  signalRunActivity();
 
   return {
     run: {

--- a/cloud/apps/api/tests/mcp/tools/start-run.test.ts
+++ b/cloud/apps/api/tests/mcp/tools/start-run.test.ts
@@ -13,6 +13,16 @@ vi.mock('../../../src/queue/boss.js', () => ({
   }),
 }));
 
+// Mock scheduler - prevent actual interval management in tests
+vi.mock('../../../src/services/run/scheduler.js', () => ({
+  signalRunActivity: vi.fn(),
+  startRecoveryScheduler: vi.fn(),
+  stopRecoveryScheduler: vi.fn(),
+  isRecoverySchedulerRunning: vi.fn().mockReturnValue(false),
+  triggerRecovery: vi.fn(),
+  RECOVERY_ACTIVITY_WINDOW_MS: 60 * 60 * 1000,
+}));
+
 // Import after mocking
 import { startRun } from '../../../src/services/run/index.js';
 

--- a/cloud/apps/api/tests/services/run/start.test.ts
+++ b/cloud/apps/api/tests/services/run/start.test.ts
@@ -22,6 +22,11 @@ vi.mock('../../../src/services/parallelism/index.js', () => ({
   getQueueNameForModel: vi.fn().mockResolvedValue('probe_scenario'),
 }));
 
+// Mock scheduler - prevent actual interval management in tests
+vi.mock('../../../src/services/run/scheduler.js', () => ({
+  signalRunActivity: vi.fn(),
+}));
+
 describe('startRun service', () => {
   const testUserId = TEST_USER.id;
   const createdDefinitionIds: string[] = [];


### PR DESCRIPTION
## Summary

- The recovery service previously ran every 5 minutes 24/7, which wastes resources when no runs are active
- Now it only runs for 1 hour after the last run was started
- When a new run starts, the 1-hour window resets

## Changes

- Add `RECOVERY_ACTIVITY_WINDOW_MS` constant (1 hour)
- Add `signalRunActivity()` function to start/extend the recovery window
- Recovery auto-stops after 1 hour of inactivity
- On server startup, recovery only starts if orphaned runs are detected
- Call `signalRunActivity()` from `startRun()` when jobs are queued

## Behavior

| Scenario | Recovery Behavior |
|----------|-------------------|
| No active runs | Scheduler is idle (no CPU usage) |
| Run started | Recovery runs every 5 min for the next hour |
| Another run started within the hour | The 1-hour window resets |
| 1 hour of no new runs | Recovery automatically stops |
| Server restart with orphaned runs | Recovery starts automatically for 1 hour |

## Test plan

- [x] All existing recovery tests pass
- [x] All start.test.ts tests pass
- [x] MCP start-run.test.ts tests pass
- [x] Build succeeds with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)