### PR TITLE
fix(runs): use allTags for inherited tag sorting in folder views

### DIFF
--- a/cloud/apps/web/src/api/operations/runs.ts
+++ b/cloud/apps/web/src/api/operations/runs.ts
@@ -150,7 +150,7 @@ export const RUN_FRAGMENT = gql`
     definition {
       id
       name
-      tags {
+      tags: allTags {
         id
         name
       }


### PR DESCRIPTION
## Summary
- Fixed bug where runs based on forked scenario definitions don't sort correctly by their inherited tags
- Changed GraphQL query to use `tags: allTags` field alias so inherited tags from parent definitions are included
- No TypeScript or component changes needed due to aliasing approach

## Root Cause
The `RUN_FRAGMENT` GraphQL query was fetching `definition.tags` which only returns local/direct tags. Forked definitions inherit tags from their parent definitions via the `allTags` field, but this wasn't being used.

## Test plan
- [x] Build passes
- [x] All 988 tests pass
- [ ] Manually verify: create a forked definition from a parent with tags, create a run, verify it appears in the correct tag folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)