### PR TITLE
fix: handle null SEM in StabilityTab to prevent crash

### DIFF
--- a/cloud/apps/web/src/components/analysis/tabs/StabilityTab.tsx
+++ b/cloud/apps/web/src/components/analysis/tabs/StabilityTab.tsx
@@ -381,10 +381,10 @@ function ConditionStabilityMatrix({
                                                 <span className="text-gray-300">-</span>
                                             ) : (
                                                 <div className="flex flex-col items-center">
-                                                    {sem === -1 ? (
-                                                        <span className={getSEMTextColor(sem)}>N&lt;2</span>
+                                                    {sem === -1 || sem === null ? (
+                                                        <span className={getSEMTextColor(-1)}>N&lt;2</span>
                                                     ) : (
-                                                        <span className={getSEMTextColor(sem!)}>{sem!.toFixed(3)}</span>
+                                                        <span className={getSEMTextColor(sem)}>{sem.toFixed(3)}</span>
                                                     )}
                                                     <span className="text-[10px] text-gray-400 mt-0.5">n={count}</span>
                                                 </div>


### PR DESCRIPTION
Fixes a production crash when SEM is null due to insufficient samples (N<2). Adds regression test.