### PR TITLE
Exclude survey runs from Aggregated Trials and comparison run lists

### DIFF
--- a/cloud/apps/web/src/hooks/useComparisonData.ts
+++ b/cloud/apps/web/src/hooks/useComparisonData.ts
@@ -22,6 +22,7 @@ import type {
   ValueWinRate,
 } from '../components/compare/types';
 import { cohensD } from '../lib/statistics/cohens-d';
+import { isNonSurveyRun } from '../lib/runClassification';
 
 type UseComparisonDataOptions = {
   /** IDs of runs to fetch with full analysis */
@@ -97,7 +98,7 @@ export function useComparisonData(options: UseComparisonDataOptions): UseCompari
 
   // Transform selected runs to RunWithAnalysis type with computed aggregates
   const selectedRuns = useMemo<RunWithAnalysis[]>(() => {
-    const runs = selectedResult.data?.runsWithAnalysis ?? [];
+    const runs = (selectedResult.data?.runsWithAnalysis ?? []).filter(isNonSurveyRun);
 
     // Maintain order of selectedRunIds
     return selectedRunIds

--- a/cloud/apps/web/src/hooks/useInfiniteComparisonRuns.ts
+++ b/cloud/apps/web/src/hooks/useInfiniteComparisonRuns.ts
@@ -13,6 +13,7 @@ import {
   type ComparisonRunsListQueryResult,
 } from '../api/operations/comparison';
 import { useInfiniteQuery, type UseInfiniteQueryResult } from './useInfiniteQuery';
+import { isNonSurveyRun } from '../lib/runClassification';
 
 type UseInfiniteComparisonRunsOptions = {
   definitionId?: string;
@@ -75,8 +76,14 @@ export function useInfiniteComparisonRuns(
     pause,
   });
 
+  const nonSurveyRuns = useMemo(
+    () => result.items.filter(isNonSurveyRun),
+    [result.items]
+  );
+
   return {
     ...result,
-    runs: result.items,
+    items: nonSurveyRuns,
+    runs: nonSurveyRuns,
   };
 }

--- a/cloud/apps/web/src/hooks/useInfiniteRunsWithAnalysis.ts
+++ b/cloud/apps/web/src/hooks/useInfiniteRunsWithAnalysis.ts
@@ -13,6 +13,7 @@ import {
   type RunsQueryResult,
 } from '../api/operations/runs';
 import { useInfiniteQuery, type UseInfiniteQueryResult } from './useInfiniteQuery';
+import { isNonSurveyRun } from '../lib/runClassification';
 
 type UseInfiniteRunsWithAnalysisOptions = {
   analysisStatus?: 'CURRENT' | 'SUPERSEDED';
@@ -73,8 +74,14 @@ export function useInfiniteRunsWithAnalysis(
     pause,
   });
 
+  const nonSurveyRuns = useMemo(
+    () => result.items.filter(isNonSurveyRun),
+    [result.items]
+  );
+
   return {
     ...result,
-    runs: result.items,
+    items: nonSurveyRuns,
+    runs: nonSurveyRuns,
   };
 }

--- a/cloud/apps/web/src/hooks/useRunsWithAnalysis.ts
+++ b/cloud/apps/web/src/hooks/useRunsWithAnalysis.ts
@@ -5,6 +5,7 @@ import {
   type RunsQueryVariables,
   type RunsQueryResult,
 } from '../api/operations/runs';
+import { isNonSurveyRun } from '../lib/runClassification';
 
 type UseRunsWithAnalysisOptions = {
   analysisStatus?: 'CURRENT' | 'SUPERSEDED';
@@ -50,7 +51,7 @@ export function useRunsWithAnalysis(options: UseRunsWithAnalysisOptions = {}): U
   });
 
   return {
-    runs: result.data?.runs ?? [],
+    runs: (result.data?.runs ?? []).filter(isNonSurveyRun),
     loading: result.fetching,
     error: result.error ? new Error(result.error.message) : null,
     refetch: () => reexecuteQuery({ requestPolicy: 'network-only' }),

--- a/cloud/apps/web/src/lib/runClassification.ts
+++ b/cloud/apps/web/src/lib/runClassification.ts
@@ -1,0 +1,15 @@
+type RunLike = {
+  definition?: {
+    name?: string | null;
+  } | null;
+};
+
+const SURVEY_RUN_PREFIX = '[Survey]';
+
+export function isSurveyRun(run: RunLike): boolean {
+  return (run.definition?.name ?? '').startsWith(SURVEY_RUN_PREFIX);
+}
+
+export function isNonSurveyRun(run: RunLike): boolean {
+  return !isSurveyRun(run);
+}


### PR DESCRIPTION
## Summary\n- exclude survey runs from analysis hooks used by Aggregated Trials\n- exclude survey runs from comparison run selection/results data\n- add a shared run classification helper for survey-vs-non-survey filtering\n\n## Validation\n- npm run lint (cloud/apps/web)\n- npm run typecheck (cloud/apps/web)