### PR TITLE
feat(summarize): increase parallelism limit and fix rate limiter reload

### DIFF
--- a/cloud/apps/api/src/queue/handlers/index.ts
+++ b/cloud/apps/api/src/queue/handlers/index.ts
@@ -351,10 +351,15 @@ export async function reregisterSummarizeHandler(boss: PgBoss): Promise<void> {
   // 3. Clear cache to force reload from database
   clearSummarizationCache();
 
-  // 4. Load fresh parallelism setting
+  // 4. Clear summarize rate limiters so they're recreated with new settings
+  const { clearSummarizeLimiters } = await import('../../services/rate-limiter/index.js');
+  clearSummarizeLimiters();
+  log.debug('Summarize rate limiters cleared');
+
+  // 5. Load fresh parallelism setting
   const newBatchSize = await getMaxParallelSummarizations();
 
-  // 5. Register new handler with updated batchSize
+  // 6. Register new handler with updated batchSize
   //    This immediately starts processing queued jobs with the new concurrency
   const summarizeHandler = createSummarizeTranscriptHandler();
 

--- a/cloud/apps/web/src/components/settings/infra/ParallelismSettings.tsx
+++ b/cloud/apps/web/src/components/settings/infra/ParallelismSettings.tsx
@@ -58,12 +58,12 @@ export function ParallelismSettings({
             <input
               type="number"
               min={1}
-              max={100}
+              max={500}
               value={value}
               onChange={(e) => onChange(parseInt(e.target.value, 10) || 1)}
               className="w-24 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
             />
-            <span className="text-sm text-gray-500">Range: 1-100 (default: 8)</span>
+            <span className="text-sm text-gray-500">Range: 1-500 (default: 8)</span>
           </div>
         </div>
 
@@ -88,7 +88,7 @@ export function ParallelismSettings({
             <Button
               variant="primary"
               onClick={onSave}
-              disabled={!hasChanges || isSaving || value < 1 || value > 100}
+              disabled={!hasChanges || isSaving || value < 1 || value > 500}
               isLoading={isSaving}
             >
               Save Configuration


### PR DESCRIPTION
## Summary
- Increase max parallelism from 100 to 500 in UI and validation
- Add concurrencyOverride option to rate limiter for summarization
- Use max(summarizationParallelism, providerMaxParallel) for effective concurrency
- Clear summarize rate limiters when settings change to apply new concurrency
- Use fixed limiter key pattern (provider:summarize) instead of including value

This ensures summarization can run at higher concurrency than probe limits, and that changing the parallelism setting properly reloads the rate limiter without data loss.

## Test plan
- [x] Build passes
- [x] All 1419 tests pass
- [ ] Manual test: Change summarization parallelism via settings UI and verify rate limiter is recreated

🤖 Generated with [Claude Code](https://claude.com/claude-code)