### PR TITLE
feat(summarize): parallel processing with rate limiting

### DIFF
--- a/cloud/apps/api/src/mcp/tools/set-summarization-parallelism.ts
+++ b/cloud/apps/api/src/mcp/tools/set-summarization-parallelism.ts
@@ -1,7 +1,7 @@
 /**
  * set_summarization_parallelism MCP Tool
  *
- * Configures max parallel summarization jobs (1-100).
+ * Configures max parallel summarization jobs (1-500).
  * Updates the setting and hot-reloads the handler with new batchSize.
  */
 
@@ -22,8 +22,8 @@ const SetSummarizationParallelismInputSchema = {
     .number()
     .int()
     .min(1)
-    .max(100)
-    .describe('Maximum parallel summarization jobs (1-100)'),
+    .max(500)
+    .describe('Maximum parallel summarization jobs (1-500)'),
 };
 
 /**
@@ -64,7 +64,7 @@ function registerSetSummarizationParallelismTool(server: McpServer): void {
   server.registerTool(
     'set_summarization_parallelism',
     {
-      description: `Configure max parallel summarization jobs (1-100).
+      description: `Configure max parallel summarization jobs (1-500).
 
 **What this setting controls:**
 - Number of summarization jobs processed concurrently

--- a/cloud/apps/api/src/services/summarization-parallelism/index.ts
+++ b/cloud/apps/api/src/services/summarization-parallelism/index.ts
@@ -23,7 +23,7 @@ const DEFAULT_PARALLELISM = 8;
 
 // Valid range for the setting
 const MIN_PARALLELISM = 1;
-const MAX_PARALLELISM = 100;
+const MAX_PARALLELISM = 500;
 
 // Cache configuration
 const CACHE_TTL_MS = 60000; // 1 minute
@@ -83,7 +83,7 @@ export async function getMaxParallelSummarizations(): Promise<number> {
 /**
  * Set the maximum parallel summarizations.
  *
- * @param value - Number between 1 and 100
+ * @param value - Number between 1 and 500
  * @throws ValidationError if value is out of range
  */
 export async function setMaxParallelSummarizations(value: number): Promise<void> {

--- a/cloud/apps/api/tests/mcp/tools/set-summarization-parallelism.test.ts
+++ b/cloud/apps/api/tests/mcp/tools/set-summarization-parallelism.test.ts
@@ -82,35 +82,35 @@ describe('set_summarization_parallelism MCP Tool', () => {
       expect(value).toBe(1);
     });
 
-    it('accepts maximum value of 100', async () => {
-      await setMaxParallelSummarizations(100);
+    it('accepts maximum value of 500', async () => {
+      await setMaxParallelSummarizations(500);
       clearSummarizationCache();
 
       const value = await getMaxParallelSummarizations();
-      expect(value).toBe(100);
+      expect(value).toBe(500);
     });
 
     it('rejects value below minimum', async () => {
       await expect(setMaxParallelSummarizations(0)).rejects.toThrow(
-        'max_parallel must be an integer between 1 and 100'
+        'max_parallel must be an integer between 1 and 500'
       );
     });
 
     it('rejects value above maximum', async () => {
-      await expect(setMaxParallelSummarizations(101)).rejects.toThrow(
-        'max_parallel must be an integer between 1 and 100'
+      await expect(setMaxParallelSummarizations(501)).rejects.toThrow(
+        'max_parallel must be an integer between 1 and 500'
       );
     });
 
     it('rejects non-integer values', async () => {
       await expect(setMaxParallelSummarizations(5.5)).rejects.toThrow(
-        'max_parallel must be an integer between 1 and 100'
+        'max_parallel must be an integer between 1 and 500'
       );
     });
 
     it('rejects negative values', async () => {
       await expect(setMaxParallelSummarizations(-10)).rejects.toThrow(
-        'max_parallel must be an integer between 1 and 100'
+        'max_parallel must be an integer between 1 and 500'
       );
     });
   });

--- a/cloud/apps/api/tests/services/summarization-parallelism/index.test.ts
+++ b/cloud/apps/api/tests/services/summarization-parallelism/index.test.ts
@@ -85,7 +85,7 @@ describe('Summarization Parallelism Service', () => {
       await db.systemSetting.create({
         data: {
           key: SETTING_KEY,
-          value: { value: 500 },
+          value: { value: 1000 },
         },
       });
 
@@ -189,40 +189,40 @@ describe('Summarization Parallelism Service', () => {
       expect(value).toBe(1);
     });
 
-    it('accepts maximum value of 100', async () => {
-      await setMaxParallelSummarizations(100);
+    it('accepts maximum value of 500', async () => {
+      await setMaxParallelSummarizations(500);
 
       const value = await getMaxParallelSummarizations();
-      expect(value).toBe(100);
+      expect(value).toBe(500);
     });
 
     it('throws ValidationError for value below minimum', async () => {
       await expect(setMaxParallelSummarizations(0)).rejects.toThrow(
-        'max_parallel must be an integer between 1 and 100'
+        'max_parallel must be an integer between 1 and 500'
       );
     });
 
     it('throws ValidationError for value above maximum', async () => {
-      await expect(setMaxParallelSummarizations(101)).rejects.toThrow(
-        'max_parallel must be an integer between 1 and 100'
+      await expect(setMaxParallelSummarizations(501)).rejects.toThrow(
+        'max_parallel must be an integer between 1 and 500'
       );
     });
 
     it('throws ValidationError for negative value', async () => {
       await expect(setMaxParallelSummarizations(-5)).rejects.toThrow(
-        'max_parallel must be an integer between 1 and 100'
+        'max_parallel must be an integer between 1 and 500'
       );
     });
 
     it('throws ValidationError for non-integer value', async () => {
       await expect(setMaxParallelSummarizations(5.5)).rejects.toThrow(
-        'max_parallel must be an integer between 1 and 100'
+        'max_parallel must be an integer between 1 and 500'
       );
     });
 
     it('throws ValidationError for NaN', async () => {
       await expect(setMaxParallelSummarizations(NaN)).rejects.toThrow(
-        'max_parallel must be an integer between 1 and 100'
+        'max_parallel must be an integer between 1 and 500'
       );
     });
   });


### PR DESCRIPTION
## Summary
- Fix summarization handler to process jobs in parallel instead of sequentially
- Add rate limiting via Bottleneck to respect provider RPM limits
- Increase max parallelism setting from 100 to 500

## Problem
The summarization handler was processing jobs one at a time in a `for` loop, even when `batchSize` was set to 100. This meant we were seeing only ~3 completions at a time (the time for one LLM call) instead of the expected burst of parallel requests.

## Solution
- Changed from sequential `for` loop to `Promise.allSettled()` for concurrent processing
- Route all summarization jobs through the rate limiter (Bottleneck) for the summarizer provider
- This respects the provider's `maxParallelRequests` and `requestsPerMinute` settings
- Extracted `processSummarizeJob()` function for cleaner parallel execution

## Test plan
- [x] All existing tests pass (1419 tests)
- [x] Build succeeds with no type errors
- [ ] Deploy to production and verify summarization throughput increases
- [ ] Monitor for rate limit errors from summarizer provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)