### PR TITLE
Domain analysis: add vnew signature filtering

### DIFF
--- a/cloud/apps/api/src/utils/vnew-signature.ts
+++ b/cloud/apps/api/src/utils/vnew-signature.ts
@@ -1,0 +1,34 @@
+function normalizeTemperatureToken(temperature: number): string {
+  return temperature.toFixed(3).replace(/\.?0+$/, '');
+}
+
+export function isVnewSignature(signature: string | null | undefined): boolean {
+  return typeof signature === 'string' && signature.startsWith('vnewt');
+}
+
+export function parseVnewTemperature(signature: string): number | null {
+  if (!isVnewSignature(signature)) {
+    throw new Error(`Not a vnew signature: ${signature}`);
+  }
+  const token = signature.slice('vnewt'.length).trim();
+  if (token === 'd') return null;
+  const parsed = Number.parseFloat(token);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid vnew signature temperature token: ${signature}`);
+  }
+  return parsed;
+}
+
+export function formatVnewSignature(temperature: number | null): string {
+  if (temperature === null || !Number.isFinite(temperature)) {
+    return 'vnewtd';
+  }
+  return `vnewt${normalizeTemperatureToken(temperature)}`;
+}
+
+export function formatVnewLabel(temperature: number | null): string {
+  if (temperature === null || !Number.isFinite(temperature)) {
+    return 'Latest @ default';
+  }
+  return `Latest @ t=${normalizeTemperatureToken(temperature)}`;
+}

--- a/cloud/apps/api/tests/utils/vnew-signature.test.ts
+++ b/cloud/apps/api/tests/utils/vnew-signature.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatVnewLabel,
+  formatVnewSignature,
+  isVnewSignature,
+  parseVnewTemperature,
+} from '../../src/utils/vnew-signature.js';
+
+describe('vnew-signature utils', () => {
+  it('formats signatures', () => {
+    expect(formatVnewSignature(null)).toBe('vnewtd');
+    expect(formatVnewSignature(0)).toBe('vnewt0');
+    expect(formatVnewSignature(0.7)).toBe('vnewt0.7');
+    expect(formatVnewSignature(1.25)).toBe('vnewt1.25');
+  });
+
+  it('parses signatures', () => {
+    expect(parseVnewTemperature('vnewtd')).toBeNull();
+    expect(parseVnewTemperature('vnewt0')).toBe(0);
+    expect(parseVnewTemperature('vnewt0.7')).toBeCloseTo(0.7, 8);
+  });
+
+  it('detects vnew token', () => {
+    expect(isVnewSignature('vnewtd')).toBe(true);
+    expect(isVnewSignature('vnewt0')).toBe(true);
+    expect(isVnewSignature('v2t0')).toBe(false);
+    expect(isVnewSignature(null)).toBe(false);
+  });
+
+  it('throws for invalid vnew signatures', () => {
+    expect(() => parseVnewTemperature('v2t0')).toThrow();
+    expect(() => parseVnewTemperature('vnewtabc')).toThrow();
+  });
+
+  it('formats labels', () => {
+    expect(formatVnewLabel(null)).toBe('Latest @ default');
+    expect(formatVnewLabel(0)).toBe('Latest @ t=0');
+    expect(formatVnewLabel(0.75)).toBe('Latest @ t=0.75');
+  });
+});

--- a/cloud/apps/web/src/api/operations/domainAnalysis.ts
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.ts
@@ -7,6 +7,8 @@ export const DOMAIN_ANALYSIS_QUERY = gql`
       domainName
       totalDefinitions
       targetedDefinitions
+      coveredDefinitions
+      missingDefinitionIds
       definitionsWithAnalysis
       generatedAt
       models {
@@ -73,6 +75,9 @@ export const DOMAIN_ANALYSIS_VALUE_DETAIL_QUERY = gql`
       deprioritized
       neutral
       totalTrials
+      targetedDefinitions
+      coveredDefinitions
+      missingDefinitionIds
       generatedAt
       vignettes {
         definitionId
@@ -176,6 +181,17 @@ export const DOMAIN_ANALYSIS_CONDITION_TRANSCRIPTS_QUERY = gql`
   }
 `;
 
+export const DOMAIN_AVAILABLE_SIGNATURES_QUERY = gql`
+  query DomainAvailableSignatures($domainId: ID!) {
+    domainAvailableSignatures(domainId: $domainId) {
+      signature
+      label
+      isVirtual
+      temperature
+    }
+  }
+`;
+
 export type DomainAnalysisValueScore = {
   valueKey: string;
   score: number;
@@ -202,6 +218,8 @@ export type DomainAnalysisResult = {
   domainName: string;
   totalDefinitions: number;
   targetedDefinitions: number;
+  coveredDefinitions: number;
+  missingDefinitionIds: string[];
   definitionsWithAnalysis: number;
   generatedAt: string;
   models: DomainAnalysisModel[];
@@ -255,8 +273,26 @@ export type DomainAnalysisValueDetailResult = {
   deprioritized: number;
   neutral: number;
   totalTrials: number;
+  targetedDefinitions: number;
+  coveredDefinitions: number;
+  missingDefinitionIds: string[];
   generatedAt: string;
   vignettes: DomainAnalysisValueDetailVignette[];
+};
+
+export type DomainAvailableSignature = {
+  signature: string;
+  label: string;
+  isVirtual: boolean;
+  temperature: number | null;
+};
+
+export type DomainAvailableSignaturesQueryResult = {
+  domainAvailableSignatures: DomainAvailableSignature[];
+};
+
+export type DomainAvailableSignaturesQueryVariables = {
+  domainId: string;
 };
 
 export type DomainAnalysisValueDetailQueryResult = {


### PR DESCRIPTION
## Summary
- add `vnew` signature utilities (`vnewt0`, `vnewtd`, etc.) and tests in API
- add `domainAvailableSignatures(domainId)` GraphQL query based on latest-per-lineage completed runs
- refactor domain analysis resolvers to share signature resolution logic, including vnew temperature resolution and missing-definition coverage metadata
- update domain analysis web page to use backend-provided signature options (instead of definition fetch), default to first available option, and show coverage warning when selected signature excludes vignettes

## Verification
- `npm run typecheck --workspace=@valuerank/api` (run from `cloud/`)
- `npm run typecheck --workspace=@valuerank/web` (run from `cloud/`)
- `npm run lint --workspace=@valuerank/api` (run from `cloud/`)
- `npm run lint --workspace=@valuerank/web` (run from `cloud/`; passes with existing warnings in `cloud/apps/web/src/components/settings/AccountPanel.tsx`)
- `npm run test --workspace=@valuerank/api -- tests/utils/vnew-signature.test.ts` (run from `cloud/`)
