### PR TITLE
Add remaining budget column to System Health providers

### DIFF
--- a/cloud/apps/api/src/graphql/queries/health.ts
+++ b/cloud/apps/api/src/graphql/queries/health.ts
@@ -46,6 +46,7 @@ builder.queryField('providerHealth', (t) =>
         providers: result.providers.map((p) => ({
           ...p,
           error: p.error ?? null,
+          remainingBudgetUsd: p.remainingBudgetUsd ?? null,
         })),
       };
     },
@@ -138,11 +139,12 @@ builder.queryField('systemHealth', (t) =>
       return {
         providers: {
           ...providers,
-          providers: providers.providers.map((p) => ({
-            ...p,
-            error: p.error ?? null,
-          })),
-        },
+        providers: providers.providers.map((p) => ({
+          ...p,
+          error: p.error ?? null,
+          remainingBudgetUsd: p.remainingBudgetUsd ?? null,
+        })),
+      },
         queue: {
           ...queue,
           error: queue.error ?? null,

--- a/cloud/apps/api/src/graphql/types/health.ts
+++ b/cloud/apps/api/src/graphql/types/health.ts
@@ -14,6 +14,7 @@ export const ProviderHealthStatusType = builder.objectRef<{
   configured: boolean;
   connected: boolean;
   error: string | null;
+  remainingBudgetUsd: number | null;
   lastChecked: Date | null;
 }>('ProviderHealthStatus').implement({
   description: 'Health status for an LLM provider',
@@ -34,6 +35,11 @@ export const ProviderHealthStatusType = builder.objectRef<{
       nullable: true,
       description: 'Error message if health check failed',
     }),
+    remainingBudgetUsd: t.exposeFloat('remainingBudgetUsd', {
+      nullable: true,
+      description:
+        'Remaining budget in USD when available. For providers with spend-only APIs, this requires a configured monthly cap.',
+    }),
     lastChecked: t.field({
       type: 'DateTime',
       nullable: true,
@@ -51,6 +57,7 @@ export const ProviderHealthType = builder.objectRef<{
     configured: boolean;
     connected: boolean;
     error: string | null;
+    remainingBudgetUsd: number | null;
     lastChecked: Date | null;
   }>;
   checkedAt: Date;
@@ -191,6 +198,7 @@ export const SystemHealthType = builder.objectRef<{
       configured: boolean;
       connected: boolean;
       error: string | null;
+      remainingBudgetUsd: number | null;
       lastChecked: Date | null;
     }>;
     checkedAt: Date;

--- a/cloud/apps/web/src/api/operations/health.ts
+++ b/cloud/apps/web/src/api/operations/health.ts
@@ -10,6 +10,7 @@ export type ProviderHealthStatus = {
   configured: boolean;
   connected: boolean;
   error: string | null;
+  remainingBudgetUsd: number | null;
   lastChecked: string | null;
 };
 
@@ -69,6 +70,7 @@ export const PROVIDER_HEALTH_QUERY = gql`
         configured
         connected
         error
+        remainingBudgetUsd
         lastChecked
       }
       checkedAt
@@ -124,6 +126,7 @@ export const SYSTEM_HEALTH_QUERY = gql`
           configured
           connected
           error
+          remainingBudgetUsd
           lastChecked
         }
         checkedAt

--- a/cloud/apps/web/src/components/settings/ProviderStatus.tsx
+++ b/cloud/apps/web/src/components/settings/ProviderStatus.tsx
@@ -11,6 +11,15 @@ const PROVIDER_COLORS: Record<string, string> = {
   mistral: 'bg-orange-100 text-orange-700',
 };
 
+const PROVIDER_USAGE_DASHBOARD_URLS: Record<string, string> = {
+  openai: 'https://platform.openai.com/usage',
+  anthropic: 'https://console.anthropic.com/settings/cost',
+  google: 'https://console.cloud.google.com/billing',
+  xai: 'https://console.x.ai/',
+  deepseek: 'https://platform.deepseek.com/top_up',
+  mistral: 'https://console.mistral.ai/billing/',
+};
+
 type ProviderStatusProps = {
   providers: ProviderHealthStatus[];
   loading?: boolean;
@@ -52,15 +61,17 @@ function ProviderItem({
   loading?: boolean;
 }) {
   const colorClass = PROVIDER_COLORS[provider.id] ?? 'bg-gray-100 text-gray-700';
+  const usageDashboardUrl = PROVIDER_USAGE_DASHBOARD_URLS[provider.id];
+  const hasBudget = typeof provider.remainingBudgetUsd === 'number' && Number.isFinite(provider.remainingBudgetUsd);
 
   return (
-    <div className="flex items-center justify-between py-3 px-4 border-b border-gray-100 last:border-b-0">
+    <div className="grid grid-cols-[minmax(220px,1fr)_160px_220px] items-center gap-4 py-3 px-4 border-b border-gray-100 last:border-b-0">
       <div className="flex items-center gap-3">
-        <div className={`w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold ${colorClass}`}>
+        <div className={`w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold ${colorClass} flex-shrink-0`}>
           {provider.name.slice(0, 2).toUpperCase()}
         </div>
-        <div>
-          <p className="font-medium text-gray-900">{provider.name}</p>
+        <div className="min-w-0">
+          <p className="font-medium text-gray-900 truncate">{provider.name}</p>
           <p className="text-xs text-gray-500">
             {provider.configured ? (
               provider.connected ? 'Connected' : provider.error ?? 'Connection failed'
@@ -70,7 +81,29 @@ function ProviderItem({
           </p>
         </div>
       </div>
-      <StatusIcon configured={provider.configured} connected={provider.connected} loading={loading} />
+
+      <div className="flex items-center">
+        <StatusIcon configured={provider.configured} connected={provider.connected} loading={loading} />
+      </div>
+
+      <div className="text-sm text-gray-700">
+        {hasBudget ? (
+          <span className="font-medium">
+            ${provider.remainingBudgetUsd!.toFixed(2)}
+          </span>
+        ) : usageDashboardUrl ? (
+          <a
+            href={usageDashboardUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-teal-700 hover:text-teal-800 underline"
+          >
+            Usage dashboard
+          </a>
+        ) : (
+          <span className="text-gray-500">Unavailable</span>
+        )}
+      </div>
     </div>
   );
 }
@@ -88,6 +121,11 @@ export function ProviderStatus({ providers, loading }: ProviderStatusProps) {
         </span>
       </div>
       <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+        <div className="grid grid-cols-[minmax(220px,1fr)_160px_220px] gap-4 px-4 py-2 bg-gray-50 border-b border-gray-200 text-xs font-medium uppercase tracking-wide text-gray-600">
+          <span>Provider</span>
+          <span>Status</span>
+          <span>Remaining Budget</span>
+        </div>
         {providers.map((provider) => (
           <ProviderItem key={provider.id} provider={provider} loading={loading} />
         ))}


### PR DESCRIPTION
## Summary
- add `remainingBudgetUsd` to provider health in API and expose it via GraphQL (`providerHealth` and `systemHealth`)
- implement provider budget fetch logic in health service:
  - DeepSeek: uses `/user/balance` and parses `balance_infos[].total_balance`
  - OpenAI: computes remaining from monthly cap minus MTD spend via `/v1/organization/costs` (when cap + scope are available)
  - Anthropic: computes remaining from monthly cap minus MTD usage report spend (requires admin key)
- update Settings > System Health provider table to show a `Remaining Budget` column
- when remaining budget is unavailable, show provider usage dashboard links

## Config
Optional env vars for cap-based providers:
- `BUDGET_CAP_OPENAI_USD` (or `OPENAI_MONTHLY_BUDGET_USD`)
- `BUDGET_CAP_ANTHROPIC_USD` (or `ANTHROPIC_MONTHLY_BUDGET_USD`)

## Validation
- npm run lint --workspace=@valuerank/api
- npm run typecheck --workspace=@valuerank/api
- npm run lint --workspace=@valuerank/web
- npm run typecheck --workspace=@valuerank/web
- verified local health payload includes `deepseek.remainingBudgetUsd`
