### PR TITLE
feat(mcp): Add cross-model value analysis tools

### DIFF
--- a/cloud/apps/api/src/mcp/tools/export-pairwise-outcomes.ts
+++ b/cloud/apps/api/src/mcp/tools/export-pairwise-outcomes.ts
@@ -1,0 +1,290 @@
+/**
+ * export_pairwise_outcomes MCP Tool
+ *
+ * Returns flat pairwise value outcome rows suitable for Bradley-Terry analysis.
+ * Joins definition value pairs with analysis results to produce per-model,
+ * per-vignette win-rate data.
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { db } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+import { buildMcpResponse, truncateArray } from '../../services/mcp/index.js';
+import { addToolRegistrar } from './registry.js';
+import { fetchDefinitionValuePairs } from './value-pair-helpers.js';
+import { zAnalysisOutput } from '../../services/analysis/aggregate.js';
+
+const log = createLogger('mcp:tools:export-pairwise-outcomes');
+
+const ExportPairwiseOutcomesInputSchema = {
+  folder: z
+    .string()
+    .optional()
+    .describe('Filter definitions by name (contains match)'),
+  tag: z.string().optional().describe('Filter definitions by tag name'),
+  definition_ids: z
+    .array(z.string())
+    .optional()
+    .describe('Explicit definition IDs (overrides folder/tag filters)'),
+  include_ci: z
+    .boolean()
+    .default(false)
+    .describe('Include confidence interval bounds in output'),
+  aggregate_only: z
+    .boolean()
+    .default(true)
+    .describe('Only use Aggregate-tagged runs (default: true)'),
+};
+
+type PairwiseOutcomeRow = {
+  vignetteName: string;
+  valueA: string;
+  valueB: string;
+  modelId: string;
+  sampleSize: number;
+  valueAPrioritized: number;
+  valueADeprioritized: number;
+  valueANeutral: number;
+  valueAWinRate: number;
+  valueBPrioritized: number;
+  valueBDeprioritized: number;
+  valueBNeutral: number;
+  valueBWinRate: number;
+  valueACiLower?: number;
+  valueACiUpper?: number;
+  valueBCiLower?: number;
+  valueBCiUpper?: number;
+};
+
+type ExportPairwiseOutput = {
+  rows: PairwiseOutcomeRow[];
+  count: number;
+  definitionsMatched: number;
+  definitionsWithData: number;
+  skippedDefinitions: number;
+};
+
+function registerExportPairwiseOutcomesTool(server: McpServer): void {
+  log.info('Registering export_pairwise_outcomes tool');
+
+  server.registerTool(
+    'export_pairwise_outcomes',
+    {
+      description: `Export flat pairwise value outcome data for cross-model analysis (e.g., Bradley-Terry ranking).
+For each vignette and model, returns prioritized/deprioritized/neutral counts and win rates for both values.
+By default uses only Aggregate-tagged runs. Set aggregate_only=false for all completed runs.
+Supports filtering by folder name, tag, or explicit definition IDs.
+Limited to 100KB token budget.`,
+      inputSchema: ExportPairwiseOutcomesInputSchema,
+    },
+    async (args, extra) => {
+      const startTime = Date.now();
+      const requestId = String(extra.requestId ?? 'unknown');
+
+      log.debug({ args, requestId }, 'export_pairwise_outcomes called');
+
+      try {
+        // Step 1: Get definition → value pair mappings
+        const pairResult = await fetchDefinitionValuePairs({
+          folder: args.folder,
+          tag: args.tag,
+          definitionIds: args.definition_ids,
+          limit: 200,
+          offset: 0,
+        });
+
+        if (pairResult.pairs.length === 0) {
+          const data: ExportPairwiseOutput = {
+            rows: [],
+            count: 0,
+            definitionsMatched: 0,
+            definitionsWithData: 0,
+            skippedDefinitions: pairResult.skipped,
+          };
+          const response = buildMcpResponse({
+            toolName: 'export_pairwise_outcomes',
+            data,
+            requestId,
+            startTime,
+          });
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(response, null, 2),
+              },
+            ],
+          };
+        }
+
+        const defIds = pairResult.pairs.map((p) => p.definitionId);
+        const pairMap = new Map(
+          pairResult.pairs.map((p) => [p.definitionId, p])
+        );
+
+        // Step 2: Query runs for those definitions
+        const runWhere = args.aggregate_only
+          ? {
+              definitionId: { in: defIds },
+              deletedAt: null,
+              tags: { some: { tag: { name: 'Aggregate' } } },
+            }
+          : {
+              definitionId: { in: defIds },
+              deletedAt: null,
+              status: 'COMPLETED' as const,
+            };
+
+        const runs = await db.run.findMany({
+          where: runWhere,
+          select: {
+            id: true,
+            definitionId: true,
+            createdAt: true,
+            analysisResults: {
+              where: { status: 'CURRENT' },
+              orderBy: { createdAt: 'desc' },
+              take: 1,
+              select: {
+                id: true,
+                output: true,
+              },
+            },
+          },
+          orderBy: { createdAt: 'desc' },
+        });
+
+        // Step 3: Group by definitionId, take most recent run per definition
+        const runByDef = new Map<string, (typeof runs)[number]>();
+        for (const run of runs) {
+          if (!runByDef.has(run.definitionId)) {
+            runByDef.set(run.definitionId, run);
+          }
+        }
+
+        // Step 4: Extract pairwise outcomes
+        const rows: PairwiseOutcomeRow[] = [];
+        let definitionsWithData = 0;
+
+        for (const [defId, run] of runByDef) {
+          const pair = pairMap.get(defId);
+          if (pair === undefined) continue;
+
+          const analysis = run.analysisResults[0];
+          if (analysis === undefined) continue;
+
+          const parsed = zAnalysisOutput.safeParse(analysis.output);
+          if (!parsed.success) {
+            log.warn(
+              { analysisId: analysis.id, defId, error: parsed.error },
+              'Invalid analysis output, skipping'
+            );
+            continue;
+          }
+
+          const perModel = parsed.data.perModel;
+          let hasModelData = false;
+
+          for (const [modelId, modelStats] of Object.entries(perModel)) {
+            if (modelStats.values === undefined) continue;
+
+            const valueAStats = modelStats.values[pair.valueA];
+            const valueBStats = modelStats.values[pair.valueB];
+
+            if (valueAStats === undefined && valueBStats === undefined) continue;
+
+            hasModelData = true;
+
+            const row: PairwiseOutcomeRow = {
+              vignetteName: pair.name,
+              valueA: pair.valueA,
+              valueB: pair.valueB,
+              modelId,
+              sampleSize: modelStats.sampleSize ?? 0,
+              valueAPrioritized: valueAStats?.count.prioritized ?? 0,
+              valueADeprioritized: valueAStats?.count.deprioritized ?? 0,
+              valueANeutral: valueAStats?.count.neutral ?? 0,
+              valueAWinRate: valueAStats?.winRate ?? 0,
+              valueBPrioritized: valueBStats?.count.prioritized ?? 0,
+              valueBDeprioritized: valueBStats?.count.deprioritized ?? 0,
+              valueBNeutral: valueBStats?.count.neutral ?? 0,
+              valueBWinRate: valueBStats?.winRate ?? 0,
+            };
+
+            if (args.include_ci) {
+              row.valueACiLower = valueAStats?.confidenceInterval.lower ?? 0;
+              row.valueACiUpper = valueAStats?.confidenceInterval.upper ?? 0;
+              row.valueBCiLower = valueBStats?.confidenceInterval.lower ?? 0;
+              row.valueBCiUpper = valueBStats?.confidenceInterval.upper ?? 0;
+            }
+
+            rows.push(row);
+          }
+
+          if (hasModelData) {
+            definitionsWithData += 1;
+          }
+        }
+
+        const data: ExportPairwiseOutput = {
+          rows,
+          count: rows.length,
+          definitionsMatched: pairResult.pairs.length,
+          definitionsWithData,
+          skippedDefinitions: pairResult.skipped,
+        };
+
+        const response = buildMcpResponse({
+          toolName: 'export_pairwise_outcomes',
+          data,
+          requestId,
+          startTime,
+          truncator: (payload) => ({
+            ...payload,
+            rows: truncateArray(payload.rows, 200),
+            count: Math.min(payload.count, 200),
+          }),
+        });
+
+        log.info(
+          {
+            requestId,
+            rows: rows.length,
+            definitionsMatched: pairResult.pairs.length,
+            definitionsWithData,
+            executionMs: response.metadata.executionMs,
+          },
+          'export_pairwise_outcomes completed'
+        );
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(response, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        log.error({ err, requestId }, 'export_pairwise_outcomes failed');
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'INTERNAL_ERROR',
+                message: 'Failed to export pairwise outcomes',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}
+
+addToolRegistrar(registerExportPairwiseOutcomesTool);
+
+export { registerExportPairwiseOutcomesTool };

--- a/cloud/apps/api/src/mcp/tools/get-value-pairs.ts
+++ b/cloud/apps/api/src/mcp/tools/get-value-pairs.ts
@@ -1,0 +1,148 @@
+/**
+ * get_definition_value_pairs MCP Tool
+ *
+ * Returns the value pair (two Schwartz dimensions) tested by each definition.
+ * Useful for mapping vignettes to their value tensions before running
+ * cross-model analysis like Bradley-Terry ranking.
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createLogger } from '@valuerank/shared';
+import { buildMcpResponse, truncateArray } from '../../services/mcp/index.js';
+import { addToolRegistrar } from './registry.js';
+import { fetchDefinitionValuePairs } from './value-pair-helpers.js';
+
+const log = createLogger('mcp:tools:get-value-pairs');
+
+const GetValuePairsInputSchema = {
+  folder: z
+    .string()
+    .optional()
+    .describe('Filter definitions by name (contains match)'),
+  tag: z.string().optional().describe('Filter definitions by tag name'),
+  definition_ids: z
+    .array(z.string())
+    .optional()
+    .describe('Explicit definition IDs (overrides folder/tag filters)'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(200)
+    .default(100)
+    .describe('Maximum definitions to return (default: 100, max: 200)'),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe('Number of definitions to skip for pagination'),
+};
+
+type ValuePairRow = {
+  definitionId: string;
+  name: string;
+  value_a: string;
+  value_b: string;
+};
+
+type GetValuePairsOutput = {
+  pairs: ValuePairRow[];
+  count: number;
+  skipped: number;
+};
+
+function registerGetValuePairsTool(server: McpServer): void {
+  log.info('Registering get_definition_value_pairs tool');
+
+  server.registerTool(
+    'get_definition_value_pairs',
+    {
+      description: `Get the value pair (two Schwartz dimensions) tested by each definition/vignette.
+Returns definitionId, name, value_a, and value_b for each definition matching the filter.
+Use this to map vignettes to their value tensions before cross-model analysis.
+Supports filtering by folder name, tag, or explicit definition IDs.
+Limited to 10KB token budget.`,
+      inputSchema: GetValuePairsInputSchema,
+    },
+    async (args, extra) => {
+      const startTime = Date.now();
+      const requestId = String(extra.requestId ?? 'unknown');
+
+      log.debug({ args, requestId }, 'get_definition_value_pairs called');
+
+      try {
+        const result = await fetchDefinitionValuePairs({
+          folder: args.folder,
+          tag: args.tag,
+          definitionIds: args.definition_ids,
+          limit: args.limit,
+          offset: args.offset,
+        });
+
+        const pairs: ValuePairRow[] = result.pairs.map((p) => ({
+          definitionId: p.definitionId,
+          name: p.name,
+          value_a: p.valueA,
+          value_b: p.valueB,
+        }));
+
+        const data: GetValuePairsOutput = {
+          pairs,
+          count: pairs.length,
+          skipped: result.skipped,
+        };
+
+        const response = buildMcpResponse({
+          toolName: 'get_definition_value_pairs',
+          data,
+          requestId,
+          startTime,
+          truncator: (payload) => ({
+            ...payload,
+            pairs: truncateArray(payload.pairs, 50),
+            count: Math.min(payload.count, 50),
+          }),
+        });
+
+        log.info(
+          {
+            requestId,
+            count: pairs.length,
+            skipped: result.skipped,
+            executionMs: response.metadata.executionMs,
+          },
+          'get_definition_value_pairs completed'
+        );
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(response, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        log.error({ err, requestId }, 'get_definition_value_pairs failed');
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'INTERNAL_ERROR',
+                message: 'Failed to get definition value pairs',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}
+
+addToolRegistrar(registerGetValuePairsTool);
+
+export { registerGetValuePairsTool };

--- a/cloud/apps/api/src/mcp/tools/index.ts
+++ b/cloud/apps/api/src/mcp/tools/index.ts
@@ -62,6 +62,9 @@ import './recover-run.js';
 import './trigger-recovery.js';
 import './get-job-queue-status.js';
 import './get-unsummarized-transcripts.js';
+// Cross-model value analysis tools
+import './get-value-pairs.js';
+import './export-pairwise-outcomes.js';
 
 /**
  * Registers all MCP tools on the given server

--- a/cloud/apps/api/src/mcp/tools/value-pair-helpers.ts
+++ b/cloud/apps/api/src/mcp/tools/value-pair-helpers.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared helpers for cross-model value analysis MCP tools.
+ *
+ * Extracts definition → value-pair mappings by resolving content
+ * and reading dimension names.
+ */
+
+import { db, loadDefinitionContent, resolveDefinitionContent } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+
+const log = createLogger('mcp:tools:value-pair-helpers');
+
+export type DefinitionValuePair = {
+  definitionId: string;
+  name: string;
+  valueA: string;
+  valueB: string;
+};
+
+export type FetchValuePairsOptions = {
+  folder?: string;
+  tag?: string;
+  definitionIds?: string[];
+  limit: number;
+  offset: number;
+};
+
+export type FetchValuePairsResult = {
+  pairs: DefinitionValuePair[];
+  skipped: number;
+};
+
+/**
+ * Fetches definitions and extracts value pairs from their dimensions.
+ *
+ * For root definitions, parses content directly.
+ * For forked definitions, walks the ancestor chain to resolve inherited content.
+ * Skips definitions with fewer than 2 dimensions.
+ */
+export async function fetchDefinitionValuePairs(
+  opts: FetchValuePairsOptions
+): Promise<FetchValuePairsResult> {
+  const where: {
+    deletedAt: null;
+    id?: { in: string[] };
+    name?: { contains: string };
+    definitionTags?: { some: { tag: { name: string }; deletedAt: null } };
+  } = {
+    deletedAt: null,
+  };
+
+  if (opts.definitionIds !== undefined && opts.definitionIds.length > 0) {
+    where.id = { in: opts.definitionIds };
+  } else {
+    if (opts.folder !== undefined && opts.folder !== '') {
+      where.name = { contains: opts.folder };
+    }
+    if (opts.tag !== undefined && opts.tag !== '') {
+      where.definitionTags = {
+        some: { tag: { name: opts.tag }, deletedAt: null },
+      };
+    }
+  }
+
+  const definitions = await db.definition.findMany({
+    where,
+    select: {
+      id: true,
+      name: true,
+      content: true,
+      parentId: true,
+    },
+    orderBy: { createdAt: 'desc' },
+    take: opts.limit,
+    skip: opts.offset,
+  });
+
+  const pairs: DefinitionValuePair[] = [];
+  let skipped = 0;
+
+  for (const def of definitions) {
+    try {
+      let dimensions: { name: string }[];
+
+      if (def.parentId === null) {
+        // Root definition — parse content directly
+        const content = loadDefinitionContent(def.content);
+        dimensions = content.dimensions;
+      } else {
+        // Forked definition — resolve inheritance chain
+        const resolved = await resolveDefinitionContent(def.id);
+        dimensions = resolved.resolvedContent.dimensions;
+      }
+
+      if (dimensions.length < 2) {
+        skipped += 1;
+        log.debug(
+          { definitionId: def.id, dimensionCount: dimensions.length },
+          'Skipping definition with fewer than 2 dimensions'
+        );
+        continue;
+      }
+
+      pairs.push({
+        definitionId: def.id,
+        name: def.name,
+        valueA: dimensions[0]!.name,
+        valueB: dimensions[1]!.name,
+      });
+    } catch (err) {
+      skipped += 1;
+      log.warn(
+        { err, definitionId: def.id },
+        'Failed to resolve definition content'
+      );
+    }
+  }
+
+  return { pairs, skipped };
+}

