### PR TITLE
fix(lint): restore db package in ESLint unsafe-* overrides

### DIFF
--- a/cloud/.eslintrc.cjs
+++ b/cloud/.eslintrc.cjs
@@ -105,15 +105,15 @@ module.exports = {
       },
     },
     // ============================================================================
-    // API Server Overrides
-    // The API codebase uses dynamic data from Prisma, GraphQL resolvers, and
-    // external APIs. We downgrade all no-unsafe-* rules to warnings for the
-    // entire API to allow gradual type safety improvements.
+    // API Server and DB Package Overrides
+    // These codebases use dynamic data from Prisma, GraphQL resolvers, and
+    // external APIs. We downgrade all no-unsafe-* rules to warnings to allow
+    // gradual type safety improvements.
     // ============================================================================
     {
-      // All API source files: downgrade unsafe-* rules to warnings
+      // API and DB source files: downgrade unsafe-* rules to warnings
       // This allows the codebase to build while we incrementally improve types
-      files: ['apps/api/src/**/*.ts'],
+      files: ['apps/api/src/**/*.ts', 'packages/db/src/**/*.ts'],
       rules: {
         '@typescript-eslint/no-unsafe-assignment': 'warn',
         '@typescript-eslint/no-unsafe-member-access': 'warn',


### PR DESCRIPTION
## Summary
Restores the `packages/db/src/**/*.ts` glob pattern that was accidentally removed in the previous ESLint consolidation PR.

## Problem
PR #84 consolidated the API ESLint overrides but accidentally removed the db package from the override. This caused deployment to fail with 141+ errors in `@valuerank/db`.

## Fix
Added `packages/db/src/**/*.ts` back to the same override block as the API files.

## Test plan
- [x] `npx turbo lint --force` passes with 0 errors
- [x] `npx turbo build --force` passes
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)