### PR TITLE
docs: update documentation for recently implemented features

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ npm run dev
 ```
 
 This starts:
-- **API server** at http://localhost:3001 (GraphQL at `/graphql`)
+- **API server** at http://localhost:3031 (GraphQL at `/graphql`)
 - **Web frontend** at http://localhost:3030
 
 ### Test Credentials
@@ -82,7 +82,7 @@ After seeding, log in with:
 ┌───────────────┐            ┌─────────────────┐            ┌───────────────┐
 │  Web Frontend │            │   GraphQL API   │            │  MCP Server   │
 │  (React/Vite) │───────────▶│   (Express)     │◀───────────│  (Stdio)      │
-│  :3030        │            │   :3001         │            │               │
+│  :3030        │            │   :3031         │            │               │
 └───────────────┘            └────────┬────────┘            └───────────────┘
                                       │
                     ┌─────────────────┼─────────────────┐
@@ -200,14 +200,16 @@ Per `specs/high-level.md`, the following stages are complete:
 | 9 | Run Execution & Basic Export | ✅ |
 | 11 | Analysis System & Visualizations | ✅ |
 | 12, 14 | MCP Read & Write Tools | ✅ |
+| 13 | Run Comparison | ✅ |
 | 15 | Data Export & CLI Compatibility | ✅ |
+| 16 (partial) | Cost Estimation & Sampling | ✅ |
 | 17 | Production Deployment (Railway) | ✅ |
-| 13 | Provider Metadata | ✅ |
+| 17 | Parallel Summarization | ✅ |
+| 18 | MCP Operations Tools | ✅ |
 
 **Deferred:**
 - Stage 10: Experiment Framework
-- Stage 13 (partial): Run Comparison & Delta Analysis
-- Stage 16: Scale & Efficiency
+- Stage 16 (remaining): Batch Processing, Cost Dashboard
 
 See [Future Features](./deferred/future-features.md) for details on deferred work.
 

--- a/docs/api/graphql-schema.md
+++ b/docs/api/graphql-schema.md
@@ -43,6 +43,8 @@ X-API-Key: <api_key>
 enum RunStatus {
   PENDING
   RUNNING
+  PAUSED
+  SUMMARIZING
   COMPLETED
   FAILED
   CANCELLED

--- a/docs/frontend/pages-and-routes.md
+++ b/docs/frontend/pages-and-routes.md
@@ -19,6 +19,7 @@ Cloud ValueRank uses React Router v6 for client-side routing. All routes except 
 | `/definitions/new` | `DefinitionDetail` | Yes | Create new definition (special case) |
 | `/runs` | `Runs` | Yes | List all runs with filtering |
 | `/runs/:id` | `RunDetail` | Yes | View run progress and results |
+| `/compare` | `Compare` | Yes | Cross-run comparison with visualizations |
 | `/experiments` | `Experiments` | Yes | Placeholder for Stage 10 |
 | `/settings` | `Settings` | Yes | System health, models, API keys |
 | `*` | Redirect to `/` | - | Catch-all for unknown routes |
@@ -249,6 +250,27 @@ Active tab is highlighted with a teal underline. Icons hide on small screens.
 
 **Key Code:** `pages/RunDetail.tsx`
 
+### Compare (`/compare`)
+
+**Purpose:** Cross-run comparison for analyzing differences between runs.
+
+**Features:**
+- Run selector (multi-select from available completed runs)
+- Side-by-side comparison of runs with same definition
+- Multiple visualization types (overview, decisions, scenarios, values, agreement)
+- Filter by model and display mode (overlay, side-by-side)
+- URL state preservation (`/compare?runs=id1,id2&viz=overview`)
+
+**Key Components:**
+- `RunSelector` - Multi-select completed runs
+- `ComparisonHeader` - Shows selected runs metadata
+- `VisualizationNav` - Tab navigation between viz types
+- Visualization components in `components/compare/visualizations/`
+
+**Key Code:** `pages/Compare.tsx`
+
+---
+
 ### Experiments (`/experiments`)
 
 **Purpose:** Placeholder for the Experiment Framework (Stage 10, deferred).
@@ -328,11 +350,10 @@ The original frontend design (see `docs/preplanning/frontend-design.md`) planned
 | Version Tree | Phase 2 | Implemented |
 | Analysis Dashboard | Phase 3 | Implemented |
 | API Key Manager | Phase 3 | Implemented |
-| Run Comparison | Phase 4 | Deferred (Stage 13) |
+| Run Comparison | Phase 4 | Implemented |
 
 **Key Deviations from Plan:**
 - Experiment Framework deferred to focus on core run workflow
-- Run Comparison deferred to focus on single-run analysis
 - Deep analysis (PCA, outliers) not yet implemented
 
 ---
@@ -349,6 +370,7 @@ The original frontend design (see `docs/preplanning/frontend-design.md`) planned
 | `apps/web/src/pages/DefinitionDetail.tsx` | Definition detail page |
 | `apps/web/src/pages/Runs.tsx` | Runs list page |
 | `apps/web/src/pages/RunDetail.tsx` | Run detail page |
+| `apps/web/src/pages/Compare.tsx` | Run comparison page |
 | `apps/web/src/pages/Experiments.tsx` | Experiments placeholder |
 | `apps/web/src/pages/Settings.tsx` | Settings page |
 | `apps/web/src/components/ProtectedRoute.tsx` | Auth guard |


### PR DESCRIPTION
## Summary

- Update documentation to reflect features previously listed as deferred that have since been implemented
- Fix incorrect port number in docs (3001 → 3031)
- Complete rewrite of MCP tools documentation with all 33 tools
- Update to 19 canonical Schwartz values (was 14)

## Changes

### docs/deferred/future-features.md
- Add "Recently Implemented" section listing:
  - Run Comparison (Stage 13)
  - Cost Estimation & Actual Cost Tracking
  - Sampling/Partial Runs
  - Parallel Summarization
- Remove Stage 13 from deferred list
- Update Stage 16 to show partial implementation

### docs/api/mcp-tools.md (complete rewrite)
- Document all 33 MCP tools organized by category:
  - 8 Query Tools
  - 5 Definition Tools
  - 2 Run Tools
  - 11 LLM Management Tools
  - 7 Operations Tools
- Update from old 14 values to 19 canonical Schwartz values

### docs/api/graphql-schema.md
- Add `PAUSED` and `SUMMARIZING` to RunStatus enum

### docs/README.md
- Fix API port (3001 → 3031) in text and diagram
- Update implementation status table with new completed stages

### docs/frontend/pages-and-routes.md
- Add `/compare` route to route table
- Add Compare page documentation
- Update feature status table

## Test plan

- [x] All markdown files render correctly
- [x] Links are valid within documentation
- [x] No broken references to code files

🤖 Generated with [Claude Code](https://claude.com/claude-code)