### PR TITLE
feat(api): add GraphQL count queries for pagination support

### DIFF
--- a/cloud/apps/api/src/graphql/queries/tag.ts
+++ b/cloud/apps/api/src/graphql/queries/tag.ts
@@ -76,3 +76,29 @@ builder.queryField('tag', (t) =>
     },
   })
 );
+
+// Query: tagCount - Get count of tags matching filters
+builder.queryField('tagCount', (t) =>
+  t.field({
+    type: 'Int',
+    description: 'Get the count of tags matching the specified filters. Useful for pagination.',
+    args: {
+      search: t.arg.string({
+        required: false,
+        description: 'Search tags by name (contains match)',
+      }),
+    },
+    resolve: async (_root, args, ctx) => {
+      ctx.log.debug({ search: args.search }, 'Counting tags');
+
+      const where = args.search
+        ? { name: { contains: args.search.toLowerCase(), mode: 'insensitive' as const } }
+        : {};
+
+      const count = await db.tag.count({ where });
+
+      ctx.log.debug({ count }, 'Tag count fetched');
+      return count;
+    },
+  })
+);


### PR DESCRIPTION
## Summary
- Add count queries to support virtualized list controls with accurate pagination
- New queries: `runCount`, `definitionCount`, `tagCount`, `analysisHistoryCount`
- Each count query accepts the same filters as its list counterpart
- Fix `analysisHistory` query to enforce max limit (was unbounded, now capped at 100)

## Changes
| Query | Filters | File |
|-------|---------|------|
| `runCount` | `definitionId`, `experimentId`, `status`, `hasAnalysis`, `analysisStatus` | `run.ts` |
| `definitionCount` | `rootOnly`, `search`, `tagIds`, `hasRuns` | `definition.ts` |
| `tagCount` | `search` | `tag.ts` |
| `analysisHistoryCount` | `runId` (required) | `analysis.ts` |

## Test plan
- [x] Build passes with no errors
- [x] All 1437 tests pass
- [ ] Manual testing of new queries in GraphQL playground

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)