### PR TITLE
Follow-up: address PR 274 review feedback

### DIFF
--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -47,6 +47,13 @@ export function DomainAnalysis() {
     () => signatureData?.domainAvailableSignatures ?? [],
     [signatureData],
   );
+  const hasValidSelectedSignature = useMemo(
+    () => selectedSignature !== '' && signatureOptions.some((option) => option.signature === selectedSignature),
+    [selectedSignature, signatureOptions],
+  );
+  const signatureSelectionReady = selectedDomainId !== ''
+    && !signaturesLoading
+    && (signatureOptions.length === 0 || hasValidSelectedSignature);
 
   useEffect(() => {
     if (domains.length === 0) return;
@@ -94,7 +101,7 @@ export function DomainAnalysis() {
       scoreMethod,
       signature: selectedSignature === '' ? undefined : selectedSignature,
     },
-    pause: selectedDomainId === '' || useLegacyQuery,
+    pause: selectedDomainId === '' || useLegacyQuery || !signatureSelectionReady,
     requestPolicy: 'cache-and-network',
   });
   const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<DomainAnalysisQueryResult, { domainId: string }>({


### PR DESCRIPTION
## Summary
Follow-up fixes for review feedback on merged PR #274.

### Fixed
1. Added auth guard to `domainAvailableSignatures` to require authenticated users.
2. Added explicit inline documentation in `resolveSignatureRuns` for `vnew` semantics (fresh completed runs per latest definition lineage, not restricted to aggregate `sourceRunIds`).
3. Refactored `domainAnalysisConditionTranscripts` signature-resolution call into named variables for readability.
4. Prevented initial unfiltered double-fetch in `DomainAnalysis` by pausing analysis query until signature selection is ready.

## Validation
- `npm run typecheck --workspace=@valuerank/api` (from `cloud/`)
- `npm run typecheck --workspace=@valuerank/web` (from `cloud/`)
- `npm run lint --workspace=@valuerank/api` (from `cloud/`)
- `npm run lint --workspace=@valuerank/web` (from `cloud/`, existing warnings only in `cloud/apps/web/src/components/settings/AccountPanel.tsx`)
