### PR TITLE
feat(expansion): add cancel button for scenario expansion

### DIFF
--- a/cloud/apps/api/src/services/scenario/cancel-expansion.ts
+++ b/cloud/apps/api/src/services/scenario/cancel-expansion.ts
@@ -1,0 +1,117 @@
+/**
+ * Cancel Expansion Service
+ *
+ * Cancels an in-progress scenario expansion job for a definition.
+ */
+
+import { db, Prisma } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+import { getBoss } from '../../queue/boss.js';
+
+const log = createLogger('services:scenario:cancel-expansion');
+
+export type CancelExpansionResult = {
+  definitionId: string;
+  cancelled: boolean;
+  jobId: string | null;
+  message: string;
+};
+
+/**
+ * Cancel any pending or active expansion jobs for a definition.
+ * Also clears the expansionProgress field.
+ */
+export async function cancelScenarioExpansion(
+  definitionId: string
+): Promise<CancelExpansionResult> {
+  log.info({ definitionId }, 'Cancelling scenario expansion');
+
+  try {
+    // Find active/pending expansion job for this definition
+    const jobs = await db.$queryRaw<Array<{
+      id: string;
+      state: string;
+    }>>`
+      SELECT id, state
+      FROM pgboss.job
+      WHERE name = 'expand_scenarios'
+        AND data->>'definitionId' = ${definitionId}
+        AND state IN ('created', 'retry', 'active')
+      ORDER BY created_on DESC
+      LIMIT 1
+    `;
+
+    const job = jobs[0];
+
+    if (!job) {
+      // No active job - just clear any stale progress
+      await db.definition.update({
+        where: { id: definitionId },
+        data: {
+          expansionProgress: Prisma.JsonNull,
+          expansionDebug: {
+            rawResponse: null,
+            extractedYaml: null,
+            parseError: 'Cancelled by user (no active job found)',
+            timestamp: new Date().toISOString(),
+          },
+        },
+      });
+
+      log.info({ definitionId }, 'No active expansion job found, cleared progress');
+      return {
+        definitionId,
+        cancelled: false,
+        jobId: null,
+        message: 'No active expansion job found',
+      };
+    }
+
+    // Cancel the job in PgBoss
+    const boss = getBoss();
+    await boss.cancel('expand_scenarios', job.id);
+
+    log.info({ definitionId, jobId: job.id, state: job.state }, 'PgBoss job cancelled');
+
+    // Clear expansion progress and record cancellation
+    await db.definition.update({
+      where: { id: definitionId },
+      data: {
+        expansionProgress: Prisma.JsonNull,
+        expansionDebug: {
+          rawResponse: null,
+          extractedYaml: null,
+          parseError: 'Cancelled by user',
+          jobId: job.id,
+          timestamp: new Date().toISOString(),
+          scenariosCreated: 0,
+        },
+      },
+    });
+
+    log.info({ definitionId, jobId: job.id }, 'Expansion cancelled successfully');
+
+    return {
+      definitionId,
+      cancelled: true,
+      jobId: job.id,
+      message: `Cancelled expansion job ${job.id}`,
+    };
+  } catch (error) {
+    log.error({ error, definitionId }, 'Failed to cancel expansion');
+
+    // Still try to clear the progress even if cancel fails
+    try {
+      await db.definition.update({
+        where: { id: definitionId },
+        data: {
+          expansionProgress: Prisma.JsonNull,
+        },
+      });
+    } catch (clearError) {
+      log.warn({ clearError, definitionId }, 'Failed to clear expansion progress');
+    }
+
+    throw error;
+  }
+}

--- a/cloud/apps/api/src/services/scenario/index.ts
+++ b/cloud/apps/api/src/services/scenario/index.ts
@@ -6,3 +6,7 @@ export {
   type ExpansionJobStatus,
   type ExpansionProgress,
 } from './expansion-status.js';
+export {
+  cancelScenarioExpansion,
+  type CancelExpansionResult,
+} from './cancel-expansion.js';

--- a/cloud/apps/web/src/api/operations/definitions.ts
+++ b/cloud/apps/web/src/api/operations/definitions.ts
@@ -444,3 +444,24 @@ export type RegenerateScenariosResult = {
     queued: boolean;
   };
 };
+
+// Cancel scenario expansion mutation
+export const CANCEL_SCENARIO_EXPANSION_MUTATION = gql`
+  mutation CancelScenarioExpansion($definitionId: String!) {
+    cancelScenarioExpansion(definitionId: $definitionId) {
+      definitionId
+      cancelled
+      jobId
+      message
+    }
+  }
+`;
+
+export type CancelScenarioExpansionResult = {
+  cancelScenarioExpansion: {
+    definitionId: string;
+    cancelled: boolean;
+    jobId: string | null;
+    message: string;
+  };
+};


### PR DESCRIPTION
## Summary
- Add Cancel button to scenario expansion UI that appears when expansion is in progress
- Allows users to stop long-running LLM generation without waiting for 15-minute timeout
- Cancels the PgBoss job and clears expansion progress

## Changes
- **Backend**: Add `cancelScenarioExpansion` GraphQL mutation and service
- **Frontend**: Add Cancel button to ExpandedScenarios component

## Test plan
- [ ] Start scenario expansion on a definition
- [ ] Click Cancel button while expansion is in progress
- [ ] Verify expansion status changes and progress is cleared
- [ ] Verify Regenerate button reappears after cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)