### PR TITLE
Add infinite scroll to Definitions (Vignettes) page

### DIFF
--- a/cloud/apps/web/src/api/operations/definitions.ts
+++ b/cloud/apps/web/src/api/operations/definitions.ts
@@ -373,6 +373,13 @@ export const DELETE_DEFINITION_MUTATION = gql`
   }
 `;
 
+// Count of definitions matching filters
+export const DEFINITION_COUNT_QUERY = gql`
+  query DefinitionCount($rootOnly: Boolean, $search: String, $tagIds: [ID!], $hasRuns: Boolean) {
+    definitionCount(rootOnly: $rootOnly, search: $search, tagIds: $tagIds, hasRuns: $hasRuns)
+  }
+`;
+
 // ============================================================================
 // QUERY RESULT TYPES
 // ============================================================================
@@ -388,6 +395,17 @@ export type DefinitionsQueryVariables = {
 
 export type DefinitionsQueryResult = {
   definitions: Definition[];
+};
+
+export type DefinitionCountQueryVariables = {
+  rootOnly?: boolean;
+  search?: string;
+  tagIds?: string[];
+  hasRuns?: boolean;
+};
+
+export type DefinitionCountQueryResult = {
+  definitionCount: number;
 };
 
 export type DefinitionQueryVariables = {

--- a/cloud/apps/web/src/hooks/useInfiniteComparisonRuns.ts
+++ b/cloud/apps/web/src/hooks/useInfiniteComparisonRuns.ts
@@ -12,6 +12,10 @@ import {
   type ComparisonRunsListQueryVariables,
   type ComparisonRunsListQueryResult,
 } from '../api/operations/comparison';
+import {
+  RUN_COUNT_QUERY,
+  type RunCountQueryResult,
+} from '../api/operations/runs';
 import { useInfiniteQuery, type UseInfiniteQueryResult } from './useInfiniteQuery';
 import { isNonSurveyRun } from '../lib/runClassification';
 
@@ -46,9 +50,9 @@ export function useInfiniteComparisonRuns(
     [definitionId, analysisStatus]
   );
 
-  // Count query filters
+  // Count query variables
   // Note: hasAnalysis needs to be passed for runCount query
-  const countFilters = useMemo(
+  const countVariables = useMemo(
     () => ({
       hasAnalysis: true as const,
       definitionId: definitionId || undefined,
@@ -63,6 +67,11 @@ export function useInfiniteComparisonRuns(
     []
   );
 
+  const getCount = useCallback(
+    (data: unknown) => (data as RunCountQueryResult).runCount,
+    []
+  );
+
   const result = useInfiniteQuery<
     ComparisonRunsListQueryResult,
     ComparisonRunsListQueryVariables,
@@ -71,7 +80,9 @@ export function useInfiniteComparisonRuns(
     query: COMPARISON_RUNS_LIST_QUERY,
     filters,
     getItems,
-    countFilters,
+    countQuery: RUN_COUNT_QUERY,
+    countVariables,
+    getCount,
     pageSize,
     pause,
   });

--- a/cloud/apps/web/src/hooks/useInfiniteDefinitions.ts
+++ b/cloud/apps/web/src/hooks/useInfiniteDefinitions.ts
@@ -1,0 +1,101 @@
+/**
+ * useInfiniteDefinitions Hook
+ *
+ * Hook for infinite scrolling through definitions (vignettes).
+ * Wraps the generic useInfiniteQuery with definition-specific configuration.
+ */
+
+import { useMemo, useCallback } from 'react';
+import {
+  DEFINITIONS_QUERY,
+  DEFINITION_COUNT_QUERY,
+  type Definition,
+  type DefinitionsQueryVariables,
+  type DefinitionsQueryResult,
+  type DefinitionCountQueryResult,
+} from '../api/operations/definitions';
+import { useInfiniteQuery, type UseInfiniteQueryResult } from './useInfiniteQuery';
+
+type UseInfiniteDefinitionsOptions = {
+  search?: string;
+  rootOnly?: boolean;
+  tagIds?: string[];
+  hasRuns?: boolean;
+  pageSize?: number;
+  pause?: boolean;
+};
+
+type UseInfiniteDefinitionsResult = UseInfiniteQueryResult<Definition> & {
+  /** Alias for items to match previous API */
+  definitions: Definition[];
+};
+
+/**
+ * Hook for infinite scrolling through definitions.
+ * Loads pages incrementally and concatenates results.
+ */
+export function useInfiniteDefinitions(
+  options: UseInfiniteDefinitionsOptions = {}
+): UseInfiniteDefinitionsResult {
+  const {
+    search,
+    rootOnly,
+    tagIds,
+    hasRuns,
+    pageSize,
+    pause = false,
+  } = options;
+
+  // Build filters object
+  const filters = useMemo(
+    () => ({
+      search: search || undefined,
+      rootOnly: rootOnly || undefined,
+      tagIds: tagIds?.length ? tagIds : undefined,
+      hasRuns: hasRuns || undefined,
+    }),
+    [search, rootOnly, tagIds, hasRuns]
+  );
+
+  // Count query variables (same filters, no limit/offset)
+  const countVariables = useMemo(
+    () => ({
+      search: search || undefined,
+      rootOnly: rootOnly || undefined,
+      tagIds: tagIds?.length ? tagIds : undefined,
+      hasRuns: hasRuns || undefined,
+    }),
+    [search, rootOnly, tagIds, hasRuns]
+  );
+
+  // Extract definitions from query result
+  const getItems = useCallback(
+    (data: DefinitionsQueryResult) => data.definitions ?? [],
+    []
+  );
+
+  const getCount = useCallback(
+    (data: unknown) => (data as DefinitionCountQueryResult).definitionCount,
+    []
+  );
+
+  const result = useInfiniteQuery<
+    DefinitionsQueryResult,
+    DefinitionsQueryVariables,
+    Definition
+  >({
+    query: DEFINITIONS_QUERY,
+    filters,
+    getItems,
+    countQuery: DEFINITION_COUNT_QUERY,
+    countVariables,
+    getCount,
+    pageSize,
+    pause,
+  });
+
+  return {
+    ...result,
+    definitions: result.items,
+  };
+}

--- a/cloud/apps/web/src/hooks/useInfiniteRuns.ts
+++ b/cloud/apps/web/src/hooks/useInfiniteRuns.ts
@@ -8,9 +8,11 @@
 import { useMemo, useCallback } from 'react';
 import {
   RUNS_QUERY,
+  RUN_COUNT_QUERY,
   type Run,
   type RunsQueryVariables,
   type RunsQueryResult,
+  type RunCountQueryResult,
 } from '../api/operations/runs';
 import { useInfiniteQuery, type UseInfiniteQueryResult } from './useInfiniteQuery';
 
@@ -58,8 +60,8 @@ export function useInfiniteRuns(options: UseInfiniteRunsOptions = {}): UseInfini
     [definitionId, experimentId, status, runTypeFilter]
   );
 
-  // Count query filters
-  const countFilters = useMemo(
+  // Count query variables
+  const countVariables = useMemo(
     () => ({
       definitionId: definitionId || undefined,
       experimentId: experimentId || undefined,
@@ -75,11 +77,18 @@ export function useInfiniteRuns(options: UseInfiniteRunsOptions = {}): UseInfini
     []
   );
 
+  const getCount = useCallback(
+    (data: unknown) => (data as RunCountQueryResult).runCount,
+    []
+  );
+
   const result = useInfiniteQuery<RunsQueryResult, RunsQueryVariables, Run>({
     query: RUNS_QUERY,
     filters,
     getItems,
-    countFilters,
+    countQuery: RUN_COUNT_QUERY,
+    countVariables,
+    getCount,
     pageSize,
     pause,
   });

--- a/cloud/apps/web/src/hooks/useInfiniteRunsWithAnalysis.ts
+++ b/cloud/apps/web/src/hooks/useInfiniteRunsWithAnalysis.ts
@@ -8,9 +8,11 @@
 import { useMemo, useCallback } from 'react';
 import {
   RUNS_QUERY,
+  RUN_COUNT_QUERY,
   type Run,
   type RunsQueryVariables,
   type RunsQueryResult,
+  type RunCountQueryResult,
 } from '../api/operations/runs';
 import { useInfiniteQuery, type UseInfiniteQueryResult } from './useInfiniteQuery';
 import { isNonSurveyRun } from '../lib/runClassification';
@@ -48,8 +50,8 @@ export function useInfiniteRunsWithAnalysis(
     [analysisStatus, definitionId, experimentId]
   );
 
-  // Count query filters
-  const countFilters = useMemo(
+  // Count query variables
+  const countVariables = useMemo(
     () => ({
       hasAnalysis: true as const,
       analysisStatus: analysisStatus || undefined,
@@ -65,11 +67,18 @@ export function useInfiniteRunsWithAnalysis(
     []
   );
 
+  const getCount = useCallback(
+    (data: unknown) => (data as RunCountQueryResult).runCount,
+    []
+  );
+
   const result = useInfiniteQuery<RunsQueryResult, RunsQueryVariables, Run>({
     query: RUNS_QUERY,
     filters,
     getItems,
-    countFilters,
+    countQuery: RUN_COUNT_QUERY,
+    countVariables,
+    getCount,
     pageSize,
     pause,
   });

--- a/cloud/apps/web/src/pages/Definitions.tsx
+++ b/cloud/apps/web/src/pages/Definitions.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DefinitionList } from '../components/definitions/DefinitionList';
 import { type DefinitionFilterState } from '../components/definitions/DefinitionFilters';
-import { useDefinitions } from '../hooks/useDefinitions';
+import { useInfiniteDefinitions } from '../hooks/useInfiniteDefinitions';
 
 const defaultFilters: DefinitionFilterState = {
   search: '',
@@ -15,12 +15,13 @@ export function Definitions() {
   const navigate = useNavigate();
   const [filters, setFilters] = useState<DefinitionFilterState>(defaultFilters);
 
-  const { definitions, loading, error } = useDefinitions({
-    search: filters.search || undefined,
-    rootOnly: filters.rootOnly || undefined,
-    hasRuns: filters.hasRuns || undefined,
-    tagIds: filters.tagIds.length > 0 ? filters.tagIds : undefined,
-  });
+  const { definitions, loading, loadingMore, error, hasNextPage, totalCount, loadMore } =
+    useInfiniteDefinitions({
+      search: filters.search || undefined,
+      rootOnly: filters.rootOnly || undefined,
+      hasRuns: filters.hasRuns || undefined,
+      tagIds: filters.tagIds.length > 0 ? filters.tagIds : undefined,
+    });
 
   const handleCreateNew = () => {
     navigate('/definitions/new');
@@ -32,7 +33,11 @@ export function Definitions() {
       <DefinitionList
         definitions={definitions}
         loading={loading}
+        loadingMore={loadingMore}
         error={error}
+        hasNextPage={hasNextPage}
+        totalCount={totalCount}
+        onLoadMore={loadMore}
         onCreateNew={handleCreateNew}
         filters={filters}
         onFiltersChange={setFilters}

--- a/cloud/apps/web/tests/components/definitions/DefinitionList.test.tsx
+++ b/cloud/apps/web/tests/components/definitions/DefinitionList.test.tsx
@@ -40,6 +40,7 @@ function createMockClient() {
 function renderDefinitionList(props: {
   definitions: Definition[];
   loading: boolean;
+  loadingMore?: boolean;
   error: Error | null;
   onCreateNew?: () => void;
 }) {
@@ -64,12 +65,13 @@ describe('DefinitionList', () => {
       expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
     });
 
-    it('should show "Loading more..." when loading with existing definitions', async () => {
+    it('should show "Loading more..." when loadingMore with existing definitions', async () => {
       const user = userEvent.setup();
       const definitions = [createMockDefinition()];
       renderDefinitionList({
         definitions,
-        loading: true,
+        loading: false,
+        loadingMore: true,
         error: null,
       });
       // Switch to flat view to see loading indicator with definitions

--- a/cloud/apps/web/tests/pages/Definitions.test.tsx
+++ b/cloud/apps/web/tests/pages/Definitions.test.tsx
@@ -3,13 +3,19 @@ import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { Definitions } from '../../src/pages/Definitions';
 
-// Mock the useDefinitions hook
-vi.mock('../../src/hooks/useDefinitions', () => ({
-  useDefinitions: () => ({
+// Mock the useInfiniteDefinitions hook
+vi.mock('../../src/hooks/useInfiniteDefinitions', () => ({
+  useInfiniteDefinitions: () => ({
     definitions: [],
+    items: [],
     loading: false,
+    loadingMore: false,
     error: null,
+    hasNextPage: false,
+    totalCount: 0,
+    loadMore: vi.fn(),
     refetch: vi.fn(),
+    softRefetch: vi.fn(),
   }),
 }));
 


### PR DESCRIPTION
## Summary
- Adds offset-based infinite scrolling to the Definitions page, which previously only showed the first 20 vignettes with no pagination
- Generalizes `useInfiniteQuery` to accept any count query (was hardcoded to `RUN_COUNT_QUERY`), enabling reuse for definitions
- Shows "Showing X of Y vignettes" count display and an IntersectionObserver sentinel for automatic page loading

## Changes
- **New file:** `useInfiniteDefinitions.ts` - wraps `useInfiniteQuery` with definition-specific config
- **`useInfiniteQuery.ts`** - replaced hardcoded `RUN_COUNT_QUERY` with generic `countQuery`/`getCount` params
- **`useInfiniteRuns.ts`, `useInfiniteComparisonRuns.ts`, `useInfiniteRunsWithAnalysis.ts`** - updated for the new generic API
- **`definitions.ts`** - added `DEFINITION_COUNT_QUERY` GraphQL query and types
- **`Definitions.tsx`** - switched from `useDefinitions` to `useInfiniteDefinitions`
- **`DefinitionList.tsx`** - added sentinel div, IntersectionObserver, total count display, "All vignettes loaded" indicator
- **Tests** - updated mocks and assertions for the new hook

## Test plan
- [x] `npx turbo run test` - all 3,061 tests pass (shared:59, db:255, web:1,193, api:1,554)
- [x] `npx turbo run lint --filter=@valuerank/web` - 0 errors (3 pre-existing warnings in unrelated file)
- [ ] Manual: open Definitions page, confirm all 45+ Jobs vignettes load as you scroll
- [ ] Manual: verify "Showing X of Y vignettes" count displays correctly
- [ ] Manual: verify folder view also triggers infinite scroll
- [ ] Manual: verify search/filter changes reset scroll and show correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)