### PR TITLE
fix(build): add ^build dependency to lint task in turbo.json

### DIFF
--- a/cloud/turbo.json
+++ b/cloud/turbo.json
@@ -18,6 +18,7 @@
       "outputs": ["coverage/**"]
     },
     "lint": {
+      "dependsOn": ["^build"],
       "outputs": []
     },
     "lint:fix": {


### PR DESCRIPTION
## Summary
- Fixes Railway deploy failures caused by lint running before dependency packages are built
- The lint task now depends on `^build` to ensure `@valuerank/db` types are available

## Problem
Clean clones (and Railway) had 3 ESLint errors for `no-unnecessary-type-assertion` because:
1. Lint ran before `@valuerank/db` was built
2. Without compiled `.d.ts` files, Prisma types resolved differently
3. Type assertions that are necessary with proper types appeared "unnecessary"

## Test Plan
- [x] Verified fix in clean clone - now 0 errors (was 3)
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)