### PR TITLE
fix(google): correctly send maxOutputTokens for Gemini 2.5 Flash models

### DIFF
--- a/cloud/workers/common/llm_adapters/providers/google.py
+++ b/cloud/workers/common/llm_adapters/providers/google.py
@@ -73,7 +73,7 @@ class GeminiAdapter(BaseLLMAdapter):
         # Only add maxOutputTokens if not unlimited (None)
         # For Gemini 2.5 thinking models, omitting this allows full thinking + output
         # (Default 1024 is too low for thinking models)
-        if resolved_max_tokens is not None and not model.startswith("gemini-2.5"):
+        if resolved_max_tokens is not None and "thinking" not in model:
             generation_config["maxOutputTokens"] = resolved_max_tokens
 
         # Add optional config values (Google supports topP and stopSequences)


### PR DESCRIPTION
This PR fixes an issue where maxOutputTokens was being stripped for all Gemini 2.5 models, assuming they were thinking models. It now only strips it if 'thinking' is in the model name.