### PR TITLE
feat(mcp): add definition management tools (update, tag, untag)

### DIFF
--- a/cloud/apps/api/src/mcp/tools/add-tags-to-definitions.ts
+++ b/cloud/apps/api/src/mcp/tools/add-tags-to-definitions.ts
@@ -1,0 +1,233 @@
+/**
+ * add_tags_to_definitions MCP Tool
+ *
+ * Bulk-add tags to one or more definitions.
+ * Finds-or-creates tags, creates associations idempotently.
+ */
+
+import { z } from 'zod';
+import crypto from 'crypto';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { db } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+import { logAuditEvent } from '../../services/mcp/index.js';
+import { addToolRegistrar } from './registry.js';
+
+const log = createLogger('mcp:tools:add-tags-to-definitions');
+
+const TAG_NAME_REGEX = /^[a-z0-9_-]+$/;
+
+/**
+ * Input schema for add_tags_to_definitions tool
+ */
+const AddTagsInputSchema = {
+  definition_ids: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(100)
+    .describe('IDs of definitions to add tags to (max 100)'),
+  tag_names: z
+    .array(z.string().min(1).max(50))
+    .min(1)
+    .max(20)
+    .describe('Tag names to add (max 20). Will be normalized to lowercase.'),
+};
+
+/**
+ * Format error response for MCP
+ */
+function formatError(code: string, message: string, details?: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ error: code, message, details }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+/**
+ * Format success response for MCP
+ */
+function formatSuccess(data: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(data, null, 2),
+      },
+    ],
+  };
+}
+
+/**
+ * Registers the add_tags_to_definitions tool on the MCP server
+ */
+function registerAddTagsToDefinitionsTool(server: McpServer): void {
+  log.info('Registering add_tags_to_definitions tool');
+
+  server.registerTool(
+    'add_tags_to_definitions',
+    {
+      description: `Bulk-add tags to one or more definitions.
+
+Tags are normalized to lowercase and trimmed. Invalid names are rejected.
+Tag names must match /^[a-z0-9_-]+$/ (lowercase alphanumeric, hyphens, underscores).
+
+Idempotent - if a tag is already assigned to a definition, it is skipped.
+Tags do NOT increment the definition version.
+
+Example:
+{
+  "definition_ids": ["def1", "def2", "def3"],
+  "tag_names": ["job", "generated"]
+}`,
+      inputSchema: AddTagsInputSchema,
+    },
+    async (args, extra) => {
+      const requestId = String(extra.requestId ?? crypto.randomUUID());
+      const userId = 'mcp-user';
+
+      log.debug(
+        {
+          definitionCount: args.definition_ids.length,
+          tagCount: args.tag_names.length,
+          requestId,
+        },
+        'add_tags_to_definitions called'
+      );
+
+      try {
+        // Step 1: Normalize and validate tag names
+        const normalizedTags = args.tag_names.map((t) => t.toLowerCase().trim());
+        const invalidTags = normalizedTags.filter((t) => !TAG_NAME_REGEX.test(t));
+        if (invalidTags.length > 0) {
+          return formatError(
+            'VALIDATION_ERROR',
+            'Invalid tag names. Must contain only lowercase letters, numbers, hyphens, and underscores.',
+            { invalid_tags: invalidTags }
+          );
+        }
+
+        // Step 2: Validate all definitions exist and are not soft-deleted
+        const definitions = await db.definition.findMany({
+          where: {
+            id: { in: args.definition_ids },
+            deletedAt: null,
+          },
+          select: { id: true },
+        });
+
+        const foundIds = new Set(definitions.map((d) => d.id));
+        const missingIds = args.definition_ids.filter((id) => !foundIds.has(id));
+        if (missingIds.length > 0) {
+          return formatError(
+            'NOT_FOUND',
+            `${missingIds.length} definition(s) not found or soft-deleted`,
+            { missing_ids: missingIds }
+          );
+        }
+
+        // Step 3: Find-or-create each tag
+        const tagRecords = await Promise.all(
+          normalizedTags.map(async (name) => {
+            let tag = await db.tag.findUnique({ where: { name } });
+            if (!tag) {
+              tag = await db.tag.create({ data: { name } });
+              log.info({ requestId, tagId: tag.id, tagName: name }, 'Tag created');
+            }
+            return tag;
+          })
+        );
+
+        // Step 4: Create associations (idempotent)
+        let added = 0;
+        let skipped = 0;
+
+        for (const def of definitions) {
+          for (const tag of tagRecords) {
+            const existing = await db.definitionTag.findUnique({
+              where: {
+                definitionId_tagId: {
+                  definitionId: def.id,
+                  tagId: tag.id,
+                },
+              },
+            });
+
+            if (existing) {
+              // If soft-deleted, restore it
+              if (existing.deletedAt !== null) {
+                await db.definitionTag.update({
+                  where: { id: existing.id },
+                  data: { deletedAt: null },
+                });
+                added++;
+              } else {
+                skipped++;
+              }
+            } else {
+              await db.definitionTag.create({
+                data: {
+                  definitionId: def.id,
+                  tagId: tag.id,
+                },
+              });
+              added++;
+            }
+          }
+        }
+
+        log.info(
+          {
+            requestId,
+            definitionCount: definitions.length,
+            tagCount: tagRecords.length,
+            added,
+            skipped,
+          },
+          'Tags added to definitions'
+        );
+
+        // Step 5: Audit log
+        logAuditEvent({
+          action: 'add_tags_to_definitions',
+          userId,
+          entityId: 'bulk',
+          entityType: 'definition',
+          requestId,
+          metadata: {
+            definitionIds: args.definition_ids,
+            tagNames: normalizedTags,
+            added,
+            skipped,
+          },
+        });
+
+        // Step 6: Return success
+        return formatSuccess({
+          success: true,
+          definitions_processed: definitions.length,
+          tags_processed: normalizedTags,
+          associations_added: added,
+          associations_skipped: skipped,
+          total_associations: added + skipped,
+        });
+      } catch (err) {
+        log.error({ err, requestId }, 'add_tags_to_definitions failed');
+
+        return formatError(
+          'INTERNAL_ERROR',
+          err instanceof Error ? err.message : 'Failed to add tags to definitions'
+        );
+      }
+    }
+  );
+}
+
+// Register this tool with the tool registry
+addToolRegistrar(registerAddTagsToDefinitionsTool);
+
+export { registerAddTagsToDefinitionsTool };

