### PR TITLE
fix(api): resolve production cost-estimate failure for Gemini legacy IDs

### DIFF
--- a/cloud/apps/api/src/services/models/aliases.ts
+++ b/cloud/apps/api/src/services/models/aliases.ts
@@ -1,26 +1,55 @@
 /**
- * Legacy model ID aliasing.
+ * Legacy model ID compatibility helpers.
  *
- * Keeps old model identifiers working after provider/model renames.
+ * Some environments still store historical Gemini IDs while others have newer
+ * replacements. These helpers treat them as equivalent and resolve to whatever
+ * exists in the current database.
  */
 
-const LEGACY_MODEL_ALIASES: Record<string, string> = {
-  // Gemini 2.5 Flash preview IDs were replaced by the stable ID.
-  'gemini-2.5-flash-preview-05-20': 'gemini-2.5-flash',
-  'gemini-2.5-flash-preview-09-2025': 'gemini-2.5-flash',
-};
+const MODEL_EQUIVALENCE_GROUPS: string[][] = [
+  [
+    'gemini-2.5-flash',
+    'gemini-2.5-flash-preview-09-2025',
+    'gemini-2.5-flash-preview-05-20',
+  ],
+];
 
 /**
- * Normalize a model ID, mapping known legacy IDs to current canonical IDs.
+ * Returns all known equivalent model IDs for a given model ID.
+ * If no aliases are known, returns the input model ID only.
  */
-export function normalizeLegacyModelId(modelId: string): string {
-  return LEGACY_MODEL_ALIASES[modelId] ?? modelId;
+export function getEquivalentModelIds(modelId: string): string[] {
+  for (const group of MODEL_EQUIVALENCE_GROUPS) {
+    if (group.includes(modelId)) {
+      return [...group];
+    }
+  }
+  return [modelId];
 }
 
 /**
- * Normalize a list of model IDs.
+ * Resolve a requested model ID against a set of available IDs.
+ *
+ * Preference order:
+ * 1) exact match
+ * 2) first equivalent that exists in available IDs
+ * 3) null if nothing matches
  */
-export function normalizeLegacyModelIds(modelIds: string[]): string[] {
-  return modelIds.map(normalizeLegacyModelId);
+export function resolveModelIdFromAvailable(
+  requestedModelId: string,
+  availableModelIds: Set<string>
+): string | null {
+  if (availableModelIds.has(requestedModelId)) {
+    return requestedModelId;
+  }
+
+  const candidates = getEquivalentModelIds(requestedModelId);
+  for (const candidate of candidates) {
+    if (availableModelIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
 }
 


### PR DESCRIPTION
## Summary
- add centralized legacy model ID normalization for Gemini 2.5 Flash aliases
- normalize legacy IDs in GraphQL `estimateCost` and `startRun` mutation paths
- map old preview IDs to current stable ID: `gemini-2.5-flash`

## Why
Production trial start failed during cost estimation with:
`Model not found: gemini-2.5-flash-preview-09-2025`

This keeps historical/legacy model IDs working after model catalog changes.

## Validation
- `npm run build --workspace=@valuerank/api`
- `npm run build --workspace=@valuerank/web`
