### PR TITLE
Fix decision-side legend mapping for two-dimension runs

### DIFF
--- a/cloud/apps/web/src/components/analysis/AnalysisPanel.tsx
+++ b/cloud/apps/web/src/components/analysis/AnalysisPanel.tsx
@@ -26,16 +26,7 @@ import {
 import { useAnalysis } from '../../hooks/useAnalysis';
 import { exportRunAsXLSX, getODataFeedUrl, getCSVFeedUrl } from '../../api/export';
 import type { PerModelStats, AnalysisWarning } from '../../api/operations/analysis';
-
-type DefinitionContentShape = {
-  dimensions: Array<{
-    name: string;
-    levels: Array<{
-      score: number;
-      label: string;
-    }>;
-  }>;
-};
+import { deriveDecisionDimensionLabels } from '../../utils/decisionLabels';
 
 type AnalysisPanelProps = {
   runId: string;
@@ -236,63 +227,10 @@ export function AnalysisPanel({
     analysisStatus,
   });
 
-  const dimensionLabels = useMemo(() => {
-    const content = definitionContent as DefinitionContentShape | undefined;
-    if (!content?.dimensions?.length) return undefined;
-
-    // 1. Look for an explicit "Decision" dimension (case-insensitive)
-    const decisionDim = content.dimensions.find(d =>
-      // Check for name "decision" or similar
-      ['decision', 'rubric', 'evaluation'].some(term =>
-        d.name?.toLowerCase() === term
-      )
-    );
-
-    if (decisionDim?.levels?.length === 5) {
-      const labels: Record<string, string> = {};
-      let validCount = 0;
-
-      decisionDim.levels.forEach((level) => {
-        if (level?.score != null && level?.label?.trim()) {
-          labels[String(level.score)] = level.label;
-          validCount++;
-        }
-      });
-
-      // Only use if we got all 5 valid labels
-      if (validCount === 5) return labels;
-    }
-
-    // 2. Derive labels from Attribute names (e.g. "Privacy" vs "Security")
-    // If we have exactly 2 dimensions, assume they are the conflicting values
-    if (content.dimensions.length === 2) {
-      const dim1Name = content.dimensions[0]?.name ?? 'Option A';
-      const dim2Name = content.dimensions[1]?.name ?? 'Option B';
-
-      return {
-        '1': `Strongly Support ${dim1Name}`,
-        '2': `Somewhat Support ${dim1Name}`,
-        '3': 'Neutral',
-        '4': `Somewhat Support ${dim2Name}`,
-        '5': `Strongly Support ${dim2Name}`,
-      };
-    }
-
-    // 3. If 1 dimension, assume it's "Support X" vs "Oppose X"
-    if (content.dimensions.length === 1) {
-      const dimName = content.dimensions[0]?.name ?? 'Attribute';
-      return {
-        '1': `Strongly Support ${dimName}`,
-        '2': `Somewhat Support ${dimName}`,
-        '3': 'Neutral',
-        '4': `Somewhat Oppose ${dimName}`,
-        '5': `Strongly Oppose ${dimName}`,
-      };
-    }
-
-    // 4. Fallback: If we can't be smart, return undefined to use defaults
-    return undefined;
-  }, [definitionContent]);
+  const dimensionLabels = useMemo(
+    () => deriveDecisionDimensionLabels(definitionContent),
+    [definitionContent]
+  );
 
   const [activeTab, setActiveTab] = useState<AnalysisTab>('overview');
   const [filters, setFilters] = useState<FilterState>({

--- a/cloud/apps/web/src/components/analysis/tabs/OverviewTab.tsx
+++ b/cloud/apps/web/src/components/analysis/tabs/OverviewTab.tsx
@@ -11,6 +11,7 @@ import { formatPercent } from './types';
 import type { VisualizationData } from '../../../api/operations/analysis';
 import { Button } from '../../ui/Button';
 import { CopyVisualButton } from '../../ui/CopyVisualButton';
+import { getDecisionSideNames } from '../../../utils/decisionLabels';
 
 type OverviewTabProps = {
   runId: string;
@@ -102,25 +103,6 @@ function getScoreTextColor(value: number): string {
   if (value <= 2.5) return 'text-blue-700';
   if (value >= 3.5) return 'text-orange-700';
   return 'text-gray-700';
-}
-
-function extractAttributeName(label: string): string {
-  const prefixes = [
-    'Strongly Support ',
-    'Somewhat Support ',
-    'Strongly Oppose ',
-    'Somewhat Oppose ',
-  ];
-  for (const prefix of prefixes) {
-    if (label.startsWith(prefix)) return label.slice(prefix.length).trim();
-  }
-  return label.trim();
-}
-
-function getDecisionSideNames(dimensionLabels?: Record<string, string>): { aName: string; bName: string } {
-  const aName = dimensionLabels?.['1'] ? extractAttributeName(dimensionLabels['1']) : 'Attribute A';
-  const bName = dimensionLabels?.['5'] ? extractAttributeName(dimensionLabels['5']) : 'Attribute B';
-  return { aName, bName };
 }
 
 function ConditionDecisionMatrix({

--- a/cloud/apps/web/src/utils/decisionLabels.ts
+++ b/cloud/apps/web/src/utils/decisionLabels.ts
@@ -1,0 +1,85 @@
+type DefinitionContentShape = {
+  dimensions?: Array<{
+    name?: string;
+    levels?: Array<{
+      score?: number;
+      label?: string;
+    }>;
+  }>;
+};
+
+export function extractAttributeName(label: string): string {
+  const prefixes = [
+    'Strongly Support ',
+    'Somewhat Support ',
+    'Strongly Oppose ',
+    'Somewhat Oppose ',
+  ];
+  for (const prefix of prefixes) {
+    if (label.startsWith(prefix)) return label.slice(prefix.length).trim();
+  }
+  return label.trim();
+}
+
+/**
+ * Build decision-code labels (1..5) from definition content.
+ *
+ * For two-attribute definitions, score direction follows probe prompts:
+ * - 5 supports option A (first attribute)
+ * - 1 supports option B (second attribute)
+ */
+export function deriveDecisionDimensionLabels(
+  definitionContent: unknown
+): Record<string, string> | undefined {
+  const content = definitionContent as DefinitionContentShape | undefined;
+  if (!content?.dimensions?.length) return undefined;
+
+  const decisionDim = content.dimensions.find((dimension) => (
+    ['decision', 'rubric', 'evaluation'].some((term) => dimension.name?.toLowerCase() === term)
+  ));
+
+  if (decisionDim?.levels?.length === 5) {
+    const labels: Record<string, string> = {};
+    let validCount = 0;
+    decisionDim.levels.forEach((level) => {
+      if (level?.score != null && level?.label?.trim()) {
+        labels[String(level.score)] = level.label;
+        validCount++;
+      }
+    });
+    if (validCount === 5) return labels;
+  }
+
+  if (content.dimensions.length === 2) {
+    const optionAName = content.dimensions[0]?.name ?? 'Option A';
+    const optionBName = content.dimensions[1]?.name ?? 'Option B';
+    return {
+      '1': `Strongly Support ${optionBName}`,
+      '2': `Somewhat Support ${optionBName}`,
+      '3': 'Neutral',
+      '4': `Somewhat Support ${optionAName}`,
+      '5': `Strongly Support ${optionAName}`,
+    };
+  }
+
+  if (content.dimensions.length === 1) {
+    const dimName = content.dimensions[0]?.name ?? 'Attribute';
+    return {
+      '1': `Strongly Support ${dimName}`,
+      '2': `Somewhat Support ${dimName}`,
+      '3': 'Neutral',
+      '4': `Somewhat Oppose ${dimName}`,
+      '5': `Strongly Oppose ${dimName}`,
+    };
+  }
+
+  return undefined;
+}
+
+export function getDecisionSideNames(
+  dimensionLabels?: Record<string, string>
+): { aName: string; bName: string } {
+  const aName = dimensionLabels?.['1'] ? extractAttributeName(dimensionLabels['1']) : 'Attribute A';
+  const bName = dimensionLabels?.['5'] ? extractAttributeName(dimensionLabels['5']) : 'Attribute B';
+  return { aName, bName };
+}

--- a/cloud/apps/web/tests/lib/decisionLabels.test.ts
+++ b/cloud/apps/web/tests/lib/decisionLabels.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveDecisionDimensionLabels,
+  getDecisionSideNames,
+} from '../../src/utils/decisionLabels';
+
+describe('decisionLabels', () => {
+  it('derives score labels from explicit decision dimension when present', () => {
+    const labels = deriveDecisionDimensionLabels({
+      dimensions: [
+        {
+          name: 'Decision',
+          levels: [
+            { score: 1, label: 'Strongly Support B' },
+            { score: 2, label: 'Somewhat Support B' },
+            { score: 3, label: 'Neutral' },
+            { score: 4, label: 'Somewhat Support A' },
+            { score: 5, label: 'Strongly Support A' },
+          ],
+        },
+      ],
+    });
+
+    expect(labels?.['1']).toBe('Strongly Support B');
+    expect(labels?.['5']).toBe('Strongly Support A');
+  });
+
+  it('maps two-attribute definitions to score direction used in probe prompts', () => {
+    const labels = deriveDecisionDimensionLabels({
+      dimensions: [
+        { name: 'Self_Direction_Action', levels: [] },
+        { name: 'Achievement', levels: [] },
+      ],
+    });
+
+    expect(labels).toEqual({
+      '1': 'Strongly Support Achievement',
+      '2': 'Somewhat Support Achievement',
+      '3': 'Neutral',
+      '4': 'Somewhat Support Self_Direction_Action',
+      '5': 'Strongly Support Self_Direction_Action',
+    });
+  });
+
+  it('computes side names from score-1 and score-5 labels', () => {
+    const names = getDecisionSideNames({
+      '1': 'Strongly Support Achievement',
+      '5': 'Strongly Support Self_Direction_Action',
+    });
+
+    expect(names.aName).toBe('Achievement');
+    expect(names.bName).toBe('Self_Direction_Action');
+  });
+});


### PR DESCRIPTION
## Summary
- fix derived decision labels for two-dimension definitions so score direction matches probe prompts
- centralize decision-label logic in a shared web utility and reuse it across analysis views
- align transcript bucket label rendering with overview bucket labels
- add regression tests for two-dimension label derivation and side-name extraction

## Root Cause
For definitions with exactly two value dimensions and no explicit Decision/Rubric dimension, we inferred labels as:
- 1/2 -> first dimension
- 4/5 -> second dimension

But probe prompts are scored in the opposite direction:
- 5/4 support option A (first dimension)
- 1/2 support option B (second dimension)

This inverted legend and "Favors" labels in analysis bucket views.

## Validation
- `cd cloud/apps/web && npm run test -- tests/lib/decisionLabels.test.ts`
- `cd cloud/apps/web && npm run typecheck`
- `cd cloud/apps/web && npm run lint`
