### PR TITLE
fix: resolve Railway DB lint failure in llm query

### DIFF
--- a/cloud/packages/db/src/queries/llm.ts
+++ b/cloud/packages/db/src/queries/llm.ts
@@ -279,7 +279,7 @@ export async function deprecateModel(id: string): Promise<{
 }> {
   log.info({ id }, 'Deprecating model');
 
-  const model = await getModelById(id);
+  await getModelById(id); // Verify exists
   await db.llmModel.update({ where: { id }, data: { status: 'DEPRECATED', isDefault: false } });
 
   return { model: await getModelById(id), newDefault: null };


### PR DESCRIPTION
## Summary
- remove unused `model` variable in `deprecateModel`
- keep existence check via `await getModelById(id)`

## Validation
- `npm run lint --workspace @valuerank/db` (0 errors)
