### PR TITLE
fix: repair Feature Factory paths broken by docs reorganization

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_deliver.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_deliver.py
@@ -15,7 +15,7 @@ from factory_state import (  # noqa: E402
     load_checkpoint_manifest,
 )
 
-REVIEW_SCRIPTS = REPO_ROOT / "docs" / "operations" / "codex-skills" / "review-lens" / "scripts"
+REVIEW_SCRIPTS = REPO_ROOT / "docs" / "workflow" / "operations" / "codex-skills" / "review-lens" / "scripts"
 if str(REVIEW_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(REVIEW_SCRIPTS))
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review.py
@@ -34,7 +34,7 @@ from factory_state import (  # noqa: E402
     parse_review_frontmatter,
 )
 
-REVIEW_SCRIPTS = REPO_ROOT / "docs" / "operations" / "codex-skills" / "review-lens" / "scripts"
+REVIEW_SCRIPTS = REPO_ROOT / "docs" / "workflow" / "operations" / "codex-skills" / "review-lens" / "scripts"
 if str(REVIEW_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(REVIEW_SCRIPTS))
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_stages.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_stages.py
@@ -27,7 +27,7 @@ from factory_state import (  # noqa: E402
     parse_review_frontmatter,
 )
 
-REVIEW_SCRIPTS = REPO_ROOT / "docs" / "operations" / "codex-skills" / "review-lens" / "scripts"
+REVIEW_SCRIPTS = REPO_ROOT / "docs" / "workflow" / "operations" / "codex-skills" / "review-lens" / "scripts"
 if str(REVIEW_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(REVIEW_SCRIPTS))
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_state.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_state.py
@@ -16,8 +16,8 @@ from pathlib import Path
 # Repository root + canonical subdirectory roots
 # ---------------------------------------------------------------------------
 
-REPO_ROOT: Path = Path(__file__).resolve().parents[5]
-FACTORY_RUNS_ROOT: Path = REPO_ROOT / "docs" / "feature-runs"
+REPO_ROOT: Path = Path(__file__).resolve().parents[6]
+FACTORY_RUNS_ROOT: Path = REPO_ROOT / "docs" / "workflow" / "feature-runs"
 
 # ---------------------------------------------------------------------------
 # String constants used as workflow-state dictionary keys

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py
@@ -49,7 +49,7 @@ from factory_state import (  # noqa: E402
     load_checkpoint_manifest,
 )
 
-REVIEW_SCRIPTS = REPO_ROOT / "docs" / "operations" / "codex-skills" / "review-lens" / "scripts"
+REVIEW_SCRIPTS = REPO_ROOT / "docs" / "workflow" / "operations" / "codex-skills" / "review-lens" / "scripts"
 if str(REVIEW_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(REVIEW_SCRIPTS))
 


### PR DESCRIPTION
## Summary

- The docs reorganization in #556 moved files from `docs/operations/` to `docs/workflow/operations/` but didn't update 5 hardcoded paths in the Feature Factory Python scripts
- `REVIEW_SCRIPTS` path was wrong in 4 files (missing `workflow/` segment)
- `REPO_ROOT` parent index was off by 1, and `FACTORY_RUNS_ROOT` was missing `workflow/`
- Feature Factory was completely broken — `ModuleNotFoundError: No module named 'workflow_utils'`

## Test plan

- [x] `run_factory.py status --slug test` runs successfully after fix
- [x] All 5 path references updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)