### PR TITLE
feat(runs): add summarize progress tracking with live status updates

### DIFF
--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -96,6 +96,24 @@ builder.objectType(RunRef, {
       },
     }),
 
+    // Summarize progress for SUMMARIZING state
+    summarizeProgress: t.field({
+      type: RunProgress,
+      nullable: true,
+      description: 'Progress information for transcript summarization (only populated in SUMMARIZING state)',
+      resolve: (run) => {
+        const progress = run.summarizeProgress as ProgressData | null;
+        if (!progress) return null;
+
+        return {
+          total: progress.total,
+          completed: progress.completed,
+          failed: progress.failed,
+          percentComplete: calculatePercentComplete(progress),
+        };
+      },
+    }),
+
     // Recent completed/failed tasks from PgBoss
     recentTasks: t.field({
       type: [TaskResult],

--- a/cloud/apps/api/src/services/run/index.ts
+++ b/cloud/apps/api/src/services/run/index.ts
@@ -13,6 +13,9 @@ export {
   incrementFailed,
   getProgress,
   calculatePercentComplete,
+  updateSummarizeProgress,
+  incrementSummarizeCompleted,
+  incrementSummarizeFailed,
 } from './progress.js';
 export type { ProgressUpdate, ProgressData } from './progress.js';
 

--- a/cloud/apps/web/src/api/operations/runs.ts
+++ b/cloud/apps/web/src/api/operations/runs.ts
@@ -94,6 +94,7 @@ export type Run = {
   config: RunConfig;
   progress: { total: number; completed: number; failed: number } | null;
   runProgress: RunProgress | null;
+  summarizeProgress: RunProgress | null;
   startedAt: string | null;
   completedAt: string | null;
   createdAt: string;
@@ -128,6 +129,12 @@ export const RUN_FRAGMENT = gql`
     config
     progress
     runProgress {
+      total
+      completed
+      failed
+      percentComplete
+    }
+    summarizeProgress {
       total
       completed
       failed

--- a/cloud/apps/web/src/components/runs/RunCard.tsx
+++ b/cloud/apps/web/src/components/runs/RunCard.tsx
@@ -23,6 +23,15 @@ const STATUS_CONFIG: Record<RunStatus, { icon: React.ElementType; color: string;
   CANCELLED: { icon: AlertCircle, color: 'text-gray-600', bg: 'bg-gray-100', label: 'Cancelled' },
 };
 
+function getStatusLabel(run: Run): string {
+  const statusConfig = STATUS_CONFIG[run.status];
+  if (run.status === 'SUMMARIZING' && run.summarizeProgress) {
+    const { completed, total } = run.summarizeProgress;
+    return `Summarizing (${completed}/${total})`;
+  }
+  return statusConfig.label;
+}
+
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
   return date.toLocaleDateString('en-US', {
@@ -75,7 +84,7 @@ export function RunCard({ run, onClick }: RunCardProps) {
                 {formatRunName(run)}
               </h3>
               <span className={`text-xs px-2 py-0.5 rounded-full ${statusConfig.bg} ${statusConfig.color}`}>
-                {statusConfig.label}
+                {getStatusLabel(run)}
               </span>
             </div>
             <p className="text-sm text-gray-500 mt-0.5">

--- a/cloud/apps/web/src/components/runs/RunProgress.tsx
+++ b/cloud/apps/web/src/components/runs/RunProgress.tsx
@@ -64,8 +64,12 @@ function StatusIcon({ status }: { status: string }) {
 /**
  * Format status for display.
  */
-function formatStatus(status: string): string {
-  return status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
+function formatStatus(run: Run): string {
+  if (run.status === 'SUMMARIZING' && run.summarizeProgress) {
+    const { completed, total } = run.summarizeProgress;
+    return `Summarizing (${completed}/${total})`;
+  }
+  return run.status.charAt(0).toUpperCase() + run.status.slice(1).toLowerCase();
 }
 
 /**
@@ -110,7 +114,7 @@ export function RunProgress({ run, showPerModel = false }: RunProgressProps) {
         <div className={`flex items-center gap-2 px-3 py-1.5 rounded-full border ${colors.bg} ${colors.border}`}>
           <StatusIcon status={run.status} />
           <span className={`text-sm font-medium ${colors.text}`}>
-            {formatStatus(run.status)}
+            {formatStatus(run)}
           </span>
         </div>
 

--- a/cloud/packages/db/prisma/migrations/20251213193917_add_summarize_progress/migration.sql
+++ b/cloud/packages/db/prisma/migrations/20251213193917_add_summarize_progress/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "runs" ADD COLUMN     "summarize_progress" JSONB;

--- a/cloud/packages/db/prisma/schema.prisma
+++ b/cloud/packages/db/prisma/schema.prisma
@@ -168,6 +168,7 @@ model Run {
   status             RunStatus @default(PENDING)
   config             Json      @db.JsonB
   progress           Json?     @db.JsonB
+  summarizeProgress  Json?     @map("summarize_progress") @db.JsonB
   startedAt          DateTime? @map("started_at")
   completedAt        DateTime? @map("completed_at")
   createdAt          DateTime  @default(now()) @map("created_at")


### PR DESCRIPTION
## Summary
- Add detailed progress tracking during the SUMMARIZING phase
- Status now shows "Summarizing (42/500)" instead of just "Summarizing"
- Progress updates in real-time as each transcript is processed

## Changes
- **Database**: Add `summarize_progress` JSONB column to runs table
- **Backend**: Initialize and increment progress atomically during summarization
- **GraphQL**: Expose `summarizeProgress` field on Run type (reuses `RunProgress` structure)
- **Frontend**: Update RunCard and RunProgress components to display progress count

## Test plan
- [ ] Start a new run on a definition with scenarios
- [ ] Verify status shows "Summarizing (X/Y)" during summarization phase
- [ ] Verify progress bar updates correctly
- [ ] Verify completed runs still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)