### PR TITLE
test(api): rewrite MCP tool tests with proper handler mocking

### DIFF
--- a/cloud/apps/web/tests/components/definitions/DimensionLevelEditor.test.tsx
+++ b/cloud/apps/web/tests/components/definitions/DimensionLevelEditor.test.tsx
@@ -176,6 +176,7 @@ describe('DimensionLevelEditor', () => {
 
     const optionsInput = screen.getByDisplayValue('minimal, negligible');
     fireEvent.change(optionsInput, { target: { value: 'low, minimal, trivial' } });
+    fireEvent.blur(optionsInput);
 
     expect(onChange).toHaveBeenCalledWith({
       ...mockLevel,
@@ -199,6 +200,7 @@ describe('DimensionLevelEditor', () => {
 
     const optionsInput = screen.getByDisplayValue('minimal, negligible');
     fireEvent.change(optionsInput, { target: { value: '' } });
+    fireEvent.blur(optionsInput);
 
     expect(onChange).toHaveBeenCalledWith({
       ...mockLevel,
@@ -338,6 +340,7 @@ describe('DimensionLevelEditor', () => {
 
     const optionsInput = screen.getByDisplayValue('minimal, negligible');
     fireEvent.change(optionsInput, { target: { value: '  option1  ,  option2  ' } });
+    fireEvent.blur(optionsInput);
 
     expect(onChange).toHaveBeenCalledWith({
       ...mockLevel,
@@ -361,6 +364,7 @@ describe('DimensionLevelEditor', () => {
 
     const optionsInput = screen.getByDisplayValue('minimal, negligible');
     fireEvent.change(optionsInput, { target: { value: 'option1, , option2, ' } });
+    fireEvent.blur(optionsInput);
 
     expect(onChange).toHaveBeenCalledWith({
       ...mockLevel,


### PR DESCRIPTION
## Summary
- Rewrote 6 MCP tool test files to properly test tool handlers instead of database behavior directly
- Each test now mocks `@valuerank/db` before importing and captures tool handler via mock server registration
- Fixed `DimensionLevelEditor.test.tsx` to add `fireEvent.blur()` after change events

## Files Updated
| Tool | Tests | Coverage |
|------|-------|----------|
| `create-definition.ts` | 13 | 98.77% |
| `fork-definition.ts` | 17 | 99.43% |
| `delete-definition.ts` | 12 | ~98% |
| `delete-run.ts` | 12 | 98.38% |
| `list-runs.ts` | 14 | 100% |
| `start-run.ts` | 17 | 98.87% |

**Total: 85 tests passing**

## Testing Pattern Established
Each test file now follows the correct pattern:
1. Mock `@valuerank/db` before importing
2. Mock MCP services (`validateDefinitionContent`, `logAuditEvent`, etc.)
3. Capture tool handler via mock server registration
4. Dynamically import to trigger registration
5. Invoke handler directly with test arguments

## Test plan
- [x] All 85 rewritten tests pass
- [x] Pre-push lint and build checks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)