### PR TITLE
fix: omit probe temperature for target AI runs

### DIFF
--- a/cloud/apps/api/src/queue/handlers/probe-scenario.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-scenario.ts
@@ -134,7 +134,7 @@ type ProbeWorkerInput = {
     followups: Array<{ label: string; prompt: string }>;
   };
   config: {
-    temperature: number;
+    temperature?: number;
     maxTokens: number;
     maxTurns: number;
   };
@@ -309,7 +309,7 @@ async function buildWorkerInput(
   scenarioContent: unknown,
   definitionContent: unknown,
   definitionPreamble: string | undefined, // New argument for fallback
-  config: { temperature: number; maxTurns: number }
+  config: { temperature?: number; maxTurns: number }
 ): Promise<ProbeWorkerInput> {
   // Extract scenario fields (content is JSON in database)
   const content = scenarioContent as Record<string, unknown>;
@@ -340,9 +340,9 @@ async function buildWorkerInput(
       followups,
     },
     config: {
-      temperature: config.temperature,
       maxTokens: 1024, // Default max tokens
       maxTurns: config.maxTurns,
+      ...(typeof config.temperature === 'number' ? { temperature: config.temperature } : {}),
     },
   };
 

--- a/cloud/apps/api/src/queue/types.ts
+++ b/cloud/apps/api/src/queue/types.ts
@@ -15,7 +15,7 @@ export type ProbeScenarioJobData = {
   modelVersion?: string;
   sampleIndex: number; // Index within sample set (0 to N-1) for multi-sample runs
   config: {
-    temperature: number;
+    temperature?: number;
     maxTurns: number;
   };
 };

--- a/cloud/apps/api/src/services/run/recovery.ts
+++ b/cloud/apps/api/src/services/run/recovery.ts
@@ -239,7 +239,6 @@ async function requeueMissingProbes(
         modelId,
         sampleIndex,
         config: {
-          temperature: 0.7,
           maxTurns: 10,
         },
       },

--- a/cloud/apps/api/src/services/run/start.ts
+++ b/cloud/apps/api/src/services/run/start.ts
@@ -367,7 +367,6 @@ export async function startRun(input: StartRunInput): Promise<StartRunResult> {
             modelId,
             sampleIndex,
             config: {
-              temperature: 0.7, // Default, can be configured later
               maxTurns: 10,
             },
           },

--- a/cloud/workers/common/llm_adapters/base.py
+++ b/cloud/workers/common/llm_adapters/base.py
@@ -31,7 +31,7 @@ class BaseLLMAdapter(ABC):
         model: str,
         messages: list[dict[str, str]],
         *,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: int = 1024,
         model_config: Optional[dict] = None,
         timeout: Optional[int] = None,
@@ -41,7 +41,7 @@ class BaseLLMAdapter(ABC):
         Args:
             model: Model identifier
             messages: List of message dicts with 'role' and 'content'
-            temperature: Sampling temperature
+            temperature: Sampling temperature (None omits provider parameter)
             max_tokens: Maximum tokens to generate
             model_config: Optional provider-specific configuration (e.g., API parameter names)
             timeout: HTTP request timeout in seconds (defaults to adapter's timeout)

--- a/cloud/workers/common/llm_adapters/config_utils.py
+++ b/cloud/workers/common/llm_adapters/config_utils.py
@@ -105,8 +105,8 @@ def get_config_value(
 
 def resolve_temperature(
     model_config: Optional[dict],
-    default_temperature: float,
-) -> float:
+    default_temperature: Optional[float],
+) -> Optional[float]:
     """
     Resolve the temperature value from model config.
 
@@ -115,7 +115,7 @@ def resolve_temperature(
         default_temperature: Default value if not specified in config
 
     Returns:
-        The resolved temperature value (0-2)
+        The resolved temperature value (0-2), or None to omit the parameter
     """
     temp = get_config_value(model_config, "temperature", float, 0, 2)
     return temp if temp is not None else default_temperature

--- a/cloud/workers/common/llm_adapters/providers/anthropic.py
+++ b/cloud/workers/common/llm_adapters/providers/anthropic.py
@@ -34,7 +34,7 @@ class AnthropicAdapter(BaseLLMAdapter):
         model: str,
         messages: list[dict[str, str]],
         *,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: int = 1024,
         model_config: Optional[dict] = None,
         timeout: Optional[int] = None,
@@ -77,8 +77,10 @@ class AnthropicAdapter(BaseLLMAdapter):
             "model": model,
             "max_tokens": effective_max_tokens,
             "messages": anthropic_messages,
-            "temperature": resolved_temperature,
         }
