### PR TITLE
Fix Start Trial button not enabling after narratives are ready

### DIFF
--- a/cloud/apps/web/src/hooks/useExpandedScenarios.ts
+++ b/cloud/apps/web/src/hooks/useExpandedScenarios.ts
@@ -45,7 +45,7 @@ export function useExpandedScenarios(options: UseExpandedScenariosOptions): UseE
     requestPolicy: 'cache-and-network',
   });
 
-  const [countResult] = useQuery<ScenarioCountQueryResult, ScenarioCountQueryVariables>({
+  const [countResult, reexecuteCount] = useQuery<ScenarioCountQueryResult, ScenarioCountQueryVariables>({
     query: SCENARIO_COUNT_QUERY,
     variables: { definitionId },
     pause: pause || !definitionId,
@@ -61,6 +61,9 @@ export function useExpandedScenarios(options: UseExpandedScenariosOptions): UseE
       : countResult.error
         ? new Error(countResult.error.message)
         : null,
-    refetch: () => reexecuteScenarios({ requestPolicy: 'network-only' }),
+    refetch: () => {
+      reexecuteScenarios({ requestPolicy: 'network-only' });
+      reexecuteCount({ requestPolicy: 'network-only' });
+    },
   };
 }

--- a/cloud/apps/web/src/pages/DefinitionDetail/DefinitionDetail.tsx
+++ b/cloud/apps/web/src/pages/DefinitionDetail/DefinitionDetail.tsx
@@ -56,7 +56,7 @@ export function DefinitionDetail() {
   });
 
   // Fetch scenario count for run form
-  const { totalCount: scenarioCount } = useExpandedScenarios({
+  const { totalCount: scenarioCount, refetch: refetchScenarioCount } = useExpandedScenarios({
     definitionId: id || '',
     pause: isNewDefinition || !id,
     limit: 1,
@@ -73,11 +73,12 @@ export function DefinitionDetail() {
     if (isExpanding && !isNewDefinition && !isEditing) {
       const interval = setInterval(() => {
         refetch();
+        refetchScenarioCount();
       }, 3000);
       return () => clearInterval(interval);
     }
     return undefined;
-  }, [isExpanding, isNewDefinition, isEditing, refetch]);
+  }, [isExpanding, isNewDefinition, isEditing, refetch, refetchScenarioCount]);
 
   const {
     createDefinition,


### PR DESCRIPTION
## Summary
- fix stale scenario count state that could keep Start Trial disabled after narratives finished expanding
- update expanded-scenarios refetch to refresh both scenario list and scenario count queries
- during expansion polling on definition detail, refetch scenario count alongside definition status

## Root cause
Start Trial enablement depends on scenario count. After expansion completion, count could remain stale until another action (like opening Database Narratives) triggered a refresh.

## Validation
- npm run lint --workspace=@valuerank/web
- npm run typecheck --workspace=@valuerank/web

## Notes
- leaves unrelated local change in cloud/Dockerfile.api untouched