### PR TITLE
Fix transcript dimension columns missing in production

### DIFF
--- a/cloud/apps/web/src/components/runs/TranscriptList.tsx
+++ b/cloud/apps/web/src/components/runs/TranscriptList.tsx
@@ -53,6 +53,9 @@ export function TranscriptList({
     // first scenario has an empty/malformed dimensions object.
     const keys = new Set<string>();
     for (const dimensions of Object.values(scenarioDimensions)) {
+      if (!dimensions || typeof dimensions !== 'object' || Array.isArray(dimensions)) {
+        continue;
+      }
       for (const key of Object.keys(dimensions)) {
         keys.add(key);
       }


### PR DESCRIPTION
## Summary
- fix transcript list dimension key derivation to use the union of keys across all scenario dimension records
- prevent columns disappearing when the first scenario has empty/malformed dimensions in production data

## Root cause
The UI previously read dimension columns from only the first `scenarioDimensions` entry. In production, that first entry can be empty, yielding no columns.

## Validation
- `npm run build --workspace=@valuerank/web` passes locally