+
+        if resolved_temperature is not None:
+            payload["temperature"] = resolved_temperature
 
         if system_parts:
             payload["system"] = "\n\n".join(system_parts)

--- a/cloud/workers/common/llm_adapters/providers/deepseek.py
+++ b/cloud/workers/common/llm_adapters/providers/deepseek.py
@@ -36,7 +36,7 @@ class DeepSeekAdapter(BaseLLMAdapter):
         model: str,
         messages: list[dict[str, str]],
         *,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: int = 1024,
         model_config: Optional[dict] = None,
         timeout: Optional[int] = None,
@@ -66,8 +66,10 @@ class DeepSeekAdapter(BaseLLMAdapter):
         payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "temperature": resolved_temperature,
         }
+
+        if resolved_temperature is not None:
+            payload["temperature"] = resolved_temperature
 
         # Only add max_tokens if not unlimited (None)
         if resolved_max_tokens is not None:
@@ -143,7 +145,7 @@ class DeepSeekAdapter(BaseLLMAdapter):
         model: str,
         messages: list[dict[str, str]],
         *,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: int = 1024,
         model_config: Optional[dict] = None,
         timeout: Optional[int] = None,
@@ -177,10 +179,12 @@ class DeepSeekAdapter(BaseLLMAdapter):
         payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "temperature": resolved_temperature,
             "stream": True,  # Enable streaming
             "stream_options": {"include_usage": True},  # Get token counts in stream
         }
+
+        if resolved_temperature is not None:
+            payload["temperature"] = resolved_temperature
 
         if resolved_max_tokens is not None:
             payload["max_tokens"] = resolved_max_tokens

--- a/cloud/workers/common/llm_adapters/providers/google.py
+++ b/cloud/workers/common/llm_adapters/providers/google.py
@@ -33,7 +33,7 @@ class GeminiAdapter(BaseLLMAdapter):
         model: str,
         messages: list[dict[str, str]],
         *,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: int = 1024,
         model_config: Optional[dict] = None,
         timeout: Optional[int] = None,
@@ -65,9 +65,10 @@ class GeminiAdapter(BaseLLMAdapter):
         resolved_temperature = resolve_temperature(model_config, temperature)
 
         # Build generation config
-        generation_config: dict[str, Any] = {
-            "temperature": resolved_temperature,
-        }
+        generation_config: dict[str, Any] = {}
+
+        if resolved_temperature is not None:
+            generation_config["temperature"] = resolved_temperature
 
         # Only add maxOutputTokens if not unlimited (None)
         # For Gemini 2.5 thinking models, omitting this allows full thinking + output

--- a/cloud/workers/common/llm_adapters/providers/mistral.py
+++ b/cloud/workers/common/llm_adapters/providers/mistral.py
@@ -33,7 +33,7 @@ class MistralAdapter(BaseLLMAdapter):
         model: str,
         messages: list[dict[str, str]],
         *,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: int = 1024,
         model_config: Optional[dict] = None,
         timeout: Optional[int] = None,
@@ -56,8 +56,10 @@ class MistralAdapter(BaseLLMAdapter):
         payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "temperature": resolved_temperature,
         }
+
+        if resolved_temperature is not None:
+            payload["temperature"] = resolved_temperature
 
         # Only add max_tokens if not unlimited (None)
         if resolved_max_tokens is not None:

--- a/cloud/workers/common/llm_adapters/providers/openai.py
+++ b/cloud/workers/common/llm_adapters/providers/openai.py
@@ -33,7 +33,7 @@ class OpenAIAdapter(BaseLLMAdapter):
         model: str,
         messages: list[dict[str, str]],
         *,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: int = 1024,
         model_config: Optional[dict] = None,
         timeout: Optional[int] = None,
@@ -65,8 +65,10 @@ class OpenAIAdapter(BaseLLMAdapter):
         payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "temperature": resolved_temperature,
         }
+
+        if resolved_temperature is not None:
+            payload["temperature"] = resolved_temperature
 
         # Only add max_tokens if not unlimited (None)
         if resolved_max_tokens is not None:

--- a/cloud/workers/common/llm_adapters/providers/xai.py
+++ b/cloud/workers/common/llm_adapters/providers/xai.py
@@ -33,7 +33,7 @@ class XAIAdapter(BaseLLMAdapter):
         model: str,
         messages: list[dict[str, str]],
         *,
