### PR TITLE
fix(expand): increase scenario generation timeout to 15 minutes

### DIFF
--- a/cloud/apps/api/src/queue/types.ts
+++ b/cloud/apps/api/src/queue/types.ts
@@ -88,7 +88,7 @@ export const DEFAULT_JOB_OPTIONS: Record<JobType, JobOptions> = {
     retryLimit: 2,
     retryDelay: 10,
     retryBackoff: true,
-    expireInSeconds: 300, // 5 minutes
+    expireInSeconds: 900, // 15 minutes
     singletonKey: 'definition', // Only one expansion per definition at a time
   },
   'compute_token_stats': {

--- a/cloud/apps/api/src/services/scenario/expand.ts
+++ b/cloud/apps/api/src/services/scenario/expand.ts
@@ -232,7 +232,7 @@ export async function expandScenarios(
     workerPath,
     workerInput,
     {
-      timeout: 600000, // 10 minutes
+      timeout: 900000, // 15 minutes
       cwd: path.resolve(process.cwd(), '../..'),
       onProgress,
     }

--- a/cloud/apps/api/tests/services/scenario/expand.test.ts
+++ b/cloud/apps/api/tests/services/scenario/expand.test.ts
@@ -173,7 +173,7 @@ describe('Scenario Expansion Service', () => {
         expect(workerInput.content.template).toBe(contentWithDimensions.template);
         expect(workerInput.content.dimensions).toEqual(contentWithDimensions.dimensions);
         expect(workerInput.config.temperature).toBe(0.7);
-        expect(options.timeout).toBe(600000);
+        expect(options.timeout).toBe(900000);
 
         // Verify scenarios created
         expect(result.created).toBe(2);

--- a/cloud/apps/web/src/components/definitions/ExpandedScenarios.tsx
+++ b/cloud/apps/web/src/components/definitions/ExpandedScenarios.tsx
@@ -164,7 +164,7 @@ function formatProgressMessage(status?: ExpansionStatus): string {
   }
 }
 
-const EXPANSION_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const EXPANSION_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 
 function formatCountdown(remainingMs: number): string {
   if (remainingMs <= 0) return '0:00';

--- a/cloud/workers/generate_scenarios.py
+++ b/cloud/workers/generate_scenarios.py
@@ -450,8 +450,8 @@ def run_generation(data: dict[str, Any]) -> dict[str, Any]:
         message=f"Calling {model_id} to generate {expected_count} scenarios...",
     )
 
-    # 10 minute HTTP timeout for slow models like DeepSeek Reasoner
-    LLM_TIMEOUT_SECONDS = 600
+    # 15 minute HTTP timeout for slow models like DeepSeek Reasoner
+    LLM_TIMEOUT_SECONDS = 900
 
     try:
         # Call LLM using the shared adapter


### PR DESCRIPTION
## Summary
- Increased scenario generation timeout from 10 to 15 minutes across all layers
- Fixes timeout issues with large definitions (125+ scenarios) using DeepSeek Reasoner

## Changes
| Layer | Before | After |
|-------|--------|-------|
| Python LLM timeout | 600s | 900s |
| TypeScript spawn | 600000ms | 900000ms |
| PgBoss job expiry | 300s | 900s |
| Frontend polling | 10 min | 15 min |

## Test plan
- [x] expand.test.ts passes with updated timeout expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)