### PR TITLE
Link value drilldown vignettes to Analysis Conditions tab

### DIFF
--- a/cloud/apps/web/src/api/operations/domainAnalysis.ts
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.ts
@@ -48,6 +48,7 @@ export const DOMAIN_ANALYSIS_VALUE_DETAIL_QUERY = gql`
         definitionId
         definitionName
         definitionVersion
+        aggregateRunId
         otherValueKey
         prioritized
         deprioritized
@@ -156,6 +157,7 @@ export type DomainAnalysisValueDetailVignette = {
   definitionId: string;
   definitionName: string;
   definitionVersion: number;
+  aggregateRunId: string | null;
   otherValueKey: string;
   prioritized: number;
   deprioritized: number;

--- a/cloud/apps/web/src/components/analysis/AnalysisPanel.tsx
+++ b/cloud/apps/web/src/components/analysis/AnalysisPanel.tsx
@@ -34,6 +34,7 @@ type AnalysisPanelProps = {
   isOldVersion?: boolean;
   isAggregate?: boolean;
   pendingSince?: string | null;
+  initialTab?: AnalysisTab;
 };
 
 /**
@@ -222,6 +223,7 @@ export function AnalysisPanel({
   isOldVersion = false,
   isAggregate,
   pendingSince,
+  initialTab = 'overview',
 }: AnalysisPanelProps) {
   const { analysis, loading, error, recompute, recomputing } = useAnalysis({
     runId,
@@ -237,7 +239,7 @@ export function AnalysisPanel({
     [definitionContent]
   );
 
-  const [activeTab, setActiveTab] = useState<AnalysisTab>('overview');
+  const [activeTab, setActiveTab] = useState<AnalysisTab>(initialTab);
   const [isExporting, setIsExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [odataLinkCopied, setOdataLinkCopied] = useState(false);

--- a/cloud/apps/web/src/pages/AnalysisDetail.tsx
+++ b/cloud/apps/web/src/pages/AnalysisDetail.tsx
@@ -4,7 +4,7 @@
  * Displays detailed analysis for a single run with full AnalysisPanel.
  */
 
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, Play } from 'lucide-react';
 import { Button } from '../components/ui/Button';
 import { Loading } from '../components/ui/Loading';
@@ -12,10 +12,20 @@ import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { AnalysisPanel } from '../components/analysis/AnalysisPanel';
 import { useRun } from '../hooks/useRun';
 import { getRunDefinitionContent } from '../utils/runDefinitionContent';
+import type { AnalysisTab } from '../components/analysis/tabs';
+
+function parseAnalysisTab(value: string | null): AnalysisTab {
+  if (value === 'overview' || value === 'decisions' || value === 'scenarios' || value === 'stability') {
+    return value;
+  }
+  return 'overview';
+}
 
 export function AnalysisDetail() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const initialTab = parseAnalysisTab(searchParams.get('tab'));
 
   const { run, loading, error } = useRun({
     id: id || '',
@@ -107,6 +117,7 @@ export function AnalysisDetail() {
           isOldVersion={isOldVersion}
           isAggregate={isAggregate}
           pendingSince={run.completedAt}
+          initialTab={initialTab}
         />
       )}
     </div>

--- a/cloud/apps/web/src/pages/DomainAnalysisValueDetail.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysisValueDetail.tsx
@@ -167,9 +167,19 @@ export function DomainAnalysisValueDetail() {
           {detail.vignettes.map((vignette) => (
             <article key={vignette.definitionId} className="rounded border border-gray-200">
               <header className="border-b border-gray-200 bg-gray-50 px-3 py-2">
-                <p className="text-sm font-medium text-gray-900">
-                  {vignette.definitionName} (v{vignette.definitionVersion})
-                </p>
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-sm font-medium text-gray-900">
+                    {vignette.definitionName} (v{vignette.definitionVersion})
+                  </p>
+                  {vignette.aggregateRunId !== null && (
+                    <Link
+                      to={`/analysis/${vignette.aggregateRunId}?tab=scenarios`}
+                      className="text-xs font-medium text-sky-700 hover:text-sky-900 hover:underline"
+                    >
+                      Open in Vignette Analysis (Conditions)
+                    </Link>
+                  )}
+                </div>
                 <p className="text-xs text-gray-600">
                   Pair: {label} vs {VALUE_LABELS[vignette.otherValueKey as ValueKey] ?? vignette.otherValueKey} · Trials:{' '}
                   {vignette.totalTrials} · Win rate: {toPercent(vignette.selectedValueWinRate)}


### PR DESCRIPTION
## Summary
- add `aggregateRunId` to domain value detail vignettes
- add direct link from each vignette card to `/analysis/:runId?tab=scenarios`
- make `AnalysisDetail` and `AnalysisPanel` honor `?tab=` as the initial active tab
- optimize condition transcript resolver by removing full-domain latest-lineage recomputation on every click
- fix `scenarioId` filtering so null means no scenario filter (not `IS NULL` only)
- keep transcript preload behavior unchanged (limit 100 from UI)

## Validation
- npm run typecheck --workspace=@valuerank/api
- npm run lint --workspace=@valuerank/api
- npm run typecheck --workspace=@valuerank/web
- npm run lint --workspace=@valuerank/web (passes with existing unrelated warnings in AccountPanel.tsx)
