### PR TITLE
Decision overrides for transcripts (handle 'other')

### DIFF
--- a/cloud/apps/web/src/api/operations/runs.ts
+++ b/cloud/apps/web/src/api/operations/runs.ts
@@ -370,6 +370,26 @@ export const RESTART_SUMMARIZATION_MUTATION = gql`
   ${RUN_FRAGMENT}
 `;
 
+export const UPDATE_TRANSCRIPT_DECISION_MUTATION = gql`
+  mutation UpdateTranscriptDecision($transcriptId: ID!, $decisionCode: String!) {
+    updateTranscriptDecision(transcriptId: $transcriptId, decisionCode: $decisionCode) {
+      id
+      runId
+      scenarioId
+      modelId
+      modelVersion
+      content
+      decisionCode
+      turnCount
+      tokenCount
+      durationMs
+      estimatedCost
+      createdAt
+      lastAccessedAt
+    }
+  }
+`;
+
 // ============================================================================
 // INPUT TYPES
 // ============================================================================
@@ -498,4 +518,13 @@ export type RestartSummarizationMutationResult = {
     run: Run;
     queuedCount: number;
   };
+};
+
+export type UpdateTranscriptDecisionMutationVariables = {
+  transcriptId: string;
+  decisionCode: string;
+};
+
+export type UpdateTranscriptDecisionMutationResult = {
+  updateTranscriptDecision: Transcript;
 };

--- a/cloud/apps/web/src/components/analysis/PivotAnalysisTable.tsx
+++ b/cloud/apps/web/src/components/analysis/PivotAnalysisTable.tsx
@@ -149,7 +149,7 @@ export function PivotAnalysisTable({ runId, visualizationData, dimensionLabels }
 
     }, [scenarioDimensions, modelScenarioMatrix, rowDim, colDim, selectedModel]);
 
