### PR TITLE
Domain analysis: hide unavailable models and disable selection

### DIFF
--- a/cloud/apps/web/src/components/domains/SimilaritySection.tsx
+++ b/cloud/apps/web/src/components/domains/SimilaritySection.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { DOMAIN_ANALYSIS_MODELS, VALUES } from '../../data/domainAnalysisData';
+import { DOMAIN_ANALYSIS_AVAILABLE_MODELS, VALUES } from '../../data/domainAnalysisData';
 
 type PairMetric = {
   a: string;
@@ -54,16 +54,16 @@ function getSimilarityColor(value: number): string {
 export function SimilaritySection() {
   const matrix = useMemo(() => {
     const vectors = new Map<string, number[]>();
-    for (const model of DOMAIN_ANALYSIS_MODELS) {
+    for (const model of DOMAIN_ANALYSIS_AVAILABLE_MODELS) {
       vectors.set(model.model, VALUES.map((value) => model.values[value]));
     }
 
     const similarities = new Map<string, Map<string, number>>();
     const pairs: PairMetric[] = [];
 
-    for (const a of DOMAIN_ANALYSIS_MODELS) {
+    for (const a of DOMAIN_ANALYSIS_AVAILABLE_MODELS) {
       const row = new Map<string, number>();
-      for (const b of DOMAIN_ANALYSIS_MODELS) {
+      for (const b of DOMAIN_ANALYSIS_AVAILABLE_MODELS) {
         const av = vectors.get(a.model) ?? [];
         const bv = vectors.get(b.model) ?? [];
         const similarity = cosineSimilarity(av, bv);
@@ -113,7 +113,7 @@ export function SimilaritySection() {
               <th scope="col" className="px-2 py-2 text-left font-medium">
                 Model
               </th>
-              {DOMAIN_ANALYSIS_MODELS.map((model) => (
+              {DOMAIN_ANALYSIS_AVAILABLE_MODELS.map((model) => (
                 <th key={model.model} scope="col" className="px-2 py-2 text-right font-medium">
                   {model.label}
                 </th>
@@ -121,12 +121,12 @@ export function SimilaritySection() {
             </tr>
           </thead>
           <tbody>
-            {DOMAIN_ANALYSIS_MODELS.map((row) => (
+            {DOMAIN_ANALYSIS_AVAILABLE_MODELS.map((row) => (
               <tr key={row.model} className="border-b border-gray-100">
                 <th scope="row" className="px-2 py-2 text-left font-medium text-gray-900">
                   {row.label}
                 </th>
-                {DOMAIN_ANALYSIS_MODELS.map((col) => {
+                {DOMAIN_ANALYSIS_AVAILABLE_MODELS.map((col) => {
                   const similarity = row.model === col.model ? 1 : (matrix.similarities.get(row.model)?.get(col.model) ?? 0);
                   return (
                     <td

--- a/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Button } from '../ui/Button';
 import {
-  DOMAIN_ANALYSIS_MODELS,
+  DOMAIN_ANALYSIS_AVAILABLE_MODELS,
   VALUES,
   VALUE_LABELS,
   type ModelEntry,
@@ -35,7 +35,7 @@ export function ValuePrioritiesSection() {
   };
 
   const ordered = useMemo(() => {
-    const models = [...DOMAIN_ANALYSIS_MODELS];
+    const models = [...DOMAIN_ANALYSIS_AVAILABLE_MODELS];
     const key = sortState.key;
     if (key === 'model') {
       models.sort((a, b) =>
@@ -50,7 +50,7 @@ export function ValuePrioritiesSection() {
   }, [sortState]);
 
   const valueRange = useMemo(() => {
-    const all = DOMAIN_ANALYSIS_MODELS.flatMap((model) => VALUES.map((value) => model.values[value]));
+    const all = DOMAIN_ANALYSIS_AVAILABLE_MODELS.flatMap((model) => VALUES.map((value) => model.values[value]));
     return { min: Math.min(...all), max: Math.max(...all) };
   }, []);
 

--- a/cloud/apps/web/src/data/domainAnalysisData.ts
+++ b/cloud/apps/web/src/data/domainAnalysisData.ts
@@ -16,6 +16,12 @@ export type ModelEntry = {
   values: Record<ValueKey, number>;
 };
 
+export type DomainAnalysisModelAvailability = {
+  model: string;
+  label: string;
+  reason: string;
+};
+
 export const VALUES: ValueKey[] = [
   'Self_Direction_Action',
   'Universalism_Nature',
@@ -222,3 +228,19 @@ export const DOMAIN_ANALYSIS_MODELS: ModelEntry[] = [
     },
   },
 ];
+
+// Models can be temporarily unavailable when systemic probe failures leave no reliable data.
+export const DOMAIN_ANALYSIS_UNAVAILABLE_MODELS: DomainAnalysisModelAvailability[] = [
+  {
+    model: 'gpt-5-mini',
+    label: 'GPT-5 Mini',
+    reason:
+      'Unavailable in this snapshot due to systemic probe failure (temperature setting unsupported for this model).',
+  },
+];
+
+const unavailableModelIds = new Set(DOMAIN_ANALYSIS_UNAVAILABLE_MODELS.map((model) => model.model));
+
+export const DOMAIN_ANALYSIS_AVAILABLE_MODELS: ModelEntry[] = DOMAIN_ANALYSIS_MODELS.filter(
+  (model) => !unavailableModelIds.has(model.model),
+);

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -4,6 +4,7 @@ import { DominanceSection } from '../components/domains/DominanceSection';
 import { SimilaritySection } from '../components/domains/SimilaritySection';
 import { ValuePrioritiesSection } from '../components/domains/ValuePrioritiesSection';
 import { Button } from '../components/ui/Button';
+import { DOMAIN_ANALYSIS_UNAVAILABLE_MODELS } from '../data/domainAnalysisData';
 
 export function DomainAnalysis() {
   const [showInterpretation, setShowInterpretation] = useState(true);
@@ -46,6 +47,19 @@ export function DomainAnalysis() {
       <ValuePrioritiesSection />
       <DominanceSection />
       <SimilaritySection />
+
+      {DOMAIN_ANALYSIS_UNAVAILABLE_MODELS.length > 0 && (
+        <footer className="text-xs text-gray-500">
+          <p className="font-medium text-gray-600">Data availability note</p>
+          <ul className="mt-1 list-disc space-y-1 pl-5">
+            {DOMAIN_ANALYSIS_UNAVAILABLE_MODELS.map((model) => (
+              <li key={model.model}>
+                {model.label}: {model.reason} This model is excluded from analysis tables and graph selectors.
+              </li>
+            ))}
+          </ul>
+        </footer>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add explicit unavailable-model metadata for domain analysis snapshots
- exclude unavailable models from value priorities and similarity tables
- keep unavailable models visible but disabled in ranking/cycles selector
- add a domain analysis footnote explaining model unavailability and exclusion

## Validation
- npm run lint --workspace=@valuerank/web (no errors)