### PR TITLE
fix(expand): clear stale expansionProgress on job failure/expiry

### DIFF
--- a/cloud/apps/api/src/services/scenario/expansion-status.ts
+++ b/cloud/apps/api/src/services/scenario/expansion-status.ts
@@ -96,6 +96,10 @@ export async function getDefinitionExpansionStatus(
         error = output.message ?? 'Unknown error';
       }
 
+      // Only return progress for active jobs, not terminal states
+      // This prevents stale progress showing for failed/expired jobs
+      const activeProgress = (status === 'active' || status === 'pending') ? progress : null;
+
       return {
         definitionId,
         status,
@@ -105,7 +109,7 @@ export async function getDefinitionExpansionStatus(
         completedAt: currentJob.completed_on,
         error,
         scenarioCount,
-        progress,
+        progress: activeProgress,
       };
     }
 


### PR DESCRIPTION
## Summary
- Fixes UI showing "still expanding" after job timeout/failure
- Clears `expansionProgress` when job fails, stores error in `expansionDebug`
- Status service only returns progress for active/pending jobs

## Root Cause
Definition `cmj3lgukk00eraugu2y1kcves` showed as "expanding" after job expired because:
1. Queue handler catch block never cleared `expansionProgress`
2. Status service returned stale progress even for failed/expired jobs

## Test plan
- [x] expansion-status.test.ts passes
- [x] expand.test.ts passes
- [ ] After deploy, verify failed expansions show failure state in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)