### PR TITLE
Fix transcript axis labels to always match scenario attributes

### DIFF
--- a/cloud/apps/web/src/utils/decisionLabels.ts
+++ b/cloud/apps/web/src/utils/decisionLabels.ts
@@ -333,6 +333,8 @@ export function resolveScenarioAxisDimensions(
   requestedRowDim: string,
   requestedColDim: string
 ): { rowDim: string; colDim: string } {
+  // URL params can be stale (bookmarks/shared links) after scenario attributes change.
+  // Always resolve to currently available attributes, and avoid duplicate row/col axes.
   if (availableAttributes.length === 0) {
     return { rowDim: requestedRowDim, colDim: requestedColDim };
   }

--- a/cloud/apps/web/tests/lib/decisionLabels.test.ts
+++ b/cloud/apps/web/tests/lib/decisionLabels.test.ts
@@ -149,4 +149,30 @@ describe('decisionLabels', () => {
       colDim: 'Societal_Security',
     });
   });
+
+  it('returns requested axes unchanged when scenario attributes are unavailable', () => {
+    const resolved = resolveScenarioAxisDimensions(
+      [],
+      'Benevolence_Dependability',
+      'Self_Direction_Action'
+    );
+
+    expect(resolved).toEqual({
+      rowDim: 'Benevolence_Dependability',
+      colDim: 'Self_Direction_Action',
+    });
+  });
+
+  it('falls back to first and second attributes when both requested axes are invalid', () => {
+    const resolved = resolveScenarioAxisDimensions(
+      ['Benevolence_Dependability', 'Societal_Security', 'Achievement'],
+      'Invalid_Row',
+      'Invalid_Col'
+    );
+
+    expect(resolved).toEqual({
+      rowDim: 'Benevolence_Dependability',
+      colDim: 'Societal_Security',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- resolve transcript `rowDim`/`colDim` against actual scenario attributes before rendering/filtering
- prevent stale or invalid URL dims from showing incorrect attribute labels in transcript views
- reuse resolved axes for decision bucket labeling and transcript filtering logic
- add tests for invalid/duplicate axis resolution behavior

## Why
Some transcript links carried stale `colDim` values (for example `Self_Direction_Action`) that were not present in the run's scenario dimensions, causing incorrect axis labels in the UI.

## Files
- `/Users/chrislaw/valuerank-main-sync/cloud/apps/web/src/pages/AnalysisTranscripts.tsx`
- `/Users/chrislaw/valuerank-main-sync/cloud/apps/web/src/utils/decisionLabels.ts`
- `/Users/chrislaw/valuerank-main-sync/cloud/apps/web/tests/lib/decisionLabels.test.ts`

## Validation
- `npm run -w @valuerank/web test -- tests/lib/decisionLabels.test.ts`
- `npx turbo build --filter=@valuerank/web`
