### PR TITLE
Remove prompt label prefixes from CSV export

### DIFF
--- a/cloud/apps/api/src/services/export/csv.ts
+++ b/cloud/apps/api/src/services/export/csv.ts
@@ -88,7 +88,7 @@ type TranscriptContent = {
 
 /**
  * Extract the probe prompts from transcript content.
- * Combines prompts across turns; includes promptLabel when present.
+ * Combines prompts across turns.
  */
 function getProbePrompt(transcript: TranscriptWithScenario): string {
   const content = transcript.content as TranscriptContent | null;
@@ -97,12 +97,7 @@ function getProbePrompt(transcript: TranscriptWithScenario): string {
   }
 
   const prompts = content.turns
-    .map((turn) => {
-      const prompt = turn.probePrompt ?? '';
-      if (!prompt) return '';
-      const label = (turn.promptLabel ?? '').trim();
-      return label ? `[${label}] ${prompt}` : prompt;
-    })
+    .map((turn) => turn.probePrompt ?? '')
     .filter((p) => p.length > 0);
 
   return prompts.join('\n\n---\n\n');

--- a/cloud/apps/api/tests/routes/export.test.ts
+++ b/cloud/apps/api/tests/routes/export.test.ts
@@ -498,13 +498,13 @@ describe('CSV Serialization Helper', () => {
     };
 
     const row = transcriptToCSVRow(mockTranscript as Parameters<typeof transcriptToCSVRow>[0]);
-    expect(row.probePrompt).toBe('[scenario_prompt] What should I do?\n\n---\n\n[followup_1] Are you sure?');
+    expect(row.probePrompt).toBe('What should I do?\n\n---\n\nAre you sure?');
 
     const formatted = formatCSVRow(row, []);
     // Post-variable columns include Probe Prompt before Target Response.
     expect(formatted).toContain(',1,transcript-id,');
-    expect(formatted).toContain('[scenario_prompt] What should I do?');
-    expect(formatted).toContain('[followup_1] Are you sure?');
+    expect(formatted).toContain('What should I do?');
+    expect(formatted).toContain('Are you sure?');
   });
 
   it('includes sample index in CSV row for multi-sample runs', async () => {


### PR DESCRIPTION
## Summary\n- remove bracketed prompt labels (for example ) from exported CSV probe prompts\n- keep only the raw prompt text for each turn\n- update export route tests to match new CSV output\n\n## Validation\n- npm run test -- tests/routes/export.test.ts (cloud/apps/api)