### PR TITLE
Add log vs full Bradley-Terry score toggle in Domain Analysis

### DIFF
--- a/cloud/apps/web/src/api/operations/domainAnalysis.ts
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.ts
@@ -1,8 +1,8 @@
 import { gql } from 'urql';
 
 export const DOMAIN_ANALYSIS_QUERY = gql`
-  query DomainAnalysis($domainId: ID!) {
-    domainAnalysis(domainId: $domainId) {
+  query DomainAnalysis($domainId: ID!, $scoreMethod: String) {
+    domainAnalysis(domainId: $domainId, scoreMethod: $scoreMethod) {
       domainId
       domainName
       totalDefinitions
@@ -31,8 +31,8 @@ export const DOMAIN_ANALYSIS_QUERY = gql`
 `;
 
 export const DOMAIN_ANALYSIS_VALUE_DETAIL_QUERY = gql`
-  query DomainAnalysisValueDetail($domainId: ID!, $modelId: String!, $valueKey: String!) {
-    domainAnalysisValueDetail(domainId: $domainId, modelId: $modelId, valueKey: $valueKey) {
+  query DomainAnalysisValueDetail($domainId: ID!, $modelId: String!, $valueKey: String!, $scoreMethod: String) {
+    domainAnalysisValueDetail(domainId: $domainId, modelId: $modelId, valueKey: $valueKey, scoreMethod: $scoreMethod) {
       domainId
       domainName
       modelId
@@ -141,6 +141,7 @@ export type DomainAnalysisQueryResult = {
 
 export type DomainAnalysisQueryVariables = {
   domainId: string;
+  scoreMethod?: 'LOG_ODDS' | 'FULL_BT';
 };
 
 export type DomainAnalysisValueDetailCondition = {
@@ -192,6 +193,7 @@ export type DomainAnalysisValueDetailQueryVariables = {
   domainId: string;
   modelId: string;
   valueKey: string;
+  scoreMethod?: 'LOG_ODDS' | 'FULL_BT';
 };
 
 export type DomainAnalysisConditionTranscript = {

--- a/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
@@ -25,9 +25,16 @@ function getTopBottomValues(model: ModelEntry): { top: ValueKey[]; bottom: Value
 type ValuePrioritiesSectionProps = {
   models: ModelEntry[];
   selectedDomainId: string;
+  scoreMethod: 'LOG_ODDS' | 'FULL_BT';
+  onScoreMethodChange: (method: 'LOG_ODDS' | 'FULL_BT') => void;
 };
 
-export function ValuePrioritiesSection({ models, selectedDomainId }: ValuePrioritiesSectionProps) {
+export function ValuePrioritiesSection({
+  models,
+  selectedDomainId,
+  scoreMethod,
+  onScoreMethodChange,
+}: ValuePrioritiesSectionProps) {
   const navigate = useNavigate();
   const [sortState, setSortState] = useState<SortState>({ key: 'model', direction: 'asc' });
 
@@ -67,6 +74,7 @@ export function ValuePrioritiesSection({ models, selectedDomainId }: ValuePriori
       domainId: selectedDomainId,
       modelId,
       valueKey,
+      scoreMethod,
     });
     navigate(`/domains/analysis/value-detail?${params.toString()}`);
   };
@@ -78,7 +86,29 @@ export function ValuePrioritiesSection({ models, selectedDomainId }: ValuePriori
           <h2 className="text-base font-medium text-gray-900">1. Value Priorities by AI</h2>
           <p className="text-sm text-gray-600">Which values each model favors most and least.</p>
         </div>
-        <p className="text-xs text-gray-500">Click a column heading to sort.</p>
+        <div className="flex items-center gap-3">
+          <p className="text-xs text-gray-500">Click a column heading to sort.</p>
+          <div className="inline-flex rounded border border-gray-200 bg-gray-50 p-0.5">
+            <Button
+              type="button"
+              variant={scoreMethod === 'LOG_ODDS' ? 'primary' : 'ghost'}
+              size="sm"
+              className="h-7 min-h-0 px-2 text-xs"
+              onClick={() => onScoreMethodChange('LOG_ODDS')}
+            >
+              Log
+            </Button>
+            <Button
+              type="button"
+              variant={scoreMethod === 'FULL_BT' ? 'primary' : 'ghost'}
+              size="sm"
+              className="h-7 min-h-0 px-2 text-xs"
+              onClick={() => onScoreMethodChange('FULL_BT')}
+            >
+              Full BT
+            </Button>
+          </div>
+        </div>
       </div>
 
       <div className="overflow-x-auto">


### PR DESCRIPTION
## Summary
- add a score method toggle in Value Priorities by AI: Log vs Full BT
- thread selected method through Domain Analysis queries and value-detail routing
- extend API queries with `scoreMethod` argument for both table and detail endpoints
- implement full Bradley-Terry iterative fit for pairwise value strengths (`FULL_BT`)
- keep existing smoothed log-odds score as `LOG_ODDS`
- update Value Score Detail methodology text with method-specific explanations for Log vs Full BT

## Validation
- npm run typecheck --workspace=@valuerank/api
- npm run lint --workspace=@valuerank/api
- npm run typecheck --workspace=@valuerank/web
- npm run lint --workspace=@valuerank/web (passes with existing unrelated warnings in AccountPanel.tsx)
