### PR TITLE
fix(deepseek): increase max_tokens cap from 8K to 64K

### DIFF
--- a/cloud/apps/api/src/services/llm/generate.ts
+++ b/cloud/apps/api/src/services/llm/generate.ts
@@ -142,7 +142,7 @@ async function generateDeepSeek(
   options?: LLMOptions
 ): Promise<string> {
   const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const maxTokens = Math.min(options?.maxTokens || 8192, 8192); // DeepSeek optimal max
+  const maxTokens = Math.min(options?.maxTokens || 8192, 65536); // DeepSeek API limit is 64K
 
   log.debug({ promptLength: prompt.length, timeoutMs, maxTokens }, 'Calling DeepSeek API');
 

--- a/cloud/workers/common/llm_adapters.py
+++ b/cloud/workers/common/llm_adapters.py
@@ -940,9 +940,9 @@ class DeepSeekAdapter(BaseLLMAdapter):
         resolved_max_tokens = resolve_max_tokens(model_config, max_tokens)
         resolved_temperature = resolve_temperature(model_config, temperature)
 
-        # DeepSeek has a max of 8192 tokens for optimal quality
+        # DeepSeek supports up to 64K output tokens (API limit)
         if resolved_max_tokens is not None:
-            resolved_max_tokens = min(resolved_max_tokens, 8192)
+            resolved_max_tokens = min(resolved_max_tokens, 65536)
 
         payload: dict[str, Any] = {
             "model": model,

--- a/cloud/workers/tests/test_llm_adapters.py
+++ b/cloud/workers/tests/test_llm_adapters.py
@@ -260,19 +260,19 @@ class TestDeepSeekAdapter:
         adapter: DeepSeekAdapter,
         mock_openai_compatible_response: dict[str, Any],
     ) -> None:
-        """Test that max_tokens is capped at 8192."""
+        """Test that max_tokens is capped at 64K (DeepSeek API limit)."""
         with patch("requests.post") as mock_post:
             mock_post.return_value = MockResponse(mock_openai_compatible_response, 200)
 
             adapter.generate(
                 "deepseek-chat",
                 [{"role": "user", "content": "Hello"}],
-                max_tokens=10000,
+                max_tokens=100000,
             )
 
             call_args = mock_post.call_args
             payload = call_args.kwargs.get("json") or call_args[1].get("json")
-            assert payload["max_tokens"] == 8192
+            assert payload["max_tokens"] == 65536
 
 
 class TestMistralAdapter:


### PR DESCRIPTION
## Summary
- Fixed scenario expansion truncation when generating 125+ scenarios
- DeepSeek adapter was capping `max_tokens` at 8192 (outdated limit)
- Increased cap to 65536 (64K) to match actual DeepSeek API limit

## Root Cause
Definition `cmj3lgukk00eraugu2y1kcves` only generated 32 of 125 expected scenarios. 
Logs showed `outputTokens=8192` - the LLM response was truncated mid-YAML at exactly the cap.

## Test plan
- [x] Python adapter test updated and passing
- [x] TypeScript LLM generate tests passing
- [ ] After deploy, re-trigger expansion for affected definition to verify 125 scenarios generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)