### PR TITLE
feat(export): add transcript JSON download to run detail page

### DIFF
--- a/cloud/apps/web/src/api/export.ts
+++ b/cloud/apps/web/src/api/export.ts
@@ -1,7 +1,7 @@
 /**
  * Export API
  *
- * Functions for exporting run data as CSV and definitions as MD.
+ * Functions for exporting run data as CSV/JSON and definitions as MD/YAML.
  */
 
 /**
@@ -49,6 +49,60 @@ export async function exportRunAsCSV(runId: string): Promise<void> {
   // Get filename from Content-Disposition header or generate one
   const contentDisposition = response.headers.get('Content-Disposition');
   let filename = `run-${runId.slice(0, 8)}-export.csv`;
+
+  if (contentDisposition) {
+    const match = contentDisposition.match(/filename="?([^"]+)"?/);
+    if (match?.[1]) {
+      filename = match[1];
+    }
+  }
+
+  // Convert response to blob and trigger download
+  const blob = await response.blob();
+  const blobUrl = URL.createObjectURL(blob);
+
+  // Create temporary link and click it
+  const link = document.createElement('a');
+  link.href = blobUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+
+  // Cleanup
+  document.body.removeChild(link);
+  URL.revokeObjectURL(blobUrl);
+}
+
+/**
+ * Export all transcripts for a run as JSON and trigger download.
+ *
+ * @param runId - The run ID to export transcripts for
+ * @returns Promise that resolves when download starts
+ */
+export async function exportTranscriptsAsJSON(runId: string): Promise<void> {
+  const token = getAuthToken();
+  if (!token) {
+    throw new Error('Not authenticated');
+  }
+
+  const baseUrl = getApiBaseUrl();
+  const url = `${baseUrl}/api/export/runs/${runId}/transcripts.json`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Export failed: ${response.status} ${errorText}`);
+  }
+
+  // Get filename from Content-Disposition header or generate one
+  const contentDisposition = response.headers.get('Content-Disposition');
+  let filename = `transcripts-${runId.slice(0, 8)}.json`;
 
   if (contentDisposition) {
     const match = contentDisposition.match(/filename="?([^"]+)"?/);

--- a/cloud/apps/web/src/components/runs/RunResults.tsx
+++ b/cloud/apps/web/src/components/runs/RunResults.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState } from 'react';
-import { Download, FileText, BarChart2, List, Grid, DollarSign } from 'lucide-react';
+import { Download, FileText, BarChart2, List, Grid, DollarSign, FileJson } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { TranscriptList } from './TranscriptList';
 import { TranscriptViewer } from './TranscriptViewer';
@@ -15,6 +15,8 @@ type RunResultsProps = {
   run: Run;
   onExport?: () => void;
   isExporting?: boolean;
+  onExportTranscripts?: () => void;
+  isExportingTranscripts?: boolean;
 };
 
 type ViewMode = 'list' | 'grouped';
@@ -86,7 +88,13 @@ function calculateStats(transcripts: Transcript[], analysis: Run['analysis']) {
   };
 }
 
-export function RunResults({ run, onExport, isExporting = false }: RunResultsProps) {
+export function RunResults({
+  run,
+  onExport,
+  isExporting = false,
+  onExportTranscripts,
+  isExportingTranscripts = false,
+}: RunResultsProps) {
   const [selectedTranscript, setSelectedTranscript] = useState<Transcript | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('grouped');
 
@@ -219,16 +227,30 @@ export function RunResults({ run, onExport, isExporting = false }: RunResultsPro
           </Button>
         </div>
 
-        {onExport && (
-          <Button
-            variant="secondary"
-            onClick={onExport}
-            disabled={isExporting}
-          >
-            <Download className="w-4 h-4 mr-2" />
-            {isExporting ? 'Exporting...' : 'Export CSV'}
-          </Button>
-        )}
+        <div className="flex items-center gap-2">
+          {onExportTranscripts && (
+            <Button
+              variant="secondary"
+              onClick={onExportTranscripts}
+              disabled={isExportingTranscripts}
+              title="Download full conversation transcripts"
+            >
+              <FileJson className="w-4 h-4 mr-2" />
+              {isExportingTranscripts ? 'Exporting...' : 'Transcripts'}
+            </Button>
+          )}
+          {onExport && (
+            <Button
+              variant="secondary"
+              onClick={onExport}
+              disabled={isExporting}
+              title="Download summary results"
+            >
+              <Download className="w-4 h-4 mr-2" />
+              {isExporting ? 'Exporting...' : 'Export CSV'}
+            </Button>
+          )}
+        </div>
       </div>
 
       {/* Transcript list */}

--- a/cloud/apps/web/src/pages/RunDetail/RunDetail.tsx
+++ b/cloud/apps/web/src/pages/RunDetail/RunDetail.tsx
@@ -17,7 +17,7 @@ import { SummarizationControls } from '../../components/runs/SummarizationContro
 import { RerunDialog } from '../../components/runs/RerunDialog';
 import { useRun } from '../../hooks/useRun';
 import { useRunMutations } from '../../hooks/useRunMutations';
-import { exportRunAsCSV } from '../../api/export';
+import { exportRunAsCSV, exportTranscriptsAsJSON } from '../../api/export';
 import { RunHeader } from './RunHeader';
 import { RunMetadata } from './RunMetadata';
 import { RunNameEditor } from './RunNameEditor';
@@ -28,6 +28,7 @@ export function RunDetail() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const [isExporting, setIsExporting] = useState(false);
+  const [isExportingTranscripts, setIsExportingTranscripts] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [isRerunDialogOpen, setIsRerunDialogOpen] = useState(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
@@ -69,6 +70,20 @@ export function RunDetail() {
       setExportError(message);
     } finally {
       setIsExporting(false);
+    }
+  }, [run]);
+
+  const handleExportTranscripts = useCallback(async () => {
+    if (!run) return;
+    setIsExportingTranscripts(true);
+    setExportError(null);
+    try {
+      await exportTranscriptsAsJSON(run.id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Export failed';
+      setExportError(message);
+    } finally {
+      setIsExportingTranscripts(false);
     }
   }, [run]);
 
@@ -302,7 +317,13 @@ export function RunDetail() {
                 {exportError}
               </div>
             )}
-            <RunResults run={run} onExport={() => void handleExport()} isExporting={isExporting} />
+            <RunResults
+              run={run}
+              onExport={() => void handleExport()}
+              isExporting={isExporting}
+              onExportTranscripts={() => void handleExportTranscripts()}
+              isExportingTranscripts={isExportingTranscripts}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Add ability to download all transcripts for a run as a JSON file
- New REST endpoint `GET /api/export/runs/:id/transcripts.json`
- New "Transcripts" download button in the run results section

## Details
The JSON export includes:
- Export metadata (timestamp)
- Run info (id, name, status, config, definition)
- All transcripts with full conversation content, model info, scenario dimensions, token counts, and summary data

## Test plan
- [ ] Navigate to a completed run with transcripts
- [ ] Click the "Transcripts" button next to "Export CSV"
- [ ] Verify JSON file downloads with full transcript content

🤖 Generated with [Claude Code](https://claude.com/claude-code)