### PR TITLE
fix(web): show aggregate runs in analysis folder view

### DIFF
--- a/cloud/apps/web/src/components/analysis/VirtualizedAnalysisFolderView.tsx
+++ b/cloud/apps/web/src/components/analysis/VirtualizedAnalysisFolderView.tsx
@@ -360,7 +360,7 @@ export function VirtualizedAnalysisFolderView({
     setExpandedFolders(new Set());
   }, []);
 
-  if (tagGroups.length === 0 && untaggedRuns.length === 0) {
+  if (tagGroups.length === 0 && untaggedRuns.length === 0 && aggregateRuns.length === 0) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Same bug as #230 but in `VirtualizedAnalysisFolderView`
- The empty-state guard didn't check `aggregateRuns`, so the Analysis page is blank when all runs have the `Aggregate` tag

## Validation
- `npm run lint --workspace @valuerank/web`: pass
- `npm run test --workspace @valuerank/web`: 1231 pass
- `npm run build --workspace @valuerank/web`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)