--- a/cloud/apps/api/src/mcp/tools/index.ts
+++ b/cloud/apps/api/src/mcp/tools/index.ts
@@ -52,6 +52,10 @@ import './list-system-settings.js';
 import './set-summarization-parallelism.js';
 import './cancel-summarization.js';
 import './restart-summarization.js';
+// Definition management tools
+import './update-definition.js';
+import './add-tags-to-definitions.js';
+import './remove-tags-from-definitions.js';
 // Feature 018 - MCP Operations Tools
 import './recover-run.js';
 import './trigger-recovery.js';

--- a/cloud/apps/api/src/mcp/tools/remove-tags-from-definitions.ts
+++ b/cloud/apps/api/src/mcp/tools/remove-tags-from-definitions.ts
@@ -1,0 +1,228 @@
+/**
+ * remove_tags_from_definitions MCP Tool
+ *
+ * Bulk-remove tags from one or more definitions.
+ * Uses soft-delete on DefinitionTag associations.
+ */
+
+import { z } from 'zod';
+import crypto from 'crypto';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { db } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+import { logAuditEvent } from '../../services/mcp/index.js';
+import { addToolRegistrar } from './registry.js';
+
+const log = createLogger('mcp:tools:remove-tags-from-definitions');
+
+const TAG_NAME_REGEX = /^[a-z0-9_-]+$/;
+
+/**
+ * Input schema for remove_tags_from_definitions tool
+ */
+const RemoveTagsInputSchema = {
+  definition_ids: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(100)
+    .describe('IDs of definitions to remove tags from (max 100)'),
+  tag_names: z
+    .array(z.string().min(1).max(50))
+    .min(1)
+    .max(20)
+    .describe('Tag names to remove (max 20). Will be normalized to lowercase.'),
+};
+
+/**
+ * Format error response for MCP
+ */
+function formatError(code: string, message: string, details?: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ error: code, message, details }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+/**
+ * Format success response for MCP
+ */
+function formatSuccess(data: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(data, null, 2),
+      },
+    ],
+  };
+}
+
+/**
+ * Registers the remove_tags_from_definitions tool on the MCP server
+ */
+function registerRemoveTagsFromDefinitionsTool(server: McpServer): void {
+  log.info('Registering remove_tags_from_definitions tool');
+
+  server.registerTool(
+    'remove_tags_from_definitions',
+    {
+      description: `Bulk-remove tags from one or more definitions.
+
+Tag names are normalized to lowercase and trimmed.
+Tags that are not assigned to a definition are silently skipped.
+Tags do NOT affect the definition version.
+
+Example:
+{
+  "definition_ids": ["def1", "def2"],
+  "tag_names": ["deprecated", "draft"]
+}`,
+      inputSchema: RemoveTagsInputSchema,
+    },
+    async (args, extra) => {
+      const requestId = String(extra.requestId ?? crypto.randomUUID());
+      const userId = 'mcp-user';
+
+      log.debug(
+        {
+          definitionCount: args.definition_ids.length,
+          tagCount: args.tag_names.length,
+          requestId,
+        },
+        'remove_tags_from_definitions called'
+      );
+
+      try {
+        // Step 1: Normalize and validate tag names
+        const normalizedTags = args.tag_names.map((t) => t.toLowerCase().trim());
+        const invalidTags = normalizedTags.filter((t) => !TAG_NAME_REGEX.test(t));
+        if (invalidTags.length > 0) {
+          return formatError(
+            'VALIDATION_ERROR',
+            'Invalid tag names. Must contain only lowercase letters, numbers, hyphens, and underscores.',
+            { invalid_tags: invalidTags }
+          );
+        }
+
+        // Step 2: Validate all definitions exist and are not soft-deleted
+        const definitions = await db.definition.findMany({
+          where: {
+            id: { in: args.definition_ids },
+            deletedAt: null,
+          },
+          select: { id: true },
+        });
+
+        const foundIds = new Set(definitions.map((d) => d.id));
+        const missingIds = args.definition_ids.filter((id) => !foundIds.has(id));
+        if (missingIds.length > 0) {
+          return formatError(
+            'NOT_FOUND',
+            `${missingIds.length} definition(s) not found or soft-deleted`,
+            { missing_ids: missingIds }
+          );
+        }
+
+        // Step 3: Look up tag records
+        const tags = await db.tag.findMany({
+          where: { name: { in: normalizedTags } },
+        });
+
+        const foundTagNames = new Set(tags.map((t) => t.name));
+        const missingTags = normalizedTags.filter((t) => !foundTagNames.has(t));
+
+        // Step 4: Soft-delete associations
+        let removed = 0;
+        let notAssigned = 0;
+
+        const definitionIds = definitions.map((d) => d.id);
+        const tagIds = tags.map((t) => t.id);
+
+        if (tagIds.length > 0 && definitionIds.length > 0) {
+          // Find existing active associations
+          const existingAssociations = await db.definitionTag.findMany({
+            where: {
+              definitionId: { in: definitionIds },
+              tagId: { in: tagIds },
+              deletedAt: null,
+            },
+            select: { id: true },
+          });
+
+          if (existingAssociations.length > 0) {
+            await db.definitionTag.updateMany({
+              where: {
+                id: { in: existingAssociations.map((a) => a.id) },
+              },
+              data: { deletedAt: new Date() },
+            });
+            removed = existingAssociations.length;
+          }
+
+          // Calculate how many were not assigned
+          const totalPossible = definitionIds.length * tagIds.length;
+          notAssigned = totalPossible - removed;
+        }
+
+        // Count associations that couldn't be found because tags don't exist
+        const missingTagAssociations = missingTags.length * definitionIds.length;
+        notAssigned += missingTagAssociations;
+
+        log.info(
+          {
+            requestId,
+            definitionCount: definitions.length,
+            tagCount: normalizedTags.length,
+            removed,
+            notAssigned,
+            missingTags,
+          },
+          'Tags removed from definitions'
+        );
+
+        // Step 5: Audit log
+        logAuditEvent({
+          action: 'remove_tags_from_definitions',
+          userId,
+          entityId: 'bulk',
+          entityType: 'definition',
+          requestId,
+          metadata: {
+            definitionIds: args.definition_ids,
+            tagNames: normalizedTags,
+            removed,
+            notAssigned,
+            missingTags,
+          },
+        });
+
+        // Step 6: Return success
+        return formatSuccess({
+          success: true,
+          definitions_processed: definitions.length,
+          tags_requested: normalizedTags,
+          tags_not_found: missingTags.length > 0 ? missingTags : undefined,
+          associations_removed: removed,
+          associations_not_assigned: notAssigned,
+        });
+      } catch (err) {
+        log.error({ err, requestId }, 'remove_tags_from_definitions failed');
+
+        return formatError(
+          'INTERNAL_ERROR',
+          err instanceof Error ? err.message : 'Failed to remove tags from definitions'
+        );
+      }
+    }
+  );
+}
+
+// Register this tool with the tool registry
+addToolRegistrar(registerRemoveTagsFromDefinitionsTool);
+
+export { registerRemoveTagsFromDefinitionsTool };

