### PR TITLE
refactor(mcp): use shared CANONICAL_DIMENSIONS for value lists

### DIFF
--- a/cloud/apps/api/src/mcp/resources/value-pairs.ts
+++ b/cloud/apps/api/src/mcp/resources/value-pairs.ts
@@ -5,11 +5,16 @@
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLogger } from '@valuerank/shared';
+import { createLogger, CANONICAL_DIMENSIONS } from '@valuerank/shared';
 
 const log = createLogger('mcp:resources:value-pairs');
 
 export const VALUE_PAIRS_URI = 'valuerank://authoring/value-pairs';
+
+// Generate the canonical values table from shared dimensions
+const canonicalValuesTable = CANONICAL_DIMENSIONS
+  .map(d => `| ${d.name} | ${d.description} |`)
+  .join('\n');
 
 export const valuePairsContent = `
 # ValueRank Value Pairs & Tensions
@@ -20,20 +25,7 @@ The 14 canonical values in ValueRank create natural tensions. Use these pairs to
 
 | Value | Description |
 |-------|-------------|
-| Physical_Safety | Protection from bodily harm |
-| Compassion | Empathy and care for others' suffering |
-| Fair_Process | Following rules and procedures equally |
-| Equal_Outcomes | Ensuring everyone gets the same result |
-| Freedom | Individual autonomy and choice |
-| Social_Duty | Obligations to society and community |
-| Harmony | Maintaining peace and avoiding conflict |
-| Loyalty | Faithfulness to groups and relationships |
-| Economics | Financial efficiency and resource optimization |
-| Human_Worthiness | Inherent dignity and value of humans |
-| Childrens_Rights | Special protections for minors |
-| Animal_Rights | Consideration for non-human animals |
-| Environmental_Rights | Protection of ecosystems and nature |
-| Tradition | Preserving established customs and practices |
+${canonicalValuesTable}
 
 ---
 

--- a/cloud/apps/api/src/mcp/tools/create-definition.ts
+++ b/cloud/apps/api/src/mcp/tools/create-definition.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import crypto from 'crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { db, type Dimension, type Prisma } from '@valuerank/db';
-import { createLogger } from '@valuerank/shared';
+import { createLogger, getCanonicalDimensionNames } from '@valuerank/shared';
 import {
   validateDefinitionContent,
   validateContentStructure,
@@ -23,6 +23,9 @@ const log = createLogger('mcp:tools:create-definition');
 
 const CURRENT_SCHEMA_VERSION = 2;
 
+// Generate canonical values list from shared package
+const CANONICAL_VALUES_LIST = getCanonicalDimensionNames().join(', ');
+
 /**
  * Zod schema for dimension input
  */
@@ -34,7 +37,7 @@ const DimensionLevelSchema = z.object({
 });
 
 const DimensionSchema = z.object({
-  name: z.string().min(1).describe('Must be a VALUE name from the 14 canonical values: Physical_Safety, Compassion, Fair_Process, Equal_Outcomes, Freedom, Social_Duty, Harmony, Loyalty, Economics, Human_Worthiness, Childrens_Rights, Animal_Rights, Environmental_Rights, Tradition'),
+  name: z.string().min(1).describe(`Must be a VALUE name from the 14 canonical values: ${CANONICAL_VALUES_LIST}`),
   levels: z.array(DimensionLevelSchema).min(3).max(5).describe('REQUIRED: 3-5 intensity levels with scores 1-5'),
 });
 
@@ -123,7 +126,7 @@ Each dimension must have:
   - options: Array of alternative phrasings (randomly selected during expansion)
 
 **The 14 Canonical Values:**
-Physical_Safety, Compassion, Fair_Process, Equal_Outcomes, Freedom, Social_Duty, Harmony, Loyalty, Economics, Human_Worthiness, Childrens_Rights, Animal_Rights, Environmental_Rights, Tradition
+${CANONICAL_VALUES_LIST}
 
 **Template Rules:**
 - Use [ValueName] placeholders matching dimension names


### PR DESCRIPTION
## Summary
- Replace hardcoded canonical value lists in MCP tools/resources with dynamic generation from `@valuerank/shared`
- `create-definition.ts` now imports `getCanonicalDimensionNames()` for tool descriptions
- `value-pairs.ts` now generates the values table from `CANONICAL_DIMENSIONS`

## Test plan
- [x] Build passes (`npx turbo build`)
- [x] All tests pass (1237 passed)
- [ ] Verify MCP tool descriptions show correct values in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)