-        temperature: float = 0.7,
+        temperature: Optional[float] = None,
         max_tokens: int = 1024,
         model_config: Optional[dict] = None,
         timeout: Optional[int] = None,
@@ -56,8 +56,10 @@ class XAIAdapter(BaseLLMAdapter):
         payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "temperature": resolved_temperature,
         }
+
+        if resolved_temperature is not None:
+            payload["temperature"] = resolved_temperature
 
         # Only add max_tokens if not unlimited (None)
         if resolved_max_tokens is not None:

--- a/cloud/workers/common/llm_adapters/registry.py
+++ b/cloud/workers/common/llm_adapters/registry.py
@@ -117,7 +117,7 @@ def generate(
     model: str,
     messages: list[dict[str, str]],
     *,
-    temperature: float = 0.7,
+    temperature: Optional[float] = None,
     max_tokens: int = 1024,
     model_config: Optional[dict] = None,
     timeout: Optional[int] = None,
@@ -130,7 +130,7 @@ def generate(
     Args:
         model: Model ID (e.g., "gpt-4", "claude-3-sonnet-20240229")
         messages: List of message dicts with 'role' and 'content'
-        temperature: Sampling temperature
+        temperature: Sampling temperature (None omits provider parameter)
         max_tokens: Maximum tokens to generate
         model_config: Optional provider-specific configuration from database
         timeout: HTTP request timeout in seconds (defaults to adapter's default)
@@ -156,7 +156,7 @@ def generate_stream(
     model: str,
     messages: list[dict[str, str]],
     *,
-    temperature: float = 0.7,
+    temperature: Optional[float] = None,
     max_tokens: int = 1024,
     model_config: Optional[dict] = None,
     timeout: Optional[int] = None,
@@ -170,7 +170,7 @@ def generate_stream(
     Args:
         model: Model ID (e.g., "deepseek:deepseek-reasoner")
         messages: List of message dicts with 'role' and 'content'
-        temperature: Sampling temperature
+        temperature: Sampling temperature (None omits provider parameter)
         max_tokens: Maximum tokens to generate
         model_config: Optional provider-specific configuration from database
         timeout: HTTP request timeout in seconds

--- a/cloud/workers/probe.py
+++ b/cloud/workers/probe.py
@@ -18,7 +18,7 @@ Input format (ProbeWorkerInput):
     "followups": [{ "label": string, "prompt": string }]
   },
   "config": {
-    "temperature": number,
+    "temperature": number,  # Optional
     "maxTokens": number,
     "maxTurns": number
   },
@@ -207,7 +207,7 @@ def run_probe(data: dict[str, Any]) -> dict[str, Any]:
     model_cost = data.get("modelCost")  # Optional cost configuration
     model_config = data.get("modelConfig")  # Optional API configuration
 
-    temperature = config.get("temperature", 0.7)
+    temperature = config.get("temperature")
     max_tokens = config.get("maxTokens", 1024)
     max_turns = config.get("maxTurns", 10)
 
@@ -236,12 +236,17 @@ def run_probe(data: dict[str, Any]) -> dict[str, Any]:
     try:
         # Turn 1: Initial prompt
         log.debug("Executing turn 1", modelId=model_id)
+        generate_kwargs: dict[str, Any] = {
+            "max_tokens": max_tokens,
+            "model_config": model_config,
+        }
+        if isinstance(temperature, (int, float)):
+            generate_kwargs["temperature"] = float(temperature)
+
         response = generate(
             model_id,
             messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            model_config=model_config,
+            **generate_kwargs,
         )
 
         turn = Turn(
@@ -283,9 +288,7 @@ def run_probe(data: dict[str, Any]) -> dict[str, Any]:
             response = generate(
                 model_id,
                 messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                model_config=model_config,
+                **generate_kwargs,
             )
 
             turn = Turn(


### PR DESCRIPTION
## Summary
- remove hardcoded probe temperature from run start and recovery job payloads
- make probe job config temperature optional through the queue handler and worker input
- update worker and adapter stack so `temperature` is only sent to providers when explicitly set

## Why
- fixes provider/model combinations (such as OpenAI GPT-5 family) that reject non-default temperature values
- aligns with the requirement to not set temperature for target AI probes

## Validation
- `python3 -m compileall cloud/workers/probe.py cloud/workers/common/llm_adapters`
- `npm run build --workspace @valuerank/api`
