### PR TITLE
Fix Railway API lint warnings for surveys

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/survey.ts
+++ b/cloud/apps/api/src/graphql/mutations/survey.ts
@@ -158,7 +158,7 @@ function buildSurveyPrompt(
   const optionLines = responseOptions.map((option) => option.label.trim()).filter((label) => label !== '');
 
   const sections: string[] = [];
-  if (instructions && instructions.trim() !== '') {
+  if (typeof instructions === 'string' && instructions.trim() !== '') {
     sections.push(instructions.trim());
   }
   sections.push(questionText);
@@ -178,13 +178,15 @@ function buildSurveyPlan(
   instructions?: string,
   description?: string
 ): SurveyPlan {
+  const normalizedDescription = typeof description === 'string' ? description.trim() : '';
+  const normalizedInstructions = typeof instructions === 'string' ? instructions.trim() : '';
   return {
     kind: 'survey',
     version,
     surveyKey,
     definitionId,
-    ...(description && description.trim() !== '' ? { description: description.trim() } : {}),
-    ...(instructions && instructions.trim() !== '' ? { instructions: instructions.trim() } : {}),
+    ...(normalizedDescription !== '' ? { description: normalizedDescription } : {}),
+    ...(normalizedInstructions !== '' ? { instructions: normalizedInstructions } : {}),
     responseOptions,
     questions,
   };
@@ -255,8 +257,8 @@ builder.mutationField('createSurvey', (t) =>
     },
     resolve: async (_root, args, ctx) => {
       const name = args.input.name.trim();
-      const description = args.input.description?.trim() || '';
-      const instructions = args.input.instructions?.trim() || '';
+      const description = typeof args.input.description === 'string' ? args.input.description.trim() : '';
+      const instructions = typeof args.input.instructions === 'string' ? args.input.instructions.trim() : '';
       const questions = normalizeQuestions(args.input.questions);
       const responseOptions = normalizeResponseOptions(args.input.responseOptions);
 
@@ -326,12 +328,13 @@ builder.mutationField('updateSurvey', (t) =>
         analysisPlan: existing.analysisPlan,
       });
 
-      const nextName = args.input.name?.trim() || parsed.name;
+      const trimmedInputName = typeof args.input.name === 'string' ? args.input.name.trim() : '';
+      const nextName = trimmedInputName !== '' ? trimmedInputName : parsed.name;
       const nextDescription = args.input.description !== undefined
-        ? (args.input.description?.trim() || '')
+        ? (typeof args.input.description === 'string' ? args.input.description.trim() : '')
         : parsed.description;
       const nextInstructions = args.input.instructions !== undefined
-        ? (args.input.instructions?.trim() || '')
+        ? (typeof args.input.instructions === 'string' ? args.input.instructions.trim() : '')
         : parsed.instructions;
       const nextQuestions = args.input.questions
         ? normalizeQuestions(args.input.questions)
@@ -420,7 +423,8 @@ builder.mutationField('duplicateSurvey', (t) =>
         analysisPlan: existing.analysisPlan,
       });
 
-      const duplicateName = args.name?.trim() || `${parsed.name} (Copy)`;
+      const trimmedDuplicateName = typeof args.name === 'string' ? args.name.trim() : '';
+      const duplicateName = trimmedDuplicateName !== '' ? trimmedDuplicateName : `${parsed.name} (Copy)`;
       const surveyKey = randomUUID();
 
       const duplicated = await db.$transaction(async (tx) => {

--- a/cloud/apps/api/src/graphql/queries/survey.ts
+++ b/cloud/apps/api/src/graphql/queries/survey.ts
@@ -7,7 +7,7 @@ type SurveyPlan = {
 };
 
 function isSurveyExperiment(analysisPlan: unknown): boolean {
-  if (!analysisPlan || typeof analysisPlan !== 'object') {
+  if (analysisPlan === null || analysisPlan === undefined || typeof analysisPlan !== 'object') {
     return false;
   }
   const plan = analysisPlan as SurveyPlan;
@@ -25,11 +25,12 @@ builder.queryField('surveys', (t) =>
       }),
     },
     resolve: async (_root, args, ctx) => {
+      const search = typeof args.search === 'string' ? args.search.trim() : '';
       const experiments = await db.experiment.findMany({
-        where: args.search && args.search.trim() !== ''
+        where: search !== ''
           ? {
             name: {
-              contains: args.search.trim(),
+              contains: search,
               mode: 'insensitive',
             },
           }
@@ -58,7 +59,7 @@ builder.queryField('survey', (t) =>
         where: { id: surveyId },
       });
 
-      if (!experiment || !isSurveyExperiment(experiment.analysisPlan)) {
+      if (experiment === null || !isSurveyExperiment(experiment.analysisPlan)) {
         ctx.log.debug({ surveyId }, 'Survey not found');
         return null;
       }


### PR DESCRIPTION
## What this PR does
This PR fixes the remaining survey-related lint warnings that were causing noisy Railway/API lint output.

## Changes made
- Updated survey mutation code to handle optional strings explicitly instead of relying on truthy checks.
- Updated survey query checks to use explicit null/undefined handling.
- Kept behavior the same; this is a lint-safety cleanup only.

## Why this matters
The API lint step now runs cleanly, which prevents warning/error confusion in CI and Railway deploy logs.

## Verification
- Ran `npm run lint` in `cloud/apps/api`
- Result: no lint errors or warnings