-    const handleCellClick = (row: string, col: string) => {
+    const handleCellClick = (row: string, col: string, options?: { decisionCode?: string }) => {
         const params = new URLSearchParams({
             rowDim,
             colDim,
@@ -157,6 +157,9 @@ export function PivotAnalysisTable({ runId, visualizationData, dimensionLabels }
             col,
             model: selectedModel || '',
         });
+        if (options?.decisionCode) {
+            params.set('decisionCode', options.decisionCode);
+        }
         navigate(`/analysis/${runId}/transcripts?${params.toString()}`);
     };
 
@@ -246,20 +249,21 @@ export function PivotAnalysisTable({ runId, visualizationData, dimensionLabels }
                                     {pivotData.cols.map(col => {
                                         const cell = pivotData.grid[row]?.[col];
                                         const mean = cell && cell.count > 0 ? cell.sum / cell.count : null;
-                                        const canOpen = Boolean(mean);
+                                        const isOtherCell = mean === null;
+                                        const canOpen = true;
 
                                         return (
                                             <td
                                                 key={`${row}-${col}`}
                                                 className={`p-4 border border-gray-100 text-center text-sm transition-colors ${canOpen ? 'cursor-pointer hover:ring-1 hover:ring-teal-300' : ''}`}
                                                 style={{ backgroundColor: mean ? getHeatmapColor(mean) : undefined }}
-                                                onClick={canOpen ? () => handleCellClick(row, col) : undefined}
+                                                onClick={() => handleCellClick(row, col, isOtherCell ? { decisionCode: 'other' } : undefined)}
                                             >
                                                 {mean ? (
                                                     <span className={`font-semibold ${getScoreTextColor(mean)}`}>
                                                         {mean.toFixed(2)}
                                                     </span>
-                                                ) : <span className="text-gray-300">-</span>}
+                                                ) : <span className="text-gray-500">-</span>}
                                             </td>
                                         );
                                     })}

--- a/cloud/apps/web/src/components/analysis/tabs/OverviewTab.tsx
+++ b/cloud/apps/web/src/components/analysis/tabs/OverviewTab.tsx
@@ -206,7 +206,7 @@ function ConditionDecisionMatrix({
     return count > 0 ? sum / count : null;
   };
 
-  const handleCellClick = (modelId: string, row: ConditionRow) => {
+  const handleCellClick = (modelId: string, row: ConditionRow, options?: { decisionCode?: string }) => {
     const params = new URLSearchParams({
       rowDim: attributeA,
       colDim: attributeB,
@@ -214,6 +214,9 @@ function ConditionDecisionMatrix({
       col: row.attributeBLevel,
       model: modelId,
     });
+    if (options?.decisionCode) {
+      params.set('decisionCode', options.decisionCode);
+    }
     const url = `/analysis/${runId}/transcripts?${params.toString()}`;
     navigate(url);
   };
@@ -338,7 +341,8 @@ function ConditionDecisionMatrix({
                 </td>
                 {visibleModels.map((modelId) => {
                   const mean = getMeanDecision(modelId, row.scenarioIds);
-                  const canOpen = mean !== null;
+                  const isOtherCell = mean === null;
+                  const canOpen = true;
                   return (
                     <td
                       key={`${row.id}-${modelId}`}
@@ -347,13 +351,13 @@ function ConditionDecisionMatrix({
                       style={{ backgroundColor: mean === null ? undefined : getHeatmapColor(mean) }}
                       title={
                         canOpen
-                          ? `View transcripts for ${modelId} | ${attributeA}: ${row.attributeALevel}, ${attributeB}: ${row.attributeBLevel}`
-                          : 'No score available'
+                          ? `View transcripts for ${modelId} | ${attributeA}: ${row.attributeALevel}, ${attributeB}: ${row.attributeBLevel}${isOtherCell ? ' | Decision: other' : ''}`
+                          : ''
                       }
-                      onClick={canOpen ? () => handleCellClick(modelId, row) : undefined}
+                      onClick={() => handleCellClick(modelId, row, isOtherCell ? { decisionCode: 'other' } : undefined)}
                     >
                       {mean === null ? (
-                        <span className="text-gray-300">-</span>
+                        <span className="text-gray-500">-</span>
                       ) : (
                         <span className={`font-semibold ${getScoreTextColor(mean)}`}>{mean.toFixed(2)}</span>
                       )}

--- a/cloud/apps/web/src/pages/RunDetail/RunDetail.tsx
+++ b/cloud/apps/web/src/pages/RunDetail/RunDetail.tsx
@@ -65,6 +65,7 @@ export function RunDetail() {
     updateRun,
     cancelSummarization,
     restartSummarization,
+    updateTranscriptDecision,
   } = useRunMutations();
 
   const handleSaveName = useCallback(
@@ -162,6 +163,14 @@ export function RunDetail() {
       return { queuedCount: result.queuedCount };
     },
     [restartSummarization, refetch]
+  );
+
+  const handleUpdateTranscriptDecision = useCallback(
+    async (transcriptId: string, decisionCode: string) => {
+      await updateTranscriptDecision(transcriptId, decisionCode);
+      refetch();
+    },
+    [updateTranscriptDecision, refetch]
   );
 
   // Loading state
@@ -350,6 +359,7 @@ export function RunDetail() {
               onExportTranscripts={() => void handleExportTranscripts()}
               isExportingTranscripts={isExportingTranscripts}
               scenarioDimensions={analysis?.visualizationData?.scenarioDimensions}
+              onUpdateTranscriptDecision={handleUpdateTranscriptDecision}
             />
           </div>
         )}

--- a/cloud/apps/web/src/utils/scenarioUtils.ts
+++ b/cloud/apps/web/src/utils/scenarioUtils.ts
@@ -44,6 +44,7 @@ type FilterTranscriptsForPivotCellInput = {
   row: string;
   col: string;
   selectedModel?: string;
+  decisionCode?: string;
 };
 
 export function filterTranscriptsForPivotCell({
@@ -54,6 +55,7 @@ export function filterTranscriptsForPivotCell({
   row,
   col,
   selectedModel = '',
+  decisionCode,
 }: FilterTranscriptsForPivotCellInput): Transcript[] {
   if (!transcripts.length || !scenarioDimensions || !rowDim || !colDim || !row || !col) {
     return [];
@@ -73,6 +75,7 @@ export function filterTranscriptsForPivotCell({
   const selectedModelNormalized = selectedModel ? normalizeModelId(selectedModel) : '';
 
   return transcripts.filter((transcript) => {
+    if (decisionCode && transcript.decisionCode !== decisionCode) return false;
     if (!transcript.scenarioId) return false;
 
     const transcriptScenarioId = String(transcript.scenarioId);

--- a/cloud/apps/web/tests/components/runs/RunResults.test.tsx
+++ b/cloud/apps/web/tests/components/runs/RunResults.test.tsx
@@ -23,6 +23,7 @@ function createMockTranscript(overrides: Partial<Transcript> = {}): Transcript {
         { role: 'assistant', content: 'Hi there!' },
       ],
     },
+    decisionCode: '3',
     turnCount: 2,
     tokenCount: 100,
     durationMs: 1500,
@@ -195,7 +196,7 @@ describe('RunResults', () => {
     await user.click(screen.getByText('gpt-4'));
 
     // Click on a transcript row (contains scenario text)
-    const transcriptButton = screen.getByText(/Scenario:/);
+    const transcriptButton = screen.getByText('scenario');
     await user.click(transcriptButton);
 
     // Should show transcript viewer modal
@@ -213,7 +214,7 @@ describe('RunResults', () => {
 
     // Open viewer
     await user.click(screen.getByText('gpt-4'));
-    await user.click(screen.getByText(/Scenario:/));
+    await user.click(screen.getByText('scenario'));
 
     // Close viewer
     await user.click(screen.getByRole('button', { name: /close/i }));

--- a/cloud/apps/web/tests/lib/scenarioUtils.test.ts
+++ b/cloud/apps/web/tests/lib/scenarioUtils.test.ts
@@ -52,9 +52,9 @@ describe('scenarioUtils', () => {
 
   it('filters transcripts with exact and normalized scenario/model matches', () => {
     const transcripts = [
-      makeTranscript({ id: 't-1', scenarioId: 'scenario-a', modelId: 'anthropic:claude-sonnet-4-5' }),
-      makeTranscript({ id: 't-2', scenarioId: 'a', modelId: 'claude-sonnet-4-5' }),
-      makeTranscript({ id: 't-3', scenarioId: 'scenario-b', modelId: 'claude-sonnet-4-5' }),
+      makeTranscript({ id: 't-1', scenarioId: 'scenario-a', modelId: 'anthropic:claude-sonnet-4-5', decisionCode: '3' }),
+      makeTranscript({ id: 't-2', scenarioId: 'a', modelId: 'claude-sonnet-4-5', decisionCode: 'other' }),
+      makeTranscript({ id: 't-3', scenarioId: 'scenario-b', modelId: 'claude-sonnet-4-5', decisionCode: '3' }),
     ];
 
     const filtered = filterTranscriptsForPivotCell({
@@ -71,6 +71,28 @@ describe('scenarioUtils', () => {
     });
 
     expect(filtered.map((t) => t.id)).toEqual(['t-1', 't-2']);
+  });
+
+  it('filters transcripts by decisionCode when provided', () => {
+    const transcripts = [
+      makeTranscript({ id: 't-1', scenarioId: 'scenario-a', modelId: 'claude-sonnet-4-5', decisionCode: 'other' }),
+      makeTranscript({ id: 't-2', scenarioId: 'scenario-a', modelId: 'claude-sonnet-4-5', decisionCode: '3' }),
+    ];
+
+    const filtered = filterTranscriptsForPivotCell({
+      transcripts,
+      scenarioDimensions: {
+        'scenario-a': { power: '1', conformity: '1' },
+      },
+      rowDim: 'power',
+      colDim: 'conformity',
+      row: '1',
+      col: '1',
+      selectedModel: 'claude-sonnet-4-5',
+      decisionCode: 'other',
+    });
+
+    expect(filtered.map((t) => t.id)).toEqual(['t-1']);
   });
 
   it('returns empty when required pivot parameters are missing', () => {

--- a/cloud/apps/web/tests/pages/RunDetail.test.tsx
+++ b/cloud/apps/web/tests/pages/RunDetail.test.tsx
@@ -136,6 +136,7 @@ describe('RunDetail', () => {
       updateRun: mockUpdateRun,
       cancelSummarization: vi.fn(),
       restartSummarization: vi.fn(),
+      updateTranscriptDecision: vi.fn(),
       loading: false,
       error: null,
     });


### PR DESCRIPTION
### What
- Add `updateTranscriptDecision` GraphQL mutation to override transcript decision codes to 1-5
- UI: when a transcript decision is `other`, show `other` plus a dropdown to set 1-5 (list rows + viewer + analysis transcripts page)
- Analysis tables: clicking `-` now navigates to transcripts filtered to `decisionCode=other`

### Tests
- `npm run test --workspace=@valuerank/api -- tests/graphql/mutations/run.test.ts`
- `npm run test --workspace=@valuerank/web -- tests/components/runs/TranscriptList.test.tsx tests/components/runs/RunResults.test.tsx tests/lib/scenarioUtils.test.ts`
- `npm run typecheck --workspace=@valuerank/api`
- `npm run typecheck --workspace=@valuerank/web`
