### PR TITLE
Add failed-run system banner for budget and API failures

### DIFF
--- a/cloud/apps/web/tests/pages/RunDetail.test.tsx
+++ b/cloud/apps/web/tests/pages/RunDetail.test.tsx
@@ -391,6 +391,56 @@ describe('RunDetail', () => {
     expect(screen.getByText('Results')).toBeInTheDocument();
   });
 
+  it('shows provider budget banner for budget-related failures', () => {
+    const run = createMockRun({
+      status: 'FAILED',
+      recentTasks: [
+        {
+          scenarioId: 's-1',
+          modelId: 'gpt-5.1',
+          status: 'FAILED',
+          error: 'insufficient_quota: You exceeded your current quota',
+          completedAt: '2024-01-15T10:05:00Z',
+        },
+      ],
+    });
+    vi.mocked(useRun).mockReturnValue({
+      run,
+      loading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    renderWithRouter();
+
+    expect(screen.getByText('OpenAI failure. Check budget.')).toBeInTheDocument();
+  });
+
+  it('shows API budget-check banner for unknown API failures', () => {
+    const run = createMockRun({
+      status: 'FAILED',
+      recentTasks: [
+        {
+          scenarioId: 's-1',
+          modelId: 'gemini-2.5-pro',
+          status: 'FAILED',
+          error: 'HTTP 500 Internal Server Error',
+          completedAt: '2024-01-15T10:05:00Z',
+        },
+      ],
+    });
+    vi.mocked(useRun).mockReturnValue({
+      run,
+      loading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    renderWithRouter();
+
+    expect(screen.getByText('API failure. Check budget.')).toBeInTheDocument();
+  });
+
   it('has back button that navigates to runs list', () => {
     const run = createMockRun();
     vi.mocked(useRun).mockReturnValue({


### PR DESCRIPTION
## Summary
- add a red system banner on Run Detail when a trial fails (`status=FAILED`)
- classify failed runs using recent failed task errors:
  - budget/quota-style failures show `<Provider> failure. Check budget.`
  - unknown API failures show `API failure. Check budget.`
- infer provider from failed `modelId` for OpenAI/Anthropic/Google/DeepSeek/Mistral/xAI

## Testing
- npm run lint --workspace=@valuerank/web
- npm run typecheck --workspace=@valuerank/web
- npm run test --workspace=@valuerank/web -- tests/pages/RunDetail.test.tsx

## Notes
- includes tests for both provider budget failure and unknown API failure banner variants
- leaves unrelated local change in `cloud/Dockerfile.api` untouched