--- a/cloud/apps/api/src/services/analysis/aggregate.ts
+++ b/cloud/apps/api/src/services/analysis/aggregate.ts
@@ -35,7 +35,7 @@ const zConfidenceInterval = z.object({
     method: z.string(),
 });
 
-const zValueStats = z.object({
+export const zValueStats = z.object({
     count: z.object({
         prioritized: z.number(),
         deprioritized: z.number(),
@@ -45,7 +45,7 @@ const zValueStats = z.object({
     confidenceInterval: zConfidenceInterval,
 });
 
-const zModelStats = z.object({
+export const zModelStats = z.object({
     sampleSize: z.number().optional(),
     values: z.record(zValueStats).optional(),
     overall: z.object({
@@ -112,7 +112,7 @@ type ModelVarianceStats = z.infer<typeof zModelVarianceStats>;
 type VarianceStats = z.infer<typeof zVarianceStats>;
 type ScenarioVarianceStats = z.infer<typeof zScenarioVarianceStats>;
 
-const zAnalysisOutput = z.object({
+export const zAnalysisOutput = z.object({
     perModel: z.record(zModelStats),
     visualizationData: zVisualizationData.optional(),
     mostContestedScenarios: z.array(zContestedScenario).optional(),

--- a/cloud/apps/api/src/services/mcp/response.ts
+++ b/cloud/apps/api/src/services/mcp/response.ts
@@ -37,7 +37,9 @@ export const TOKEN_BUDGETS = {
   get_transcript_summary: 1 * 1024, // 1KB
   get_transcript: 10 * 1024, // 10KB
   get_run_results: 8 * 1024, // 8KB
-  graphql_query: 10 * 1024, // 10KB
+  graphql_query: 50 * 1024, // 50KB
+  get_definition_value_pairs: 10 * 1024, // 10KB
+  export_pairwise_outcomes: 100 * 1024, // 100KB
 } as const;
 
 export type ToolName = keyof typeof TOKEN_BUDGETS;

--- a/cloud/apps/api/tests/mcp/integration.test.ts
+++ b/cloud/apps/api/tests/mcp/integration.test.ts
@@ -291,7 +291,7 @@ describe('MCP Integration', () => {
       // All budgets should be positive and reasonable
       Object.entries(TOKEN_BUDGETS).forEach(([tool, budget]) => {
         expect(budget).toBeGreaterThan(0);
-        expect(budget).toBeLessThanOrEqual(10 * 1024); // Max 10KB
+        expect(budget).toBeLessThanOrEqual(100 * 1024); // Max 100KB
       });
     });
   });

--- a/cloud/apps/api/tests/mcp/response.test.ts
+++ b/cloud/apps/api/tests/mcp/response.test.ts
@@ -21,7 +21,9 @@ describe('MCP Response Builder', () => {
       expect(TOKEN_BUDGETS.get_run_summary).toBe(5 * 1024);
       expect(TOKEN_BUDGETS.get_dimension_analysis).toBe(2 * 1024);
       expect(TOKEN_BUDGETS.get_transcript_summary).toBe(1 * 1024);
-      expect(TOKEN_BUDGETS.graphql_query).toBe(10 * 1024);
+      expect(TOKEN_BUDGETS.graphql_query).toBe(50 * 1024);
+      expect(TOKEN_BUDGETS.get_definition_value_pairs).toBe(10 * 1024);
+      expect(TOKEN_BUDGETS.export_pairwise_outcomes).toBe(100 * 1024);
     });
   });
 

--- a/cloud/apps/api/tests/mcp/tools/export-pairwise-outcomes.test.ts
+++ b/cloud/apps/api/tests/mcp/tools/export-pairwise-outcomes.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+vi.mock('@valuerank/db', () => ({
+  db: {
+    definition: {
+      findMany: vi.fn(),
+    },
+    run: {
+      findMany: vi.fn(),
+    },
+  },
+  loadDefinitionContent: vi.fn(),
+  resolveDefinitionContent: vi.fn(),
+}));
+
+import { db, loadDefinitionContent } from '@valuerank/db';
+
+describe('export_pairwise_outcomes tool', () => {
+  let toolHandler: (
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>
+  ) => Promise<unknown>;
+
+  const mockServer = {
+    registerTool: vi.fn((name, _config, handler) => {
+      if (name === 'export_pairwise_outcomes') {
+        toolHandler = handler;
+      }
+    }),
+  } as unknown as McpServer;
+
+  const makeDefinitions = () => [
+    {
+      id: 'def-1',
+      name: 'Ethics Vignette 1',
+      content: {
+        schema_version: 1,
+        template: 'test',
+        dimensions: [
+          { name: 'Achievement' },
+          { name: 'Benevolence_Caring' },
+        ],
+      },
+      parentId: null,
+    },
+    {
+      id: 'def-2',
+      name: 'Ethics Vignette 2',
+      content: {
+        schema_version: 1,
+        template: 'test',
+        dimensions: [
+          { name: 'Power_Dominance' },
+          { name: 'Universalism_Concern' },
+        ],
+      },
+      parentId: null,
+    },
+  ];
+
+  const makeAnalysisOutput = (
+    valueA: string,
+    valueB: string,
+    modelId: string
+  ) => ({
+    perModel: {
+      [modelId]: {
+        sampleSize: 5,
+        values: {
+          [valueA]: {
+            count: { prioritized: 3, deprioritized: 1, neutral: 1 },
+            winRate: 0.75,
+            confidenceInterval: {
+              lower: 0.5,
+              upper: 0.95,
+              level: 0.95,
+              method: 'wilson',
+            },
+          },
+          [valueB]: {
+            count: { prioritized: 1, deprioritized: 3, neutral: 1 },
+            winRate: 0.25,
+            confidenceInterval: {
+              lower: 0.05,
+              upper: 0.5,
+              level: 0.95,
+              method: 'wilson',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { registerExportPairwiseOutcomesTool } = await import(
+      '../../../src/mcp/tools/export-pairwise-outcomes.js'
+    );
+    registerExportPairwiseOutcomesTool(mockServer);
+  });
+
+  it('registers tool with expected schema', () => {
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'export_pairwise_outcomes',
+      expect.objectContaining({
+        inputSchema: expect.objectContaining({
+          folder: expect.any(Object),
+          tag: expect.any(Object),
+          definition_ids: expect.any(Object),
+          include_ci: expect.any(Object),
+          aggregate_only: expect.any(Object),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('returns pairwise outcome rows from aggregate runs', async () => {
+    const defs = makeDefinitions();
+    vi.mocked(db.definition.findMany).mockResolvedValue(defs as never);
+    vi.mocked(loadDefinitionContent).mockImplementation((raw) => raw as never);
+
+    vi.mocked(db.run.findMany).mockResolvedValue([
+      {
+        id: 'run-1',
+        definitionId: 'def-1',
+        createdAt: new Date('2026-01-01'),
+        analysisResults: [
+          {
+            id: 'ar-1',
+            output: makeAnalysisOutput(
+              'Achievement',
+              'Benevolence_Caring',
+              'gpt-4'
+            ),
+          },
+        ],
+      },
+      {
+        id: 'run-2',
+        definitionId: 'def-2',
+        createdAt: new Date('2026-01-01'),
+        analysisResults: [
+          {
+            id: 'ar-2',
+            output: makeAnalysisOutput(
+              'Power_Dominance',
+              'Universalism_Concern',
+              'gpt-4'
+            ),
+          },
+        ],
+      },
+    ] as never);
+
+    const result = await toolHandler(
+      { folder: 'Ethics', aggregate_only: true, include_ci: false, limit: 100, offset: 0 },
+      { requestId: 'req-1' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.count).toBe(2);
+    expect(response.data.definitionsMatched).toBe(2);
+    expect(response.data.definitionsWithData).toBe(2);
+
+    const row1 = response.data.rows[0];
+    expect(row1.vignetteName).toBe('Ethics Vignette 1');
+    expect(row1.valueA).toBe('Achievement');
+    expect(row1.valueB).toBe('Benevolence_Caring');
+    expect(row1.modelId).toBe('gpt-4');
+    expect(row1.valueAWinRate).toBe(0.75);
+    expect(row1.valueBWinRate).toBe(0.25);
+    expect(row1.valueAPrioritized).toBe(3);
+    expect(row1.valueBDeprioritized).toBe(3);
+
+    // CI fields should not be present when include_ci=false
+    expect(row1.valueACiLower).toBeUndefined();
+    expect(row1.valueACiUpper).toBeUndefined();
+  });
+
+  it('includes confidence intervals when include_ci=true', async () => {
+    const defs = makeDefinitions().slice(0, 1);
+    vi.mocked(db.definition.findMany).mockResolvedValue(defs as never);
+    vi.mocked(loadDefinitionContent).mockImplementation((raw) => raw as never);
+
+    vi.mocked(db.run.findMany).mockResolvedValue([
+      {
+        id: 'run-1',
+        definitionId: 'def-1',
+        createdAt: new Date('2026-01-01'),
+        analysisResults: [
+          {
+            id: 'ar-1',
+            output: makeAnalysisOutput(
+              'Achievement',
+              'Benevolence_Caring',
+              'claude-3'
+            ),
+          },
+        ],
+      },
+    ] as never);
+
+    const result = await toolHandler(
+      { include_ci: true, aggregate_only: true, limit: 100, offset: 0 },
+      { requestId: 'req-ci' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    const row = response.data.rows[0];
+    expect(row.valueACiLower).toBe(0.5);
+    expect(row.valueACiUpper).toBe(0.95);
+    expect(row.valueBCiLower).toBe(0.05);
+    expect(row.valueBCiUpper).toBe(0.5);
+  });
+
+  it('returns empty result when no definitions match', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue([]);
+
+    const result = await toolHandler(
+      { folder: 'nonexistent', aggregate_only: true, include_ci: false, limit: 100, offset: 0 },
+      { requestId: 'req-empty' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.count).toBe(0);
+    expect(response.data.rows).toEqual([]);
+    expect(response.data.definitionsMatched).toBe(0);
+  });
+
+  it('takes most recent run per definition', async () => {
+    const defs = makeDefinitions().slice(0, 1);
+    vi.mocked(db.definition.findMany).mockResolvedValue(defs as never);
+    vi.mocked(loadDefinitionContent).mockImplementation((raw) => raw as never);
+
+    // Two runs for same definition - older run returned first since orderBy desc
+    vi.mocked(db.run.findMany).mockResolvedValue([
+      {
+        id: 'run-new',
+        definitionId: 'def-1',
+        createdAt: new Date('2026-02-01'),
+        analysisResults: [
+          {
+            id: 'ar-new',
+            output: makeAnalysisOutput(
+              'Achievement',
+              'Benevolence_Caring',
+              'gpt-4'
+            ),
+          },
+        ],
+      },
+      {
+        id: 'run-old',
+        definitionId: 'def-1',
+        createdAt: new Date('2026-01-01'),
+        analysisResults: [
+          {
+            id: 'ar-old',
+            output: {
+              perModel: {
+                'gpt-4': {
+                  sampleSize: 1,
+                  values: {
+                    Achievement: {
+                      count: { prioritized: 1, deprioritized: 0, neutral: 0 },
+                      winRate: 1.0,
+                      confidenceInterval: {
+                        lower: 0.5,
+                        upper: 1.0,
+                        level: 0.95,
+                        method: 'wilson',
+                      },
+                    },
+                    Benevolence_Caring: {
+                      count: { prioritized: 0, deprioritized: 1, neutral: 0 },
+                      winRate: 0.0,
+                      confidenceInterval: {
+                        lower: 0.0,
+                        upper: 0.5,
+                        level: 0.95,
+                        method: 'wilson',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    ] as never);
+
+    const result = await toolHandler(
+      { aggregate_only: true, include_ci: false, limit: 100, offset: 0 },
+      { requestId: 'req-dedup' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    // Should use the newer run (sampleSize: 5, not 1)
+    expect(response.data.count).toBe(1);
+    expect(response.data.rows[0].sampleSize).toBe(5);
+  });
+
+  it('skips runs with invalid analysis output', async () => {
+    const defs = makeDefinitions().slice(0, 1);
+    vi.mocked(db.definition.findMany).mockResolvedValue(defs as never);
+    vi.mocked(loadDefinitionContent).mockImplementation((raw) => raw as never);
+
+    vi.mocked(db.run.findMany).mockResolvedValue([
+      {
+        id: 'run-bad',
+        definitionId: 'def-1',
+        createdAt: new Date('2026-01-01'),
+        analysisResults: [
+          {
+            id: 'ar-bad',
+            output: { invalid: 'data' },
+          },
+        ],
+      },
+    ] as never);
+
+    const result = await toolHandler(
+      { aggregate_only: true, include_ci: false, limit: 100, offset: 0 },
+      { requestId: 'req-invalid' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.count).toBe(0);
+    expect(response.data.definitionsWithData).toBe(0);
+  });
+
+  it('queries with Aggregate tag when aggregate_only=true', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue([]);
+
+    await toolHandler(
+      { aggregate_only: true, include_ci: false, limit: 100, offset: 0 },
+      { requestId: 'req-agg-filter' }
+    );
+
+    // No runs query made since no definitions matched
+    expect(db.run.findMany).not.toHaveBeenCalled();
+  });
+
+  it('queries by COMPLETED status when aggregate_only=false', async () => {
+    const defs = makeDefinitions().slice(0, 1);
+    vi.mocked(db.definition.findMany).mockResolvedValue(defs as never);
+    vi.mocked(loadDefinitionContent).mockImplementation((raw) => raw as never);
+    vi.mocked(db.run.findMany).mockResolvedValue([]);
+
+    await toolHandler(
+      { aggregate_only: false, include_ci: false, limit: 100, offset: 0 },
+      { requestId: 'req-completed' }
+    );
+
+    expect(db.run.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: 'COMPLETED',
+        }),
+      })
+    );
+  });
+});

--- a/cloud/apps/api/tests/mcp/tools/get-value-pairs.test.ts
+++ b/cloud/apps/api/tests/mcp/tools/get-value-pairs.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+vi.mock('@valuerank/db', () => ({
+  db: {
+    definition: {
+      findMany: vi.fn(),
+    },
+  },
+  loadDefinitionContent: vi.fn(),
+  resolveDefinitionContent: vi.fn(),
+}));
+
+import { db, loadDefinitionContent, resolveDefinitionContent } from '@valuerank/db';
+
+describe('get_definition_value_pairs tool', () => {
+  let toolHandler: (
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>
+  ) => Promise<unknown>;
+
+  const mockServer = {
+    registerTool: vi.fn((name, _config, handler) => {
+      if (name === 'get_definition_value_pairs') {
+        toolHandler = handler;
+      }
+    }),
+  } as unknown as McpServer;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { registerGetValuePairsTool } = await import(
+      '../../../src/mcp/tools/get-value-pairs.js'
+    );
+    registerGetValuePairsTool(mockServer);
+  });
+
+  it('registers tool with expected schema', () => {
+    expect(mockServer.registerTool).toHaveBeenCalledWith(
+      'get_definition_value_pairs',
+      expect.objectContaining({
+        inputSchema: expect.objectContaining({
+          folder: expect.any(Object),
+          tag: expect.any(Object),
+          definition_ids: expect.any(Object),
+          limit: expect.any(Object),
+          offset: expect.any(Object),
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('returns value pairs for root definitions', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue([
+      {
+        id: 'def-1',
+        name: 'Job Ethics 1',
+        content: {
+          schema_version: 1,
+          template: 'test',
+          dimensions: [
+            { name: 'Achievement' },
+            { name: 'Benevolence_Caring' },
+          ],
+        },
+        parentId: null,
+      },
+      {
+        id: 'def-2',
+        name: 'Job Ethics 2',
+        content: {
+          schema_version: 1,
+          template: 'test',
+          dimensions: [
+            { name: 'Power_Dominance' },
+            { name: 'Universalism_Concern' },
+          ],
+        },
+        parentId: null,
+      },
+    ] as never);
+
+    vi.mocked(loadDefinitionContent).mockImplementation((raw) => raw as never);
+
+    const result = await toolHandler(
+      { folder: 'Job', limit: 100, offset: 0 },
+      { requestId: 'req-1' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.count).toBe(2);
+    expect(response.data.pairs[0]).toEqual({
+      definitionId: 'def-1',
+      name: 'Job Ethics 1',
+      value_a: 'Achievement',
+      value_b: 'Benevolence_Caring',
+    });
+    expect(response.data.pairs[1]).toEqual({
+      definitionId: 'def-2',
+      name: 'Job Ethics 2',
+      value_a: 'Power_Dominance',
+      value_b: 'Universalism_Concern',
+    });
+  });
+
+  it('resolves forked definitions via inheritance chain', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue([
+      {
+        id: 'fork-1',
+        name: 'Forked Vignette',
+        content: { schema_version: 2 },
+        parentId: 'parent-1',
+      },
+    ] as never);
+
+    vi.mocked(resolveDefinitionContent).mockResolvedValue({
+      resolvedContent: {
+        schema_version: 2,
+        template: 'test',
+        dimensions: [
+          { name: 'Tradition' },
+          { name: 'Self_Direction_Thought' },
+        ],
+      },
+    } as never);
+
+    const result = await toolHandler(
+      { limit: 100, offset: 0 },
+      { requestId: 'req-fork' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.count).toBe(1);
+    expect(response.data.pairs[0].value_a).toBe('Tradition');
+    expect(response.data.pairs[0].value_b).toBe('Self_Direction_Thought');
+    expect(resolveDefinitionContent).toHaveBeenCalledWith('fork-1');
+  });
+
+  it('skips definitions with fewer than 2 dimensions', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue([
+      {
+        id: 'def-single',
+        name: 'Single Dimension',
+        content: {
+          schema_version: 1,
+          template: 'test',
+          dimensions: [{ name: 'Achievement' }],
+        },
+        parentId: null,
+      },
+    ] as never);
+
+    vi.mocked(loadDefinitionContent).mockImplementation((raw) => raw as never);
+
+    const result = await toolHandler(
+      { limit: 100, offset: 0 },
+      { requestId: 'req-skip' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.count).toBe(0);
+    expect(response.data.skipped).toBe(1);
+  });
+
+  it('passes definition_ids filter to query', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue([]);
+
+    await toolHandler(
+      { definition_ids: ['id-a', 'id-b'], limit: 100, offset: 0 },
+      { requestId: 'req-ids' }
+    );
+
+    expect(db.definition.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ['id-a', 'id-b'] },
+          deletedAt: null,
+        }),
+      })
+    );
+  });
+
+  it('returns empty result when no definitions match', async () => {
+    vi.mocked(db.definition.findMany).mockResolvedValue([]);
+
+    const result = await toolHandler(
+      { folder: 'nonexistent', limit: 100, offset: 0 },
+      { requestId: 'req-empty' }
+    );
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const response = JSON.parse(content[0].text);
+
+    expect(response.data.count).toBe(0);
+    expect(response.data.pairs).toEqual([]);
+  });
+});

--- a/cloud/apps/api/tests/mcp/tools/graphql-query.test.ts
+++ b/cloud/apps/api/tests/mcp/tools/graphql-query.test.ts
@@ -109,17 +109,17 @@ describe('graphql_query tool', () => {
     });
 
     it('very large responses exceed budget', () => {
-      const largeResponse = { data: { items: 'x'.repeat(15000) } };
+      const largeResponse = { data: { items: 'x'.repeat(55000) } };
       expect(exceedsBudget('graphql_query', largeResponse)).toBe(true);
     });
 
-    it('10KB budget for graphql_query', () => {
-      // Just under 10KB
-      const justUnder = { data: { text: 'x'.repeat(9000) } };
+    it('50KB budget for graphql_query', () => {
+      // Just under 50KB
+      const justUnder = { data: { text: 'x'.repeat(49000) } };
       expect(exceedsBudget('graphql_query', justUnder)).toBe(false);
 
-      // Just over 10KB
-      const justOver = { data: { text: 'x'.repeat(11000) } };
+      // Just over 50KB
+      const justOver = { data: { text: 'x'.repeat(52000) } };
       expect(exceedsBudget('graphql_query', justOver)).toBe(true);
     });
   });

--- a/docs/plans/cross-model-value-analysis.md
+++ b/docs/plans/cross-model-value-analysis.md
@@ -1,0 +1,167 @@
+# Cross-Model Value Bias Analysis: Bradley-Terry & Win-Rate Rankings
+
+## Goal
+
+Generate a global stack ranking of the 10 Schwartz values that each AI model prioritizes, using data from all 45 completed job-domain vignettes across 10 models. Produce CSV/Excel output for manual review before implementing in the ValueRank UI.
+
+## Context
+
+- **45 job-domain vignettes**, each pitting 2 of 10 Schwartz values against each other
+- **10 models** evaluated on each vignette
+- **10 values** with complete pairwise coverage (10 choose 2 = 45 pairs)
+- Each vignette produces a `decisionCode` (1-5) and per-value `prioritized`/`deprioritized`/`neutral` outcomes per model
+
+## Data Model Reference
+
+| Field | Location | Contains |
+|-------|----------|----------|
+| Value pair tested | `Definition.content.dimensions[].name` | The 2 Schwartz values in tension |
+| Scenario intensity | `Scenario.content.dimension_values` | `{ "Value_A": "3", "Value_B": "4" }` |
+| Per-value outcome | `Transcript.content.summary.values` | `{ "Value_A": "prioritized", "Value_B": "deprioritized" }` |
+| Aggregated win rates | `AnalysisResult.output.perModel[modelId].values` | Win rate + Wilson CI per value |
+
+## Phase 1: Extract Production Data
+
+### Step 1a: List all job-domain vignettes
+Use MCP `list_definitions` with `folder: "jobs"` to get all 45 definition IDs.
+
+### Step 1b: List completed runs
+Use MCP `list_runs` with `status: "completed"` and filter to job-domain definitions.
+
+### Step 1c: Pull per-run analysis results
+For each completed run, use MCP `get_run_summary` to get:
+- Per-model win rates for each value
+- Confidence intervals
+- Model agreement scores
+
+### Step 1d: Pull raw transcript-level outcomes
+Use MCP `graphql_query` to fetch all transcripts for job-domain runs:
+```graphql
+query {
+  run(id: "...") {
+    transcripts {
+      modelId
+      scenarioId
+      decisionCode
+      # Need summary.values for pairwise outcomes
+    }
+    definition {
+      name
+      content  # Contains dimensions (the value pair)
+    }
+  }
+}
+```
+
+### Step 1e: Export to CSV
+Create a master CSV with columns:
+```
+vignette_name, value_a, value_b, model_id, decision_code, value_a_outcome, value_b_outcome
+```
+
+Where outcome is `prioritized`, `deprioritized`, or `neutral`.
+
+This gives us ~450 rows (45 vignettes x 10 models), each representing one pairwise value comparison.
+
+## Phase 2: Win-Rate Analysis
+
+### Per-model value win rates
+For each model, for each of the 10 values:
+```
+win_rate = times_prioritized / (times_prioritized + times_deprioritized)
+```
+
+**Output: `win-rate-rankings.csv`**
+```
+model_id, value_name, win_rate, prioritized_count, deprioritized_count, neutral_count, wilson_ci_lower, wilson_ci_upper, rank
+```
+
+This already exists in the `AnalysisResult` data per-run, but we need to aggregate across ALL runs for a given model (not just per-vignette).
+
+### Cross-model comparison table
+Pivot table: models as rows, values as columns, win rates as cells. Sort each model's values by win rate to produce the stack ranking.
+
+## Phase 3: Bradley-Terry Analysis
+
+### Input data format
+For Bradley-Terry, each observation is a "match" between two values:
+```
+value_winner, value_loser, model_id
+```
+
+Derived from the transcript outcomes: the `prioritized` value wins, the `deprioritized` value loses.
+
+### Fitting the model
+For each of the 10 models independently, fit a Bradley-Terry model:
+
+```python
+# Using Python (choix library or custom MLE)
+import choix
+import numpy as np
+
+# For each model:
+# matchups = [(winner_idx, loser_idx), ...] across all 45 vignettes
+params = choix.ilsr_pairwise(n_values, matchups)
+# params are log-strength scores; exponentiate for strength ratios
+strengths = np.exp(params)
+```
+
+Alternative: use R's `BradleyTerry2` package or implement MLE directly.
+
+### Output: `bradley-terry-rankings.csv`
+```
+model_id, value_name, bt_strength, bt_log_strength, bt_rank, bt_ci_lower, bt_ci_upper
+```
+
+### Interpretation
+- Strength scores are on a ratio scale: if Value A has strength 2.0 and Value B has 1.0, the model prioritizes A over B ~67% of the time
+- Confidence intervals from bootstrap resampling (resample the 45 vignette outcomes, refit BT, take 2.5th/97.5th percentiles)
+
+## Phase 4: Output Files
+
+### File 1: `raw-data.csv`
+All transcript-level pairwise outcomes. One row per model-vignette.
+
+### File 2: `win-rate-rankings.csv`
+Win rates per model per value, with Wilson CIs and rank.
+
+### File 3: `bradley-terry-rankings.csv`
+BT strength scores per model per value, with bootstrap CIs and rank.
+
+### File 4: `model-comparison-matrix.csv`
+Pivot table showing side-by-side value rankings for all 10 models.
+
+### File 5: `pairwise-divergence.csv`
+For each of the 45 model pairs (10 choose 2):
+- Kendall's tau rank correlation on their value rankings
+- Top values where they diverge most
+
+## Phase 5: Visualizations (optional, for review)
+
+- Heatmap: models (rows) x values (columns), colored by BT strength
+- Bump chart: value rank position across models
+- Schwartz circumplex: each model plotted by its 2D motivational center
+
+## Implementation Notes
+
+### Tools needed
+- **Python** with `numpy`, `scipy`, `pandas`, `choix` (or custom BT implementation)
+- Or **R** with `BradleyTerry2` package
+- Could also implement BT fitting in TypeScript if we want to keep it in-repo
+
+### Statistical considerations
+- With 45 vignettes and 10 values, each value appears in ~9 vignettes (complete round-robin). That's decent but not huge — CIs will be meaningful.
+- Neutral outcomes should be excluded from BT fitting (only include clear prioritized/deprioritized outcomes).
+- Multi-sample runs: if a vignette was run multiple times (e.g., 3 samples), each sample is an independent observation for BT.
+
+### Data access
+- Use ValueRank MCP tools (`list_definitions`, `list_runs`, `get_run_summary`, `graphql_query`) to pull all data from production
+- Alternative: direct GraphQL curl against the production API with a JWT token
+
+## Future: UI Integration
+
+Once the CSV analysis is validated, implement in the ValueRank web UI as:
+- A new "Cross-Model Analysis" view for folders/tags containing multiple vignettes
+- BT strength chart with CIs per model
+- Interactive model-vs-model comparison
+- Value stack ranking table sortable by any model


### PR DESCRIPTION
## Summary

- Add `get_definition_value_pairs` MCP tool — returns the two Schwartz value dimensions tested by each vignette, with folder/tag/ID filtering (10KB budget)
- Add `export_pairwise_outcomes` MCP tool — joins definition value pairs with analysis results to produce flat per-model win-rate rows suitable for Bradley-Terry ranking (100KB budget)
- Raise `graphql_query` budget from 10KB to 50KB to reduce round-trips for bulk data queries
- Export `zValueStats`, `zModelStats`, `zAnalysisOutput` Zod schemas from the aggregate module for reuse
- Add shared `fetchDefinitionValuePairs()` helper for definition → value-pair extraction with inheritance resolution

## Test plan

- [x] `npx turbo run build` — all 4 packages compile
- [x] `npx turbo run test` — 131 test files pass (1621 passed, 1 skipped)
- [x] New tests for `get_definition_value_pairs` (5 tests: root defs, forked defs, skip logic, ID filtering, empty results)
- [x] New tests for `export_pairwise_outcomes` (7 tests: aggregate runs, CI inclusion, empty results, dedup, invalid output, filter modes)
- [x] Updated existing budget tests in response, graphql-query, and integration test files
- [ ] Manual: call `get_definition_value_pairs` via MCP with `folder: "jobs"` — returns value pairs for job-domain vignettes
- [ ] Manual: call `export_pairwise_outcomes` with `folder: "jobs"` — returns flat pairwise data for Bradley-Terry analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)