### PR TITLE
Revert PR #163 transcript column changes

### DIFF
--- a/cloud/apps/web/src/components/runs/TranscriptList.tsx
+++ b/cloud/apps/web/src/components/runs/TranscriptList.tsx
@@ -48,9 +48,19 @@ export function TranscriptList({
 
   const dimensionKeys = useMemo(() => {
     if (!scenarioDimensions) return [];
-    const firstScenario = Object.values(scenarioDimensions)[0];
-    if (!firstScenario) return [];
-    return Object.keys(firstScenario);
+
+    // Use the union of keys across all scenarios so sparse/empty first
+    // entries do not drop valid columns from the table.
+    const keys = new Set<string>();
+    for (const dimensions of Object.values(scenarioDimensions)) {
+      if (!dimensions || typeof dimensions !== 'object' || Array.isArray(dimensions)) {
+        continue;
+      }
+      for (const key of Object.keys(dimensions)) {
+        keys.add(key);
+      }
+    }
+    return Array.from(keys);
   }, [scenarioDimensions]);
 
   const normalizedScenarioDimensions = useMemo(() => {


### PR DESCRIPTION
## Summary
- revert merged PR #163 ("Fix transcript dimension columns missing in production")
- restore prior transcript list behavior to unblock production deploy stability

## Why
Production deployment/regression concerns were reported after this merge. This PR backs out the change cleanly so behavior returns to the known prior state.

## Notes
- This is a targeted revert commit generated with `git revert -m 1` of merge commit `36e47d9`.
- Follow-up fixes can be reintroduced later in a fresh PR after validation.