--- a/cloud/apps/api/src/mcp/tools/update-definition.ts
+++ b/cloud/apps/api/src/mcp/tools/update-definition.ts
@@ -1,0 +1,237 @@
+/**
+ * update_definition MCP Tool
+ *
+ * Updates a definition's name and/or preamble version.
+ * Increments version on preamble changes (matches UX behavior).
+ */
+
+import { z } from 'zod';
+import crypto from 'crypto';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { db, type Prisma } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+import { logAuditEvent } from '../../services/mcp/index.js';
+import { addToolRegistrar } from './registry.js';
+
+const log = createLogger('mcp:tools:update-definition');
+
+/**
+ * Input schema for update_definition tool
+ */
+const UpdateDefinitionInputSchema = {
+  definition_id: z.string().min(1).describe('ID of the definition to update'),
+  name: z.string().min(1).max(255).optional().describe('New name for the definition'),
+  preamble_version_id: z
+    .string()
+    .nullable()
+    .optional()
+    .describe('Preamble version ID to set, or null to clear. Omit to leave unchanged.'),
+};
+
+/**
+ * Format error response for MCP
+ */
+function formatError(code: string, message: string, details?: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ error: code, message, details }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+/**
+ * Format success response for MCP
+ */
+function formatSuccess(data: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(data, null, 2),
+      },
+    ],
+  };
+}
+
+/**
+ * Registers the update_definition tool on the MCP server
+ */
+function registerUpdateDefinitionTool(server: McpServer): void {
+  log.info('Registering update_definition tool');
+
+  server.registerTool(
+    'update_definition',
+    {
+      description: `Update a definition's name and/or preamble version.
+
+Preamble changes increment the definition version (matching UX behavior).
+Name changes do NOT increment the version.
+
+To clear the preamble, set preamble_version_id to null.
+To leave preamble unchanged, omit preamble_version_id entirely.
+
+Example - set preamble:
+{
+  "definition_id": "abc123",
+  "preamble_version_id": "preamble-v1-id"
+}
+
+Example - clear preamble:
+{
+  "definition_id": "abc123",
+  "preamble_version_id": null
+}
+
+Example - rename only:
+{
+  "definition_id": "abc123",
+  "name": "New Name"
+}`,
+      inputSchema: UpdateDefinitionInputSchema,
+    },
+    async (args, extra) => {
+      const requestId = String(extra.requestId ?? crypto.randomUUID());
+      const userId = 'mcp-user';
+
+      log.debug(
+        { definitionId: args.definition_id, requestId },
+        'update_definition called'
+      );
+
+      try {
+        // Step 1: Validate definition exists and is not soft-deleted
+        const existing = await db.definition.findUnique({
+          where: { id: args.definition_id },
+        });
+
+        if (!existing || existing.deletedAt !== null) {
+          log.warn({ requestId, definitionId: args.definition_id }, 'Definition not found');
+          return formatError('NOT_FOUND', `Definition not found: ${args.definition_id}`);
+        }
+
+        // Step 2: Check that at least one field is being updated
+        const hasNameChange = args.name !== undefined;
+        const hasPreambleChange = args.preamble_version_id !== undefined;
+
+        if (!hasNameChange && !hasPreambleChange) {
+          return formatError(
+            'VALIDATION_ERROR',
+            'At least one of name or preamble_version_id must be provided'
+          );
+        }
+
+        // Step 3: Validate preamble version exists (if provided and non-null)
+        if (hasPreambleChange && args.preamble_version_id !== null) {
+          const preambleVersion = await db.preambleVersion.findUnique({
+            where: { id: args.preamble_version_id as string },
+          });
+          if (!preambleVersion) {
+            return formatError(
+              'NOT_FOUND',
+              `Preamble version not found: ${args.preamble_version_id}`
+            );
+          }
+        }
+
+        // Step 4: Build update data
+        const updateData: Prisma.DefinitionUpdateInput = {};
+        const changes: string[] = [];
+
+        if (hasNameChange) {
+          updateData.name = args.name;
+          changes.push(`name: "${existing.name}" → "${args.name}"`);
+        }
+
+        let needsVersionIncrement = false;
+        if (hasPreambleChange && existing.preambleVersionId !== args.preamble_version_id) {
+          if (args.preamble_version_id === null) {
+            updateData.preambleVersion = { disconnect: true };
+          } else {
+            updateData.preambleVersion = { connect: { id: args.preamble_version_id as string } };
+          }
+          needsVersionIncrement = true;
+          changes.push(
+            `preambleVersionId: ${existing.preambleVersionId ?? 'null'} → ${args.preamble_version_id ?? 'null'}`
+          );
+        } else if (hasPreambleChange) {
+          // Preamble was provided but is the same value - no change needed
+          changes.push('preambleVersionId: unchanged (already set to requested value)');
+        }
+
+        if (needsVersionIncrement) {
+          updateData.version = { increment: 1 };
+        }
+
+        // Step 5: Apply update
+        const updated = await db.definition.update({
+          where: { id: args.definition_id },
+          data: updateData,
+          include: {
+            preambleVersion: {
+              include: { preamble: true },
+            },
+          },
+        });
+
+        log.info(
+          {
+            requestId,
+            definitionId: args.definition_id,
+            changes,
+            versionBefore: existing.version,
+            versionAfter: updated.version,
+          },
+          'Definition updated'
+        );
+
+        // Step 6: Audit log
+        logAuditEvent({
+          action: 'update_definition',
+          userId,
+          entityId: args.definition_id,
+          entityType: 'definition',
+          requestId,
+          metadata: {
+            changes,
+            versionBefore: existing.version,
+            versionAfter: updated.version,
+          },
+        });
+
+        // Step 7: Return success
+        return formatSuccess({
+          success: true,
+          definition_id: updated.id,
+          name: updated.name,
+          version: {
+            before: existing.version,
+            after: updated.version,
+            incremented: needsVersionIncrement,
+          },
+          preamble: {
+            version_id: updated.preambleVersionId,
+            preamble_name: updated.preambleVersion?.preamble?.name ?? null,
+            version_label: updated.preambleVersion?.version ?? null,
+          },
+          changes,
+        });
+      } catch (err) {
+        log.error({ err, requestId }, 'update_definition failed');
+
+        return formatError(
+          'INTERNAL_ERROR',
+          err instanceof Error ? err.message : 'Failed to update definition'
+        );
+      }
+    }
+  );
+}
+
+// Register this tool with the tool registry
+addToolRegistrar(registerUpdateDefinitionTool);
+
+export { registerUpdateDefinitionTool };

