### PR TITLE
fix(editor): handle forked definitions with sparse content

### DIFF
--- a/cloud/apps/web/src/components/definitions/DefinitionEditor.tsx
+++ b/cloud/apps/web/src/components/definitions/DefinitionEditor.tsx
@@ -80,7 +80,7 @@ export function DefinitionEditor({
 
   // Get dimension names for template editor autocomplete
   const dimensionNames = useMemo(
-    () => content.dimensions.map((d) => d.name).filter((n) => n.trim() !== ''),
+    () => (content.dimensions ?? []).map((d) => d.name).filter((n) => n.trim() !== ''),
     [content.dimensions]
   );
 
@@ -152,7 +152,7 @@ export function DefinitionEditor({
 
     // Check that all placeholders in template have corresponding dimensions
     const placeholders = content.template.match(/\[([^\]]+)\]/g) || [];
-    const dimensionNames = new Set(content.dimensions.map((d) => d.name.toLowerCase()));
+    const dimensionNames = new Set((content.dimensions ?? []).map((d) => d.name.toLowerCase()));
 
     for (const placeholder of placeholders) {
       const name = placeholder.slice(1, -1).toLowerCase();
@@ -163,7 +163,7 @@ export function DefinitionEditor({
     }
 
     // Validate dimensions
-    content.dimensions.forEach((dim, i) => {
+    (content.dimensions ?? []).forEach((dim, i) => {
       if (!dim.name.trim()) {
         newErrors[`dimension-${i}`] = 'Dimension name is required';
       }
@@ -316,13 +316,13 @@ export function DefinitionEditor({
         {/* Canonical Dimension Chips */}
         <div className="mb-4">
           <CanonicalDimensionChips
-            existingDimensionNames={content.dimensions.map((d) => d.name)}
+            existingDimensionNames={(content.dimensions ?? []).map((d) => d.name)}
             onAddDimension={handleAddCanonicalDimension}
             disabled={isSaving}
           />
         </div>
 
-        {content.dimensions.length === 0 ? (
+        {(content.dimensions ?? []).length === 0 ? (
           <div className="text-center py-8 bg-gray-50 rounded-lg border border-dashed border-gray-300">
             <p className="text-sm text-gray-500 mb-2">No dimensions yet</p>
             <p className="text-xs text-gray-400">
@@ -331,14 +331,14 @@ export function DefinitionEditor({
           </div>
         ) : (
           <div className="space-y-4">
-            {content.dimensions.map((dimension, index) => (
+            {(content.dimensions ?? []).map((dimension, index) => (
               <DimensionEditor
                 key={index}
                 dimension={dimension}
                 index={index}
                 onChange={(dim) => handleDimensionChange(index, dim)}
                 onRemove={() => handleDimensionRemove(index)}
-                canRemove={content.dimensions.length > 0}
+                canRemove={(content.dimensions ?? []).length > 0}
               />
             ))}
           </div>

--- a/cloud/apps/web/src/pages/DefinitionDetail.tsx
+++ b/cloud/apps/web/src/pages/DefinitionDetail.tsx
@@ -63,19 +63,19 @@ export function DefinitionDetail() {
 
   const { startRun, loading: isStartingRun } = useRunMutations();
 
-  // Poll for definition updates while expansion is in progress
+  // Poll for definition updates while expansion is in progress (but not while editing)
   const isExpanding = definition?.expansionStatus?.status === 'PENDING' ||
                       definition?.expansionStatus?.status === 'ACTIVE';
 
   useEffect(() => {
-    if (isExpanding && !isNewDefinition) {
+    if (isExpanding && !isNewDefinition && !isEditing) {
       const interval = setInterval(() => {
         refetch();
       }, 3000);
       return () => clearInterval(interval);
     }
     return undefined;
-  }, [isExpanding, isNewDefinition, refetch]);
+  }, [isExpanding, isNewDefinition, isEditing, refetch]);
 
   const {
     createDefinition,
@@ -267,10 +267,14 @@ export function DefinitionDetail() {
           <DefinitionEditor
             mode="edit"
             initialName={definition.name}
-            initialContent={definition.content}
+            initialContent={definition.resolvedContent ?? definition.content}
             onSave={handleSave}
             onCancel={handleCancel}
             isSaving={isUpdating}
+            isForked={definition.isForked}
+            parentName={definition.parent?.name}
+            parentId={definition.parentId ?? undefined}
+            overrides={definition.overrides}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Fix crash when editing forked definitions that use sparse content storage
- Add null guards for `content.dimensions` throughout `DefinitionEditor`
- Use `resolvedContent` (with inheritance merged) when editing forked definitions
- Disable polling while in edit mode to prevent form refreshing during edits

## Test plan
- [ ] Create a definition with dimensions
- [ ] Fork the definition (inherits all content)
- [ ] Click Edit on the forked definition - should not crash
- [ ] Verify dimensions are properly displayed from inherited content
- [ ] Verify form doesn't refresh while editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)