### PR TITLE
Fix: pivot tables all '-' (normalize modelScenarioMatrix keys)

### DIFF
--- a/cloud/apps/api/tests/graphql/queries/analysis-cost.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/analysis-cost.test.ts
@@ -332,7 +332,12 @@ describe('AnalysisResult actualCost', () => {
         output: {
           visualizationData: {
             decisionDistribution: {},
-            modelScenarioMatrix: {},
+            // Simulate older output that keyed scenarios by *name*.
+            modelScenarioMatrix: {
+              'test-model': {
+                [scenario.name]: 3.2,
+              },
+            },
           },
         },
       },
@@ -363,6 +368,9 @@ describe('AnalysisResult actualCost', () => {
       power: '2',
       conformity: '1',
     });
+
+    // Matrix should be normalized to scenario IDs.
+    expect(response.body.data.analysis.visualizationData.modelScenarioMatrix['test-model'][scenario.id]).toBe(3.2);
 
     await db.analysisResult.deleteMany({ where: { runId: run.id } });
     await db.transcript.deleteMany({ where: { runId: run.id } });

--- a/cloud/workers/stats/basic_stats.py
+++ b/cloud/workers/stats/basic_stats.py
@@ -164,8 +164,7 @@ def compute_visualization_data(
 
     for t in transcripts:
         model_id = t.get("modelId", "unknown")
-        scenario = t.get("scenario", {})
-        scenario_name = scenario.get("name", t.get("scenarioId", "unknown"))
+        scenario_id = t.get("scenarioId", "unknown")
         summary = t.get("summary", {})
         score = summary.get("score")
 
@@ -184,17 +183,17 @@ def compute_visualization_data(
         # Build model-scenario matrix
         if model_id not in model_scenario_scores:
             model_scenario_scores[model_id] = {}
-        if scenario_name not in model_scenario_scores[model_id]:
-            model_scenario_scores[model_id][scenario_name] = []
-        model_scenario_scores[model_id][scenario_name].append(float(score))
+        if scenario_id not in model_scenario_scores[model_id]:
+            model_scenario_scores[model_id][scenario_id] = []
+        model_scenario_scores[model_id][scenario_id].append(float(score))
 
     # Compute averages for model-scenario matrix
     model_scenario_matrix: dict[str, dict[str, float]] = {}
     for model_id, scenarios in model_scenario_scores.items():
         model_scenario_matrix[model_id] = {}
-        for scenario_name, scores in scenarios.items():
+        for scenario_id, scores in scenarios.items():
             if scores:
-                model_scenario_matrix[model_id][scenario_name] = round(
+                model_scenario_matrix[model_id][scenario_id] = round(
                     float(np.mean(scores)), 2
                 )
 


### PR DESCRIPTION
### Problem
Pivot/overview tables were showing `-` for every cell because `analysis.output.visualizationData.modelScenarioMatrix` was keyed by scenario *name* (Python worker), while the UI looks up scores by scenario *id*.

### Fix
- Python analyze_basic worker now emits `modelScenarioMatrix` keyed by `scenarioId`.
- GraphQL `AnalysisResult.visualizationData` backfill path now also normalizes legacy matrices (name-keyed -> id-keyed) using the run’s definition scenarios.

### Test
- Extends API integration test to assert legacy name-keyed matrices are normalized.
