### PR TITLE
fix(web): eagerly load all definitions instead of infinite scroll

### DIFF
--- a/cloud/apps/web/src/pages/Definitions.tsx
+++ b/cloud/apps/web/src/pages/Definitions.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DefinitionList } from '../components/definitions/DefinitionList';
 import { type DefinitionFilterState } from '../components/definitions/DefinitionFilters';
-import { useInfiniteDefinitions } from '../hooks/useInfiniteDefinitions';
+import { useDefinitions } from '../hooks/useDefinitions';
 
 const defaultFilters: DefinitionFilterState = {
   search: '',
@@ -15,13 +15,13 @@ export function Definitions() {
   const navigate = useNavigate();
   const [filters, setFilters] = useState<DefinitionFilterState>(defaultFilters);
 
-  const { definitions, loading, loadingMore, error, hasNextPage, totalCount, loadMore } =
-    useInfiniteDefinitions({
-      search: filters.search || undefined,
-      rootOnly: filters.rootOnly || undefined,
-      hasRuns: filters.hasRuns || undefined,
-      tagIds: filters.tagIds.length > 0 ? filters.tagIds : undefined,
-    });
+  const { definitions, loading, error } = useDefinitions({
+    search: filters.search || undefined,
+    rootOnly: filters.rootOnly || undefined,
+    hasRuns: filters.hasRuns || undefined,
+    tagIds: filters.tagIds.length > 0 ? filters.tagIds : undefined,
+    limit: 1000,
+  });
 
   const handleCreateNew = () => {
     navigate('/definitions/new');
@@ -33,11 +33,7 @@ export function Definitions() {
       <DefinitionList
         definitions={definitions}
         loading={loading}
-        loadingMore={loadingMore}
         error={error}
-        hasNextPage={hasNextPage}
-        totalCount={totalCount}
-        onLoadMore={loadMore}
         onCreateNew={handleCreateNew}
         filters={filters}
         onFiltersChange={setFilters}

--- a/cloud/apps/web/tests/components/definitions/DefinitionList.test.tsx
+++ b/cloud/apps/web/tests/components/definitions/DefinitionList.test.tsx
@@ -40,7 +40,6 @@ function createMockClient() {
 function renderDefinitionList(props: {
   definitions: Definition[];
   loading: boolean;
-  loadingMore?: boolean;
   error: Error | null;
   onCreateNew?: () => void;
 }) {
@@ -65,19 +64,6 @@ describe('DefinitionList', () => {
       expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
     });
 
-    it('should show "Loading more..." when loadingMore with existing definitions', async () => {
-      const user = userEvent.setup();
-      const definitions = [createMockDefinition()];
-      renderDefinitionList({
-        definitions,
-        loading: false,
-        loadingMore: true,
-        error: null,
-      });
-      // Switch to flat view to see loading indicator with definitions
-      await user.click(screen.getByRole('button', { name: /list view/i }));
-      expect(screen.getByText('Loading more...')).toBeInTheDocument();
-    });
   });
 
   describe('error state', () => {

--- a/cloud/apps/web/tests/pages/Definitions.test.tsx
+++ b/cloud/apps/web/tests/pages/Definitions.test.tsx
@@ -3,19 +3,13 @@ import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { Definitions } from '../../src/pages/Definitions';
 
-// Mock the useInfiniteDefinitions hook
-vi.mock('../../src/hooks/useInfiniteDefinitions', () => ({
-  useInfiniteDefinitions: () => ({
+// Mock the useDefinitions hook
+vi.mock('../../src/hooks/useDefinitions', () => ({
+  useDefinitions: () => ({
     definitions: [],
-    items: [],
     loading: false,
-    loadingMore: false,
     error: null,
-    hasNextPage: false,
-    totalCount: 0,
-    loadMore: vi.fn(),
     refetch: vi.fn(),
-    softRefetch: vi.fn(),
   }),
 }));
 


### PR DESCRIPTION
## Summary
- Replaces infinite scroll on the Definitions page with eager loading (limit 1000)
- Infinite scroll didn't work with folder view — collapsed folders meant no scrollable content to trigger pagination
- Removes scroll listener, sentinel div, loading indicators, and pagination props from `DefinitionList`
- Simplifies `Definitions.tsx` to use `useDefinitions` with `limit: 1000`

## Test plan
- [x] Build passes (`npx turbo run build --filter=@valuerank/web`)
- [x] Lint passes (`npx turbo run lint --filter=@valuerank/web`)
- [x] All 3,099 tests pass across all packages (1 skipped, expected)
- [ ] Manual: open Definitions page, verify all vignettes load in both flat and folder views

## Validation
```
npx turbo run build --filter=@valuerank/web  ✅
npx turbo run lint --filter=@valuerank/web   ✅
npx turbo run test --force                   ✅ 3099 passed, 1 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)