### PR TITLE
fix(expand): improve scenario expansion debugging and error handling

### DIFF
--- a/cloud/apps/api/src/graphql/queries/definition.ts
+++ b/cloud/apps/api/src/graphql/queries/definition.ts
@@ -15,6 +15,7 @@ type RawDefinitionRow = {
   name: string;
   content: Prisma.JsonValue;
   expansion_progress: Prisma.JsonValue | null;
+  expansion_debug: Prisma.JsonValue | null;
   created_at: Date;
   updated_at: Date;
   last_accessed_at: Date | null;
@@ -207,7 +208,7 @@ builder.queryField('definitionAncestors', (t) =>
           JOIN ancestry a ON d.id = a.parent_id
           WHERE a.parent_id IS NOT NULL AND a.depth < ${maxDepth} AND d.deleted_at IS NULL
         )
-        SELECT id, parent_id, name, content, expansion_progress, created_at, updated_at, last_accessed_at, created_by_user_id, deleted_by_user_id
+        SELECT id, parent_id, name, content, expansion_progress, expansion_debug, created_at, updated_at, last_accessed_at, created_by_user_id, deleted_by_user_id
         FROM ancestry
         WHERE id != ${id}
         ORDER BY created_at ASC
@@ -220,6 +221,7 @@ builder.queryField('definitionAncestors', (t) =>
         name: a.name,
         content: a.content,
         expansionProgress: a.expansion_progress,
+        expansionDebug: a.expansion_debug,
         createdAt: a.created_at,
         updatedAt: a.updated_at,
         lastAccessedAt: a.last_accessed_at,
@@ -272,7 +274,7 @@ builder.queryField('definitionDescendants', (t) =>
           JOIN tree t ON d.parent_id = t.id
           WHERE t.depth < ${maxDepth} AND d.deleted_at IS NULL
         )
-        SELECT id, parent_id, name, content, expansion_progress, created_at, updated_at, last_accessed_at, created_by_user_id, deleted_by_user_id
+        SELECT id, parent_id, name, content, expansion_progress, expansion_debug, created_at, updated_at, last_accessed_at, created_by_user_id, deleted_by_user_id
         FROM tree
         WHERE id != ${id}
         ORDER BY created_at DESC
@@ -285,6 +287,7 @@ builder.queryField('definitionDescendants', (t) =>
         name: d.name,
         content: d.content,
         expansionProgress: d.expansion_progress,
+        expansionDebug: d.expansion_debug,
         createdAt: d.created_at,
         updatedAt: d.updated_at,
         lastAccessedAt: d.last_accessed_at,

--- a/cloud/apps/api/src/graphql/types/definition.ts
+++ b/cloud/apps/api/src/graphql/types/definition.ts
@@ -137,6 +137,7 @@ type RawDefinitionRow = {
   name: string;
   content: Prisma.JsonValue;
   expansion_progress: Prisma.JsonValue | null;
+  expansion_debug: Prisma.JsonValue | null;
   created_at: Date;
   updated_at: Date;
   last_accessed_at: Date | null;
@@ -274,6 +275,13 @@ builder.objectType(DefinitionRef, {
       resolve: async (definition) => {
         return getDefinitionExpansionStatus(definition.id);
       },
+    }),
+
+    // Debug info from last scenario expansion (for troubleshooting)
+    expansionDebug: t.expose('expansionDebug', {
+      type: 'JSON',
+      nullable: true,
+      description: 'Debug info from last scenario expansion, including raw LLM response and parse errors',
     }),
 
     // Relation: tags (via DataLoader for N+1 prevention)
@@ -423,7 +431,7 @@ builder.objectType(DefinitionRef, {
             JOIN ancestry a ON d.id = a.parent_id
             WHERE a.parent_id IS NOT NULL AND a.depth < ${DEFAULT_MAX_DEPTH} AND d.deleted_at IS NULL
           )
-          SELECT id, parent_id, name, content, expansion_progress, created_at, updated_at, last_accessed_at, created_by_user_id, deleted_by_user_id
+          SELECT id, parent_id, name, content, expansion_progress, expansion_debug, created_at, updated_at, last_accessed_at, created_by_user_id, deleted_by_user_id
           FROM ancestry
           WHERE id != ${definition.id}
           ORDER BY created_at ASC
@@ -435,6 +443,7 @@ builder.objectType(DefinitionRef, {
           name: a.name,
           content: a.content,
           expansionProgress: a.expansion_progress,
+          expansionDebug: a.expansion_debug,
           createdAt: a.created_at,
           updatedAt: a.updated_at,
           lastAccessedAt: a.last_accessed_at,
@@ -458,7 +467,7 @@ builder.objectType(DefinitionRef, {
             JOIN tree t ON d.parent_id = t.id
             WHERE t.depth < ${DEFAULT_MAX_DEPTH} AND d.deleted_at IS NULL
           )
-          SELECT id, parent_id, name, content, expansion_progress, created_at, updated_at, last_accessed_at, created_by_user_id, deleted_by_user_id
+          SELECT id, parent_id, name, content, expansion_progress, expansion_debug, created_at, updated_at, last_accessed_at, created_by_user_id, deleted_by_user_id
           FROM tree
           WHERE id != ${definition.id}
           ORDER BY created_at DESC
@@ -470,6 +479,7 @@ builder.objectType(DefinitionRef, {
           name: d.name,
           content: d.content,
           expansionProgress: d.expansion_progress,
+          expansionDebug: d.expansion_debug,
           createdAt: d.created_at,
           updatedAt: d.updated_at,
           lastAccessedAt: d.last_accessed_at,

--- a/cloud/apps/api/tests/services/scenario/expand.test.ts
+++ b/cloud/apps/api/tests/services/scenario/expand.test.ts
@@ -173,7 +173,7 @@ describe('Scenario Expansion Service', () => {
         expect(workerInput.content.template).toBe(contentWithDimensions.template);
         expect(workerInput.content.dimensions).toEqual(contentWithDimensions.dimensions);
         expect(workerInput.config.temperature).toBe(0.7);
-        expect(options.timeout).toBe(300000);
+        expect(options.timeout).toBe(600000);
 
         // Verify scenarios created
         expect(result.created).toBe(2);

--- a/cloud/packages/db/prisma/migrations/20251213013310_add_expansion_debug/migration.sql
+++ b/cloud/packages/db/prisma/migrations/20251213013310_add_expansion_debug/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "definitions" ADD COLUMN     "expansion_debug" JSONB;

--- a/cloud/packages/db/prisma/schema.prisma
+++ b/cloud/packages/db/prisma/schema.prisma
@@ -100,6 +100,7 @@ model Definition {
   name              String
   content           Json      @db.JsonB
   expansionProgress Json?     @map("expansion_progress") @db.JsonB
+  expansionDebug    Json?     @map("expansion_debug") @db.JsonB
   createdAt         DateTime  @default(now()) @map("created_at")
   updatedAt         DateTime  @updatedAt @map("updated_at")
   lastAccessedAt    DateTime? @map("last_accessed_at")


### PR DESCRIPTION
## Summary

This PR addresses several issues with scenario expansion, particularly for DeepSeek Reasoner which can take a long time to generate large scenario sets (125 scenarios).

### Key Fixes

- **Debug Info Capture**: Add `expansionDebug` field to store raw LLM response, extracted YAML, and parse errors for troubleshooting failed expansions
- **Timeout Improvements**: Increase process timeout to 10 minutes and add HTTP request timeout to all LLM adapters
- **Error Handling**: Properly detect and fail on YAML parse errors instead of silently creating a default scenario
- **Token Limit Fix**: Increase maxTokens from 8192 to 32768 to prevent output truncation for large scenario counts
- **UI Enhancement**: Add countdown timer to expansion status badge

## Test plan

- [ ] Trigger scenario expansion with DeepSeek Reasoner on a 3-dimension definition (125 scenarios)
- [ ] Verify expansion completes successfully with all scenarios
- [ ] Verify debug info is captured and visible via GraphQL
- [ ] Verify countdown timer appears during expansion
- [ ] Verify parse errors are properly reported as failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)