--- a/cloud/apps/api/src/services/mcp/audit.ts
+++ b/cloud/apps/api/src/services/mcp/audit.ts
@@ -77,7 +77,11 @@ export type AuditAction =
   | 'trigger_recovery'
   | 'get_job_queue_status'
   | 'get_unsummarized_transcripts'
-  | 'recompute_analysis';
+  | 'recompute_analysis'
+  // Definition management tools
+  | 'update_definition'
+  | 'add_tags_to_definitions'
+  | 'remove_tags_from_definitions';
 
 /**
  * Audit entry for MCP write operations

--- a/cloud/apps/api/tests/mcp/tools/add-tags-to-definitions.test.ts
+++ b/cloud/apps/api/tests/mcp/tools/add-tags-to-definitions.test.ts
@@ -1,0 +1,296 @@
+/**
+ * add_tags_to_definitions Tool Tests
+ *
+ * Tests the add_tags_to_definitions MCP tool handler.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// Mock db before importing the tool
+vi.mock('@valuerank/db', () => ({
+  db: {
+    definition: {
+      findMany: vi.fn(),
+    },
+    tag: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    definitionTag: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+// Mock MCP services
+vi.mock('../../../src/services/mcp/index.js', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
+// Import after mocks
+import { db } from '@valuerank/db';
+
+describe('add_tags_to_definitions tool', () => {
+  const defIds = ['def-1', 'def-2', 'def-3'];
+
+  let toolHandler: (
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>
+  ) => Promise<unknown>;
+
+  const mockServer = {
+    registerTool: vi.fn((name, config, handler) => {
+      toolHandler = handler;
+    }),
+  } as unknown as McpServer;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const { registerAddTagsToDefinitionsTool } = await import(
+      '../../../src/mcp/tools/add-tags-to-definitions.js'
+    );
+    registerAddTagsToDefinitionsTool(mockServer);
+  });
+
+  it('registers the tool with correct name and schema', () => {
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'add_tags_to_definitions',
+      expect.objectContaining({
+        description: expect.stringContaining('Bulk-add tags'),
+        inputSchema: expect.objectContaining({
+          definition_ids: expect.any(Object),
+          tag_names: expect.any(Object),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('adds new tags to definitions successfully', async () => {
+    // All definitions exist
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      defIds.map((id) => ({ id })) as never
+    );
+
+    // Tags don't exist yet - will be created
+    vi.mocked(db.tag.findUnique).mockResolvedValue(null);
+    vi.mocked(db.tag.create)
+      .mockResolvedValueOnce({ id: 'tag-1', name: 'job', createdAt: new Date() } as never)
+      .mockResolvedValueOnce({ id: 'tag-2', name: 'generated', createdAt: new Date() } as never);
+
+    // No existing associations
+    vi.mocked(db.definitionTag.findUnique).mockResolvedValue(null);
+    vi.mocked(db.definitionTag.create).mockResolvedValue({} as never);
+
+    const result = await toolHandler(
+      { definition_ids: defIds, tag_names: ['job', 'generated'] },
+      { requestId: 'req-1' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.success).toBe(true);
+    expect(response.definitions_processed).toBe(3);
+    expect(response.tags_processed).toEqual(['job', 'generated']);
+    expect(response.associations_added).toBe(6); // 3 defs * 2 tags
+    expect(response.associations_skipped).toBe(0);
+  });
+
+  it('skips already-assigned tags', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never
+    );
+    vi.mocked(db.tag.findUnique).mockResolvedValue(
+      { id: 'tag-1', name: 'job', createdAt: new Date() } as never
+    );
+
+    // Already assigned (not soft-deleted)
+    vi.mocked(db.definitionTag.findUnique).mockResolvedValue({
+      id: 'dt-1',
+      definitionId: 'def-1',
+      tagId: 'tag-1',
+      deletedAt: null,
+    } as never);
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['job'] },
+      { requestId: 'req-2' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.associations_added).toBe(0);
+    expect(response.associations_skipped).toBe(1);
+  });
+
+  it('restores soft-deleted associations', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never
+    );
+    vi.mocked(db.tag.findUnique).mockResolvedValue(
+      { id: 'tag-1', name: 'job', createdAt: new Date() } as never
+    );
+
+    // Exists but soft-deleted
+    vi.mocked(db.definitionTag.findUnique).mockResolvedValue({
+      id: 'dt-1',
+      definitionId: 'def-1',
+      tagId: 'tag-1',
+      deletedAt: new Date(),
+    } as never);
+    vi.mocked(db.definitionTag.update).mockResolvedValue({} as never);
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['job'] },
+      { requestId: 'req-3' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.associations_added).toBe(1);
+    expect(response.associations_skipped).toBe(0);
+    expect(db.definitionTag.update).toHaveBeenCalledWith({
+      where: { id: 'dt-1' },
+      data: { deletedAt: null },
+    });
+  });
+
+  it('normalizes tag names to lowercase', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never
+    );
+    vi.mocked(db.tag.findUnique).mockResolvedValue(
+      { id: 'tag-1', name: 'job', createdAt: new Date() } as never
+    );
+    vi.mocked(db.definitionTag.findUnique).mockResolvedValue(null);
+    vi.mocked(db.definitionTag.create).mockResolvedValue({} as never);
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['JOB'] },
+      { requestId: 'req-4' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.tags_processed).toEqual(['job']);
+  });
+
+  it('returns VALIDATION_ERROR for invalid tag names', async () => {
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['invalid tag!', 'ok-tag'] },
+      { requestId: 'req-5' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('VALIDATION_ERROR');
+    expect(response.details.invalid_tags).toContain('invalid tag!');
+  });
+
+  it('returns NOT_FOUND when definitions are missing', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never // Only 1 of 3 found
+    );
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1', 'def-missing-1', 'def-missing-2'], tag_names: ['job'] },
+      { requestId: 'req-6' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('NOT_FOUND');
+    expect(response.details.missing_ids).toEqual(['def-missing-1', 'def-missing-2']);
+  });
+
+  it('returns INTERNAL_ERROR on database failure', async () => {
+    vi.mocked(db.definition.findMany).mockRejectedValue(
+      new Error('Database connection failed')
+    );
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['job'] },
+      { requestId: 'req-7' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('INTERNAL_ERROR');
+    expect(response.message).toContain('Database connection failed');
+  });
+
+  it('handles non-Error exception', async () => {
+    vi.mocked(db.definition.findMany).mockRejectedValue('string error');
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['job'] },
+      { requestId: 'req-8' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('INTERNAL_ERROR');
+    expect(response.message).toBe('Failed to add tags to definitions');
+  });
+
+  it('generates requestId when not provided', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never
+    );
+    vi.mocked(db.tag.findUnique).mockResolvedValue(
+      { id: 'tag-1', name: 'job', createdAt: new Date() } as never
+    );
+    vi.mocked(db.definitionTag.findUnique).mockResolvedValue(null);
+    vi.mocked(db.definitionTag.create).mockResolvedValue({} as never);
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['job'] },
+      {}
+    );
+
+    expect(result).not.toHaveProperty('isError');
+  });
+
+  it('reuses existing tags instead of creating duplicates', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never
+    );
+
+    // Tag already exists
+    vi.mocked(db.tag.findUnique).mockResolvedValue(
+      { id: 'existing-tag', name: 'job', createdAt: new Date() } as never
+    );
+    vi.mocked(db.definitionTag.findUnique).mockResolvedValue(null);
+    vi.mocked(db.definitionTag.create).mockResolvedValue({} as never);
+
+    await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['job'] },
+      { requestId: 'req-9' }
+    );
+
+    // Should NOT create the tag
+    expect(db.tag.create).not.toHaveBeenCalled();
+    // Should still create the association
+    expect(db.definitionTag.create).toHaveBeenCalled();
+  });
+});

--- a/cloud/apps/api/tests/mcp/tools/remove-tags-from-definitions.test.ts
+++ b/cloud/apps/api/tests/mcp/tools/remove-tags-from-definitions.test.ts
@@ -1,0 +1,250 @@
+/**
+ * remove_tags_from_definitions Tool Tests
+ *
+ * Tests the remove_tags_from_definitions MCP tool handler.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// Mock db before importing the tool
+vi.mock('@valuerank/db', () => ({
+  db: {
+    definition: {
+      findMany: vi.fn(),
+    },
+    tag: {
+      findMany: vi.fn(),
+    },
+    definitionTag: {
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+// Mock MCP services
+vi.mock('../../../src/services/mcp/index.js', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
+// Import after mocks
+import { db } from '@valuerank/db';
+
+describe('remove_tags_from_definitions tool', () => {
+  let toolHandler: (
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>
+  ) => Promise<unknown>;
+
+  const mockServer = {
+    registerTool: vi.fn((name, config, handler) => {
+      toolHandler = handler;
+    }),
+  } as unknown as McpServer;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const { registerRemoveTagsFromDefinitionsTool } = await import(
+      '../../../src/mcp/tools/remove-tags-from-definitions.js'
+    );
+    registerRemoveTagsFromDefinitionsTool(mockServer);
+  });
+
+  it('registers the tool with correct name and schema', () => {
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'remove_tags_from_definitions',
+      expect.objectContaining({
+        description: expect.stringContaining('Bulk-remove tags'),
+        inputSchema: expect.objectContaining({
+          definition_ids: expect.any(Object),
+          tag_names: expect.any(Object),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('removes tags from definitions successfully', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }, { id: 'def-2' }] as never
+    );
+    vi.mocked(db.tag.findMany).mockResolvedValue(
+      [{ id: 'tag-1', name: 'job' }] as never
+    );
+    vi.mocked(db.definitionTag.findMany).mockResolvedValue(
+      [{ id: 'dt-1' }, { id: 'dt-2' }] as never
+    );
+    vi.mocked(db.definitionTag.updateMany).mockResolvedValue({ count: 2 } as never);
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1', 'def-2'], tag_names: ['job'] },
+      { requestId: 'req-1' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.success).toBe(true);
+    expect(response.definitions_processed).toBe(2);
+    expect(response.associations_removed).toBe(2);
+
+    // Verify soft-delete was used
+    expect(db.definitionTag.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+      })
+    );
+  });
+
+  it('handles tags that are not assigned (silently skips)', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never
+    );
+    vi.mocked(db.tag.findMany).mockResolvedValue(
+      [{ id: 'tag-1', name: 'job' }] as never
+    );
+    // No existing associations
+    vi.mocked(db.definitionTag.findMany).mockResolvedValue([] as never);
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['job'] },
+      { requestId: 'req-2' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.associations_removed).toBe(0);
+    expect(response.associations_not_assigned).toBe(1);
+    expect(db.definitionTag.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('handles tags that do not exist in the system', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never
+    );
+    // No matching tags found
+    vi.mocked(db.tag.findMany).mockResolvedValue([] as never);
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['nonexistent'] },
+      { requestId: 'req-3' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.success).toBe(true);
+    expect(response.tags_not_found).toEqual(['nonexistent']);
+    expect(response.associations_removed).toBe(0);
+  });
+
+  it('normalizes tag names to lowercase', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never
+    );
+    vi.mocked(db.tag.findMany).mockResolvedValue(
+      [{ id: 'tag-1', name: 'job' }] as never
+    );
+    vi.mocked(db.definitionTag.findMany).mockResolvedValue(
+      [{ id: 'dt-1' }] as never
+    );
+    vi.mocked(db.definitionTag.updateMany).mockResolvedValue({ count: 1 } as never);
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['JOB'] },
+      { requestId: 'req-4' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    // The tag query should have used lowercase
+    expect(db.tag.findMany).toHaveBeenCalledWith({
+      where: { name: { in: ['job'] } },
+    });
+  });
+
+  it('returns VALIDATION_ERROR for invalid tag names', async () => {
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['invalid tag!'] },
+      { requestId: 'req-5' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('VALIDATION_ERROR');
+    expect(response.details.invalid_tags).toContain('invalid tag!');
+  });
+
+  it('returns NOT_FOUND when definitions are missing', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never
+    );
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1', 'def-missing'], tag_names: ['job'] },
+      { requestId: 'req-6' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('NOT_FOUND');
+    expect(response.details.missing_ids).toEqual(['def-missing']);
+  });
+
+  it('returns INTERNAL_ERROR on database failure', async () => {
+    vi.mocked(db.definition.findMany).mockRejectedValue(
+      new Error('Database connection failed')
+    );
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['job'] },
+      { requestId: 'req-7' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('INTERNAL_ERROR');
+    expect(response.message).toContain('Database connection failed');
+  });
+
+  it('handles non-Error exception', async () => {
+    vi.mocked(db.definition.findMany).mockRejectedValue('string error');
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['job'] },
+      { requestId: 'req-8' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('INTERNAL_ERROR');
+    expect(response.message).toBe('Failed to remove tags from definitions');
+  });
+
+  it('generates requestId when not provided', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue(
+      [{ id: 'def-1' }] as never
+    );
+    vi.mocked(db.tag.findMany).mockResolvedValue([] as never);
+
+    const result = await toolHandler(
+      { definition_ids: ['def-1'], tag_names: ['job'] },
+      {}
+    );
+
+    expect(result).not.toHaveProperty('isError');
+  });
+});

--- a/cloud/apps/api/tests/mcp/tools/update-definition.test.ts
+++ b/cloud/apps/api/tests/mcp/tools/update-definition.test.ts
@@ -1,0 +1,357 @@
+/**
+ * update_definition Tool Tests
+ *
+ * Tests the update_definition MCP tool handler.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// Mock db before importing the tool
+vi.mock('@valuerank/db', () => ({
+  db: {
+    definition: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    preambleVersion: {
+      findUnique: vi.fn(),
+    },
+  },
+  Prisma: {},
+}));
+
+// Mock MCP services
+vi.mock('../../../src/services/mcp/index.js', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
+// Import after mocks
+import { db } from '@valuerank/db';
+
+describe('update_definition tool', () => {
+  const testDefinitionId = 'cmtest-def-update-001';
+
+  const existingDefinition = {
+    id: testDefinitionId,
+    name: 'Original Name',
+    version: 1,
+    preambleVersionId: null,
+    deletedAt: null,
+    content: {},
+  };
+
+  let toolHandler: (
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>
+  ) => Promise<unknown>;
+
+  const mockServer = {
+    registerTool: vi.fn((name, config, handler) => {
+      toolHandler = handler;
+    }),
+  } as unknown as McpServer;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const { registerUpdateDefinitionTool } = await import(
+      '../../../src/mcp/tools/update-definition.js'
+    );
+    registerUpdateDefinitionTool(mockServer);
+  });
+
+  it('registers the tool with correct name and schema', () => {
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'update_definition',
+      expect.objectContaining({
+        description: expect.stringContaining('Update a definition'),
+        inputSchema: expect.objectContaining({
+          definition_id: expect.any(Object),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('updates definition name without incrementing version', async () => {
+    vi.mocked(db.definition.findUnique).mockResolvedValue(existingDefinition as never);
+    vi.mocked(db.definition.update).mockResolvedValue({
+      ...existingDefinition,
+      name: 'New Name',
+      preambleVersion: null,
+    } as never);
+
+    const result = await toolHandler(
+      { definition_id: testDefinitionId, name: 'New Name' },
+      { requestId: 'req-1' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.success).toBe(true);
+    expect(response.name).toBe('New Name');
+    expect(response.version.before).toBe(1);
+    expect(response.version.after).toBe(1);
+    expect(response.version.incremented).toBe(false);
+  });
+
+  it('updates preamble version and increments version', async () => {
+    const preambleVersionId = 'preamble-v1';
+    vi.mocked(db.definition.findUnique).mockResolvedValue(existingDefinition as never);
+    vi.mocked(db.preambleVersion.findUnique).mockResolvedValue({
+      id: preambleVersionId,
+      preambleId: 'preamble-1',
+      version: 'v1',
+      content: 'test preamble',
+      createdAt: new Date(),
+    } as never);
+    vi.mocked(db.definition.update).mockResolvedValue({
+      ...existingDefinition,
+      version: 2,
+      preambleVersionId,
+      preambleVersion: {
+        id: preambleVersionId,
+        version: 'v1',
+        preamble: { name: 'No Reframe' },
+      },
+    } as never);
+
+    const result = await toolHandler(
+      { definition_id: testDefinitionId, preamble_version_id: preambleVersionId },
+      { requestId: 'req-2' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.success).toBe(true);
+    expect(response.version.before).toBe(1);
+    expect(response.version.after).toBe(2);
+    expect(response.version.incremented).toBe(true);
+    expect(response.preamble.version_id).toBe(preambleVersionId);
+    expect(response.preamble.preamble_name).toBe('No Reframe');
+  });
+
+  it('clears preamble with null and increments version', async () => {
+    const defWithPreamble = {
+      ...existingDefinition,
+      preambleVersionId: 'old-preamble',
+    };
+    vi.mocked(db.definition.findUnique).mockResolvedValue(defWithPreamble as never);
+    vi.mocked(db.definition.update).mockResolvedValue({
+      ...defWithPreamble,
+      version: 2,
+      preambleVersionId: null,
+      preambleVersion: null,
+    } as never);
+
+    const result = await toolHandler(
+      { definition_id: testDefinitionId, preamble_version_id: null },
+      { requestId: 'req-3' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.success).toBe(true);
+    expect(response.version.incremented).toBe(true);
+    expect(response.preamble.version_id).toBeNull();
+  });
+
+  it('does not increment version when preamble is already the same', async () => {
+    const defWithPreamble = {
+      ...existingDefinition,
+      preambleVersionId: 'same-preamble',
+    };
+    vi.mocked(db.definition.findUnique).mockResolvedValue(defWithPreamble as never);
+    vi.mocked(db.preambleVersion.findUnique).mockResolvedValue({
+      id: 'same-preamble',
+      preambleId: 'p1',
+      version: 'v1',
+      content: 'test',
+      createdAt: new Date(),
+    } as never);
+    vi.mocked(db.definition.update).mockResolvedValue({
+      ...defWithPreamble,
+      preambleVersion: {
+        id: 'same-preamble',
+        version: 'v1',
+        preamble: { name: 'Test' },
+      },
+    } as never);
+
+    const result = await toolHandler(
+      { definition_id: testDefinitionId, preamble_version_id: 'same-preamble' },
+      { requestId: 'req-4' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.version.incremented).toBe(false);
+  });
+
+  it('returns NOT_FOUND when definition does not exist', async () => {
+    vi.mocked(db.definition.findUnique).mockResolvedValue(null);
+
+    const result = await toolHandler(
+      { definition_id: 'nonexistent', name: 'New Name' },
+      { requestId: 'req-5' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('NOT_FOUND');
+    expect(response.message).toContain('nonexistent');
+  });
+
+  it('returns NOT_FOUND when definition is soft-deleted', async () => {
+    vi.mocked(db.definition.findUnique).mockResolvedValue({
+      ...existingDefinition,
+      deletedAt: new Date(),
+    } as never);
+
+    const result = await toolHandler(
+      { definition_id: testDefinitionId, name: 'New Name' },
+      { requestId: 'req-6' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('NOT_FOUND');
+  });
+
+  it('returns NOT_FOUND when preamble version does not exist', async () => {
+    vi.mocked(db.definition.findUnique).mockResolvedValue(existingDefinition as never);
+    vi.mocked(db.preambleVersion.findUnique).mockResolvedValue(null);
+
+    const result = await toolHandler(
+      { definition_id: testDefinitionId, preamble_version_id: 'bad-id' },
+      { requestId: 'req-7' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('NOT_FOUND');
+    expect(response.message).toContain('Preamble version not found');
+  });
+
+  it('returns VALIDATION_ERROR when no fields provided', async () => {
+    vi.mocked(db.definition.findUnique).mockResolvedValue(existingDefinition as never);
+
+    const result = await toolHandler(
+      { definition_id: testDefinitionId },
+      { requestId: 'req-8' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('VALIDATION_ERROR');
+    expect(response.message).toContain('At least one');
+  });
+
+  it('returns INTERNAL_ERROR on database failure', async () => {
+    vi.mocked(db.definition.findUnique).mockResolvedValue(existingDefinition as never);
+    vi.mocked(db.definition.update).mockRejectedValue(new Error('DB connection lost'));
+
+    const result = await toolHandler(
+      { definition_id: testDefinitionId, name: 'New Name' },
+      { requestId: 'req-9' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('INTERNAL_ERROR');
+    expect(response.message).toContain('DB connection lost');
+  });
+
+  it('handles non-Error exception', async () => {
+    vi.mocked(db.definition.findUnique).mockResolvedValue(existingDefinition as never);
+    vi.mocked(db.definition.update).mockRejectedValue('string error');
+
+    const result = await toolHandler(
+      { definition_id: testDefinitionId, name: 'New Name' },
+      { requestId: 'req-10' }
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.error).toBe('INTERNAL_ERROR');
+    expect(response.message).toBe('Failed to update definition');
+  });
+
+  it('generates requestId when not provided', async () => {
+    vi.mocked(db.definition.findUnique).mockResolvedValue(existingDefinition as never);
+    vi.mocked(db.definition.update).mockResolvedValue({
+      ...existingDefinition,
+      name: 'New Name',
+      preambleVersion: null,
+    } as never);
+
+    const result = await toolHandler(
+      { definition_id: testDefinitionId, name: 'New Name' },
+      {}
+    );
+
+    expect(result).not.toHaveProperty('isError');
+  });
+
+  it('updates both name and preamble simultaneously', async () => {
+    const preambleVersionId = 'preamble-v1';
+    vi.mocked(db.definition.findUnique).mockResolvedValue(existingDefinition as never);
+    vi.mocked(db.preambleVersion.findUnique).mockResolvedValue({
+      id: preambleVersionId,
+      preambleId: 'p1',
+      version: 'v1',
+      content: 'test',
+      createdAt: new Date(),
+    } as never);
+    vi.mocked(db.definition.update).mockResolvedValue({
+      ...existingDefinition,
+      name: 'Updated Name',
+      version: 2,
+      preambleVersionId,
+      preambleVersion: {
+        id: preambleVersionId,
+        version: 'v1',
+        preamble: { name: 'Test Preamble' },
+      },
+    } as never);
+
+    const result = await toolHandler(
+      {
+        definition_id: testDefinitionId,
+        name: 'Updated Name',
+        preamble_version_id: preambleVersionId,
+      },
+      { requestId: 'req-11' }
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.success).toBe(true);
+    expect(response.name).toBe('Updated Name');
+    expect(response.version.incremented).toBe(true);
+    expect(response.changes).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 3 new MCP write tools for managing vignette metadata without GraphQL mutations
- **`update_definition`**: update name and/or preamble version with automatic version incrementing on preamble changes
- **`add_tags_to_definitions`**: bulk-add tags to up to 100 definitions (find-or-create tags, idempotent associations, restores soft-deleted links)
- **`remove_tags_from_definitions`**: bulk-remove tags via soft-delete on associations
- 34 new unit tests covering success paths, validation errors, NOT_FOUND, soft-delete handling, tag normalization, idempotency, and error cases

## Motivation
45 job vignettes were generated but are missing "job" and "generated" tags and have no preamble set. The MCP `graphql_query` tool is read-only and can't execute mutations. These tools let agents manage tags and preamble on production.

## Test plan
- [x] `npx turbo run build` — all 4 packages pass (0 errors)
- [x] `npx turbo run test` — 3134 tests (3133 passed, 1 skipped, 0 failed)
- [x] 34 new tests across 3 test files
- [ ] After deploy, use `add_tags_to_definitions` with 45 job definition IDs and tags `["job", "generated"]`
- [ ] Use `update_definition` on each definition to set `preamble_version_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)