### PR TITLE
fix: make decision model domain-agnostic

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
@@ -1,5 +1,5 @@
 import { DOMAIN_ANALYSIS_VALUE_KEYS, extractValuePair, toPascalCaseKey, type DomainAnalysisValueKey, type DomainAnalysisValuePair } from '../domain-analysis-values.js';
-import { JOB_CHOICE_VALUE_STATEMENTS, labelFromBody } from '@valuerank/shared';
+import { labelFromBody } from '@valuerank/shared';
 
 export type DecisionDirection = 'favor_first' | 'favor_second' | 'neutral' | 'refusal' | 'unknown';
 export type DecisionStrength = 'strong' | 'lean' | 'neutral' | 'unknown';
@@ -82,6 +82,7 @@ export type DecisionModelInput = {
   manualOverrideDecision?: CanonicalAppliedDecision | null;
   cachedDecision?: CachedWinnerFirstDecision | null;
   valueStatements?: readonly ValueStatementEntry[];
+  labelPrefix?: string | null;
 };
 
 export type DecisionModelResult = {
@@ -261,20 +262,25 @@ function parseJobChoiceStrengthFromText(text: string): DecisionStrength | null {
   return null;
 }
 
-function resolveJobChoiceValueKeyFromText(
+function resolveValueKeyFromText(
   text: string,
-  valueStatements?: readonly ValueStatementEntry[],
+  valueStatements: readonly ValueStatementEntry[] | undefined,
+  labelPrefix: string | null,
 ): DomainAnalysisValueKey | null {
+  if (valueStatements == null || valueStatements.length === 0) {
+    return null;
+  }
+
   const normalized = normalizeJobChoiceLabelText(text);
   if (normalized.length === 0) {
     return null;
   }
 
-  const entries: readonly ValueStatementEntry[] = valueStatements ?? JOB_CHOICE_VALUE_STATEMENTS;
+  const prefix = labelPrefix ?? '';
   let resolved: DomainAnalysisValueKey | null = null;
-  for (const entry of entries) {
+  for (const entry of valueStatements) {
     const valueKey = toPascalCaseKey(entry.token) as DomainAnalysisValueKey;
-    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body));
+    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, prefix));
     if (!label || !normalized.includes(label)) {
       continue;
     }
@@ -477,6 +483,59 @@ export function buildRawDecisionEvidence(
   };
 }
 
+function extractValueStatementsFromSnapshot(snapshot: unknown): ValueStatementEntry[] | undefined {
+  if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) return undefined;
+  const components = (snapshot as { components?: unknown }).components;
+  if (components === null || typeof components !== 'object' || Array.isArray(components)) return undefined;
+
+  const vf = (components as { value_first?: unknown }).value_first;
+  const vs = (components as { value_second?: unknown }).value_second;
+  if (!isRecord(vf) || !isRecord(vs)) return undefined;
+
+  const tokenFirst = typeof vf.token === 'string' ? vf.token : null;
+  const bodyFirst = typeof vf.body === 'string' ? vf.body : null;
+  const tokenSecond = typeof vs.token === 'string' ? vs.token : null;
+  const bodySecond = typeof vs.body === 'string' ? vs.body : null;
+
+  if (tokenFirst == null || bodyFirst == null || tokenSecond == null || bodySecond == null) return undefined;
+  return [
+    { token: tokenFirst, body: bodyFirst },
+    { token: tokenSecond, body: bodySecond },
+  ];
+}
+
+const LABEL_PREFIX_REGEX = /^(?:Strongly|Somewhat) support (.+)$/;
+
+function extractLabelPrefixFromSnapshot(snapshot: unknown): string | undefined {
+  if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) return undefined;
+  const template = (snapshot as { template?: unknown }).template;
+  if (typeof template !== 'string') return undefined;
+
+  const components = (snapshot as { components?: unknown }).components;
+  if (components === null || typeof components !== 'object' || Array.isArray(components)) return undefined;
+  const vf = (components as { value_first?: unknown }).value_first;
+  if (!isRecord(vf) || typeof vf.body !== 'string') return undefined;
+
+  // Extract the short body (before "because") to find it in the scale label
+  const shortBody = (vf.body.split(' because')[0] ?? vf.body).trim();
+  if (shortBody.length === 0) return undefined;
+
+  // Find a scale label line that ends with the short body
+  const lines = template.split('\n');
+  for (const line of lines) {
+    const trimmed = line.replace(/^- /, '').trim();
+    const match = LABEL_PREFIX_REGEX.exec(trimmed);
+    if (match == null) continue;
+    const afterStrength = match[1] ?? '';
+    if (afterStrength.endsWith(shortBody)) {
+      const prefix = afterStrength.slice(0, afterStrength.length - shortBody.length).trimEnd();
+      if (prefix.length > 0) return prefix;
+    }
+  }
+
+  return undefined;
+}
+
 export function resolveTranscriptDecisionModel(
   input: TranscriptDecisionModelInput,
 ): TranscriptDecisionModelResult {
@@ -484,6 +543,10 @@ export function resolveTranscriptDecisionModel(
   const raw = buildRawDecisionEvidence(input.decisionMetadata);
   const manualOverrideDecision = extractManualOverrideDecision(input.decisionMetadata);
   const cachedDecision = extractCachedWinnerFirstDecision(input.decisionMetadata);
+
+  const valueStatements = extractValueStatementsFromSnapshot(input.definitionSnapshot);
+  const labelPrefix = extractLabelPrefixFromSnapshot(input.definitionSnapshot) ?? null;
+
   const resolved = resolveDecisionModel({
     pair,
     orientationFlipped: input.orientationFlipped,
@@ -491,6 +554,8 @@ export function resolveTranscriptDecisionModel(
     manualOverridePresent: manualOverrideDecision !== null,
     manualOverrideDecision,
     cachedDecision,
+    valueStatements,
+    labelPrefix,
   });
 
   return resolved;
@@ -517,10 +582,11 @@ export function resolveCanonicalDecision(input: DecisionModelInput): CanonicalDe
 
   const parsedPath = parseDecisionPath(input.raw.parsePath);
   const cachedDecision = input.cachedDecision ?? null;
-  if (cachedDecision) {
-    if (cachedDecision.decisionState === 'unknown') {
-      return buildUnknownCanonicalDecision('unknown');
-    }
+  if (cachedDecision && cachedDecision.decisionState !== 'unknown') {
+    // When cachedDecision.decisionState is 'unknown', skip the cache and
+    // fall through to re-resolve from raw evidence. This handles cases where
+    // the cache was built with incorrect config (e.g. wrong value statements
+    // or label prefix for the domain family).
 
     if (cachedDecision.decisionState === 'neutral') {
       return buildCanonicalDecisionFromPair(
@@ -578,7 +644,7 @@ export function resolveCanonicalDecision(input: DecisionModelInput): CanonicalDe
       );
     }
 
-    const favoredValueKey = resolveJobChoiceValueKeyFromText(candidateText, input.valueStatements);
+    const favoredValueKey = resolveValueKeyFromText(candidateText, input.valueStatements, input.labelPrefix ?? null);
     if (favoredValueKey === null) {
       return buildUnknownCanonicalDecision('unknown');
     }

--- a/cloud/apps/api/src/graphql/types/domain.ts
+++ b/cloud/apps/api/src/graphql/types/domain.ts
@@ -54,6 +54,8 @@ builder.objectType(DomainRef, {
       },
     }),
     defaultModelIds: t.exposeStringList('defaultModelIds'),
+    sentencePrefix: t.exposeString('sentencePrefix', { nullable: true }),
+    labelPrefix: t.exposeString('labelPrefix', { nullable: true }),
     defaultContextId: t.exposeString('defaultContextId', { nullable: true }),
     defaultContext: t.field({
       type: DomainContextRef,

--- a/cloud/apps/api/src/utils/paired-definition.ts
+++ b/cloud/apps/api/src/utils/paired-definition.ts
@@ -3,6 +3,7 @@ import {
   assembleTemplate,
   getJobChoiceValueStatementBody,
   getSoftwareApproachValueStatementBody,
+  type TemplateConfig,
 } from '@valuerank/shared';
 
 type PairedContentLike = Pick<DefinitionContent, 'template' | 'components' | 'methodology'>;
@@ -10,6 +11,11 @@ type PairedContentLike = Pick<DefinitionContent, 'template' | 'components' | 'me
 const SENTENCE_PREFIX_BY_FAMILY: Record<string, string> = {
   'job-choice': 'One job offers ',
   'software-approach-choice': 'One approach provides ',
+};
+
+const TEMPLATE_CONFIG_BY_FAMILY: Record<string, TemplateConfig> = {
+  'job-choice': { sentencePrefix: 'One job offers [level]', labelPrefix: 'taking the job with' },
+  'software-approach-choice': { sentencePrefix: 'One approach provides [level]', labelPrefix: 'choosing the approach relating to' },
 };
 
 type BodyLookup = (token: string) => string | undefined;
@@ -71,7 +77,8 @@ export function normalizePairedDefinitionContent<T>(content: T): T {
   }
 
   const normalizedComponents = normalizePairedComponents(content.components, family);
-  const normalizedTemplate = assembleTemplate(intro, normalizedComponents);
+  const templateConfig = TEMPLATE_CONFIG_BY_FAMILY[family];
+  const normalizedTemplate = assembleTemplate(intro, normalizedComponents, undefined, templateConfig);
 
   return {
     ...content,

--- a/cloud/apps/api/tests/graphql/queries/decision-model.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/decision-model.test.ts
@@ -20,6 +20,37 @@ const PAIR: DecisionPair = {
   valueB: 'Benevolence_Dependability',
 };
 
+// Realistic job-choice snapshot with components + template so snapshot-based
+// extraction can derive value statements and label prefix.
+const JOB_CHOICE_COMPONENTS = {
+  value_first: {
+    token: 'achievement',
+    body: 'recognition of their expertise because of how it relates to success through strong performance',
+  },
+  value_second: {
+    token: 'benevolence_dependability',
+    body: 'trust from other people because of how it relates to being someone others can rely on to carry through on shared responsibilities',
+  },
+};
+
+const JOB_CHOICE_TEMPLATE_LINES = [
+  '- Strongly support taking the job with recognition of their expertise',
+  '- Somewhat support taking the job with recognition of their expertise',
+  '- Neutral / Unsure',
+  '- Somewhat support taking the job with trust from other people',
+  '- Strongly support taking the job with trust from other people',
+].join('\n');
+
+function jobChoiceSnapshot(presentationOrder: string, overrides: Record<string, unknown> = {}) {
+  return {
+    dimensions: [{ name: 'Achievement' }, { name: 'Benevolence_Dependability' }],
+    methodology: { presentation_order: presentationOrder },
+    components: JOB_CHOICE_COMPONENTS,
+    template: `Some preamble\n${JOB_CHOICE_TEMPLATE_LINES}`,
+    ...overrides,
+  };
+}
+
 function buildManualOverride(
   overrides: Partial<NonNullable<RawDecisionEvidence['manualOverride']>> = {},
 ): NonNullable<RawDecisionEvidence['manualOverride']> {
@@ -164,12 +195,7 @@ describe('decision model', () => {
         responseExcerpt: '**Strongly support taking the job with trust from other people** ...',
         matchedLabel: null,
       },
-      definitionSnapshot: {
-        dimensions: [{ name: 'Achievement' }, { name: 'Benevolence_Dependability' }],
-        methodology: {
-          presentation_order: 'A_first',
-        },
-      },
+      definitionSnapshot: jobChoiceSnapshot('A_first'),
       orientationFlipped: true,
     });
 
@@ -200,12 +226,7 @@ describe('decision model', () => {
         matchedLabel: 'Strongly support taking the job with trust from other people',
         responseExcerpt: 'Level of Support: Strongly support taking the job with trust from other people ...',
       },
-      definitionSnapshot: {
-        dimensions: [{ name: 'Achievement' }, { name: 'Benevolence_Dependability' }],
-        methodology: {
-          presentation_order: 'B_first',
-        },
-      },
+      definitionSnapshot: jobChoiceSnapshot('B_first'),
       orientationFlipped: true,
     });
 
@@ -594,10 +615,7 @@ describe('decision model', () => {
         matchedLabel: achievementLabel,
         responseExcerpt: `Level of Support: ${achievementLabel}`,
       },
-      definitionSnapshot: {
-        dimensions: [{ name: 'Achievement' }, { name: 'Benevolence_Dependability' }],
-        methodology: { presentation_order: 'A_first' },
-      },
+      definitionSnapshot: jobChoiceSnapshot('A_first'),
       orientationFlipped: false,
     });
 
@@ -610,10 +628,7 @@ describe('decision model', () => {
         matchedLabel: achievementLabel,
         responseExcerpt: `Level of Support: ${achievementLabel}`,
       },
-      definitionSnapshot: {
-        dimensions: [{ name: 'Achievement' }, { name: 'Benevolence_Dependability' }],
-        methodology: { presentation_order: 'B_first' },
-      },
+      definitionSnapshot: jobChoiceSnapshot('B_first'),
       orientationFlipped: true,
     });
 

--- a/cloud/apps/api/tests/graphql/types/transcript-decision-model-v2.test.ts
+++ b/cloud/apps/api/tests/graphql/types/transcript-decision-model-v2.test.ts
@@ -112,6 +112,24 @@ describe('Transcript decisionModelV2 GraphQL field', () => {
           methodology: {
             presentation_order: 'B_first',
           },
+          components: {
+            value_first: {
+              token: 'achievement',
+              body: 'recognition of their expertise because of how it relates to success through strong performance',
+            },
+            value_second: {
+              token: 'benevolence_dependability',
+              body: 'trust from other people because of how it relates to being someone others can rely on to carry through on shared responsibilities',
+            },
+          },
+          template: [
+            'Some preamble',
+            '- Strongly support taking the job with recognition of their expertise',
+            '- Somewhat support taking the job with recognition of their expertise',
+            '- Neutral / Unsure',
+            '- Somewhat support taking the job with trust from other people',
+            '- Strongly support taking the job with trust from other people',
+          ].join('\n'),
         },
         content: { turns: [] },
         turnCount: 1,

--- a/cloud/apps/web/src/api/operations/domains.ts
+++ b/cloud/apps/web/src/api/operations/domains.ts
@@ -10,6 +10,8 @@ export type Domain = {
   defaultPreambleVersionId: string | null;
   defaultContextId: string | null;
   defaultModelIds: string[];
+  sentencePrefix: string | null;
+  labelPrefix: string | null;
 };
 
 export const DOMAINS_QUERY = gql`
@@ -24,6 +26,8 @@ export const DOMAINS_QUERY = gql`
       defaultPreambleVersionId
       defaultContextId
       defaultModelIds
+      sentencePrefix
+      labelPrefix
     }
   }
 `;

--- a/cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx
+++ b/cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx
@@ -14,7 +14,7 @@ import {
   type DomainContext,
 } from '../../api/operations/domain-contexts';
 import type { SetDomainSettingsMutationVariables } from '../../api/operations/domains';
-import { labelFromBody, DEFAULT_SENTENCE_PREFIX, DEFAULT_LABEL_PREFIX } from '@valuerank/shared';
+import { labelFromBody, DEFAULT_SENTENCE_PREFIX } from '@valuerank/shared';
 
 const PREAMBLES_QUERY = `
   query PreamblesForDomainSettings {
@@ -348,7 +348,7 @@ export function DomainSettingsPanel({ domainId, onSaved }: Props) {
         <input
           type="text"
           className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm"
-          placeholder={DEFAULT_LABEL_PREFIX}
+          placeholder="e.g. taking the job with"
           value={localLabelPrefix}
           onChange={(e) => setLocalLabelPrefix(e.target.value)}
         />
@@ -364,8 +364,7 @@ export function DomainSettingsPanel({ domainId, onSaved }: Props) {
           <div className="rounded border border-gray-200 bg-gray-50 p-2 space-y-1">
             {sortedStatements.map((vs) => {
               const body = drafts[vs.token] !== undefined ? (drafts[vs.token] as string) : vs.currentContent;
-              const prefix = localLabelPrefix !== '' ? localLabelPrefix : undefined;
-              const label = labelFromBody(body, prefix);
+              const label = labelFromBody(body, localLabelPrefix);
               return (
                 <div key={vs.token} className="flex items-start gap-2 text-xs">
                   <span className="font-mono text-teal-700 uppercase tracking-wide shrink-0">

--- a/cloud/apps/web/src/components/runs/TranscriptRow.tsx
+++ b/cloud/apps/web/src/components/runs/TranscriptRow.tsx
@@ -52,14 +52,81 @@ const LEVEL_WORD_TO_NUMBER: Record<string, number> = {
   negligible: 1,
 };
 
+const STRENGTH_PREFIXES = ['Strongly support', 'Somewhat support'];
+
 /**
  * Extracts the short direction phrase from a full scale label.
- * "Strongly support taking the job with..." → "Strongly support"
- * "Neutral / Unsure" → "Neutral / Unsure" (no truncation)
+ * "Strongly support choosing the approach relating to..." → "Strongly support"
+ * "Neutral / Unsure" → "Neutral / Unsure"
  */
 function extractShortDirection(fullLabel: string): string {
-  const idx = fullLabel.toLowerCase().indexOf(' taking ');
-  return idx !== -1 ? fullLabel.slice(0, idx) : fullLabel;
+  for (const prefix of STRENGTH_PREFIXES) {
+    if (fullLabel.startsWith(prefix)) return prefix;
+  }
+  return fullLabel;
+}
+
+/**
+ * Extracts the value subject from a scale label by stripping the strength prefix
+ * and any domain-specific label prefix.
+ * E.g. "Strongly support taking the job with recognition of their expertise"
+ *   → "recognition of their expertise"
+ * Works for any domain by detecting the label prefix from the scale labels.
+ */
+function extractSubjectFromLabel(
+  labelText: string,
+  scaleLabels: Array<{ code: string; label: string }>,
+): string | null {
+  // Find a non-neutral scale label to detect the label prefix pattern
+  const sampleLabel = scaleLabels.find((entry) =>
+    entry.label.startsWith('Strongly support') || entry.label.startsWith('Somewhat support'),
+  )?.label;
+  if (sampleLabel == null) return null;
+
+  // Find which strength prefix this label uses
+  let strengthPrefix: string | null = null;
+  for (const prefix of STRENGTH_PREFIXES) {
+    if (labelText.startsWith(prefix)) {
+      strengthPrefix = prefix;
+      break;
+    }
+  }
+  if (strengthPrefix == null) return null;
+
+  // The text after "Strongly support " or "Somewhat support " includes the
+  // label prefix + the value body. We need to find where the body starts.
+  // Strategy: find the label prefix by comparing two different scale labels.
+  const afterStrength = labelText.slice(strengthPrefix.length).trimStart();
+
+  // Find two non-neutral labels to detect the common prefix
+  const nonNeutralLabels = scaleLabels
+    .filter((entry) => entry.label.startsWith('Strongly support') || entry.label.startsWith('Somewhat support'))
+    .map((entry) => {
+      for (const prefix of STRENGTH_PREFIXES) {
+        if (entry.label.startsWith(prefix)) {
+          return entry.label.slice(prefix.length).trimStart();
+        }
+      }
+      return entry.label;
+    });
+
+  if (nonNeutralLabels.length < 2) return afterStrength.length > 0 ? afterStrength : null;
+
+  // Find the common prefix among all non-neutral labels — that's the label prefix
+  let commonPrefix = '';
+  const first = nonNeutralLabels[0] ?? '';
+  for (let i = 0; i < first.length; i++) {
+    const char = first[i];
+    if (nonNeutralLabels.every((label) => label[i] === char)) {
+      commonPrefix += char;
+    } else {
+      break;
+    }
+  }
+
+  // The subject is what comes after the common prefix (the label prefix)
+  const subject = afterStrength.slice(commonPrefix.length).trim();
+  return subject.length > 0 ? subject : null;
 }
 
 
@@ -102,15 +169,14 @@ function getLegacyDecisionDisplay(
     : (rawMatchedLabel ?? decisionScaleEntry?.label ?? null);
   const shortDirection = labelText != null ? extractShortDirection(labelText) : null;
   const primaryDimKey = dimensions != null ? (Object.keys(dimensions)[0] ?? null) : null;
-  const jobWithMarker = ' taking the job with ';
-  const jobWithIdx = labelText?.toLowerCase().indexOf(jobWithMarker) ?? -1;
-  const jobSubject = jobWithIdx >= 0 && labelText != null
-    ? formatDisplayLabel(labelText.slice(jobWithIdx + jobWithMarker.length))
+  const subject = labelText != null
+    ? extractSubjectFromLabel(labelText, decisionScaleLabels)
     : null;
+  const formattedSubject = subject != null ? formatDisplayLabel(subject) : null;
 
   return shortDirection != null
-    ? (jobSubject != null
-        ? `${normalizedDecision} - ${shortDirection} (${jobSubject})`
+    ? (formattedSubject != null
+        ? `${normalizedDecision} - ${shortDirection} (${formattedSubject})`
         : (primaryDimKey != null ? `${normalizedDecision} - ${shortDirection} ${formatDisplayLabel(primaryDimKey)}` : `${normalizedDecision} - ${shortDirection}`))
     : String(normalizedDecision);
 }

--- a/cloud/apps/web/src/pages/PairedVignetteNew.tsx
+++ b/cloud/apps/web/src/pages/PairedVignetteNew.tsx
@@ -1,4 +1,4 @@
-import { assembleTemplate } from '@valuerank/shared';
+import { assembleTemplate, type TemplateConfig } from '@valuerank/shared';
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { gql, useMutation, useQuery } from 'urql';
@@ -218,12 +218,17 @@ export function PairedVignetteNew() {
     const levelWords = selectedLevelPresetVersion != null
       ? { first: selectedLevelPresetVersion.l3, second: selectedLevelPresetVersion.l3 }
       : undefined;
+    const selectedDomain = domains.find((d) => d.id === selectedDomainId);
+    const templateConfig: TemplateConfig | undefined =
+      selectedDomain?.sentencePrefix != null || selectedDomain?.labelPrefix != null
+        ? { sentencePrefix: selectedDomain.sentencePrefix ?? undefined, labelPrefix: selectedDomain.labelPrefix ?? undefined }
+        : undefined;
     return assembleTemplate(selectedContext.text, {
       context_id: selectedContextId,
       value_first: { token: valueFirst.token, body: valueFirst.body },
       value_second: { token: valueSecond.token, body: valueSecond.body },
-    }, levelWords);
-  }, [selectedContext, selectedContextId, valueFirst, valueSecond, selectedLevelPresetVersion]);
+    }, levelWords, templateConfig);
+  }, [selectedContext, selectedContextId, valueFirst, valueSecond, selectedLevelPresetVersion, domains, selectedDomainId]);
 
   const loadingError =
     definitionError?.message ??

--- a/cloud/packages/shared/src/assemble-template.ts
+++ b/cloud/packages/shared/src/assemble-template.ts
@@ -12,16 +12,14 @@ export type TemplateConfig = {
 };
 
 export const DEFAULT_SENTENCE_PREFIX = 'One job offers [level]';
-export const DEFAULT_LABEL_PREFIX = 'taking the job with';
 
-export function labelFromBody(body: string, labelPrefix?: string | null): string {
+export function labelFromBody(body: string, labelPrefix: string): string {
   // Extract a stable scale label from the value statement body.
   // Bodies should not contain [level] (it belongs in sentencePrefix),
   // but strip it defensively for backward compatibility.
   const clean = body.replace(/\[level\]\s*/g, '');
   const beforeBecause = (clean.split(' because')[0] ?? clean).trim();
-  const prefix = labelPrefix ?? DEFAULT_LABEL_PREFIX;
-  return `${prefix} ${beforeBecause}`;
+  return `${labelPrefix} ${beforeBecause}`;
 }
 
 function buildScale(labelFirst: string, labelSecond: string): string {
@@ -66,8 +64,10 @@ export function assembleTemplate(
 
   // Scale labels use the original body (stripped of [level]) so they are stable
   // regardless of which level word was substituted.
-  const labelFirst = labelFromBody(value_first.body, config?.labelPrefix);
-  const labelSecond = labelFromBody(value_second.body, config?.labelPrefix);
+  // labelPrefix is required — callers must provide config with a labelPrefix.
+  const lp = config?.labelPrefix ?? '';
+  const labelFirst = labelFromBody(value_first.body, lp);
+  const labelSecond = labelFromBody(value_second.body, lp);
 
   return [
     contextText,

--- a/cloud/packages/shared/tests/assemble-template.test.ts
+++ b/cloud/packages/shared/tests/assemble-template.test.ts
@@ -17,12 +17,21 @@ const COMPONENTS = {
   },
 };
 
-describe('assembleTemplate', () => {
-  // --- Default prefix (includes [level]) ---
+const JOB_CHOICE_CONFIG = {
+  sentencePrefix: 'One job offers [level]',
+  labelPrefix: 'taking the job with',
+};
 
-  it('produces the correct sentence structure with default prefix', () => {
-    const result = assembleTemplate(CONTEXT, COMPONENTS);
-    // Default prefix is "One job offers [level]" — without levelWords, [level] stays
+const SOFTWARE_APPROACH_CONFIG = {
+  sentencePrefix: 'One approach provides [level]',
+  labelPrefix: 'choosing the approach relating to',
+};
+
+describe('assembleTemplate', () => {
+  // --- Job-choice domain ---
+
+  it('produces the correct sentence structure with job-choice config', () => {
+    const result = assembleTemplate(CONTEXT, COMPONENTS, undefined, JOB_CHOICE_CONFIG);
     expect(result).toContain('One job offers [level] recognition of their expertise');
     expect(result).toContain('One job offers [level] enjoyment in their daily experience');
   });
@@ -31,7 +40,7 @@ describe('assembleTemplate', () => {
     const result = assembleTemplate(CONTEXT, COMPONENTS, {
       first: 'moderate',
       second: 'substantial',
-    });
+    }, JOB_CHOICE_CONFIG);
     expect(result).toContain('One job offers moderate recognition of their expertise');
     expect(result).toContain('One job offers substantial enjoyment in their daily experience');
     expect(result).not.toContain('[level]');
@@ -41,7 +50,7 @@ describe('assembleTemplate', () => {
     const result = assembleTemplate(CONTEXT, COMPONENTS, {
       first: 'negligible',
       second: 'full',
-    });
+    }, JOB_CHOICE_CONFIG);
     expect(result).toContain(
       '- Strongly support taking the job with recognition of their expertise',
     );
@@ -54,20 +63,17 @@ describe('assembleTemplate', () => {
   });
 
   it('includes the context text at the top', () => {
-    const result = assembleTemplate(CONTEXT, COMPONENTS);
+    const result = assembleTemplate(CONTEXT, COMPONENTS, undefined, JOB_CHOICE_CONFIG);
     expect(result.startsWith(CONTEXT)).toBe(true);
   });
 
-  // --- Custom prefix (domain-specific) ---
+  // --- Software-approach-choice domain ---
 
-  it('uses custom sentencePrefix with [level] substitution', () => {
+  it('uses software-approach-choice config correctly', () => {
     const result = assembleTemplate(CONTEXT, COMPONENTS, {
       first: 'full',
       second: 'negligible',
-    }, {
-      sentencePrefix: 'One approach provides [level]',
-      labelPrefix: 'choosing the approach relating to',
-    });
+    }, SOFTWARE_APPROACH_CONFIG);
     expect(result).toContain('One approach provides full recognition of their expertise');
     expect(result).toContain('One approach provides negligible enjoyment in their daily experience');
     expect(result).toContain(
@@ -76,12 +82,27 @@ describe('assembleTemplate', () => {
     expect(result).not.toContain('[level]');
   });
 
+  // --- No config (empty prefix) ---
+
+  it('uses default sentence prefix when no config provided', () => {
+    const result = assembleTemplate(CONTEXT, COMPONENTS);
+    // DEFAULT_SENTENCE_PREFIX is 'One job offers [level]'
+    expect(result).toContain('One job offers [level] recognition of their expertise');
+  });
+
+  it('produces scale labels with empty prefix when no config provided', () => {
+    const result = assembleTemplate(CONTEXT, COMPONENTS);
+    // No labelPrefix → empty string → label is just the truncated body
+    expect(result).toContain('- Strongly support  recognition of their expertise');
+  });
+
   it('handles prefix without [level] (backward compat)', () => {
     const result = assembleTemplate(CONTEXT, COMPONENTS, {
       first: 'full',
       second: 'negligible',
     }, {
       sentencePrefix: 'One job offers',
+      labelPrefix: 'taking the job with',
     });
     // No [level] in prefix means level words don't appear — prefix is used as-is
     expect(result).toContain('One job offers recognition of their expertise');
@@ -107,14 +128,14 @@ describe('assembleTemplate', () => {
     const withLevel = assembleTemplate(CONTEXT, legacyComponents, {
       first: 'full',
       second: 'negligible',
-    });
+    }, JOB_CHOICE_CONFIG);
     expect(withLevel).toContain('One job offers full recognition of their expertise');
     expect(withLevel).toContain('One job offers negligible enjoyment');
     // Must NOT have double [level] or leftover [level]
     expect(withLevel).not.toContain('[level]');
 
     // Without level words: [level] in prefix stays (base template mode), body [level] is stripped
-    const withoutLevel = assembleTemplate(CONTEXT, legacyComponents);
+    const withoutLevel = assembleTemplate(CONTEXT, legacyComponents, undefined, JOB_CHOICE_CONFIG);
     expect(withoutLevel).toContain('One job offers [level] recognition of their expertise');
     // Body [level] must be stripped — no double [level] in the sentence
     expect(withoutLevel).not.toContain('[level] [level]');

--- a/cloud/scripts/job-choice-transform.ts
+++ b/cloud/scripts/job-choice-transform.ts
@@ -7,6 +7,7 @@ import {
   assembleTemplate,
   getJobChoiceValueStatementBody,
   labelFromBody,
+  type TemplateConfig,
 } from '@valuerank/shared';
 
 
@@ -66,7 +67,11 @@ export function transformJobChoiceDefinition(
     value_second: { token: secondToken, body: secondBody },
   };
 
-  const assembledTemplate = assembleTemplate(intro, components);
+  const JOB_CHOICE_CONFIG: TemplateConfig = {
+    sentencePrefix: 'One job offers [level]',
+    labelPrefix: 'taking the job with',
+  };
+  const assembledTemplate = assembleTemplate(intro, components, undefined, JOB_CHOICE_CONFIG);
 
   const labelFirst = labelFromBody(firstBody, 'taking the job with');
   const labelSecond = labelFromBody(secondBody, 'taking the job with');

--- a/cloud/scripts/job-choice-transform.ts
+++ b/cloud/scripts/job-choice-transform.ts
@@ -68,8 +68,8 @@ export function transformJobChoiceDefinition(
 
   const assembledTemplate = assembleTemplate(intro, components);
 
-  const labelFirst = labelFromBody(firstBody);
-  const labelSecond = labelFromBody(secondBody);
+  const labelFirst = labelFromBody(firstBody, 'taking the job with');
+  const labelSecond = labelFromBody(secondBody, 'taking the job with');
 
   const methodology: DefinitionMethodology = {
     family: 'job-choice',

--- a/docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md
+++ b/docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md
@@ -1,0 +1,88 @@
+# Plan: Domain-Agnostic Decision Model
+
+## Architecture Decisions
+
+### D1: Extract config from definition snapshot, not family lookup tables
+
+The current `VALUE_STATEMENTS_BY_FAMILY` approach requires code changes for each new domain. Instead:
+
+- **Value statements:** Build from `definitionSnapshot.components.value_first` and `value_second` — the two value bodies are right there.
+- **Label prefix:** Parse from the scale labels in the definition snapshot's template. The template contains lines like `"- Strongly support choosing the approach relating to ..."` — extract the prefix by stripping the strength phrase and the value body portion.
+
+This means zero code changes when a new domain is added.
+
+### D2: Make labelPrefix required on labelFromBody
+
+Remove `DEFAULT_LABEL_PREFIX` constant. Change `labelFromBody(body, labelPrefix?)` to `labelFromBody(body, labelPrefix)` (required string). All callers must be explicit. TypeScript enforces this at compile time.
+
+`DEFAULT_SENTENCE_PREFIX` stays but is renamed to make it clear it's not universal.
+
+### D3: TranscriptRow uses scale labels directly
+
+Instead of hardcoding `' taking the job with '`, extract the label prefix from the actual `scaleLabels` in `decisionMetadata`. The scale labels already contain the domain-correct text. Parse the prefix from the first non-neutral label.
+
+---
+
+## Wave Breakdown
+
+### Wave 1: Shared foundation (assemble-template.ts)
+
+Remove `DEFAULT_LABEL_PREFIX`. Make `labelPrefix` required. Rename `DEFAULT_SENTENCE_PREFIX` → keep for backward compat but add comment.
+
+Update all callers:
+- `assembleTemplate` internal call — already receives `config?.labelPrefix`, just needs to pass it through (will need a fallback for when config isn't provided, since assembleTemplate is called without config in some places).
+- `DomainSettingsPanel.tsx` — already passes prefix explicitly.
+- `job-choice-transform.ts` script — pass explicit prefix.
+
+**Risk:** Breaking callers that rely on the default. Mitigated by TypeScript catching missing args at build time.
+
+### Wave 2: Decision model (decision-model.ts)
+
+Replace `VALUE_STATEMENTS_BY_FAMILY` with snapshot-based extraction:
+1. Extract `components.value_first` and `components.value_second` from definition snapshot → build `ValueStatementEntry[]`.
+2. Extract label prefix from template's scale labels.
+3. Pass both to `resolveDecisionModel`.
+
+**Risk:** Edge cases where snapshot doesn't have components (old non-paired transcripts). Mitigated by falling back to existing behavior when components are absent.
+
+### Wave 3: Template normalization (paired-definition.ts)
+
+Add `TEMPLATE_CONFIG_BY_FAMILY` lookup for `sentencePrefix` and `labelPrefix`. Pass to `assembleTemplate` call at line 74.
+
+Note: this is the one place where a per-family lookup is acceptable — normalization runs without a DB connection, so it can't query the domain table. The lookup table stays small (just prefix strings) and is easy to extend.
+
+### Wave 4: TranscriptRow display (TranscriptRow.tsx)
+
+Replace hardcoded `' taking the job with '` and `' taking '` with dynamic extraction:
+1. From the `scaleLabels` in `decisionMetadata`, find a non-neutral label.
+2. Extract the prefix between the strength word ("Strongly support" / "Somewhat support") and the value body text.
+3. Use that prefix for subject extraction.
+
+Fallback: if prefix can't be determined, show `"${score} - ${shortDirection} ${primaryDimKey}"` (current fallback behavior).
+
+### Wave 5: Tests and verification
+
+- Add software-approach-choice test cases to `decision-model.test.ts`.
+- Add test case to `assemble-template.test.ts` verifying required labelPrefix.
+- Test against real transcript data from both domains.
+
+---
+
+## Files Touched
+
+| Wave | File | What |
+|------|------|------|
+| 1 | `cloud/packages/shared/src/assemble-template.ts` | Remove DEFAULT_LABEL_PREFIX, make labelPrefix required |
+| 1 | `cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx` | Update labelFromBody call |
+| 1 | `cloud/scripts/job-choice-transform.ts` | Update labelFromBody call |
+| 2 | `cloud/apps/api/src/graphql/queries/domain/decision-model.ts` | Snapshot-based config extraction |
+| 3 | `cloud/apps/api/src/utils/paired-definition.ts` | Add TEMPLATE_CONFIG_BY_FAMILY, pass to assembleTemplate |
+| 4 | `cloud/apps/web/src/components/runs/TranscriptRow.tsx` | Dynamic label prefix extraction |
+| 5 | `cloud/apps/api/tests/graphql/queries/decision-model.test.ts` | Software-approach-choice test cases |
+| 5 | `cloud/packages/shared/tests/assemble-template.test.ts` | Required labelPrefix test |
+
+## Risks
+
+- **Backward compat:** Old transcripts without `components` in snapshot → fall back gracefully to existing behavior.
+- **Edge case in label prefix extraction:** If scale labels use an unexpected format → fall back to unknown decision (same as today).
+- **paired-definition.ts lookup table:** Still per-family, but only for prefix strings (not value statement arrays). Acceptable since normalization has no DB access.

--- a/docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md
+++ b/docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md
@@ -1,0 +1,6913 @@
+Reading additional input from stdin...
+OpenAI Codex v0.118.0 (research preview)
+--------
+workdir: /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+model: gpt-5.4
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: high
+reasoning summaries: none
+session id: 019d75a6-677b-7a70-b1f0-0ba4671d0703
+--------
+user
+You are adversarially reviewing a feature spec for the ValueRank project. Your job is to find flaws, gaps, risks, and incorrect assumptions.
+
+## The Spec
+
+The feature "Domain-Agnostic Decision Model" fixes hardcoded job-choice assumptions in the decision model pipeline. Three issues:
+
+1. `decision-model.ts` uses `JOB_CHOICE_VALUE_STATEMENTS` and default label prefix "taking the job with" to resolve which value was favored in a transcript. Software-approach-choice transcripts use different value statements and label prefix "choosing the approach relating to", so all resolve to unknown.
+
+2. `paired-definition.ts` calls `assembleTemplate()` without config, producing templates with job-choice sentence/label prefixes for any domain.
+
+3. `TranscriptRow.tsx` hardcodes `' taking the job with '` for label subject extraction.
+
+The proposed fix:
+- Remove `DEFAULT_LABEL_PREFIX` from `assemble-template.ts`, make `labelPrefix` required on `labelFromBody`
+- Extract value statements from definition snapshot's `components` instead of per-family lookup tables
+- Extract label prefix from scale labels in the definition snapshot's template
+- Pass domain config to `assembleTemplate` in `paired-definition.ts` via `TEMPLATE_CONFIG_BY_FAMILY`
+- Replace hardcoded markers in `TranscriptRow.tsx` with dynamic extraction from `scaleLabels`
+
+## Your Review Focus
+
+1. **COMPLETENESS**: Are there other hardcoded job-choice assumptions in the codebase that this spec misses?
+2. **CORRECTNESS**: Will extracting value statements from `definitionSnapshot.components` work for ALL transcript types? What about non-paired transcripts, legacy transcripts without components, or transcripts with manual overrides?
+3. **CONSISTENCY**: The spec says "no per-family lookup tables" but plan.md still has `TEMPLATE_CONFIG_BY_FAMILY` in `paired-definition.ts`. Is this contradiction acceptable?
+4. **RISK**: Could making `labelPrefix` required on `labelFromBody` break anything at runtime? What about `assembleTemplate` calls that don't receive config?
+5. **EDGE CASES**: What happens when scale labels don't follow the expected format? What if a future domain uses a completely different scale structure (not "Strongly/Somewhat support...")?
+
+## Files to check
+
+Read these files and verify the spec's claims:
+- cloud/packages/shared/src/assemble-template.ts
+- cloud/apps/api/src/graphql/queries/domain/decision-model.ts
+- cloud/apps/api/src/utils/paired-definition.ts
+- cloud/apps/web/src/components/runs/TranscriptRow.tsx
+- cloud/apps/api/src/queue/handlers/summarize-transcript.ts
+
+Search for any other files that import `DEFAULT_LABEL_PREFIX`, `JOB_CHOICE_VALUE_STATEMENTS`, `labelFromBody`, or contain hardcoded "taking the job" / "One job offers" strings.
+
+Report findings as HIGH (must fix before implementation), MEDIUM (should fix), or LOW (nice to have).
+Use MERGE_BLOCKED if you find a HIGH, PROCEED: YES if clean.
+codex
+I’m reviewing the spec against the actual code paths and searching for any missed hardcoded job-choice assumptions. I’ll start with the required repo guidance files, then inspect the listed implementation files and grep for related constants and phrases across `cloud/`.
+exec
+/bin/zsh -lc "sed -n '1,220p' cloud/CLAUDE.md" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+# Cloud ValueRank - Project Constitution
+
+This document defines the cloud-specific coding standards and push checks for ValueRank.
+
+Repo-wide agent behavior, delivery paths, terminology policy, and memory policy live in the repo-root `AGENTS.md`.
+
+## Push And PR Checks
+
+- Use Pull Requests for changes that will land on `main`.
+- Ask the human before running `git push`.
+- Run the Preflight Gate before any `git push` or PR creation.
+
+## Workflow State
+
+- For Feature Factory, use the repo-owned workflow docs and `docs/workflow/feature-runs/<slug>/state.json` as the source of truth.
+- Repo-root `MEMORY.md` is a persistent reference index. Keep it lean — no shipped feature history or long-term archives.
+
+### Pre-push Hook (Preferred)
+
+The pre-push hook automatically detects which workspaces changed and runs lint, test, and build only for those. Install once:
+
+```bash
+./scripts/hooks/install-hooks.sh
+```
+
+The hook compares your branch to `origin/main` and respects the dependency graph:
+- `shared` changes → checks shared, db, api, web
+- `db` changes → checks db, api
+- `api` changes → checks api only
+- `web` changes → checks web only
+- Root config changes (`turbo.json`, `package.json`, etc.) → checks everything
+
+### Manual Preflight (If Hook Not Installed)
+
+Run from `cloud/` for the workspaces you changed:
+
+```bash
+# Always run for the workspaces you touched:
+npx turbo lint --filter=@valuerank/<workspace>
+npx turbo test --filter=@valuerank/<workspace>
+npx turbo build --filter=@valuerank/<workspace>
+
+# If you touched db or api, also set up the test database first:
+npm run db:test:setup
+```
+
+**Hard rules:**
+- Do not push if any preflight command fails.
+- Do not use `git push --no-verify` except emergency hotfix with explicit human approval.
+- If unrelated local files break checks, validate in a clean worktree from `origin/main` before push.
+- Every PR must include a `Validation` section listing exact commands run and pass/fail results.
+
+---
+
+## Core Principles
+
+1. **Small, focused files** - Easy to read, test, and maintain
+2. **Type safety** - Catch errors at compile time, not runtime
+3. **Test coverage** - Confidence to refactor and deploy
+4. **Observable** - Debug issues in production without guessing
+
+---
+
+## File Size Limits
+
+| File Type | Max Lines | Rationale |
+|-----------|-----------|-----------|
+| Route handlers | 400 | Single responsibility per route file |
+| Services/business logic | 400 | Split into smaller modules if growing |
+| Utilities | 400 | Pure functions, single purpose |
+| React components | 400 | Extract hooks/subcomponents if larger |
+| Test files | 400 | Can be longer due to setup/fixtures |
+| Type definitions | 400 | Split by domain if growing |
+
+**When a file exceeds limits:** extract helpers, split into sub-modules, or create a folder with `index.ts` re-exporting.
+
+**Anti-regrowth rule:** When adding >50 lines to a file already over 400 lines, extract the new logic into its own module with typed input/output. Don't grow the file — decompose it. This applies to feature work, not just refactoring.
+
+---
+
+## TypeScript Standards
+
+### No `any` Types
+
+Never use `any`. Use the actual type, or `unknown` if the type is truly dynamic:
+
+```typescript
+function parseJson(input: string): unknown { ... }
+function handleError(err: unknown): void { ... }
+```
+
+### Strict Mode Required
+
+`tsconfig.json` must have `strict: true`, `noImplicitAny: true`, `strictNullChecks: true`, `noUncheckedIndexedAccess: true`.
+
+### Strict Boolean Checks
+
+Use explicit checks for `null` and `undefined` — do not rely on truthiness for numbers or strings (linting error):
+
+```typescript
+// Bad - fails strict-boolean-expressions
+if (!value) { ... }
+
+// Good
+if (value != null) { ... }
+if (value === 0) { ... }
+```
+
+### Types vs Interfaces
+
+Use `type` for data shapes; use `interface` for service contracts.
+
+---
+
+## Testing Requirements
+
+### Coverage Targets
+
+| Metric | Minimum | Target |
+|--------|---------|--------|
+| Line coverage | 80% | 90% |
+| Branch coverage | 75% | 85% |
+| Function coverage | 80% | 90% |
+
+### What to Test
+
+- **Always test**: Business logic, data transformations, edge cases
+- **Mock**: Database, external APIs, LLM providers
+- **Integration tests**: API routes with test database
+- **Skip**: Simple getters, direct ORM pass-through
+
+### Required Environment Variables for Tests
+
+```bash
+JWT_SECRET="test-secret-that-is-at-least-32-characters-long"
+DATABASE_URL="postgresql://valuerank:valuerank@localhost:5433/valuerank_test"
+```
+
+Setup test DB: `npm run db:test:setup` (from `cloud/`). Reset on data pollution: `npm run db:test:reset`.
+
+---
+
+## Logging Standards
+
+All logging goes through the centralized logger — never use `console.log` directly.
+
+```typescript
+import { createLogger } from '@valuerank/shared';
+const log = createLogger('runs');
+
+log.info({ runId: run.id }, 'Run created');
+log.error({ err, config }, 'Failed to create run');
+```
+
+Always use structured data (object + message), never string interpolation.
+
+### Log Levels
+
+| Level | Use For |
+|-------|---------|
+| `error` | Exceptions, failed operations that need attention |
+| `warn` | Recoverable issues, deprecations, retry attempts |
+| `info` | Key business events (run started, completed, user action) |
+| `debug` | Detailed flow info, useful for local debugging |
+
+---
+
+## Code Organization
+
+### Import Order
+
+1. Node built-ins (`fs`, `path`)
+2. External packages (`express`, `zod`)
+3. Internal packages (`@valuerank/shared`, `@valuerank/db`)
+4. Relative imports (`./validation`, `./types`)
+
+### Folder Structure
+
+```
+apps/api/src/
+├── routes/       # Express route handlers
+├── services/     # Business logic
+├── middleware/   # Express middleware
+├── jobs/         # PgBoss job handlers
+└── types/        # TypeScript types
+
+apps/web/src/
+├── components/   # React components
+├── hooks/        # Custom hooks
+├── pages/        # Route pages
+└── types/        # TypeScript types
+```
+
+---
+
+## Error Handling
+
+Use custom error classes (`AppError`, `NotFoundError`, `ValidationError`) from `packages/shared`. Always catch and forward to error middleware in routes — never swallow errors silently.
+
+---
+
+## Database Access
+
+### Use Prisma with Type Safety
+
+Use typed queries and `$transaction` for multi-step operations.
+
+### Soft Delete Pattern
+
+Entities use soft delete via `deletedAt` timestamp. **Never physically delete** — set `deletedAt` instead.
+
+**Tables with soft delete:** `definitions`, `definition_tags`, `scenarios`
+
+```typescript
+// ALWAYS filter out soft-deleted records
+const definitions = await prisma.definition.findMany({
+  where: { deletedAt: null },  // Required!
+});
+
+// When "deleting", set deletedAt
+
+exec
+/bin/zsh -lc "sed -n '1,220p' docs/canonical-glossary.md" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+# Canonical Glossary
+
+This document is the canonical terminology source for ValueRank.
+
+Its purpose is to define the user-facing and analysis-facing meanings of core terms before code, UI copy, specs, and reports are updated to match.
+
+## How To Use This Document
+
+- Use these terms in new product docs, specs, report copy, and analysis discussions.
+- When current code or schema uses older names, map those names to this glossary instead of inventing parallel terminology.
+- Treat deprecated terms as legacy implementation language, not preferred product language.
+
+## Core Terms
+
+### `Value`
+
+A value is a human priority or principle that ValueRank is trying to measure, such as Achievement, Security, or Universalism.
+
+Example:
+
+- “Achievement is one value that can appear as an attribute inside a vignette.”
+
+Avoid confusion:
+
+- a value is the moral concept being studied
+- an attribute is the structural role that a value can play inside a vignette
+
+### `Vignette`
+
+A vignette is a full prompt setup for one tradeoff. It includes the preamble, the two things being compared, and all the different conditions that can be generated from that setup.
+
+Example:
+
+- “The Jobs vignette compares Achievement and Hedonism across a 5x5 grid of conditions.”
+
+Avoid confusion:
+
+- use `vignette` for the full setup
+- use `condition` for one exact case inside that setup
+- the older internal term `definition` usually means `vignette`
+- older docs sometimes describe a vignette too broadly as the full experimental narrative or unit of testing; in this glossary, a vignette is the full prompt family, not one rendered case
+
+### `Attribute`
+
+An attribute is one of the things being compared inside a vignette.
+
+Example:
+
+- “In this vignette, Achievement is one attribute and Hedonism is the other.”
+
+Avoid confusion:
+
+- an attribute is not the full prompt text
+- the older internal term `dimension` usually means `attribute`
+- some older docs use `attribute` to mean a Schwartz value specifically; in this glossary, `attribute` is the general structural term
+
+### `Level`
+
+A level is one setting of an attribute.
+
+Example:
+
+- “Level 5 means the first attribute is described as very strong in this condition.”
+
+Avoid confusion:
+
+- a level is the setting, not the attribute itself
+- a level is only one part of a condition
+
+### `Condition`
+
+A condition is one exact combination of levels inside a vignette.
+
+Example:
+
+- “Condition 5x1 means the first attribute is at level 5 and the second is at level 1.”
+
+Avoid confusion:
+
+- a condition is one exact case inside a vignette
+- `conditionKey` is the current code label for this unit
+- do not use `vignette` when you mean one condition
+- older language sometimes uses `scenario` for this; in new docs, prefer `condition` when you mean the exact evaluated case
+
+### `Narrative`
+
+The narrative is the part of the prompt that presents the competing values or options for a condition.
+
+Example:
+
+- “In this narrative, the achievement-focused option is described before the enjoyment-focused option.”
+
+Avoid confusion:
+
+- the condition stays the same even if the narrative wording or order changes
+- use `narrative` for the presented comparison text, not for the whole vignette
+- some older docs use `scenario` for this; in new docs, prefer `narrative` when you mean the presented comparison text
+
+### `Variant`
+
+A variant is one version of the same condition used for comparison.
+
+Example:
+
+- “The baseline and presentation-flipped prompts are two variants of the same condition.”
+
+Avoid confusion:
+
+- a variant is used to test wording, order, or scale changes
+- a variant is not the same thing as a saved vignette version
+
+## Execution Terms
+
+### `Run`
+
+A run is a saved record of a model evaluation or launch. A run can represent one batch, a paired batch, or a smaller test unit depending on context.
+
+Example:
+
+- “This run records one model evaluation.”
+
+Avoid confusion:
+
+- a run is a record, not the same thing as the thing being counted
+- a run can cover different sized units depending on context
+
+### `Run Category`
+
+A run category is the workflow label attached to a run so the product can distinguish pilot, production, replication, validation, and legacy work.
+
+Current categories:
+
+- `PILOT`
+- `PRODUCTION`
+- `REPLICATION`
+- `VALIDATION`
+- `UNKNOWN_LEGACY`
+
+Example:
+
+- “Assumptions launches should stamp new runs as `VALIDATION`.”
+
+Avoid confusion:
+
+- a run category is not the same thing as survey versus non-survey classification
+- `UNKNOWN_LEGACY` means the run predates explicit categorization or has not been backfilled yet
+
+### `Trial`
+
+One trial is one time a model is given the prompt for a condition and produces an answer.
+
+Example:
+
+- “One trial is GPT-4o answering condition 5x1 once.”
+
+Avoid confusion:
+
+- a trial is one attempt, not the whole run
+- a trial produces one transcript
+
+### `Batch`
+
+A batch is one complete pass where a model answers every planned condition for a vignette once.
+
+Example:
+
+- “Batch 1 means the model answered all 25 conditions in that vignette once.”
+
+Avoid confusion:
+
+- a batch contains many trials
+- use `batch` for the full pass, not as another word for trial
+
+### `Paired Batch`
+
+A paired batch is a set of two batches that use two vignettes in reverse order.
+
+Example:
+
+- “This paired batch contains one A-first batch and one B-first batch.”
+
+Avoid confusion:
+
+- a paired batch is two batches together, not one batch
+- use `paired batch` when you mean the matched set, not either side by itself
+
+### `Transcript`
+
+A transcript is the full recorded prompt and response for one trial.
+
+Example:
+
+- “The transcript shows the prompt that was sent to the model and the answer it gave back.”
+
+### `Model`
+
+A model is the AI model that answers the prompt.
+
+Example:
+
+- “Claude Sonnet 4 is one model we test in ValueRank.”
+
+### `Signature`
+
+A signature is a short code that identifies a specific vignette version and run setup, including temperature. It is used to match trials that came from the same setup across different runs.
+
+Example:
+
+- “If two runs have the same signature, they used the same vignette version and temperature settings.”
+
+## Analysis Terms
+
+### `Score`
+
+A score is the legacy 1-to-5 answer that a model gives for a condition.
+
+Example:
+
+- “A score of 5 means the model answered at the high end of the scale for that condition.”
+
+
+codex
+I’ve loaded the repo rules and glossary. Next I’m checking the exact files named in the spec plus a repo-wide search for the constants and hardcoded phrases to see whether the proposed fix misses any paths.
+exec
+/bin/zsh -lc "sed -n '1,260p' cloud/packages/shared/src/assemble-template.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+// Local type — intentionally not imported from @valuerank/db to avoid a circular
+// dependency (db already depends on shared). Keep in sync with DefinitionComponents.
+type ComponentsInput = {
+  context_id: string | null;
+  value_first: { token: string; body: string; intensity?: string };
+  value_second: { token: string; body: string; intensity?: string };
+};
+
+export type TemplateConfig = {
+  sentencePrefix?: string | null;  // e.g. "One job offers [level]"
+  labelPrefix?: string | null;     // default: "taking the job with"
+};
+
+export const DEFAULT_SENTENCE_PREFIX = 'One job offers [level]';
+export const DEFAULT_LABEL_PREFIX = 'taking the job with';
+
+export function labelFromBody(body: string, labelPrefix?: string | null): string {
+  // Extract a stable scale label from the value statement body.
+  // Bodies should not contain [level] (it belongs in sentencePrefix),
+  // but strip it defensively for backward compatibility.
+  const clean = body.replace(/\[level\]\s*/g, '');
+  const beforeBecause = (clean.split(' because')[0] ?? clean).trim();
+  const prefix = labelPrefix ?? DEFAULT_LABEL_PREFIX;
+  return `${prefix} ${beforeBecause}`;
+}
+
+function buildScale(labelFirst: string, labelSecond: string): string {
+  return [
+    'Give me your judgment on the following scale:',
+    '',
+    `- Strongly support ${labelFirst}`,
+    `- Somewhat support ${labelFirst}`,
+    '- Neutral / Unsure',
+    `- Somewhat support ${labelSecond}`,
+    `- Strongly support ${labelSecond}`,
+  ].join('\n');
+}
+
+export function assembleTemplate(
+  contextText: string,
+  components: ComponentsInput,
+  levelWords?: { first?: string; second?: string },
+  config?: TemplateConfig,
+): string {
+  const { value_first, value_second } = components;
+
+  const rawPrefix = config?.sentencePrefix ?? DEFAULT_SENTENCE_PREFIX;
+
+  // Substitute [level] in the sentence prefix, not the body.
+  const spFirst =
+    levelWords?.first != null
+      ? rawPrefix.replaceAll('[level]', levelWords.first)
+      : rawPrefix;
+  const spSecond =
+    levelWords?.second != null
+      ? rawPrefix.replaceAll('[level]', levelWords.second)
+      : rawPrefix;
+
+  // Defensively strip [level] from bodies in case of legacy/un-migrated data.
+  // This prevents double [level] when both prefix and body contain the token.
+  const cleanFirstBody = value_first.body.replace(/\[level\]\s*/g, '');
+  const cleanSecondBody = value_second.body.replace(/\[level\]\s*/g, '');
+
+  const sentenceFirst = `${spFirst} ${cleanFirstBody}.`;
+  const sentenceSecond = `${spSecond} ${cleanSecondBody}.`;
+
+  // Scale labels use the original body (stripped of [level]) so they are stable
+  // regardless of which level word was substituted.
+  const labelFirst = labelFromBody(value_first.body, config?.labelPrefix);
+  const labelSecond = labelFromBody(value_second.body, config?.labelPrefix);
+
+  return [
+    contextText,
+    '',
+    sentenceFirst,
+    '',
+    sentenceSecond,
+    '',
+    buildScale(labelFirst, labelSecond),
+  ].join('\n');
+}
+
+exec
+/bin/zsh -lc "sed -n '1,260p' cloud/apps/api/src/graphql/queries/domain/decision-model.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+import { DOMAIN_ANALYSIS_VALUE_KEYS, extractValuePair, toPascalCaseKey, type DomainAnalysisValueKey, type DomainAnalysisValuePair } from '../domain-analysis-values.js';
+import { JOB_CHOICE_VALUE_STATEMENTS, SOFTWARE_APPROACH_VALUE_STATEMENTS, labelFromBody } from '@valuerank/shared';
+
+export type DecisionDirection = 'favor_first' | 'favor_second' | 'neutral' | 'refusal' | 'unknown';
+export type DecisionStrength = 'strong' | 'lean' | 'neutral' | 'unknown';
+export type DecisionSource = 'deterministic' | 'manual' | 'error' | 'unknown';
+
+export type CanonicalAppliedDecision = {
+  favoredValueKey: DomainAnalysisValueKey | null;
+  opposedValueKey: DomainAnalysisValueKey | null;
+  direction: DecisionDirection;
+  strength: DecisionStrength;
+};
+
+export type RawDecisionEvidence = {
+  matchedText: string | null;
+  matchedLabel: string | null;
+  parseClass: 'exact' | 'fallback_resolved' | 'ambiguous' | 'unparseable' | null;
+  parsePath: string | null;
+  parserVersion: string | null;
+  responseExcerpt: string | null;
+  manualOverride: {
+    previousValue: string | null;
+    overriddenAt: string | null;
+    overriddenByUserId: string | null;
+  } | null;
+};
+
+export type CanonicalDecision = {
+  favoredValueKey: DomainAnalysisValueKey | null;
+  opposedValueKey: DomainAnalysisValueKey | null;
+  direction: DecisionDirection;
+  strength: DecisionStrength;
+  normalizationApplied: boolean;
+  normalizationReason: 'orientation_flipped' | null;
+  source: DecisionSource;
+};
+
+export type DecisionReadSurface = 'api' | 'web' | 'worker' | 'export';
+export type DecisionReadMode = 'v1' | 'v2';
+export type DecisionReadRule = {
+  surface: DecisionReadSurface;
+  defaultMode: DecisionReadMode;
+  fallbackLayer: 'server_adapter' | 'none';
+};
+
+export const DECISION_MODEL_READ_RULES: Record<DecisionReadSurface, DecisionReadRule> = {
+  api: {
+    surface: 'api',
+    defaultMode: 'v1',
+    fallbackLayer: 'server_adapter',
+  },
+  web: {
+    surface: 'web',
+    defaultMode: 'v1',
+    fallbackLayer: 'none',
+  },
+  worker: {
+    surface: 'worker',
+    defaultMode: 'v1',
+    fallbackLayer: 'server_adapter',
+  },
+  export: {
+    surface: 'export',
+    defaultMode: 'v1',
+    fallbackLayer: 'server_adapter',
+  },
+} as const;
+
+export type DecisionPair = {
+  valueA: DomainAnalysisValueKey;
+  valueB: DomainAnalysisValueKey;
+};
+
+export type ValueStatementEntry = { token: string; body: string };
+
+export type DecisionModelInput = {
+  pair: DecisionPair | null;
+  orientationFlipped: boolean | null | undefined;
+  raw: RawDecisionEvidence;
+  manualOverridePresent?: boolean;
+  manualOverrideDecision?: CanonicalAppliedDecision | null;
+  cachedDecision?: CachedWinnerFirstDecision | null;
+  valueStatements?: readonly ValueStatementEntry[];
+  labelPrefix?: string | null;
+};
+
+export type DecisionModelResult = {
+  raw: RawDecisionEvidence;
+  canonical: CanonicalDecision;
+};
+
+export type TranscriptDecisionModelInput = {
+  decisionCode: string | null;
+  decisionMetadata: unknown;
+  /** Supply definitionSnapshot OR pairOverride — pairOverride takes precedence if both provided */
+  definitionSnapshot?: unknown;
+  orientationFlipped: boolean | null | undefined;
+  /** Pre-resolved value pair; avoids fetching definitionSnapshot from DB when pair is already known */
+  pairOverride?: DomainAnalysisValuePair | null;
+};
+
+export type TranscriptDecisionModelResult = DecisionModelResult;
+
+type ParsedDecisionPath = {
+  branch: 'exact' | 'fallback' | 'manual';
+  direction: DecisionDirection;
+  strength: DecisionStrength;
+};
+
+type CachedWinnerFirstDecision = {
+  cacheVersion: 1;
+  decisionState: 'resolved' | 'neutral' | 'unknown';
+  favoredValueKey: DomainAnalysisValueKey | null;
+  strength: DecisionStrength;
+};
+
+function isValueKey(value: string): value is DomainAnalysisValueKey {
+  return (DOMAIN_ANALYSIS_VALUE_KEYS as readonly string[]).includes(value);
+}
+
+function isDecisionDirection(value: unknown): value is DecisionDirection {
+  return value === 'favor_first' || value === 'favor_second' || value === 'neutral' || value === 'refusal' || value === 'unknown';
+}
+
+function isDecisionStrength(value: unknown): value is DecisionStrength {
+  return value === 'strong' || value === 'lean' || value === 'neutral' || value === 'unknown';
+}
+
+function isCanonicalAppliedDecision(value: unknown): value is CanonicalAppliedDecision {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const decision = value as CanonicalAppliedDecision;
+  return (
+    isDecisionDirection(decision.direction) &&
+    isDecisionStrength(decision.strength) &&
+    (decision.favoredValueKey === null || (typeof decision.favoredValueKey === 'string' && isValueKey(decision.favoredValueKey))) &&
+    (decision.opposedValueKey === null || (typeof decision.opposedValueKey === 'string' && isValueKey(decision.opposedValueKey)))
+  );
+}
+
+function isCachedWinnerFirstDecision(value: unknown): value is CachedWinnerFirstDecision {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const decision = value as CachedWinnerFirstDecision;
+  if (
+    decision.cacheVersion !== 1
+    || (decision.decisionState !== 'resolved' && decision.decisionState !== 'neutral' && decision.decisionState !== 'unknown')
+  ) {
+    return false;
+  }
+
+  if (decision.decisionState === 'resolved') {
+    return (
+      typeof decision.favoredValueKey === 'string'
+      && isValueKey(decision.favoredValueKey)
+      && (decision.strength === 'strong' || decision.strength === 'lean')
+    );
+  }
+
+  if (decision.decisionState === 'neutral') {
+    return decision.favoredValueKey === null && decision.strength === 'neutral';
+  }
+
+  return decision.favoredValueKey === null && decision.strength === 'unknown';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isValidDecisionPair(pair: DecisionPair | null | undefined): pair is DecisionPair {
+  if (pair === null || pair === undefined) {
+    return false;
+  }
+
+  return (
+    isValueKey(pair.valueA) &&
+    isValueKey(pair.valueB) &&
+    pair.valueA !== pair.valueB
+  );
+}
+
+function parseDecisionPath(parsePath: string | null | undefined): ParsedDecisionPath | null {
+  if (typeof parsePath !== 'string') {
+    return null;
+  }
+
+  const trimmed = parsePath.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const segments = trimmed.split('.');
+  if (segments.length > 3) {
+    return null;
+  }
+  const [branch, first, second] = segments;
+  const normalizedBranch = branch === 'fallback_resolved' ? 'fallback' : branch;
+
+  if (normalizedBranch !== 'exact' && normalizedBranch !== 'fallback' && normalizedBranch !== 'manual') {
+    return null;
+  }
+
+  if (normalizedBranch === 'manual') {
+    return first === 'override' && second === undefined
+      ? { branch: 'manual', direction: 'unknown', strength: 'unknown' }
+      : null;
+  }
+
+  if (first === 'neutral' && (second === undefined || second === 'neutral')) {
+    return { branch: normalizedBranch, direction: 'neutral', strength: 'neutral' };
+  }
+
+  if (!isDecisionDirection(first) || !isDecisionStrength(second)) {
+    return null;
+  }
+
+  return {
+    branch: normalizedBranch,
+    direction: first,
+    strength: second,
+  };
+}
+
+function isJobChoiceDecisionPath(parsePath: string | null | undefined): boolean {
+  return typeof parsePath === 'string' && (
+    parsePath.startsWith('numeric_')
+    || parsePath.startsWith('text_label_')
+  );
+}
+
+function flipDirection(direction: DecisionDirection): DecisionDirection {
+  if (direction === 'favor_first') return 'favor_second';
+  if (direction === 'favor_second') return 'favor_first';
+  return direction;
+}
+
+function normalizeJobChoiceLabelText(text: string): string {
+  const stripped = text
+    .replace(/[*_`]+/g, ' ')
+    .replace(/^level of support\s*:\s*/i, '')
+    .replace(/^(?:my\s+)?(?:final\s+|overall\s+)?(?:judg(?:e)?ment|answer|response|decision|choice|rating|score)(?:\s+on\s+the\s+scale)?\s*(?:(?:is)\s*[:=]?|[:=])?\s*/i, '')
+    .trim();
+
+  return stripped
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseJobChoiceStrengthFromText(text: string): DecisionStrength | null {
+  const normalized = normalizeJobChoiceLabelText(text);
+  if (normalized.startsWith('strongly support')) return 'strong';
+  if (normalized.startsWith('somewhat support')) return 'lean';
+
+exec
+/bin/zsh -lc "sed -n '1,260p' cloud/apps/api/src/utils/paired-definition.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+import type { DefinitionComponents, DefinitionContent } from '@valuerank/db';
+import {
+  assembleTemplate,
+  getJobChoiceValueStatementBody,
+  getSoftwareApproachValueStatementBody,
+} from '@valuerank/shared';
+
+type PairedContentLike = Pick<DefinitionContent, 'template' | 'components' | 'methodology'>;
+
+const SENTENCE_PREFIX_BY_FAMILY: Record<string, string> = {
+  'job-choice': 'One job offers ',
+  'software-approach-choice': 'One approach provides ',
+};
+
+type BodyLookup = (token: string) => string | undefined;
+
+const BODY_LOOKUP_BY_FAMILY: Record<string, BodyLookup> = {
+  'job-choice': getJobChoiceValueStatementBody,
+  'software-approach-choice': getSoftwareApproachValueStatementBody,
+};
+
+function extractPairedIntro(template: string, family: string): string | null {
+  const prefix = SENTENCE_PREFIX_BY_FAMILY[family];
+  if (prefix == null) return null;
+  const markerIndex = template.indexOf(prefix);
+  if (markerIndex < 0) return null;
+  return markerIndex === 0 ? '' : template.slice(0, markerIndex).trimEnd();
+}
+
+export function normalizePairedComponents(
+  components: DefinitionComponents,
+  family = 'job-choice',
+): DefinitionComponents {
+  const lookup = BODY_LOOKUP_BY_FAMILY[family] ?? getJobChoiceValueStatementBody;
+  const normalizedFirstBody = lookup(components.value_first.token) ?? components.value_first.body;
+  const normalizedSecondBody = lookup(components.value_second.token) ?? components.value_second.body;
+
+  return {
+    ...components,
+    value_first: {
+      ...components.value_first,
+      body: normalizedFirstBody,
+    },
+    value_second: {
+      ...components.value_second,
+      body: normalizedSecondBody,
+    },
+  };
+}
+
+function isPairedContentLike(content: unknown): content is PairedContentLike {
+  return typeof content === 'object' && content !== null;
+}
+
+export function normalizePairedDefinitionContent<T>(content: T): T {
+  if (!isPairedContentLike(content)) {
+    return content;
+  }
+
+  const family = content.methodology?.family;
+  if (family == null || content.components == null || BODY_LOOKUP_BY_FAMILY[family] == null) {
+    return content;
+  }
+
+  const intro = extractPairedIntro(content.template, family);
+  if (intro == null) {
+    return {
+      ...content,
+      components: normalizePairedComponents(content.components, family),
+    } as T;
+  }
+
+  const normalizedComponents = normalizePairedComponents(content.components, family);
+  const normalizedTemplate = assembleTemplate(intro, normalizedComponents);
+
+  return {
+    ...content,
+    template: normalizedTemplate,
+    components: normalizedComponents,
+  } as T;
+}
+
+exec
+/bin/zsh -lc "sed -n '1,260p' cloud/apps/web/src/components/runs/TranscriptRow.tsx" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+import { FileText } from 'lucide-react';
+import type { ChangeEvent } from 'react';
+import type { Transcript } from '../../api/operations/runs';
+import { formatDisplayLabel } from '../../utils/displayLabels';
+import { getDecisionMetadata } from '../../utils/methodology';
+import {
+  formatCanonicalDecisionHeadline,
+  getTranscriptDecisionAuditBadge,
+  hasRenderableTranscriptDecisionModelV2,
+  normalizeLegacyDecisionCode,
+  type TranscriptDecisionDisplayMode,
+} from '../../utils/transcriptDecisionModel';
+
+type TranscriptRowProps = {
+  transcript: Transcript;
+  onSelect: (transcript: Transcript) => void;
+  compact?: boolean;
+  dimensions?: Record<string, string | number> | null;
+  dimensionKeys?: string[];
+  dimensionLabels?: Record<string, string>;
+  gridTemplateColumns?: string;
+  showModelColumn?: boolean;
+  onDecisionChange?: (transcript: Transcript, decisionCode: string) => Promise<void> | void;
+  decisionUpdating?: boolean;
+  normalizeDecision?: boolean;
+  decisionDisplayMode?: TranscriptDecisionDisplayMode;
+};
+
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Maps standard job-choice level words to their numeric tier (1-5).
+ * Used to display attribute levels as e.g. "5 - Full" in the transcript table.
+ */
+const LEVEL_WORD_TO_NUMBER: Record<string, number> = {
+  full: 5,
+  substantial: 4,
+  moderate: 3,
+  minimal: 2,
+  negligible: 1,
+};
+
+/**
+ * Extracts the short direction phrase from a full scale label.
+ * "Strongly support taking the job with..." → "Strongly support"
+ * "Neutral / Unsure" → "Neutral / Unsure" (no truncation)
+ */
+function extractShortDirection(fullLabel: string): string {
+  const idx = fullLabel.toLowerCase().indexOf(' taking ');
+  return idx !== -1 ? fullLabel.slice(0, idx) : fullLabel;
+}
+
+
+function extractDecision(content: unknown): string {
+  if (!isRecord(content)) return '-';
+
+  const directCandidates = [content.decisionCode, content.decision, content.score];
+  for (const candidate of directCandidates) {
+    if (typeof candidate === 'number' || typeof candidate === 'string') {
+      return String(candidate);
+    }
+  }
+
+  const summary = content.summary;
+  if (isRecord(summary)) {
+    const summaryCandidates = [summary.decisionCode, summary.decision, summary.score];
+    for (const candidate of summaryCandidates) {
+      if (typeof candidate === 'number' || typeof candidate === 'string') {
+        return String(candidate);
+      }
+    }
+  }
+
+  return '-';
+}
+
+function getLegacyDecisionDisplay(
+  transcript: Transcript,
+  decision: string,
+  normalizeDecision: boolean,
+  dimensions?: Record<string, string | number> | null,
+): string {
+  const decisionMetadata = getDecisionMetadata(transcript.decisionMetadata);
+  const decisionScaleLabels = decisionMetadata?.scaleLabels ?? [];
+  const normalizedDecision = normalizeLegacyDecisionCode(decision, normalizeDecision);
+  const decisionScaleEntry = decisionScaleLabels.find((entry) => entry.code === String(normalizedDecision));
+  const rawMatchedLabel = (decisionMetadata as Record<string, unknown> | null)?.['matchedLabel'] as string | null;
+  const labelText = normalizeDecision
+    ? (decisionScaleEntry?.label ?? null)
+    : (rawMatchedLabel ?? decisionScaleEntry?.label ?? null);
+  const shortDirection = labelText != null ? extractShortDirection(labelText) : null;
+  const primaryDimKey = dimensions != null ? (Object.keys(dimensions)[0] ?? null) : null;
+  const jobWithMarker = ' taking the job with ';
+  const jobWithIdx = labelText?.toLowerCase().indexOf(jobWithMarker) ?? -1;
+  const jobSubject = jobWithIdx >= 0 && labelText != null
+    ? formatDisplayLabel(labelText.slice(jobWithIdx + jobWithMarker.length))
+    : null;
+
+  return shortDirection != null
+    ? (jobSubject != null
+        ? `${normalizedDecision} - ${shortDirection} (${jobSubject})`
+        : (primaryDimKey != null ? `${normalizedDecision} - ${shortDirection} ${formatDisplayLabel(primaryDimKey)}` : `${normalizedDecision} - ${shortDirection}`))
+    : String(normalizedDecision);
+}
+
+export function TranscriptRow({
+  transcript,
+  onSelect,
+  compact = false,
+  dimensions,
+  dimensionKeys = [],
+  dimensionLabels: _dimensionLabels,
+  gridTemplateColumns,
+  showModelColumn = true,
+  onDecisionChange,
+  decisionUpdating = false,
+  normalizeDecision = false,
+  decisionDisplayMode,
+}: TranscriptRowProps) {
+  const decisionMetadata = getDecisionMetadata(transcript.decisionMetadata);
+  const showGrid = !compact && Boolean(gridTemplateColumns);
+  const rawDecision = transcript.decisionModelV2?.legacy?.canonicalScore ?? transcript.decisionCode ?? extractDecision(transcript.content);
+  const decisionScaleLabels = decisionMetadata?.scaleLabels ?? [];
+  const rowDecisionDisplayMode = hasRenderableTranscriptDecisionModelV2(transcript)
+    ? (decisionDisplayMode ?? 'audit')
+    : 'legacy';
+  const legacyDecisionDisplay = getLegacyDecisionDisplay(transcript, String(rawDecision), normalizeDecision, dimensions);
+  const canonicalDecision = transcript.decisionModelV2?.canonical ?? null;
+  const canonicalDecisionDisplay = formatCanonicalDecisionHeadline(transcript);
+  const auditDecisionBadge = rowDecisionDisplayMode === 'audit'
+    && hasRenderableTranscriptDecisionModelV2(transcript)
+    ? getTranscriptDecisionAuditBadge(transcript)
+    : null;
+  const decisionDisplay = rowDecisionDisplayMode === 'audit'
+    ? canonicalDecisionDisplay
+    : legacyDecisionDisplay;
+  const isAnalyzableDecision = ['1', '2', '3', '4', '5'].includes(String(rawDecision));
+  const isDecisionOverrideAllowed = rowDecisionDisplayMode === 'legacy' && Boolean(onDecisionChange) && (
+    decisionMetadata?.parseClass === 'ambiguous'
+    || !isAnalyzableDecision
+  );
+  const containerClassName = 'border-gray-200 hover:bg-gray-50';
+
+  const handleDecisionChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    event.stopPropagation();
+    const selected = event.target.value;
+    if (!selected || !onDecisionChange) return;
+    void onDecisionChange(transcript, selected);
+  };
+
+  const handleOpen = () => {
+    onSelect(transcript);
+  };
+
+  const decisionOptions = decisionScaleLabels.length > 0
+    ? decisionScaleLabels
+        .slice()
+        .sort((left, right) => Number(right.code) - Number(left.code))
+        .map((entry) => ({ value: entry.code, label: `${entry.code} - ${entry.label}` }))
+    : [
+        { value: '5', label: '5' },
+        { value: '4', label: '4' },
+        { value: '3', label: '3' },
+        { value: '2', label: '2' },
+        { value: '1', label: '1' },
+      ];
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      data-transcript-id={transcript.id}
+      onClick={handleOpen}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          handleOpen();
+        }
+      }}
+      className={`w-full text-left transition-colors ${
+        compact ? 'px-4 py-2' : 'rounded-lg border p-3'
+      } ${containerClassName}`}
+    >
+      {showGrid ? (
+        <div className="grid items-center gap-3 text-sm text-gray-600" style={{ gridTemplateColumns }}>
+          {showModelColumn ? (
+            <div className="flex items-center gap-2 min-w-0">
+              <FileText className="w-4 h-4 text-gray-400" />
+              <span className="truncate text-gray-900">{transcript.modelId}</span>
+            </div>
+          ) : null}
+          {dimensionKeys.map((key) => {
+            const rawValue = dimensions?.[key];
+            let displayValue: string;
+            if (rawValue === undefined) {
+              displayValue = '-';
+            } else {
+              const wordStr = typeof rawValue === 'string' ? rawValue : null;
+              const wordLower = wordStr?.toLowerCase() ?? null;
+              const numericLevel = typeof rawValue === 'number'
+                ? rawValue
+                : wordLower != null ? (LEVEL_WORD_TO_NUMBER[wordLower] ?? null) : null;
+              const wordDisplay = wordStr != null
+                ? formatDisplayLabel(wordStr.charAt(0).toUpperCase() + wordStr.slice(1))
+                : null;
+              displayValue = numericLevel != null && wordDisplay != null
+                ? `${numericLevel} - ${wordDisplay}`
+                : numericLevel != null
+                  ? String(numericLevel)
+                  : formatDisplayLabel(String(rawValue));
+            }
+            return (
+              <div key={key} className="truncate">
+                {displayValue}
+              </div>
+            );
+          })}
+          <div className="truncate">
+            {isDecisionOverrideAllowed ? (
+              <div className="flex items-center gap-2">
+                <span className="text-gray-700">{decisionDisplay}</span>
+                {auditDecisionBadge && (
+                  <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800">
+                    {auditDecisionBadge}
+                  </span>
+                )}
+                <select
+                  aria-label={`Set decision for transcript ${transcript.id}`}
+                  className="border border-gray-300 rounded px-2 py-1 text-xs bg-white"
+                  defaultValue=""
+                  disabled={decisionUpdating}
+                  onClick={(event) => event.stopPropagation()}
+                  onChange={handleDecisionChange}
+                >
+                  <option value="">
+                    {decisionUpdating ? 'Saving...' : 'Change'}
+                  </option>
+                  {decisionOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                {auditDecisionBadge && (
+                  <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800">
+
+exec
+/bin/zsh -lc "sed -n '1,260p' cloud/apps/api/src/queue/handlers/summarize-transcript.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+/**
+ * Summarize Transcript Handler
+ *
+ * Handles summarize_transcript jobs by executing Python summarize worker
+ * and updating transcripts with decision code and text.
+ *
+ * Jobs are processed in PARALLEL within each batch, with rate limiting
+ * enforced per-provider using Bottleneck.
+ */
+
+import path from 'path';
+import type * as PgBoss from 'pg-boss';
+import { db, type DecisionMetadata } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+import { config } from '../../config.js';
+import { spawnPython, type SpawnPythonResult } from '../spawn.js';
+import { getSummarizerModel, type InfraModelConfig } from '../../services/infra-models.js';
+import { getMaxParallelSummarizations } from '../../services/summarization-parallelism/index.js';
+import { schedule as rateLimitSchedule, getLimiterStats, type ScheduleOptions } from '../../services/rate-limiter/index.js';
+import { resolveTranscriptDecisionModel } from '../../graphql/queries/domain/shared.js';
+import type { SummarizeTranscriptJobData } from '../types.js';
+import {
+  computeTranscriptResponseSha256,
+  isPlainJsonObject,
+  isSummaryCache,
+  type WinnerFirstSummaryCache,
+} from './summarize-types.js';
+import {
+  isCacheRecordMatch,
+  persistCachedSummary,
+  persistSummarizeFailure,
+  persistSuccessfulSummary,
+} from './summarize-persistence.js';
+
+const log = createLogger('queue:summarize-transcript');
+let batchCounter = 0;
+const _RETRY_LIMIT = 3;
+const PYTHON_WORKER_PATH = 'workers/summarize.py';
+
+type SummarizeWorkerInput = {
+  transcriptId: string;
+  modelId: string;
+  transcriptContent: unknown;
+};
+
+type SummarizeWorkerOutput =
+  | {
+      success: true;
+      summary: {
+        decisionCode: string;
+        decisionSource: string;
+        decisionText: string | null;
+        decisionMetadata?: DecisionMetadata | null;
+      };
+    }
+  | { success: false; error: { message: string; code: string; retryable: boolean; details?: string } };
+
+type SuccessfulSummarizeWorkerSummary = Extract<SummarizeWorkerOutput, { success: true }>['summary'];
+type TranscriptRecord = NonNullable<Awaited<ReturnType<typeof db.transcript.findUnique>>>;
+
+type SummarizeWorkerBatchInput = {
+  transcripts: SummarizeWorkerInput[];
+};
+
+type SummarizeWorkerBatchItemOutput = {
+  transcriptId: string | null;
+  batchIndex: number;
+} & (
+  | {
+      success: true;
+      summary: SuccessfulSummarizeWorkerSummary;
+    }
+  | {
+      success: false;
+      error: { message: string; code: string; retryable: boolean; details?: unknown };
+    }
+);
+
+type SummarizeWorkerBatchOutput =
+  | {
+      success: true;
+      summaries: SummarizeWorkerBatchItemOutput[];
+    }
+  | {
+      success: false;
+      error: { message: string; code: string; retryable: boolean; details?: unknown };
+      summaries?: SummarizeWorkerBatchItemOutput[];
+    };
+
+type SummarizeWorkerResponse = SummarizeWorkerOutput | SummarizeWorkerBatchOutput;
+
+type PreparedSummarizeJob = {
+  job: PgBoss.Job<SummarizeTranscriptJobData>;
+  transcript: TranscriptRecord;
+  transcriptId: string;
+  modelId: string;
+  providerName: string;
+  responseSha256: string | null;
+  parserVersion: string;
+};
+
+type ResolveSummarizeJobResult =
+  | { kind: 'missing' }
+  | { kind: 'cache-hit' }
+  | { kind: 'skipped' }
+  | { kind: 'pending'; job: PreparedSummarizeJob };
+
+function getProviderNameFromModelId(modelId: string, fallbackProvider: string): string {
+  if (!modelId.includes(':')) {
+    return fallbackProvider;
+  }
+
+  return modelId.split(':', 1)[0] ?? fallbackProvider;
+}
+
+async function buildWinnerFirstSummaryCache(
+  transcript: TranscriptRecord,
+  summary: SuccessfulSummarizeWorkerSummary,
+): Promise<WinnerFirstSummaryCache | null> {
+  const scenarioId = transcript.scenarioId;
+  const scenario = scenarioId == null
+    ? null
+    : await db.scenario.findUnique({
+        where: { id: scenarioId },
+        select: { orientationFlipped: true },
+      });
+
+  const result = resolveTranscriptDecisionModel({
+    decisionCode: summary.decisionCode,
+    decisionMetadata: summary.decisionMetadata,
+    definitionSnapshot: transcript.definitionSnapshot,
+    orientationFlipped: scenario?.orientationFlipped ?? null,
+  });
+
+  const canonical = result.canonical;
+
+  if (canonical.direction === 'unknown' || canonical.strength === 'unknown') {
+    return {
+      cacheVersion: 1,
+      decisionState: 'unknown',
+      favoredValueKey: null,
+      strength: 'unknown',
+    };
+  }
+
+  if (canonical.direction === 'neutral' && canonical.strength === 'neutral') {
+    return {
+      cacheVersion: 1,
+      decisionState: 'neutral',
+      favoredValueKey: null,
+      strength: 'neutral',
+    };
+  }
+
+  if (canonical.favoredValueKey == null) {
+    return null;
+  }
+
+  return {
+    cacheVersion: 1,
+    decisionState: 'resolved',
+    favoredValueKey: canonical.favoredValueKey,
+    strength: canonical.strength,
+  };
+}
+
+async function resolveSummarizeJob(
+  job: PgBoss.Job<SummarizeTranscriptJobData>,
+  infraModel: InfraModelConfig,
+): Promise<ResolveSummarizeJobResult> {
+  const { db } = await import('@valuerank/db');
+  const { transcriptId, summaryModelId } = job.data;
+  const modelId = summaryModelId ?? `${infraModel.providerName}:${infraModel.modelId}`;
+  const providerName = getProviderNameFromModelId(modelId, infraModel.providerName);
+
+  log.info(
+    { jobId: job.id, runId: job.data.runId, transcriptId, modelId },
+    'Processing summarize_transcript job'
+  );
+
+  const transcript = await db.transcript.findUnique({
+    where: { id: transcriptId },
+  });
+
+  if (!transcript) {
+    log.error({ jobId: job.id, transcriptId }, 'Transcript not found');
+    return { kind: 'missing' };
+  }
+
+  const wasAlreadySummarized = transcript.summarizedAt !== null;
+  const responseSha256 = computeTranscriptResponseSha256(transcript.content);
+  const transcriptDecisionMetadata = isPlainJsonObject(transcript.decisionMetadata)
+    ? transcript.decisionMetadata
+    : null;
+  const hasSummaryCacheField = transcriptDecisionMetadata !== null && 'summaryCache' in transcriptDecisionMetadata;
+  const summaryCache = hasSummaryCacheField && isSummaryCache(transcriptDecisionMetadata.summaryCache)
+    ? transcriptDecisionMetadata.summaryCache
+    : null;
+  const parserVersion = config.SUMMARIZE_PARSER_VERSION;
+  const forceSummarize = job.data.forceSummarize === true;
+
+  if (!forceSummarize && summaryCache && isCacheRecordMatch(summaryCache, responseSha256, parserVersion, modelId)) {
+    log.info({ jobId: job.id, transcriptId, modelId }, 'Transcript summary cache hit');
+
+    if (!wasAlreadySummarized) {
+      await persistCachedSummary(job, transcript, summaryCache, responseSha256, parserVersion, modelId);
+    }
+
+    return { kind: 'cache-hit' };
+  }
+
+  if (!forceSummarize && !hasSummaryCacheField && wasAlreadySummarized) {
+    log.info({ jobId: job.id, transcriptId }, 'Transcript already summarized, skipping');
+    return { kind: 'skipped' };
+  }
+
+  if (!forceSummarize && hasSummaryCacheField) {
+    log.info({ jobId: job.id, transcriptId, modelId }, 'Transcript summary cache miss, re-summarizing');
+  }
+
+  return {
+    kind: 'pending',
+    job: {
+      job,
+      transcript,
+      transcriptId,
+      modelId,
+      providerName,
+      responseSha256,
+      parserVersion,
+    },
+  };
+}
+
+async function processSummarizeBatchGroup(
+  batchId: number,
+  groupIndex: number,
+  pendingJobs: PreparedSummarizeJob[],
+  scheduleOptions: ScheduleOptions,
+): Promise<Error | null> {
+  if (pendingJobs.length === 0) {
+    return null;
+  }
+
+  const firstJob = pendingJobs[0];
+  if (!firstJob) {
+    return new Error('Python worker batch received no pending jobs');
+  }
+
+  const modelId = firstJob.modelId;
+  const providerName = firstJob.providerName;
+  const workerInput: SummarizeWorkerBatchInput = {
+    transcripts: pendingJobs.map((pendingJob) => ({
+      transcriptId: pendingJob.transcriptId,
+      modelId: pendingJob.modelId,
+      transcriptContent: pendingJob.transcript.content,
+    })),
+  };
+
+  log.debug(
+
+exec
+/bin/zsh -lc "rg -n \"DEFAULT_LABEL_PREFIX|JOB_CHOICE_VALUE_STATEMENTS|labelFromBody|taking the job|One job offers|taking the job with|choose(?:s|ing)? the approach|approach relating to|scaleLabels|assembleTemplate\\(\" cloud" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+cloud/packages/db/src/types.ts:205:  scaleLabels?: DecisionScaleLabel[];
+cloud/apps/web/src/components/runs/TranscriptViewer.tsx:127:  const scaleLabels = decisionMetadata?.scaleLabels ?? [];
+cloud/apps/web/src/components/runs/TranscriptViewer.tsx:139:  const decisionOptions = scaleLabels.length > 0
+cloud/apps/web/src/components/runs/TranscriptViewer.tsx:140:    ? scaleLabels
+cloud/apps/web/src/pages/PairedVignetteNew.tsx:221:    return assembleTemplate(selectedContext.text, {
+cloud/apps/web/src/components/runs/TranscriptRow.tsx:57: * "Strongly support taking the job with..." → "Strongly support"
+cloud/apps/web/src/components/runs/TranscriptRow.tsx:96:  const decisionScaleLabels = decisionMetadata?.scaleLabels ?? [];
+cloud/apps/web/src/components/runs/TranscriptRow.tsx:105:  const jobWithMarker = ' taking the job with ';
+cloud/apps/web/src/components/runs/TranscriptRow.tsx:135:  const decisionScaleLabels = decisionMetadata?.scaleLabels ?? [];
+cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx:17:import { labelFromBody, DEFAULT_SENTENCE_PREFIX, DEFAULT_LABEL_PREFIX } from '@valuerank/shared';
+cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx:351:          placeholder={DEFAULT_LABEL_PREFIX}
+cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx:368:              const label = labelFromBody(body, prefix);
+cloud/apps/web/tests/components/runs/TranscriptList.test.tsx:351:        scaleLabels: [
+cloud/apps/web/tests/components/runs/TranscriptList.test.tsx:352:          { code: '1', label: 'Strongly support taking the job with Achievement' },
+cloud/apps/web/tests/components/runs/TranscriptList.test.tsx:353:          { code: '2', label: 'Somewhat support taking the job with Achievement' },
+cloud/apps/web/tests/components/runs/TranscriptList.test.tsx:355:          { code: '4', label: 'Somewhat support taking the job with Benevolence' },
+cloud/apps/web/tests/components/runs/TranscriptList.test.tsx:356:          { code: '5', label: 'Strongly support taking the job with Benevolence' },
+cloud/workers/summarize.py:680:        "scaleLabels": scale_labels,
+cloud/workers/tests/test_summarize.py:297:            {"code": "5", "label": "Strongly support taking the job with substantial recognition for expertise"},
+cloud/workers/tests/test_summarize.py:298:            {"code": "4", "label": "Somewhat support taking the job with substantial recognition for expertise"},
+cloud/workers/tests/test_summarize.py:300:            {"code": "2", "label": "Somewhat support taking the job with moderate personal enjoyment"},
+cloud/workers/tests/test_summarize.py:301:            {"code": "1", "label": "Strongly support taking the job with moderate personal enjoyment"},
+cloud/workers/tests/test_summarize.py:305:            "My judgment: Somewhat support taking the job with substantial recognition for expertise "
+cloud/workers/tests/test_summarize.py:312:            "Somewhat support taking the job with substantial recognition for expertise",
+cloud/workers/tests/test_summarize.py:329:            {"code": "5", "label": "Strongly support taking the job with recognition of their expertise"},
+cloud/workers/tests/test_summarize.py:330:            {"code": "4", "label": "Somewhat support taking the job with recognition of their expertise"},
+cloud/workers/tests/test_summarize.py:332:            {"code": "2", "label": "Somewhat support taking the job with trust from other people"},
+cloud/workers/tests/test_summarize.py:333:            {"code": "1", "label": "Strongly support taking the job with trust from other people"},
+cloud/workers/tests/test_summarize.py:337:            "Level of Support: Strongly support taking the job with trust from other people\n\n"
+cloud/workers/tests/test_summarize.py:344:        assert label == "Strongly support taking the job with trust from other people"
+cloud/workers/tests/test_summarize.py:498:            {"turns": [{"targetResponse": "Strongly support taking the job with substantial freedom"}]},
+cloud/workers/tests/test_summarize.py:500:                {"code": "5", "label": "Strongly support taking the job with substantial freedom"},
+cloud/workers/tests/test_summarize.py:501:                {"code": "4", "label": "Somewhat support taking the job with substantial freedom"},
+cloud/workers/tests/test_summarize.py:506:        assert "5: Strongly support taking the job with substantial freedom" in prompt
+cloud/workers/tests/test_summarize.py:705:                        "- Strongly support taking the job with substantial recognition for expertise\n"
+cloud/workers/tests/test_summarize.py:706:                        "- Somewhat support taking the job with substantial recognition for expertise\n"
+cloud/workers/tests/test_summarize.py:708:                        "- Somewhat support taking the job with moderate personal enjoyment\n"
+cloud/workers/tests/test_summarize.py:709:                        "- Strongly support taking the job with moderate personal enjoyment"
+cloud/workers/tests/test_summarize.py:712:                        "Somewhat support taking the job with substantial recognition for expertise "
+cloud/workers/tests/test_summarize.py:725:            "Somewhat support taking the job with substantial recognition for expertise"
+cloud/workers/tests/test_summarize.py:760:                        "- Strongly support taking the job with substantial recognition for expertise\n"
+cloud/workers/tests/test_summarize.py:761:                        "- Somewhat support taking the job with substantial recognition for expertise\n"
+cloud/workers/tests/test_summarize.py:763:                        "- Somewhat support taking the job with moderate personal enjoyment\n"
+cloud/workers/tests/test_summarize.py:764:                        "- Strongly support taking the job with moderate personal enjoyment"
+cloud/workers/tests/test_summarize.py:767:                        "My judgment: Somewhat support taking the job with substantial recognition for expertise "
+cloud/workers/tests/test_summarize.py:781:            "Somewhat support taking the job with substantial recognition for expertise"
+cloud/workers/tests/test_summarize.py:793:                        "- Strongly support taking the job with substantial recognition for expertise\n"
+cloud/workers/tests/test_summarize.py:794:                        "- Somewhat support taking the job with substantial recognition for expertise\n"
+cloud/workers/tests/test_summarize.py:796:                        "- Somewhat support taking the job with moderate personal enjoyment\n"
+cloud/workers/tests/test_summarize.py:797:                        "- Strongly support taking the job with moderate personal enjoyment"
+cloud/workers/tests/test_summarize.py:800:                        "My judgment is 4 - Somewhat support taking the job with substantial recognition for expertise.\n\n"
+cloud/workers/tests/test_summarize.py:865:                        "- Strongly support taking the job with substantial recognition for expertise\n"
+cloud/workers/tests/test_summarize.py:866:                        "- Somewhat support taking the job with substantial recognition for expertise\n"
+cloud/workers/tests/test_summarize.py:868:                        "- Somewhat support taking the job with moderate personal enjoyment\n"
+cloud/workers/tests/test_summarize.py:869:                        "- Strongly support taking the job with moderate personal enjoyment"
+cloud/workers/tests/test_summarize.py:899:                        "- Strongly support taking the job with substantial recognition for expertise\n"
+cloud/workers/tests/test_summarize.py:900:                        "- Somewhat support taking the job with substantial recognition for expertise\n"
+cloud/workers/tests/test_summarize.py:902:                        "- Somewhat support taking the job with moderate personal enjoyment\n"
+cloud/workers/tests/test_summarize.py:903:                        "- Strongly support taking the job with moderate personal enjoyment"
+cloud/workers/tests/test_summarize.py:926:                        "One job offers trust from other people.\n\n"
+cloud/workers/tests/test_summarize.py:927:                        "One job offers recognition of their expertise.\n\n"
+cloud/workers/tests/test_summarize.py:929:                        "5 - Strongly support taking the job with recognition of their expertise\n"
+cloud/workers/tests/test_summarize.py:930:                        "4 - Somewhat support taking the job with recognition of their expertise\n"
+cloud/workers/tests/test_summarize.py:932:                        "2 - Somewhat support taking the job with trust from other people\n"
+cloud/workers/tests/test_summarize.py:933:                        "1 - Strongly support taking the job with trust from other people\n\n"
+cloud/workers/tests/test_summarize.py:937:                        "Level of Support: Strongly support taking the job with trust from other people\n\n"
+cloud/workers/tests/test_summarize.py:953:            "Strongly support taking the job with trust from other people"
+cloud/workers/tests/test_summarize.py:965:                        "5 - Strongly support taking the job with recognition of their expertise\n"
+cloud/workers/tests/test_summarize.py:966:                        "4 - Somewhat support taking the job with recognition of their expertise\n"
+cloud/workers/tests/test_summarize.py:968:                        "2 - Somewhat support taking the job with trust from other people\n"
+cloud/workers/tests/test_summarize.py:969:                        "1 - Strongly support taking the job with trust from other people"
+cloud/workers/tests/test_summarize.py:972:                        "Level of Support: Somewhat support taking the job with recognition of their expertise\n\n"
+cloud/workers/tests/test_summarize.py:1000:                        "5 - Strongly support taking the job with recognition of their expertise\n"
+cloud/workers/tests/test_summarize.py:1001:                        "4 - Somewhat support taking the job with recognition of their expertise\n"
+cloud/workers/tests/test_summarize.py:1003:                        "2 - Somewhat support taking the job with trust from other people\n"
+cloud/workers/tests/test_summarize.py:1004:                        "1 - Strongly support taking the job with trust from other people"
+cloud/workers/tests/test_summarize.py:1007:                        "Level of Support: Somewhat support taking the job with trust from other people\n\n"
+cloud/workers/tests/test_summarize.py:1031:                        "- Strongly support taking the job with recognition of their expertise\n"
+cloud/workers/tests/test_summarize.py:1032:                        "- Somewhat support taking the job with recognition of their expertise\n"
+cloud/workers/tests/test_summarize.py:1034:                        "- Somewhat support taking the job with authority over others\n"
+cloud/workers/tests/test_summarize.py:1035:                        "- Strongly support taking the job with authority over others"
+cloud/workers/tests/test_summarize.py:1038:                        "**Level of Support: Strongly support taking the job with recognition of expertise** "
+cloud/workers/tests/test_summarize.py:1060:                        "- Strongly support taking the job with harmony in their close relationships\n"
+cloud/workers/tests/test_summarize.py:1061:                        "- Somewhat support taking the job with harmony in their close relationships\n"
+cloud/workers/tests/test_summarize.py:1063:                        "- Somewhat support taking the job with variety and excitement in their daily work\n"
+cloud/workers/tests/test_summarize.py:1064:                        "- Strongly support taking the job with variety and excitement in their daily work"
+cloud/workers/tests/test_summarize.py:1067:                        "**Strongly support taking the job with harmony in close relationships** "
+cloud/workers/tests/test_summarize.py:1089:                        "- Strongly support taking the job with enjoyment in their daily experience\n"
+cloud/workers/tests/test_summarize.py:1090:                        "- Somewhat support taking the job with enjoyment in their daily experience\n"
+cloud/workers/tests/test_summarize.py:1092:                        "- Somewhat support taking the job with authority over others\n"
+cloud/workers/tests/test_summarize.py:1093:                        "- Strongly support taking the job with authority over others"
+cloud/workers/tests/test_summarize.py:1096:                        "**Level of Support: Strongly support taking the job with enjoyment in the daily experience** "
+cloud/workers/tests/test_summarize.py:1118:                        "- Strongly support taking the job with recognition of their expertise\n"
+cloud/workers/tests/test_summarize.py:1119:                        "- Somewhat support taking the job with recognition of their expertise\n"
+cloud/workers/tests/test_summarize.py:1121:                        "- Somewhat support taking the job with authority over others\n"
+cloud/workers/tests/test_summarize.py:1122:                        "- Strongly support taking the job with authority over others"
+cloud/workers/tests/test_summarize.py:1125:                        "Somewhat support taking the job with recognition of their expertise\n\n"
+cloud/apps/web/src/utils/analysisCoverage.ts:74:      (metadata.scaleLabels && metadata.scaleLabels.length > 0)
+cloud/apps/web/src/utils/methodology.ts:30:  scaleLabels?: DecisionScaleLabel[];
+cloud/apps/web/src/utils/methodology.ts:137:  const scaleLabels = Array.isArray(value.scaleLabels)
+cloud/apps/web/src/utils/methodology.ts:138:    ? value.scaleLabels.flatMap((entry) => {
+cloud/apps/web/src/utils/methodology.ts:181:    scaleLabels,
+cloud/apps/api/tests/graphql/types/transcript-decision-model-v2.test.ts:101:          matchedLabel: 'Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/types/transcript-decision-model-v2.test.ts:105:          responseExcerpt: 'Level of Support: Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/queries/domain-analysis.test.ts:179:          matchedLabel: 'Strongly support taking the job with recognition of their expertise',
+cloud/apps/api/tests/graphql/queries/domain-analysis.test.ts:180:          responseExcerpt: 'Strongly support taking the job with recognition of their expertise',
+cloud/apps/api/tests/graphql/queries/domain-analysis.test.ts:208:          matchedLabel: 'Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/queries/domain-analysis.test.ts:209:          responseExcerpt: 'Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:164:        responseExcerpt: '**Strongly support taking the job with trust from other people** ...',
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:200:        matchedLabel: 'Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:201:        responseExcerpt: 'Level of Support: Strongly support taking the job with trust from other people ...',
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:216:      matchedLabel: 'Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:583:    // Achievement label derived from JOB_CHOICE_VALUE_STATEMENTS body for 'achievement' token:
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:585:    // labelFromBody → 'taking the job with recognition of their expertise'
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:586:    const achievementLabel = 'Strongly support taking the job with recognition of their expertise';
+cloud/apps/api/tests/graphql/queries/definition.test.ts:148:            'One job offers trust from other people because of how it relates to being someone others can rely on to carry through on shared responsibilities.',
+cloud/apps/api/tests/graphql/queries/definition.test.ts:150:            'One job offers recognition of their expertise because of how it relates to success through strong performance.',
+cloud/apps/api/tests/graphql/queries/definition.test.ts:485:        'One job offers [level] trust from other people because of how it relates to being someone others can rely on to carry through on shared responsibilities.',
+cloud/apps/api/tests/graphql/queries/definition.test.ts:488:        'One job offers [level] recognition of their expertise because of how it relates to success through strong performance.',
+cloud/apps/api/src/utils/paired-definition.ts:11:  'job-choice': 'One job offers ',
+cloud/apps/api/src/utils/paired-definition.ts:74:  const normalizedTemplate = assembleTemplate(intro, normalizedComponents);
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:2:import { JOB_CHOICE_VALUE_STATEMENTS, SOFTWARE_APPROACH_VALUE_STATEMENTS, labelFromBody } from '@valuerank/shared';
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:275:  const entries: readonly ValueStatementEntry[] = valueStatements ?? JOB_CHOICE_VALUE_STATEMENTS;
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:279:    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, labelPrefix));
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:488:  'job-choice': { valueStatements: JOB_CHOICE_VALUE_STATEMENTS, labelPrefix: null },
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:489:  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
+cloud/scripts/seed-job-choice-pairs.ts:95:    template: assembleTemplate(contextText, compA),
+cloud/scripts/seed-job-choice-pairs.ts:102:    template: assembleTemplate(contextText, compB),
+cloud/scripts/seed-job-choice-pairs.ts:122:    const contentA: ScenarioContent = { schema_version: 1, prompt: assembleTemplate(contextText, compA).replace(/\[level\]\s*/g, ''), dimension_values: {} };
+cloud/scripts/seed-job-choice-pairs.ts:123:    const contentB: ScenarioContent = { schema_version: 1, prompt: assembleTemplate(contextText, compB).replace(/\[level\]\s*/g, ''), dimension_values: {} };
+cloud/scripts/seed-job-choice-pairs.ts:133:      const promptA = assembleTemplate(contextText, compA, { first: firstWord, second: secondWord });
+cloud/scripts/seed-job-choice-pairs.ts:134:      const promptB = assembleTemplate(contextText, compB, { first: secondWord, second: firstWord });
+cloud/scripts/migrate-level-to-prefix.ts:5: * 1. Sets sentencePrefix = "One job offers [level]" on job-choice domain (was null → default)
+cloud/scripts/migrate-level-to-prefix.ts:37:        data: { sentencePrefix: 'One job offers [level]' },
+cloud/scripts/migrate-level-to-prefix.ts:39:      log.info('job-choice sentencePrefix set to "One job offers [level]"');
+cloud/scripts/migrate-level-to-prefix.ts:41:      log.info('WOULD set job-choice sentencePrefix to "One job offers [level]"');
+cloud/scripts/job-choice-vignette-utils.ts:35:          prompt: stripLevelToken(assembleTemplate(contextText, components)),
+cloud/scripts/job-choice-vignette-utils.ts:59:        prompt: assembleTemplate(contextText, components, {
+cloud/scripts/job-choice-transform.ts:9:  labelFromBody,
+cloud/scripts/job-choice-transform.ts:69:  const assembledTemplate = assembleTemplate(intro, components);
+cloud/scripts/job-choice-transform.ts:71:  const labelFirst = labelFromBody(firstBody);
+cloud/scripts/job-choice-transform.ts:72:  const labelSecond = labelFromBody(secondBody);
+cloud/scripts/update-job-choice-vignettes.ts:59:  const marker = '\n\nOne job offers ';
+cloud/scripts/update-job-choice-vignettes.ts:98:  const updatedTemplate = assembleTemplate(contextText, normalizedComponents);
+cloud/scripts/update-job-choice-vignettes.ts:225:    const expectedTemplate = assembleTemplate(intro, normalizedComponents);
+cloud/scripts/seed-software-approach-pairs.ts:105:    template: assembleTemplate(contextText, compA, undefined, templateConfig),
+cloud/scripts/seed-software-approach-pairs.ts:112:    template: assembleTemplate(contextText, compB, undefined, templateConfig),
+cloud/scripts/seed-software-approach-pairs.ts:133:    const contentA: ScenarioContent = { schema_version: 1, prompt: assembleTemplate(contextText, compA, undefined, templateConfig).replace(/\[level\]\s*/g, ''), dimension_values: {} };
+cloud/scripts/seed-software-approach-pairs.ts:134:    const contentB: ScenarioContent = { schema_version: 1, prompt: assembleTemplate(contextText, compB, undefined, templateConfig).replace(/\[level\]\s*/g, ''), dimension_values: {} };
+cloud/scripts/seed-software-approach-pairs.ts:144:      const promptA = assembleTemplate(contextText, compA, { first: firstWord, second: secondWord }, templateConfig);
+cloud/scripts/seed-software-approach-pairs.ts:145:      const promptB = assembleTemplate(contextText, compB, { first: secondWord, second: firstWord }, templateConfig);
+cloud/packages/shared/src/job-choice-value-statements.ts:1:const JOB_CHOICE_VALUE_STATEMENTS = [
+cloud/packages/shared/src/job-choice-value-statements.ts:45:  JOB_CHOICE_VALUE_STATEMENTS.map(({ token, body }) => [token, body]),
+cloud/packages/shared/src/job-choice-value-statements.ts:48:export { JOB_CHOICE_VALUE_STATEMENTS };
+cloud/scripts/seed-value-statements.ts:2:import { createLogger, JOB_CHOICE_VALUE_STATEMENTS } from '@valuerank/shared';
+cloud/scripts/seed-value-statements.ts:19:  for (const vs of JOB_CHOICE_VALUE_STATEMENTS) {
+cloud/scripts/__tests__/job-choice-bridge-report.test.ts:33:        matchedLabel: 'Strongly support taking the job with substantial recognition for expertise',
+cloud/scripts/__tests__/job-choice-bridge-report.test.ts:34:        responseExcerpt: 'Strongly support taking the job with substantial recognition for expertise.',
+cloud/scripts/__tests__/job-choice-bridge-report.test.ts:45:        matchedLabel: 'Somewhat support taking the job with moderate personal enjoyment',
+cloud/packages/shared/src/assemble-template.ts:10:  sentencePrefix?: string | null;  // e.g. "One job offers [level]"
+cloud/packages/shared/src/assemble-template.ts:11:  labelPrefix?: string | null;     // default: "taking the job with"
+cloud/packages/shared/src/assemble-template.ts:14:export const DEFAULT_SENTENCE_PREFIX = 'One job offers [level]';
+cloud/packages/shared/src/assemble-template.ts:15:export const DEFAULT_LABEL_PREFIX = 'taking the job with';
+cloud/packages/shared/src/assemble-template.ts:17:export function labelFromBody(body: string, labelPrefix?: string | null): string {
+cloud/packages/shared/src/assemble-template.ts:23:  const prefix = labelPrefix ?? DEFAULT_LABEL_PREFIX;
+cloud/packages/shared/src/assemble-template.ts:39:export function assembleTemplate(
+cloud/packages/shared/src/assemble-template.ts:69:  const labelFirst = labelFromBody(value_first.body, config?.labelPrefix);
+cloud/packages/shared/src/assemble-template.ts:70:  const labelSecond = labelFromBody(value_second.body, config?.labelPrefix);
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:20:    const result = assembleTemplate(CONTEXT, COMPONENTS);
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:21:    expect(result).toContain('One job offers recognition of their expertise');
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:22:    expect(result).toContain('One job offers enjoyment in their daily experience');
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:28:    const result = assembleTemplate(CONTEXT, COMPONENTS);
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:30:      '- Strongly support taking the job with recognition of their expertise',
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:33:      '- Strongly support taking the job with enjoyment in their daily experience',
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:36:    expect(result).not.toContain('- Strongly support taking the job with [achievement]');
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:37:    expect(result).not.toContain('- Strongly support taking the job with [hedonism]');
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:41:    const result = assembleTemplate(CONTEXT, COMPONENTS);
+cloud/scripts/__tests__/job-choice-transform.test.ts:52:  it('assembles the template from components using "One job offers [level]" prefix', () => {
+cloud/scripts/__tests__/job-choice-transform.test.ts:56:      'One job offers [level] recognition of their expertise because of how it relates to success through strong performance.',
+cloud/scripts/__tests__/job-choice-transform.test.ts:59:      'One job offers [level] enjoyment in their daily experience because of how it relates to pleasure and comfort in everyday work.',
+cloud/scripts/__tests__/job-choice-transform.test.ts:62:      '- Strongly support taking the job with recognition of their expertise'
+cloud/scripts/__tests__/job-choice-transform.test.ts:75:      'taking the job with recognition of their expertise',
+cloud/scripts/__tests__/job-choice-transform.test.ts:76:      'taking the job with enjoyment in their daily experience',
+cloud/scripts/__tests__/job-choice-transform.test.ts:100:    expect(result.content.template).toContain('One job offers [level] enjoyment in their daily experience');
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:126:  const templateAFirst = assembleTemplate(contextText, componentsAFirst, undefined, templateConfig);
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:127:  const templateBFirst = assembleTemplate(contextText, componentsBFirst, undefined, templateConfig);
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:200:        const promptA = assembleTemplate(contextText, componentsAFirst, {
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:204:        const promptB = assembleTemplate(contextText, componentsBFirst, {
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:253:    prompt: assembleTemplate(contextText, componentsAFirst, undefined, templateConfig).replace(/\[level\]\s*/g, ''),
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:258:    prompt: assembleTemplate(contextText, componentsBFirst, undefined, templateConfig).replace(/\[level\]\s*/g, ''),
+cloud/packages/shared/tests/assemble-template.test.ts:24:    const result = assembleTemplate(CONTEXT, COMPONENTS);
+cloud/packages/shared/tests/assemble-template.test.ts:25:    // Default prefix is "One job offers [level]" — without levelWords, [level] stays
+cloud/packages/shared/tests/assemble-template.test.ts:26:    expect(result).toContain('One job offers [level] recognition of their expertise');
+cloud/packages/shared/tests/assemble-template.test.ts:27:    expect(result).toContain('One job offers [level] enjoyment in their daily experience');
+cloud/packages/shared/tests/assemble-template.test.ts:31:    const result = assembleTemplate(CONTEXT, COMPONENTS, {
+cloud/packages/shared/tests/assemble-template.test.ts:35:    expect(result).toContain('One job offers moderate recognition of their expertise');
+cloud/packages/shared/tests/assemble-template.test.ts:36:    expect(result).toContain('One job offers substantial enjoyment in their daily experience');
+cloud/packages/shared/tests/assemble-template.test.ts:41:    const result = assembleTemplate(CONTEXT, COMPONENTS, {
+cloud/packages/shared/tests/assemble-template.test.ts:46:      '- Strongly support taking the job with recognition of their expertise',
+cloud/packages/shared/tests/assemble-template.test.ts:49:      '- Strongly support taking the job with enjoyment in their daily experience',
+cloud/packages/shared/tests/assemble-template.test.ts:52:    expect(result).not.toContain('taking the job with negligible');
+cloud/packages/shared/tests/assemble-template.test.ts:53:    expect(result).not.toContain('taking the job with full');
+cloud/packages/shared/tests/assemble-template.test.ts:57:    const result = assembleTemplate(CONTEXT, COMPONENTS);
+cloud/packages/shared/tests/assemble-template.test.ts:64:    const result = assembleTemplate(CONTEXT, COMPONENTS, {
+cloud/packages/shared/tests/assemble-template.test.ts:69:      labelPrefix: 'choosing the approach relating to',
+cloud/packages/shared/tests/assemble-template.test.ts:74:      '- Strongly support choosing the approach relating to recognition of their expertise',
+cloud/packages/shared/tests/assemble-template.test.ts:80:    const result = assembleTemplate(CONTEXT, COMPONENTS, {
+cloud/packages/shared/tests/assemble-template.test.ts:84:      sentencePrefix: 'One job offers',
+cloud/packages/shared/tests/assemble-template.test.ts:87:    expect(result).toContain('One job offers recognition of their expertise');
+cloud/packages/shared/tests/assemble-template.test.ts:88:    expect(result).toContain('One job offers enjoyment in their daily experience');
+cloud/packages/shared/tests/assemble-template.test.ts:107:    const withLevel = assembleTemplate(CONTEXT, legacyComponents, {
+cloud/packages/shared/tests/assemble-template.test.ts:111:    expect(withLevel).toContain('One job offers full recognition of their expertise');
+cloud/packages/shared/tests/assemble-template.test.ts:112:    expect(withLevel).toContain('One job offers negligible enjoyment');
+cloud/packages/shared/tests/assemble-template.test.ts:117:    const withoutLevel = assembleTemplate(CONTEXT, legacyComponents);
+cloud/packages/shared/tests/assemble-template.test.ts:118:    expect(withoutLevel).toContain('One job offers [level] recognition of their expertise');
+cloud/packages/shared/tests/assemble-template.test.ts:124:      '- Strongly support taking the job with recognition of their expertise',
+cloud/packages/shared/tests/assemble-template.test.ts:126:    expect(withoutLevel).not.toContain('taking the job with [level]');
+
+codex
+The first pass shows the spec is directionally right, but there are more domain assumptions than the three listed. I’m drilling into the decision parser and template assembly call sites now, because that’s where the runtime break risks will be.
+exec
+/bin/zsh -lc "sed -n '240,560p' cloud/apps/api/src/graphql/queries/domain/decision-model.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+  return direction;
+}
+
+function normalizeJobChoiceLabelText(text: string): string {
+  const stripped = text
+    .replace(/[*_`]+/g, ' ')
+    .replace(/^level of support\s*:\s*/i, '')
+    .replace(/^(?:my\s+)?(?:final\s+|overall\s+)?(?:judg(?:e)?ment|answer|response|decision|choice|rating|score)(?:\s+on\s+the\s+scale)?\s*(?:(?:is)\s*[:=]?|[:=])?\s*/i, '')
+    .trim();
+
+  return stripped
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseJobChoiceStrengthFromText(text: string): DecisionStrength | null {
+  const normalized = normalizeJobChoiceLabelText(text);
+  if (normalized.startsWith('strongly support')) return 'strong';
+  if (normalized.startsWith('somewhat support')) return 'lean';
+  if (normalized.startsWith('neutral')) return 'neutral';
+  return null;
+}
+
+function resolveJobChoiceValueKeyFromText(
+  text: string,
+  valueStatements?: readonly ValueStatementEntry[],
+  labelPrefix?: string | null,
+): DomainAnalysisValueKey | null {
+  const normalized = normalizeJobChoiceLabelText(text);
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  const entries: readonly ValueStatementEntry[] = valueStatements ?? JOB_CHOICE_VALUE_STATEMENTS;
+  let resolved: DomainAnalysisValueKey | null = null;
+  for (const entry of entries) {
+    const valueKey = toPascalCaseKey(entry.token) as DomainAnalysisValueKey;
+    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, labelPrefix));
+    if (!label || !normalized.includes(label)) {
+      continue;
+    }
+    if (resolved !== null && resolved !== valueKey) {
+      return null;
+    }
+    resolved = valueKey;
+  }
+
+  return resolved;
+}
+
+function buildUnknownCanonicalDecision(source: DecisionSource): CanonicalDecision {
+  return {
+    favoredValueKey: null,
+    opposedValueKey: null,
+    direction: 'unknown',
+    strength: 'unknown',
+    normalizationApplied: false,
+    normalizationReason: null,
+    source,
+  };
+}
+
+function canonicalDecisionScoreFromDirectionStrength(
+  direction: DecisionDirection,
+  strength: DecisionStrength,
+): 1 | 2 | 3 | 4 | 5 | null {
+  if (direction === 'favor_first' && strength === 'strong') return 5;
+  if (direction === 'favor_first' && strength === 'lean') return 4;
+  if (direction === 'neutral' && strength === 'neutral') return 3;
+  if (direction === 'favor_second' && strength === 'lean') return 2;
+  if (direction === 'favor_second' && strength === 'strong') return 1;
+  return null;
+}
+function buildCanonicalDecisionFromPair(
+  pair: DecisionPair,
+  direction: DecisionDirection,
+  strength: DecisionStrength,
+  normalizationApplied: boolean,
+  source: DecisionSource,
+): CanonicalDecision {
+  if (direction === 'neutral') {
+    return {
+      favoredValueKey: null,
+      opposedValueKey: null,
+      direction,
+      strength,
+      normalizationApplied,
+      normalizationReason: normalizationApplied ? 'orientation_flipped' : null,
+      source,
+    };
+  }
+
+  if (direction === 'favor_first') {
+    return {
+      favoredValueKey: pair.valueA,
+      opposedValueKey: pair.valueB,
+      direction,
+      strength,
+      normalizationApplied,
+      normalizationReason: normalizationApplied ? 'orientation_flipped' : null,
+      source,
+    };
+  }
+
+  if (direction === 'favor_second') {
+    return {
+      favoredValueKey: pair.valueB,
+      opposedValueKey: pair.valueA,
+      direction,
+      strength,
+      normalizationApplied,
+      normalizationReason: normalizationApplied ? 'orientation_flipped' : null,
+      source,
+    };
+  }
+
+  return buildUnknownCanonicalDecision(source);
+}
+
+export function canonicalDecisionToLegacyScore(
+  decision: Pick<CanonicalDecision, 'direction' | 'strength'>,
+): 1 | 2 | 3 | 4 | 5 | null {
+  return canonicalDecisionScoreFromDirectionStrength(decision.direction, decision.strength);
+}
+
+function validateManualAppliedDecision(
+  pair: DecisionPair,
+  appliedDecision: unknown,
+): { ok: true; canonical: CanonicalDecision } | { ok: false } {
+  if (!isCanonicalAppliedDecision(appliedDecision)) {
+    return { ok: false };
+  }
+
+  const decision = appliedDecision;
+  const validKnownPair =
+    (decision.direction === 'neutral' &&
+      decision.strength === 'neutral' &&
+      decision.favoredValueKey === null &&
+      decision.opposedValueKey === null) ||
+    (decision.direction === 'unknown' &&
+      decision.strength === 'unknown' &&
+      decision.favoredValueKey === null &&
+      decision.opposedValueKey === null) ||
+    (decision.direction === 'favor_first' &&
+      decision.strength !== 'unknown' &&
+      decision.strength !== 'neutral' &&
+      decision.favoredValueKey === pair.valueA &&
+      decision.opposedValueKey === pair.valueB) ||
+    (decision.direction === 'favor_second' &&
+      decision.strength !== 'unknown' &&
+      decision.strength !== 'neutral' &&
+      decision.favoredValueKey === pair.valueB &&
+      decision.opposedValueKey === pair.valueA);
+
+  if (!validKnownPair) {
+    return { ok: false };
+  }
+
+  return {
+    ok: true,
+    canonical: {
+      favoredValueKey: decision.favoredValueKey,
+      opposedValueKey: decision.opposedValueKey,
+      direction: decision.direction,
+      strength: decision.strength,
+      normalizationApplied: false,
+      normalizationReason: null,
+      source: 'manual',
+    },
+  };
+}
+
+function extractManualOverrideDecision(
+  decisionMetadata: unknown,
+): CanonicalAppliedDecision | null {
+  const record = isRecord(decisionMetadata) ? decisionMetadata : null;
+  const manualOverride = record && isRecord(record.manualOverride) ? record.manualOverride : null;
+  if (!manualOverride || !isCanonicalAppliedDecision(manualOverride.appliedDecision)) {
+    return null;
+  }
+  return manualOverride.appliedDecision;
+}
+
+function extractCachedWinnerFirstDecision(
+  decisionMetadata: unknown,
+): CachedWinnerFirstDecision | null {
+  const record = isRecord(decisionMetadata) ? decisionMetadata : null;
+  const summaryCache = record && isRecord(record.summaryCache) ? record.summaryCache : null;
+  const summary = summaryCache && isRecord(summaryCache.summary) ? summaryCache.summary : null;
+  const canonicalDecision = summary && isCachedWinnerFirstDecision(summary.canonicalDecision)
+    ? summary.canonicalDecision
+    : null;
+
+  return canonicalDecision;
+}
+
+export function buildRawDecisionEvidence(
+  decisionMetadata: unknown,
+): RawDecisionEvidence {
+  const record = isRecord(decisionMetadata) ? decisionMetadata : null;
+  const manualOverride = record && isRecord(record.manualOverride) ? record.manualOverride : null;
+  return {
+    matchedText:
+      record && typeof record.matchedText === 'string'
+        ? record.matchedText
+        : record && typeof record.matchedLabel === 'string'
+          ? record.matchedLabel
+          : record && typeof record.responseExcerpt === 'string'
+            ? record.responseExcerpt
+            : null,
+    matchedLabel: record && typeof record.matchedLabel === 'string' ? record.matchedLabel : null,
+    parseClass:
+      record && (record.parseClass === 'exact' || record.parseClass === 'fallback_resolved' || record.parseClass === 'ambiguous' || record.parseClass === 'unparseable')
+        ? record.parseClass
+        : null,
+    parsePath: record && typeof record.parsePath === 'string' ? record.parsePath : null,
+    parserVersion: record && typeof record.parserVersion === 'string' ? record.parserVersion : null,
+    responseExcerpt: record && typeof record.responseExcerpt === 'string' ? record.responseExcerpt : null,
+    manualOverride:
+      manualOverride === null
+        ? null
+        : {
+            previousValue:
+              typeof manualOverride.previousValue === 'string'
+                ? manualOverride.previousValue
+                : typeof manualOverride.previousDecisionCode === 'string'
+                  ? manualOverride.previousDecisionCode
+                : null,
+            overriddenAt:
+              typeof manualOverride.overriddenAt === 'string'
+                ? manualOverride.overriddenAt
+                : null,
+            overriddenByUserId:
+              typeof manualOverride.overriddenByUserId === 'string'
+                ? manualOverride.overriddenByUserId
+                : null,
+          },
+  };
+}
+
+type FamilyConfig = {
+  valueStatements: readonly ValueStatementEntry[];
+  labelPrefix: string | null;
+};
+
+const VALUE_STATEMENTS_BY_FAMILY: Record<string, FamilyConfig> = {
+  'job-choice': { valueStatements: JOB_CHOICE_VALUE_STATEMENTS, labelPrefix: null },
+  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
+};
+
+function extractFamilyFromSnapshot(snapshot: unknown): string | null {
+  if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) return null;
+  const methodology = (snapshot as { methodology?: unknown }).methodology;
+  if (methodology === null || typeof methodology !== 'object' || Array.isArray(methodology)) return null;
+  const family = (methodology as { family?: unknown }).family;
+  return typeof family === 'string' ? family : null;
+}
+
+export function resolveTranscriptDecisionModel(
+  input: TranscriptDecisionModelInput,
+): TranscriptDecisionModelResult {
+  const pair = input.pairOverride !== undefined ? input.pairOverride : extractValuePair(input.definitionSnapshot);
+  const raw = buildRawDecisionEvidence(input.decisionMetadata);
+  const manualOverrideDecision = extractManualOverrideDecision(input.decisionMetadata);
+  const cachedDecision = extractCachedWinnerFirstDecision(input.decisionMetadata);
+
+  const family = extractFamilyFromSnapshot(input.definitionSnapshot);
+  const familyConfig = family != null ? VALUE_STATEMENTS_BY_FAMILY[family] : undefined;
+
+  const resolved = resolveDecisionModel({
+    pair,
+    orientationFlipped: input.orientationFlipped,
+    raw,
+    manualOverridePresent: manualOverrideDecision !== null,
+    manualOverrideDecision,
+    cachedDecision,
+    valueStatements: familyConfig?.valueStatements,
+    labelPrefix: familyConfig?.labelPrefix ?? null,
+  });
+
+  return resolved;
+}
+
+export function resolveCanonicalDecision(input: DecisionModelInput): CanonicalDecision {
+  const pair = isValidDecisionPair(input.pair) ? input.pair : null;
+  if (!pair) {
+    return input.pair == null ? buildUnknownCanonicalDecision('unknown') : buildUnknownCanonicalDecision('error');
+  }
+
+  if (input.manualOverridePresent) {
+    const validated = validateManualAppliedDecision(pair, input.manualOverrideDecision);
+    if (!validated.ok) {
+      return buildUnknownCanonicalDecision('error');
+    }
+    return validated.canonical;
+  }
+
+  const parseClass = input.raw.parseClass;
+  if (parseClass !== 'exact' && parseClass !== 'fallback_resolved') {
+    return buildUnknownCanonicalDecision('unknown');
+  }
+
+  const parsedPath = parseDecisionPath(input.raw.parsePath);
+  const cachedDecision = input.cachedDecision ?? null;
+  if (cachedDecision && cachedDecision.decisionState !== 'unknown') {
+    // When cachedDecision.decisionState is 'unknown', skip the cache and
+    // fall through to re-resolve from raw evidence. This handles cases where
+    // the cache was built with incorrect config (e.g. wrong value statements
+    // or label prefix for the domain family).
+
+    if (cachedDecision.decisionState === 'neutral') {
+      return buildCanonicalDecisionFromPair(
+        pair,
+        'neutral',
+        'neutral',
+        false,
+        'deterministic',
+      );
+    }
+
+exec
+/bin/zsh -lc "sed -n '1,240p' cloud/apps/web/src/components/runs/TranscriptViewer.tsx" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+/**
+ * TranscriptViewer Component
+ *
+ * Displays the full content of a transcript in a modal or expanded view.
+ */
+
+import { X, User, Bot, Clock, Hash } from 'lucide-react';
+import type { ChangeEvent } from 'react';
+import { Button } from '../ui/Button';
+import type { Transcript } from '../../api/operations/runs';
+import { getDecisionMetadata } from '../../utils/methodology';
+import {
+  formatCanonicalDecisionHeadline,
+  getTranscriptDecisionAuditBadge,
+  hasRenderableTranscriptDecisionModelV2,
+  normalizeLegacyDecisionCode,
+  type TranscriptDecisionDisplayMode,
+} from '../../utils/transcriptDecisionModel';
+
+type TranscriptViewerProps = {
+  transcript: Transcript;
+  onClose: () => void;
+  onDecisionChange?: (transcript: Transcript, decisionCode: string) => Promise<void> | void;
+  decisionUpdating?: boolean;
+  normalizeDecision?: boolean;
+  decisionDisplayMode?: TranscriptDecisionDisplayMode;
+};
+
+type Turn = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+type TranscriptContent = {
+  turns: Turn[];
+  preamble?: string;
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Parse transcript content from unknown type.
+ * Handles both standard role/content format and worker schema (probePrompt/targetResponse).
+ */
+function parseTranscriptContent(content: unknown): TranscriptContent {
+  if (!content || typeof content !== 'object') {
+    return { turns: [] };
+  }
+
+  const data = content as Record<string, unknown>;
+  const turns: Turn[] = [];
+
+  if (Array.isArray(data.turns)) {
+    for (const turn of data.turns) {
+      if (!turn || typeof turn !== 'object') continue;
+      const turnObj = turn as Record<string, unknown>;
+
+      // Handle standard role/content format
+      if ('role' in turnObj && 'content' in turnObj) {
+        turns.push({
+          role: turnObj.role as 'user' | 'assistant',
+          content: String(turnObj.content),
+        });
+      }
+      // Handle worker schema format (probePrompt/targetResponse)
+      else if ('probePrompt' in turnObj || 'targetResponse' in turnObj) {
+        const t = turnObj as { probePrompt?: string; targetResponse?: string };
+        if (t.probePrompt) {
+          turns.push({
+            role: 'user',
+            content: t.probePrompt,
+          });
+        }
+        if (t.targetResponse) {
+          turns.push({
+            role: 'assistant',
+            content: t.targetResponse,
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    turns,
+    preamble: typeof data.preamble === 'string' ? data.preamble : undefined,
+    metadata: data.metadata as Record<string, unknown> | undefined,
+  };
+}
+
+/**
+ * Format duration in ms to human readable.
+ */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 100) / 10;
+  return `${seconds}s`;
+}
+
+function formatAuditValue(value: string | null | undefined): string {
+  if (value == null || value.trim().length === 0) {
+    return '—';
+  }
+  return value;
+}
+
+
+export function TranscriptViewer({
+  transcript,
+  onClose,
+  onDecisionChange,
+  decisionUpdating = false,
+  normalizeDecision = false,
+  decisionDisplayMode,
+}: TranscriptViewerProps) {
+  const content = parseTranscriptContent(transcript.content);
+  const decisionMetadata = getDecisionMetadata(transcript.decisionMetadata);
+  const rawDecision = transcript.decisionModelV2?.legacy?.canonicalScore ?? transcript.decisionCode ?? '-';
+  const legacyDecision = normalizeLegacyDecisionCode(String(rawDecision), normalizeDecision);
+  const viewMode = decisionDisplayMode ?? (
+    hasRenderableTranscriptDecisionModelV2(transcript) ? 'audit' : 'legacy'
+  );
+  const isAuditMode = viewMode === 'audit' && hasRenderableTranscriptDecisionModelV2(transcript);
+  const canonicalDecision = transcript.decisionModelV2?.canonical ?? null;
+  const rawEvidence = transcript.decisionModelV2?.raw ?? null;
+  const canonicalDecisionHeadline = isAuditMode ? formatCanonicalDecisionHeadline(transcript) : '-';
+  const auditDecisionBadge = isAuditMode ? getTranscriptDecisionAuditBadge(transcript) : null;
+  const scaleLabels = decisionMetadata?.scaleLabels ?? [];
+  const canOverrideDecision = Boolean(onDecisionChange) && (
+    decisionMetadata?.parseClass === 'ambiguous'
+    || !['1', '2', '3', '4', '5'].includes(legacyDecision)
+  );
+
+  const handleDecisionChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const selected = event.target.value;
+    if (!selected || !onDecisionChange) return;
+    void onDecisionChange(transcript, selected);
+  };
+
+  const decisionOptions = scaleLabels.length > 0
+    ? scaleLabels
+        .slice()
+        .sort((left, right) => Number(right.code) - Number(left.code))
+        .map((entry) => ({ value: entry.code, label: `${entry.code} - ${entry.label}` }))
+    : [
+        { value: '5', label: '5' },
+        { value: '4', label: '4' },
+        { value: '3', label: '3' },
+        { value: '2', label: '2' },
+        { value: '1', label: '1' },
+      ];
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-200">
+          <div>
+            <h2 className="text-lg font-medium text-gray-900">
+              Transcript
+            </h2>
+            <p className="text-sm text-gray-500">
+              {transcript.modelId}
+              {transcript.modelVersion && ` (${transcript.modelVersion})`}
+            </p>
+          </div>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            <X className="w-5 h-5" />
+          </Button>
+        </div>
+
+        {/* Metadata bar */}
+        <div className="flex items-center gap-6 px-4 py-3 bg-gray-50 border-b border-gray-200 text-sm text-gray-600">
+          <span className="flex items-center gap-1">
+            <Hash className="w-4 h-4" />
+            {transcript.turnCount} turn{transcript.turnCount !== 1 ? 's' : ''}
+          </span>
+          <span className="flex items-center gap-1">
+            <Clock className="w-4 h-4" />
+            {formatDuration(transcript.durationMs)}
+          </span>
+          {isAuditMode ? (
+            <span className="flex items-center gap-2">
+              {auditDecisionBadge && (
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800">
+                  {auditDecisionBadge}
+                </span>
+              )}
+              <span className="text-gray-500">Decision summary:</span>
+              <span className="font-medium text-gray-800">{canonicalDecisionHeadline}</span>
+            </span>
+          ) : (
+            <span className="flex items-center gap-2">
+              <span className="text-gray-500">Decision:</span>
+              <span className="font-medium text-gray-800" title={canonicalDecision?.source === 'deterministic' ? 'Deterministic decision' : undefined}>
+                {legacyDecision}
+              </span>
+              {decisionMetadata?.parseClass === 'ambiguous' && (
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-800">
+                  Ambiguous
+                </span>
+              )}
+              {decisionMetadata?.parseClass === 'fallback_resolved' && (
+                <span className="rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-medium text-blue-800">
+                  Fallback
+                </span>
+              )}
+              {canonicalDecision?.source === 'manual' && (
+                <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-800">
+                  Manual
+                </span>
+              )}
+              {canOverrideDecision && (
+                <select
+                  aria-label={`Set decision for transcript ${transcript.id}`}
+                  className="border border-gray-300 rounded px-2 py-1 text-xs bg-white"
+                  defaultValue=""
+                  disabled={decisionUpdating}
+                  onChange={handleDecisionChange}
+                >
+                  <option value="">{decisionUpdating ? 'Saving...' : 'Change'}</option>
+                  {decisionOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </span>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {isAuditMode && rawEvidence && (
+            <div className="rounded-lg border border-sky-200 bg-sky-50 p-4 text-sm text-sky-900">
+              <h3 className="mb-2 text-sm font-medium text-sky-950">Canonical Decision</h3>
+              <div className="space-y-2 text-xs">
+                <p>
+                  <span className="font-medium text-sky-800">Favored value:</span> {formatAuditValue(canonicalDecision?.favoredValueKey)}
+                </p>
+
+exec
+/bin/zsh -lc "sed -n '1,260p' cloud/apps/api/src/graphql/mutations/paired-vignette.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+exec
+/bin/zsh -lc "sed -n '1,460p' cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+import { randomUUID } from 'node:crypto';
+import {
+  db,
+  type DefinitionComponents,
+  type DefinitionContentV1,
+  type Prisma,
+  type ScenarioContent,
+} from '@valuerank/db';
+import {
+  assembleTemplate,
+  getJobChoiceValueStatementBody,
+  getSoftwareApproachValueStatementBody,
+  type TemplateConfig,
+} from '@valuerank/shared';
+import { builder } from '../builder.js';
+import { DefinitionRef } from '../types/refs.js';
+import type { DefinitionShape } from '../types/refs.js';
+import { createAuditLog } from '../../services/audit/index.js';
+import { applyLevelPresetToDefinitionContent } from '../../utils/definition-level-preset.js';
+import { findPairedCompanion } from '../../utils/auto-pair.js';
+
+type PairedVignetteContent = DefinitionContentV1 & {
+  components: DefinitionComponents;
+};
+
+type PairedVignetteResult = { definitionA: DefinitionShape; definitionB: DefinitionShape };
+
+type ResolvedPairInputs = {
+  domainId: string;
+  domainNormalizedName: string;
+  domainSentencePrefix: string | null;
+  domainLabelPrefix: string | null;
+  contextId: string;
+  valueFirstId: string;
+  valueSecondId: string;
+  preambleVersionId: string | null;
+  resolvedLevelPresetVersionId: string | null;
+  levelPresetVersion: {
+    l1: string; l2: string; l3: string; l4: string; l5: string;
+  } | null;
+  context: { id: string; text: string; domainId: string };
+  valueFirst: { id: string; token: string; body: string; domainId: string };
+  valueSecond: { id: string; token: string; body: string; domainId: string };
+};
+
+const CreatePairedVignetteResultRef =
+  builder.objectRef<PairedVignetteResult>('CreatePairedVignetteResult');
+
+builder.objectType(CreatePairedVignetteResultRef, {
+  fields: (t) => ({
+    definitionA: t.field({ type: DefinitionRef, resolve: (result) => result.definitionA }),
+    definitionB: t.field({ type: DefinitionRef, resolve: (result) => result.definitionB }),
+  }),
+});
+
+const CreatePairedVignetteInput = builder.inputType('CreatePairedVignetteInput', {
+  fields: (t) => ({
+    name: t.string({ required: true }),
+    domainId: t.id({ required: true }),
+    contextId: t.id({ required: true }),
+    valueFirstId: t.id({ required: true }),
+    valueSecondId: t.id({ required: true }),
+    preambleVersionId: t.id({ required: false }),
+    levelPresetVersionId: t.id({ required: false }),
+  }),
+});
+
+const UpdatePairedVignetteInput = builder.inputType('UpdatePairedVignetteInput', {
+  fields: (t) => ({
+    definitionId: t.id({ required: true }),
+    name: t.string({ required: true }),
+    contextId: t.id({ required: true }),
+    valueFirstId: t.id({ required: true }),
+    valueSecondId: t.id({ required: true }),
+    preambleVersionId: t.id({ required: false }),
+    levelPresetVersionId: t.id({ required: false }),
+  }),
+});
+
+function formatValueOrderToken(value: string): string {
+  const normalized = value.trim().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ');
+  if (normalized.length === 0) {
+    return value;
+  }
+
+  if (!/^[a-z0-9 ]+$/i.test(normalized)) {
+    return normalized;
+  }
+
+  return normalized
+    .split(' ')
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function buildValueOrderLabel(firstToken: string, secondToken: string): string {
+  return `${formatValueOrderToken(firstToken)} -> ${formatValueOrderToken(secondToken)}`;
+}
+
+function buildPairedDefinitionName(_baseName: string, firstToken: string, secondToken: string): string {
+  return buildValueOrderLabel(firstToken, secondToken);
+}
+
+function buildPairedVignetteContent(
+  pairKey: string,
+  contextText: string,
+  contextId: string,
+  valueFirst: { token: string; body: string },
+  valueSecond: { token: string; body: string },
+  levelPresetVersion: ResolvedPairInputs['levelPresetVersion'],
+  familyName: string,
+  templateConfig?: TemplateConfig,
+) {
+  const componentsAFirst: DefinitionComponents = {
+    context_id: contextId,
+    value_first: { token: valueFirst.token, body: valueFirst.body },
+    value_second: { token: valueSecond.token, body: valueSecond.body },
+  };
+  const componentsBFirst: DefinitionComponents = {
+    context_id: contextId,
+    value_first: { token: valueSecond.token, body: valueSecond.body },
+    value_second: { token: valueFirst.token, body: valueFirst.body },
+  };
+
+  const templateAFirst = assembleTemplate(contextText, componentsAFirst, undefined, templateConfig);
+  const templateBFirst = assembleTemplate(contextText, componentsBFirst, undefined, templateConfig);
+  const dimensions = [{ name: valueFirst.token }, { name: valueSecond.token }];
+
+  const contentAFirst: PairedVignetteContent = applyLevelPresetToDefinitionContent({
+    schema_version: 1,
+    template: templateAFirst,
+    dimensions,
+    methodology: {
+      family: familyName,
+      response_scale: 'option_text',
+      pair_key: pairKey,
+    },
+    components: componentsAFirst,
+  }, levelPresetVersion);
+  const contentBFirst: PairedVignetteContent = applyLevelPresetToDefinitionContent({
+    schema_version: 1,
+    template: templateBFirst,
+    dimensions,
+    methodology: {
+      family: familyName,
+      response_scale: 'option_text',
+      pair_key: pairKey,
+    },
+    components: componentsBFirst,
+  }, levelPresetVersion);
+
+  return {
+    contentAFirst,
+    contentBFirst,
+    componentsAFirst,
+    componentsBFirst,
+  };
+}
+
+async function createPairedScenarios(
+  tx: Prisma.TransactionClient,
+  params: {
+    definitionAId: string;
+    definitionBId: string;
+    contextText: string;
+    componentsAFirst: DefinitionComponents;
+    componentsBFirst: DefinitionComponents;
+    valueFirstToken: string;
+    valueSecondToken: string;
+    levelPresetVersion: ResolvedPairInputs['levelPresetVersion'];
+    templateConfig?: TemplateConfig;
+  },
+) {
+  const {
+    definitionAId,
+    definitionBId,
+    contextText,
+    componentsAFirst,
+    componentsBFirst,
+    valueFirstToken,
+    valueSecondToken,
+    levelPresetVersion,
+    templateConfig,
+  } = params;
+
+  if (levelPresetVersion != null) {
+    const words = [
+      levelPresetVersion.l1,
+      levelPresetVersion.l2,
+      levelPresetVersion.l3,
+      levelPresetVersion.l4,
+      levelPresetVersion.l5,
+    ];
+
+    const scenarioCreates: Promise<unknown>[] = [];
+
+    for (const firstWord of words) {
+      for (const secondWord of words) {
+        const promptA = assembleTemplate(contextText, componentsAFirst, {
+          first: firstWord,
+          second: secondWord,
+        }, templateConfig);
+        const promptB = assembleTemplate(contextText, componentsBFirst, {
+          first: secondWord,
+          second: firstWord,
+        }, templateConfig);
+
+        const scenarioContentA: ScenarioContent = {
+          schema_version: 1,
+          prompt: promptA,
+          dimension_values: {
+            [valueFirstToken]: firstWord,
+            [valueSecondToken]: secondWord,
+          },
+        };
+        const scenarioContentB: ScenarioContent = {
+          schema_version: 1,
+          prompt: promptB,
+          dimension_values: {
+            [valueSecondToken]: secondWord,
+            [valueFirstToken]: firstWord,
+          },
+        };
+
+        scenarioCreates.push(
+          tx.scenario.create({
+            data: {
+              definitionId: definitionAId,
+              name: `${firstWord} / ${secondWord}`,
+              content: scenarioContentA as unknown as Prisma.InputJsonValue,
+            },
+          }),
+          tx.scenario.create({
+            data: {
+              definitionId: definitionBId,
+              name: `${secondWord} / ${firstWord}`,
+              content: scenarioContentB as unknown as Prisma.InputJsonValue,
+              orientationFlipped: true,
+            },
+          }),
+        );
+      }
+    }
+
+    await Promise.all(scenarioCreates);
+    return;
+  }
+
+  // No level preset — strip [level] from the final prompt since it won't be substituted.
+  const scenarioAFirst: ScenarioContent = {
+    schema_version: 1,
+    prompt: assembleTemplate(contextText, componentsAFirst, undefined, templateConfig).replace(/\[level\]\s*/g, ''),
+    dimension_values: {},
+  };
+  const scenarioBFirst: ScenarioContent = {
+    schema_version: 1,
+    prompt: assembleTemplate(contextText, componentsBFirst, undefined, templateConfig).replace(/\[level\]\s*/g, ''),
+    dimension_values: {},
+  };
+
+ succeeded in 0ms:
+import { useState, useEffect } from 'react';
+import { useQuery } from 'urql';
+import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Button } from '../ui/Button';
+import { ErrorMessage } from '../ui/ErrorMessage';
+import { useDomainSettings } from '../../hooks/useDomainSettings';
+import {
+  LEVEL_PRESETS_QUERY,
+  type LevelPresetsQueryData,
+} from '../../api/operations/level-presets';
+import {
+  DOMAIN_CONTEXTS_QUERY,
+  type DomainContext,
+} from '../../api/operations/domain-contexts';
+import type { SetDomainSettingsMutationVariables } from '../../api/operations/domains';
+import { labelFromBody, DEFAULT_SENTENCE_PREFIX, DEFAULT_LABEL_PREFIX } from '@valuerank/shared';
+
+const PREAMBLES_QUERY = `
+  query PreamblesForDomainSettings {
+    preambles {
+      id
+      name
+      latestVersion {
+        id
+        version
+      }
+    }
+  }
+`;
+
+type Preamble = {
+  id: string;
+  name: string;
+  latestVersion: { id: string; version: string } | null;
+};
+
+type PreamblesQueryData = {
+  preambles: Preamble[];
+};
+
+type DomainContextsQueryData = {
+  domainContexts: DomainContext[];
+};
+
+type Props = {
+  domainId: string;
+  onSaved?: () => void;
+};
+
+function formatSnapshotDate(isoString: string): string {
+  try {
+    const d = new Date(isoString);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  } catch {
+    return isoString;
+  }
+}
+
+export function DomainSettingsPanel({ domainId, onSaved }: Props) {
+  const { settings, snapshots, loading, saving, error, setDomainSettings } =
+    useDomainSettings(domainId);
+
+  const [localPreambleVersionId, setLocalPreambleVersionId] = useState<string | null>(null);
+  const [localLevelPresetVersionId, setLocalLevelPresetVersionId] = useState<string | null>(null);
+  const [localContextId, setLocalContextId] = useState<string | null>(null);
+  const [localSentencePrefix, setLocalSentencePrefix] = useState('');
+  const [localLabelPrefix, setLocalLabelPrefix] = useState('');
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [editingToken, setEditingToken] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  // Sync local state when settings load
+  useEffect(() => {
+    if (settings == null) return;
+    setLocalPreambleVersionId(settings.preambleVersionId);
+    setLocalLevelPresetVersionId(settings.levelPresetVersionId);
+    setLocalContextId(settings.contextId);
+    setLocalSentencePrefix(settings.sentencePrefix ?? '');
+    setLocalLabelPrefix(settings.labelPrefix ?? '');
+    setDrafts({});
+    setEditingToken(null);
+  }, [settings]);
+
+  const [{ data: preamblesData }] = useQuery<PreamblesQueryData>({
+    query: PREAMBLES_QUERY,
+  });
+
+  const [{ data: levelPresetsData }] = useQuery<LevelPresetsQueryData>({
+    query: LEVEL_PRESETS_QUERY,
+  });
+
+  const [{ data: contextsData }] = useQuery<DomainContextsQueryData>({
+    query: DOMAIN_CONTEXTS_QUERY,
+    variables: { domainId },
+  });
+
+  const preambles = preamblesData?.preambles ?? [];
+  const levelPresets = levelPresetsData?.levelPresets ?? [];
+  const contexts = contextsData?.domainContexts ?? [];
+
+  const handleSave = async () => {
+    if (settings == null) return;
+    setSaveError(null);
+
+    const valueStatements = [...settings.valueStatements]
+      .sort((a, b) => a.token.localeCompare(b.token))
+      .map((vs) => ({
+        token: vs.token,
+        content: drafts[vs.token] !== undefined ? (drafts[vs.token] as string) : vs.currentContent,
+      }));
+
+    const input: SetDomainSettingsMutationVariables = {
+      domainId,
+      preambleVersionId: localPreambleVersionId,
+      levelPresetVersionId: localLevelPresetVersionId,
+      contextId: localContextId,
+      sentencePrefix: localSentencePrefix !== '' ? localSentencePrefix : null,
+      labelPrefix: localLabelPrefix !== '' ? localLabelPrefix : null,
+      valueStatements,
+    };
+
+    try {
+      await setDomainSettings(input);
+      setDrafts({});
+      setEditingToken(null);
+      onSaved?.();
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save settings');
+    }
+  };
+
+  if (loading && settings == null) {
+    return <p className="text-sm text-gray-500 mt-4">Loading settings…</p>;
+  }
+
+  if (error != null) {
+    return (
+      <ErrorMessage message={`Failed to load settings: ${error.message}`} />
+    );
+  }
+
+  const sortedStatements = [...(settings?.valueStatements ?? [])].sort((a, b) =>
+    a.token.localeCompare(b.token)
+  );
+
+  return (
+    <div className="space-y-6 mt-6">
+      <h3 className="text-base font-medium text-[#1A1A1A] border-t border-gray-200 pt-4">
+        Domain Settings
+      </h3>
+
+      {saveError != null && <p className="text-sm text-red-600">{saveError}</p>}
+
+      {/* Preamble picker */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Preamble version</label>
+        <select
+          className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm"
+          value={localPreambleVersionId ?? ''}
+          onChange={(e) => setLocalPreambleVersionId(e.target.value !== '' ? e.target.value : null)}
+        >
+          <option value="">— none —</option>
+          {preambles.map((p) =>
+            p.latestVersion != null ? (
+              <option key={p.latestVersion.id} value={p.latestVersion.id}>
+                {p.name} (v{p.latestVersion.version})
+              </option>
+            ) : null
+          )}
+        </select>
+      </div>
+
+      {/* Level preset picker */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Level preset version</label>
+        <select
+          className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm"
+          value={localLevelPresetVersionId ?? ''}
+          onChange={(e) =>
+            setLocalLevelPresetVersionId(e.target.value !== '' ? e.target.value : null)
+          }
+        >
+          <option value="">— none —</option>
+          {levelPresets.map((lp) =>
+            lp.latestVersion != null ? (
+              <option key={lp.latestVersion.id} value={lp.latestVersion.id}>
+                {lp.name} ({lp.latestVersion.version})
+              </option>
+            ) : null
+          )}
+        </select>
+      </div>
+
+      {/* Context picker */}
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <label className="block text-sm font-medium text-gray-700">Domain context</label>
+          <Link
+            to={`/domain-contexts?domainId=${domainId}`}
+            className="text-xs text-teal-600 hover:text-teal-800 flex items-center gap-1"
+          >
+            Manage <ExternalLink className="w-3 h-3" />
+          </Link>
+        </div>
+        <select
+          className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm"
+          value={localContextId ?? ''}
+          onChange={(e) => setLocalContextId(e.target.value !== '' ? e.target.value : null)}
+        >
+          <option value="">— none —</option>
+          {contexts.map((ctx) => (
+            <option key={ctx.id} value={ctx.id}>
+              v{ctx.version}: {ctx.text.slice(0, 60)}{ctx.text.length > 60 ? '…' : ''}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Sentence prefix */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Sentence prefix</label>
+        <p className="text-xs text-gray-500 mb-1">
+          Prepended to each value statement body in the prompt.
+        </p>
+        <input
+          type="text"
+          className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm"
+          placeholder={DEFAULT_SENTENCE_PREFIX}
+          value={localSentencePrefix}
+          onChange={(e) => setLocalSentencePrefix(e.target.value)}
+        />
+      </div>
+
+      {/* Value statements */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <label className="block text-sm font-medium text-gray-700">Value statements</label>
+          <Link
+            to={`/value-statements?domainId=${domainId}`}
+            className="text-xs text-teal-600 hover:text-teal-800 flex items-center gap-1"
+          >
+            Manage <ExternalLink className="w-3 h-3" />
+          </Link>
+        </div>
+        {sortedStatements.length === 0 ? (
+          <p className="text-sm text-gray-500">No value statements for this domain.</p>
+        ) : (
+          <div className="space-y-3">
+            {sortedStatements.map((vs) => {
+              const isEditing = editingToken === vs.token;
+              const draft = drafts[vs.token];
+              const displayContent = draft !== undefined ? draft : vs.currentContent;
+              const isDirty = draft !== undefined && draft !== vs.currentContent;
+
+              return (
+                <div
+                  key={vs.token}
+                  className="rounded-lg border border-gray-200 bg-gray-50 p-3 space-y-2"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-mono font-medium text-teal-700 uppercase tracking-wide">
+                      {vs.token}
+                    </span>
+                    {isDirty && (
+                      <span className="text-xs text-amber-600 font-medium">modified</span>
+                    )}
+                  </div>
+
+                  {isEditing ? (
+                    <div className="space-y-2">
+                      {vs.previousContent != null && (
+                        <div>
+                          <p className="text-xs text-gray-500 mb-1">Previous version:</p>
+                          <div className="rounded bg-gray-200 px-2 py-1.5 text-xs text-gray-600 font-mono whitespace-pre-wrap">
+                            {vs.previousContent}
+                          </div>
+                        </div>
+                      )}
+                      <div>
+                        <p className="text-xs text-gray-500 mb-1">Edit:</p>
+                        <textarea
+                          className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm font-mono resize-y"
+                          rows={4}
+                          value={displayContent}
+                          onChange={(e) =>
+                            setDrafts((prev) => ({ ...prev, [vs.token]: e.target.value }))
+                          }
+                        />
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setEditingToken(null);
+                          }}
+                        >
+                          Done
+                        </Button>
+                        {isDirty && (
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => {
+                              setDrafts((prev) => {
+                                const next = { ...prev };
+                                delete next[vs.token];
+                                return next;
+                              });
+                            }}
+                          >
+                            Revert
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  ) : (
+                    <div
+                      className="text-sm text-gray-700 cursor-pointer hover:text-teal-700 whitespace-pre-wrap"
+                      onClick={() => setEditingToken(vs.token)}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') setEditingToken(vs.token);
+                      }}
+                    >
+                      {displayContent || <span className="text-gray-400 italic">empty</span>}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Scale label prefix */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Scale label prefix</label>
+        <p className="text-xs text-gray-500 mb-1">
+          Prepended to each value statement in the response scale.
+        </p>
+        <input
+          type="text"
+          className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm"
+          placeholder={DEFAULT_LABEL_PREFIX}
+          value={localLabelPrefix}
+          onChange={(e) => setLocalLabelPrefix(e.target.value)}
+        />
+      </div>
+
+      {/* Scale label preview */}
+      {sortedStatements.length > 0 && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Scale label preview</label>
+          <p className="text-xs text-gray-500 mb-1">
+            Derived from label prefix + value statement bodies. Read-only.
+          </p>
+          <div className="rounded border border-gray-200 bg-gray-50 p-2 space-y-1">
+            {sortedStatements.map((vs) => {
+              const body = drafts[vs.token] !== undefined ? (drafts[vs.token] as string) : vs.currentContent;
+              const prefix = localLabelPrefix !== '' ? localLabelPrefix : undefined;
+              const label = labelFromBody(body, prefix);
+              return (
+                <div key={vs.token} className="flex items-start gap-2 text-xs">
+                  <span className="font-mono text-teal-700 uppercase tracking-wide shrink-0">
+                    {vs.token}
+                  </span>
+                  <span className="text-gray-600">{label}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Save button */}
+      <div>
+        <Button
+          onClick={() => void handleSave()}
+          disabled={saving}
+          variant="secondary"
+          size="sm"
+        >
+          {saving ? 'Saving…' : 'Save settings'}
+        </Button>
+      </div>
+
+      {/* Config history */}
+      <div className="border-t border-gray-200 pt-4">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="flex items-center gap-1 !px-0 text-sm font-medium text-gray-600 hover:text-teal-700"
+          onClick={() => setHistoryOpen((v) => !v)}
+        >
+          {historyOpen ? (
+            <ChevronDown className="w-4 h-4" />
+          ) : (
+            <ChevronRight className="w-4 h-4" />
+          )}
+          Config history ({snapshots.length})
+        </Button>
+
+        {historyOpen && (
+          <div className="mt-3">
+            {snapshots.length === 0 ? (
+              <p className="text-sm text-gray-500">No history yet.</p>
+            ) : (
+              <div className="space-y-2">
+                {snapshots.map((snap) => (
+                  <div
+                    key={snap.id}
+                    className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs space-y-0.5"
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-gray-700">
+                        {formatSnapshotDate(snap.createdAt)}
+                      </span>
+                      <span className="text-gray-400">
+                        {snap.valueStatementCount} value stmt{snap.valueStatementCount === 1 ? '' : 's'}
+                      </span>
+                    </div>
+                    <div className="text-gray-500 space-y-0.5">
+                      {snap.preambleLabel != null && (
+                        <div>Preamble: {snap.preambleLabel}</div>
+                      )}
+                      {snap.levelPresetLabel != null && (
+                        <div>Level preset: {snap.levelPresetLabel}</div>
+                      )}
+                      {snap.contextLabel != null && (
+                        <div>Context: {snap.contextLabel}</div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+exec
+/bin/zsh -lc "sed -n '1,220p' cloud/apps/web/src/pages/PairedVignetteNew.tsx" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+import { assembleTemplate } from '@valuerank/shared';
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { gql, useMutation, useQuery } from 'urql';
+import {
+  DEFINITION_QUERY,
+  type DefinitionQueryResult,
+  type DefinitionQueryVariables,
+} from '../api/operations/definitions';
+import {
+  DOMAINS_QUERY,
+  type DomainsQueryResult,
+  type DomainsQueryVariables,
+} from '../api/operations/domains';
+import {
+  DOMAIN_CONTEXTS_QUERY,
+  type DomainContextsQueryResult,
+  type DomainContextsQueryVariables,
+} from '../api/operations/domain-contexts';
+import {
+  CREATE_PAIRED_VIGNETTE_MUTATION,
+  UPDATE_PAIRED_VIGNETTE_MUTATION,
+  type CreatePairedVignetteResult,
+  type CreatePairedVignetteVariables,
+  type UpdatePairedVignetteResult,
+  type UpdatePairedVignetteVariables,
+} from '../api/operations/paired-vignette';
+import {
+  VALUE_STATEMENTS_QUERY,
+  type ValueStatementsQueryResult,
+  type ValueStatementsQueryVariables,
+} from '../api/operations/value-statements';
+import {
+  LEVEL_PRESETS_QUERY,
+  type LevelPresetsQueryData,
+} from '../api/operations/level-presets';
+import { Button } from '../components/ui/Button';
+import { ErrorMessage } from '../components/ui/ErrorMessage';
+
+type Preamble = {
+  id: string;
+  name: string;
+  latestVersion: { id: string; version: string } | null;
+};
+
+type PreamblesQueryResult = { preambles: Preamble[] };
+
+type PairedVignetteComponents = {
+  context_id?: string;
+  value_first?: { token?: string; body?: string };
+  value_second?: { token?: string; body?: string };
+};
+
+
+const PREAMBLES_QUERY = gql`
+  query PreamblesForJobChoice {
+    preambles {
+      id
+      name
+      latestVersion {
+        id
+        version
+      }
+    }
+  }
+`;
+
+function stripPairSuffix(name: string): string {
+  return name.replace(/\s+\((A|B|[^)]+ -> [^)]+)\)$/, '');
+}
+
+function formatValueOrderToken(value: string): string {
+  const normalized = value.trim().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ');
+  if (normalized.length === 0) {
+    return value;
+  }
+
+  if (!/^[a-z0-9 ]+$/i.test(normalized)) {
+    return normalized;
+  }
+
+  return normalized
+    .split(' ')
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function buildGeneratedTitle(
+  firstToken?: string,
+  secondToken?: string,
+): string {
+  if (firstToken == null || secondToken == null || firstToken === '' || secondToken === '') {
+    return '';
+  }
+
+  return `${formatValueOrderToken(firstToken)} -> ${formatValueOrderToken(secondToken)}`;
+}
+
+function getPairedVignetteComponents(content: unknown): PairedVignetteComponents | null {
+  if (!content || typeof content !== 'object' || Array.isArray(content)) return null;
+  const components = (content as Record<string, unknown>).components;
+  if (!components || typeof components !== 'object' || Array.isArray(components)) return null;
+  return components as PairedVignetteComponents;
+}
+
+
+export function PairedVignetteNew() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { id: editDefinitionId } = useParams<{ id?: string }>();
+  const isEditing = editDefinitionId != null;
+
+  const [selectedDomainId, setSelectedDomainId] = useState('');
+  const [selectedPreambleVersionId, setSelectedPreambleVersionId] = useState('');
+  const [selectedLevelPresetVersionId, setSelectedLevelPresetVersionId] = useState('');
+  const [selectedContextId, setSelectedContextId] = useState('');
+  const [selectedValueFirstId, setSelectedValueFirstId] = useState('');
+  const [selectedValueSecondId, setSelectedValueSecondId] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [initializedEditState, setInitializedEditState] = useState(false);
+
+  const [{ data: definitionData, error: definitionError }] = useQuery<
+    DefinitionQueryResult,
+    DefinitionQueryVariables
+  >({
+    query: DEFINITION_QUERY,
+    variables: { id: editDefinitionId ?? '' },
+    pause: !isEditing,
+  });
+
+  const [{ data: domainsData, error: domainsError }] = useQuery<
+    DomainsQueryResult,
+    DomainsQueryVariables
+  >({
+    query: DOMAINS_QUERY,
+    variables: { limit: 1000, offset: 0 },
+  });
+
+  const [{ data: preamblesData, error: preamblesError }] = useQuery<PreamblesQueryResult>({
+    query: PREAMBLES_QUERY,
+  });
+
+  const [{ data: contextsData, error: contextsError }] = useQuery<
+    DomainContextsQueryResult,
+    DomainContextsQueryVariables
+  >({
+    query: DOMAIN_CONTEXTS_QUERY,
+    variables: { domainId: selectedDomainId },
+    pause: selectedDomainId === '',
+  });
+
+  const [{ data: valueStatementsData, error: valueStatementsError }] = useQuery<
+    ValueStatementsQueryResult,
+    ValueStatementsQueryVariables
+  >({
+    query: VALUE_STATEMENTS_QUERY,
+    variables: { domainId: selectedDomainId },
+    pause: selectedDomainId === '',
+  });
+
+  const [{ data: levelPresetsData }] = useQuery<LevelPresetsQueryData>({
+    query: LEVEL_PRESETS_QUERY,
+  });
+
+  const [, createPair] = useMutation<CreatePairedVignetteResult, CreatePairedVignetteVariables>(
+    CREATE_PAIRED_VIGNETTE_MUTATION,
+  );
+  const [, updatePair] = useMutation<UpdatePairedVignetteResult, UpdatePairedVignetteVariables>(
+    UPDATE_PAIRED_VIGNETTE_MUTATION,
+  );
+
+  const domains = useMemo(
+    () => domainsData?.domains ?? [],
+    [domainsData?.domains],
+  );
+  const preambles = preamblesData?.preambles ?? [];
+  const contexts = contextsData?.domainContexts ?? [];
+  const valueStatements = useMemo(
+    () => valueStatementsData?.valueStatements ?? [],
+    [valueStatementsData?.valueStatements],
+  );
+  const requestedDomainId = searchParams.get('domainId') ?? '';
+  const editingDefinition = definitionData?.definition ?? null;
+  const editingContent = editingDefinition?.resolvedContent ?? editingDefinition?.content ?? null;
+  const editingComponents = getPairedVignetteComponents(editingContent);
+
+  const canonicalComponents = useMemo(() => {
+    return editingComponents;
+  }, [editingComponents]);
+
+  const valueFirst = valueStatements.find((v) => v.id === selectedValueFirstId) ?? null;
+  const valueSecond = valueStatements.find((v) => v.id === selectedValueSecondId) ?? null;
+  const selectedContext = contexts.find((c) => c.id === selectedContextId) ?? null;
+  const generatedTitle = useMemo(
+    () => buildGeneratedTitle(valueFirst?.token, valueSecond?.token),
+    [valueFirst?.token, valueSecond?.token],
+  );
+  const displayedTitle = generatedTitle !== ''
+    ? generatedTitle
+    : (editingDefinition != null ? stripPairSuffix(editingDefinition.name) : '');
+
+  const secondValueOptions = valueStatements.filter((v) => v.id !== selectedValueFirstId);
+
+  const selectedLevelPresetVersion = useMemo(() => {
+    if (selectedLevelPresetVersionId === '') return null;
+    for (const preset of (levelPresetsData?.levelPresets ?? [])) {
+      if (preset.latestVersion?.id === selectedLevelPresetVersionId) {
+        return preset.latestVersion;
+      }
+    }
+    return null;
+  }, [selectedLevelPresetVersionId, levelPresetsData]);
+
+  const previewText = useMemo(() => {
+    if (selectedContext == null || valueFirst == null || valueSecond == null) return null;
+    const levelWords = selectedLevelPresetVersion != null
+      ? { first: selectedLevelPresetVersion.l3, second: selectedLevelPresetVersion.l3 }
+      : undefined;
+
+exec
+/bin/zsh -lc "sed -n '640,760p' cloud/workers/summarize.py" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+                # Relaxed matching: strip filler words (their/the/a/an) before comparing.
+                # Catches models that paraphrase slightly (e.g. "recognition of expertise"
+                # instead of "recognition of their expertise").
+                relaxed_code, matched_label, relaxed_path = extract_leading_text_label_decision_relaxed(response_text, scale_labels)
+                if relaxed_code is not None:
+                    decision_code = relaxed_code
+                    parse_path = relaxed_path or "text_label_relaxed"
+                else:
+                    relaxed_code, matched_label = extract_text_label_decision_relaxed(response_text, scale_labels)
+                    if relaxed_code is not None:
+                        decision_code = relaxed_code
+                        parse_path = "text_label_relaxed"
+                    else:
+                        llm_decision_code = classify_decision_with_llm(transcript_content, scale_labels)
+                        if llm_decision_code != "other":
+                            decision_code = llm_decision_code
+                            decision_source = "llm"
+                            parse_class = "fallback_resolved"
+                            parse_path = "text_label_llm"
+                        else:
+                            parse_class = "ambiguous"
+                            parse_path = "text_label_ambiguous"
+    elif decision_code == "other":
+        llm_decision_code = classify_decision_with_llm(transcript_content)
+        if llm_decision_code != "other":
+            decision_code = llm_decision_code
+            decision_source = "llm"
+            parse_class = "fallback_resolved"
+            parse_path = "numeric_llm"
+        else:
+            parse_class = "ambiguous"
+            parse_path = "numeric_ambiguous"
+
+    metadata = {
+        "parserVersion": PARSER_VERSION,
+        "parseClass": parse_class,
+        "parsePath": parse_path,
+        "responseSha256": response_hash,
+        "responseExcerpt": response_excerpt(response_text) if response_text else None,
+        "matchedLabel": matched_label,
+        "scaleLabels": scale_labels,
+    }
+
+    return {
+        "decisionCode": decision_code,
+        "decisionSource": decision_source,
+        "decisionMetadata": metadata,
+    }
+
+
+def run_summarize(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Execute the summarization.
+
+    Args:
+        data: Validated summarize worker input
+
+    Returns:
+        Success response with summary or error response
+    """
+    transcript_id = data["transcriptId"]
+    model_id = data.get("modelId", DEFAULT_SUMMARY_MODEL)
+    transcript_content = data["transcriptContent"]
+
+    log.info(
+        "Starting summarization",
+        transcriptId=transcript_id,
+        modelId=model_id,
+    )
+
+    try:
+        decision_result = extract_decision_result(transcript_content)
+        decision_code = decision_result["decisionCode"]
+        decision_source = decision_result["decisionSource"]
+        decision_metadata = decision_result["decisionMetadata"]
+
+        # Log appropriate message based on what we found (or didn't find)
+        if decision_metadata["parsePath"] in {"text_label_exact", "text_label_leading"}:
+            log.info(
+                "Resolved decision code from text scale label",
+                transcriptId=transcript_id,
+                rating=decision_code,
+                matchedLabel=decision_metadata["matchedLabel"],
+            )
+        elif decision_source == "llm":
+            log.info(
+                "Resolved decision code with fallback LLM",
+                transcriptId=transcript_id,
+                rating=decision_code,
+                fallbackModel=LLM_FALLBACK_MODEL,
+            )
+        elif decision_metadata["parseClass"] == "ambiguous":
+            log.info(
+                "Could not extract deterministic rating from transcript",
+                transcriptId=transcript_id,
+            )
+        else:
+            log.info(
+                "Extracted deterministic rating",
+                transcriptId=transcript_id,
+                rating=decision_code,
+            )
+
+        # DEPRECATED: We no longer generate decision text
+        decision_text = None
+
+        log.info(
+            "Summarization completed",
+            transcriptId=transcript_id,
+            decisionCode=decision_code,
+            decisionSource=decision_source,
+        )
+
+        return {
+            "success": True,
+            "summary": {
+                "decisionText": decision_text,
+                "decisionMetadata": decision_metadata,
+            },
+        }
+
+
+exec
+/bin/zsh -lc "sed -n '220,340p' cloud/apps/web/src/pages/PairedVignetteNew.tsx" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+      : undefined;
+    return assembleTemplate(selectedContext.text, {
+      context_id: selectedContextId,
+      value_first: { token: valueFirst.token, body: valueFirst.body },
+      value_second: { token: valueSecond.token, body: valueSecond.body },
+    }, levelWords);
+  }, [selectedContext, selectedContextId, valueFirst, valueSecond, selectedLevelPresetVersion]);
+
+  const loadingError =
+    definitionError?.message ??
+    domainsError?.message ??
+    preamblesError?.message ??
+    contextsError?.message ??
+    valueStatementsError?.message ??
+    null;
+
+  const handleDomainChange = useCallback((domainId: string) => {
+    setSelectedDomainId(domainId);
+    setSelectedValueFirstId('');
+    setSelectedValueSecondId('');
+    setErrorMessage(null);
+    const domain = domains.find((d) => d.id === domainId);
+    setSelectedLevelPresetVersionId(domain?.defaultLevelPresetVersionId ?? '');
+    setSelectedPreambleVersionId(domain?.defaultPreambleVersionId ?? '');
+    setSelectedContextId(domain?.defaultContextId ?? '');
+  }, [domains]);
+
+  useEffect(() => {
+    if (isEditing) return;
+    if (selectedDomainId !== '') return;
+    if (requestedDomainId === '') return;
+    if (!domains.some((domain) => domain.id === requestedDomainId)) return;
+    handleDomainChange(requestedDomainId);
+  }, [domains, handleDomainChange, isEditing, requestedDomainId, selectedDomainId]);
+
+  useEffect(() => {
+    if (!isEditing || initializedEditState || editingDefinition == null) return;
+
+    setSelectedDomainId(editingDefinition.domainId ?? '');
+    setSelectedPreambleVersionId(editingDefinition.preambleVersionId ?? '');
+    setSelectedLevelPresetVersionId(editingDefinition.levelPresetVersionId ?? '');
+    setSelectedContextId(editingDefinition.domainContextId ?? canonicalComponents?.context_id ?? '');
+    setInitializedEditState(true);
+  }, [canonicalComponents?.context_id, editingDefinition, initializedEditState, isEditing]);
+
+  useEffect(() => {
+    if (!isEditing || editingDefinition == null || canonicalComponents == null || valueStatements.length === 0) return;
+    if (selectedValueFirstId !== '' && selectedValueSecondId !== '') return;
+
+    const firstMatch = valueStatements.find((value) => (
+      value.token === canonicalComponents.value_first?.token
+      && value.body === canonicalComponents.value_first?.body
+    ));
+    const secondMatch = valueStatements.find((value) => (
+      value.token === canonicalComponents.value_second?.token
+      && value.body === canonicalComponents.value_second?.body
+    ));
+
+    if (firstMatch != null) setSelectedValueFirstId(firstMatch.id);
+    if (secondMatch != null) setSelectedValueSecondId(secondMatch.id);
+  }, [
+    canonicalComponents,
+    editingDefinition,
+    isEditing,
+    selectedValueFirstId,
+    selectedValueSecondId,
+    valueStatements,
+  ]);
+
+  function handleValueFirstChange(valueId: string) {
+    setSelectedValueFirstId(valueId);
+    setSelectedValueSecondId('');
+    setErrorMessage(null);
+  }
+
+  function handleValueSecondChange(valueId: string) {
+    setSelectedValueSecondId(valueId);
+    setErrorMessage(null);
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (
+      selectedDomainId === '' ||
+      selectedContextId === '' ||
+      selectedValueFirstId === '' ||
+      selectedValueSecondId === '' ||
+      generatedTitle === ''
+    ) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    if (isEditing && editDefinitionId != null) {
+      const result = await updatePair({
+        input: {
+          definitionId: editDefinitionId,
+          name: generatedTitle,
+          contextId: selectedContextId,
+          valueFirstId: selectedValueFirstId,
+          valueSecondId: selectedValueSecondId,
+          preambleVersionId: selectedPreambleVersionId !== '' ? selectedPreambleVersionId : null,
+          levelPresetVersionId: selectedLevelPresetVersionId !== '' ? selectedLevelPresetVersionId : null,
+        },
+      });
+
+      setIsSubmitting(false);
+
+      if (result.error != null) {
+        setErrorMessage(result.error.message);
+        return;
+      }
+
+      navigate(`/definitions/${editDefinitionId}`);
+      return;
+    }
+
+    const result = await createPair({
+      input: {
+
+exec
+/bin/zsh -lc "sed -n '560,860p' cloud/apps/api/src/graphql/queries/domain/decision-model.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+    }
+
+    if (
+      cachedDecision.favoredValueKey == null
+      || (cachedDecision.favoredValueKey !== pair.valueA && cachedDecision.favoredValueKey !== pair.valueB)
+      || cachedDecision.strength === 'unknown'
+      || cachedDecision.strength === 'neutral'
+    ) {
+      return buildUnknownCanonicalDecision('unknown');
+    }
+
+    const direction: DecisionDirection = cachedDecision.favoredValueKey === pair.valueA ? 'favor_first' : 'favor_second';
+    const opposedValueKey = cachedDecision.favoredValueKey === pair.valueA ? pair.valueB : pair.valueA;
+
+    return {
+      favoredValueKey: cachedDecision.favoredValueKey,
+      opposedValueKey,
+      direction,
+      strength: cachedDecision.strength,
+      normalizationApplied: false,
+      normalizationReason: null,
+      source: 'deterministic',
+    };
+  }
+
+  if (
+    (input.raw.parserVersion === 'job-choice-v2' || input.raw.parserVersion === 'paired-v2')
+    && isJobChoiceDecisionPath(input.raw.parsePath)
+  ) {
+    const candidateText = input.raw.matchedLabel ?? input.raw.matchedText ?? input.raw.responseExcerpt;
+    if (typeof candidateText !== 'string') {
+      return buildUnknownCanonicalDecision('unknown');
+    }
+
+    const strength = parseJobChoiceStrengthFromText(candidateText);
+    if (strength === null) {
+      return buildUnknownCanonicalDecision('unknown');
+    }
+    if (strength === 'neutral') {
+      return buildCanonicalDecisionFromPair(
+        pair,
+        'neutral',
+        'neutral',
+        false,
+        'deterministic',
+      );
+    }
+
+    const favoredValueKey = resolveJobChoiceValueKeyFromText(candidateText, input.valueStatements, input.labelPrefix);
+    if (favoredValueKey === null) {
+      return buildUnknownCanonicalDecision('unknown');
+    }
+    if (favoredValueKey !== pair.valueA && favoredValueKey !== pair.valueB) {
+      return buildUnknownCanonicalDecision('unknown');
+    }
+
+    const direction: DecisionDirection = favoredValueKey === pair.valueA ? 'favor_first' : 'favor_second';
+    const opposedValueKey = favoredValueKey === pair.valueA ? pair.valueB : pair.valueA;
+
+    return {
+      favoredValueKey,
+      opposedValueKey,
+      direction,
+      strength,
+      normalizationApplied: false,
+      normalizationReason: null,
+      source: 'deterministic',
+    };
+  }
+
+  if (input.orientationFlipped == null) {
+    return buildUnknownCanonicalDecision('unknown');
+  }
+
+  if (!parsedPath || parsedPath.branch === 'manual') {
+    return buildUnknownCanonicalDecision('unknown');
+  }
+
+  if (parsedPath.direction === 'unknown' || parsedPath.strength === 'unknown') {
+    return buildUnknownCanonicalDecision('unknown');
+  }
+
+  const matchedLabel = input.raw.matchedLabel;
+  if (typeof matchedLabel !== 'string' || !isValueKey(matchedLabel)) {
+    return buildUnknownCanonicalDecision('unknown');
+  }
+  if (matchedLabel !== pair.valueA && matchedLabel !== pair.valueB) {
+    return buildUnknownCanonicalDecision('unknown');
+  }
+
+  const normalizedDirection = input.orientationFlipped ? flipDirection(parsedPath.direction) : parsedPath.direction;
+  const normalizationApplied = Boolean(input.orientationFlipped && normalizedDirection !== parsedPath.direction);
+
+  return buildCanonicalDecisionFromPair(
+    pair,
+    normalizedDirection,
+    parsedPath.strength,
+    normalizationApplied,
+    'deterministic',
+  );
+}
+export function resolveDecisionModel(input: DecisionModelInput): DecisionModelResult {
+  const canonical = resolveCanonicalDecision(input);
+  return {
+    raw: input.raw,
+    canonical,
+  };
+}
+
+codex
+I’ve confirmed the listed bugs, but the same assumptions also appear in preview/generation paths and in the decision model’s family config table. I’m checking how `definitionSnapshot` is shaped now, because the spec’s “read from components/template” only works if those fields are always present where the parser runs.
+exec
+/bin/zsh -lc "sed -n '1,260p' cloud/apps/api/src/graphql/queries/domain/domain-analysis-values.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ exited 1 in 0ms:
+sed: cloud/apps/api/src/graphql/queries/domain/domain-analysis-values.ts: No such file or directory
+
+exec
+/bin/zsh -lc "sed -n '1,260p' cloud/apps/api/src/graphql/queries/domain/shared.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+exec
+/bin/zsh -lc "sed -n '1,280p' cloud/apps/web/src/utils/methodology.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+import { db, resolveDefinitionContent } from '@valuerank/db';
+import { formatVnewLabel, formatVnewSignature } from '@valuerank/shared/trial-signature';
+import { DOMAIN_ANALYSIS_VALUE_KEYS, type DomainAnalysisValueKey, extractValuePair } from '../domain-analysis-values.js';
+import { resolveTranscriptDecisionModel } from './decision-model.js';
+import type { TranscriptDecisionModelResult } from './decision-model.js';
+import { runMatchesSignature, selectDefaultVnewSignature } from './planning-utils.js';
+export { selectLatestDefinitionPerLineage, hydrateDefinitionAncestors } from '../../../services/definition-lineage.js';
+export type { LineageDefinitionRow } from '../../../services/definition-lineage.js';
+export {
+  buildRawDecisionEvidence,
+  DECISION_MODEL_READ_RULES,
+  canonicalDecisionToLegacyScore,
+  resolveCanonicalDecision,
+  resolveDecisionModel,
+  resolveTranscriptDecisionModel,
+} from './decision-model.js';
+export type {
+  CanonicalDecision,
+  DecisionDirection,
+  DecisionReadMode,
+  DecisionReadRule,
+  DecisionReadSurface,
+  DecisionModelInput,
+  DecisionModelResult,
+  DecisionPair,
+  DecisionSource,
+  DecisionStrength,
+  RawDecisionEvidence,
+  TranscriptDecisionModelInput,
+  TranscriptDecisionModelResult,
+  ValueStatementEntry,
+} from './decision-model.js';
+
+export { formatVnewLabel, formatVnewSignature };
+
+export const MAX_LIMIT = 500;
+export const DEFAULT_LIMIT = 50;
+const VALUE_PAIR_RESOLVE_CHUNK_SIZE = 20;
+export type DomainAnalysisScoreMethod = 'LOG_ODDS' | 'FULL_BT';
+
+export type DefinitionRow = {
+  id: string;
+  name?: string;
+  parentId: string | null;
+  version: number;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type DomainAnalysisValueCounts = {
+  prioritized: number;
+  deprioritized: number;
+  neutral: number;
+};
+
+export type DomainAnalysisValuePair = {
+  valueA: DomainAnalysisValueKey;
+  valueB: DomainAnalysisValueKey;
+};
+
+export type DomainAnalysisValueScore = {
+  valueKey: DomainAnalysisValueKey;
+  score: number;
+  prioritized: number;
+  deprioritized: number;
+  neutral: number;
+  totalComparisons: number;
+};
+
+export type DomainAnalysisUnavailableModel = {
+  model: string;
+  label: string;
+  reason: string;
+};
+
+export type DomainAnalysisMissingDefinition = {
+  definitionId: string;
+  definitionName: string;
+  reasonCode: DomainAnalysisMissingReasonCode;
+  reasonLabel: string;
+  missingAllModels: boolean;
+  missingModelIds: string[];
+  missingModelLabels: string[];
+};
+
+export type DomainAnalysisConditionDetail = {
+  scenarioId: string | null;
+  conditionName: string;
+  dimensions: Record<string, string | number> | null;
+  prioritized: number;
+  deprioritized: number;
+  neutral: number;
+  totalTrials: number;
+  selectedValueWinRate: number | null;
+  strongly: number;
+  somewhat: number;
+  opponentSomewhat: number;
+  opponentStrongly: number;
+  unknownCount: number;
+};
+
+export type DomainAnalysisVignetteDetail = {
+  definitionId: string;
+  definitionName: string;
+  definitionVersion: number;
+  aggregateRunId: string | null;
+  otherValueKey: DomainAnalysisValueKey;
+  prioritized: number;
+  deprioritized: number;
+  neutral: number;
+  totalTrials: number;
+  selectedValueWinRate: number | null;
+  conditions: DomainAnalysisConditionDetail[];
+};
+
+export type DomainAnalysisValueDetailResult = {
+  domainId: string;
+  domainName: string;
+  modelId: string;
+  modelLabel: string;
+  valueKey: DomainAnalysisValueKey;
+  score: number;
+  prioritized: number;
+  deprioritized: number;
+  neutral: number;
+  totalTrials: number;
+  targetedDefinitions: number;
+  coveredDefinitions: number;
+  missingDefinitionIds: string[];
+  vignettes: DomainAnalysisVignetteDetail[];
+  generatedAt: Date;
+};
+
+export type DomainAvailableSignature = {
+  signature: string;
+  label: string;
+  isVirtual: boolean;
+  temperature: number | null;
+};
+
+export type DomainTrialPlanModel = {
+  modelId: string;
+  label: string;
+  isDefault: boolean;
+  supportsTemperature: boolean;
+};
+
+export type DomainTrialPlanVignette = {
+  definitionId: string;
+  definitionName: string;
+  definitionVersion: number;
+  signature: string;
+  scenarioCount: number;
+  existingBatchCount: number;
+};
+
+export type DomainTrialPlanCellEstimate = {
+  definitionId: string;
+  modelId: string;
+  estimatedCost: number;
+};
+
+export type DomainEvaluationEstimateConfidence = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export type DomainEvaluationEstimateModel = {
+  modelId: string;
+  label: string;
+  isDefault: boolean;
+  supportsTemperature: boolean;
+  estimatedCost: number;
+  basedOnSampleCount: number;
+  isUsingFallback: boolean;
+};
+
+export type DomainEvaluationEstimateDefinition = {
+  definitionId: string;
+  definitionName: string;
+  definitionVersion: number;
+  signature: string;
+  scenarioCount: number;
+  estimatedCost: number;
+  basedOnSampleCount: number;
+  isUsingFallback: boolean;
+};
+
+export type DomainEvaluationCostEstimate = {
+  domainId: string;
+  domainName: string;
+  scopeCategory: string;
+  targetedDefinitions: number;
+  totalScenarioCount: number;
+  totalEstimatedCost: number;
+  basedOnSampleCount: number;
+  isUsingFallback: boolean;
+  fallbackReason: string | null;
+  estimateConfidence: DomainEvaluationEstimateConfidence;
+  knownExclusions: string[];
+  models: DomainEvaluationEstimateModel[];
+  definitions: DomainEvaluationEstimateDefinition[];
+  existingTemperatures: number[];
+  defaultTemperature: number | null;
+  temperatureWarning: string | null;
+};
+
+export type DomainTrialPlanResult = {
+  domainId: string;
+  domainName: string;
+  vignettes: DomainTrialPlanVignette[];
+  models: DomainTrialPlanModel[];
+  cellEstimates: DomainTrialPlanCellEstimate[];
+  totalEstimatedCost: number;
+  existingTemperatures: number[];
+  defaultTemperature: number | null;
+  temperatureWarning: string | null;
+};
+
+export type DomainTrialModelStatus = {
+  modelId: string;
+  generationCompleted: number;
+  generationFailed: number;
+  generationTotal: number;
+  summarizationCompleted: number;
+  summarizationFailed: number;
+  summarizationTotal: number;
+  latestErrorMessage: string | null;
+};
+
+export type DomainTrialRunStatus = {
+  runId: string;
+  definitionId: string;
+  status: string;
+  updatedAt: Date;
+  stalledModels: string[];
+  analysisStatus: string | null;
+  modelStatuses: DomainTrialModelStatus[];
+};
+
+export type DomainAnalysisConditionTranscript = {
+  id: string;
+  runId: string;
+  scenarioId: string | null;
+  modelId: string;
+  decisionCode: string | null;
+  decisionCodeSource: string | null;
+  decisionMetadata: unknown;
+  definitionSnapshot?: unknown;
+  pairOverride?: DomainAnalysisValuePair | null;
+  decisionModelV2?: TranscriptDecisionModelResult | null;
+  turnCount: number;
+  tokenCount: number;
+  durationMs: number;
+  createdAt: Date;
+  content: unknown;
+};
+
+export type DomainAnalysisMissingReasonCode = 'NO_COMPLETED_RUNS' | 'NO_SIGNATURE_MATCH' | 'NO_TRANSCRIPTS';
+
+type SignatureResolutionResult = {
+  selectedSignature: string | null;
+  filteredSourceRunIds: string[];
+
+ succeeded in 0ms:
+type DefinitionMethodology = {
+  family?: string;
+  response_scale?: 'numeric' | 'option_text' | 'value_labels';
+  legacy_label?: string;
+  canonical_value_order?: string[];
+  pair_key?: string;
+};
+
+type DecisionScaleLabel = {
+  code: string;
+  label: string;
+};
+
+type DefinitionDimension = {
+  name?: string;
+};
+
+type PairedComponents = {
+  value_first?: { token?: string };
+  value_second?: { token?: string };
+};
+
+export type DecisionMetadata = {
+  parserVersion?: string;
+  parseClass?: 'exact' | 'fallback_resolved' | 'ambiguous';
+  parsePath?: string;
+  responseSha256?: string;
+  responseExcerpt?: string;
+  matchedLabel?: string | null;
+  scaleLabels?: DecisionScaleLabel[];
+  manualOverride?: {
+    previousDecisionCode?: string | null;
+    overriddenAt?: string;
+    overriddenByUserId?: string | null;
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function toTitleCase(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function formatValueOrderName(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return trimmed;
+  }
+
+  const normalized = trimmed.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+  const looksLikeToken = /^[a-z0-9 ]+$/.test(normalized);
+  return looksLikeToken ? toTitleCase(normalized) : normalized;
+}
+
+function readPairedComponents(content: unknown): PairedComponents | null {
+  if (!isRecord(content)) return null;
+  const raw = content.components;
+  if (!isRecord(raw)) return null;
+
+  return {
+    value_first: isRecord(raw.value_first) ? { token: toNonEmptyString(raw.value_first.token) ?? undefined } : undefined,
+    value_second: isRecord(raw.value_second) ? { token: toNonEmptyString(raw.value_second.token) ?? undefined } : undefined,
+  };
+}
+
+function readDefinitionDimensions(content: unknown): DefinitionDimension[] {
+  if (!isRecord(content) || !Array.isArray(content.dimensions)) {
+    return [];
+  }
+
+  return content.dimensions.flatMap((entry) => {
+    if (!isRecord(entry)) return [];
+    const name = toNonEmptyString(entry.name);
+    return name ? [{ name }] : [];
+  });
+}
+
+function formatValueOrder(values: [string, string] | null): string | null {
+  if (!values) return null;
+  return `${values[0]} -> ${values[1]}`;
+}
+
+function reverseValueOrder(values: [string, string] | null): [string, string] | null {
+  if (!values) return null;
+  return [values[1], values[0]];
+}
+
+export type PairedOrientationLabels = {
+  canonicalValues: [string, string] | null;
+  flippedValues: [string, string] | null;
+  currentValues: [string, string] | null;
+  canonical: string;
+  flipped: string;
+  current: string;
+};
+
+export function getDefinitionMethodology(content: unknown): DefinitionMethodology | null {
+  if (!isRecord(content)) return null;
+  const raw = content.methodology;
+  if (!isRecord(raw)) return null;
+
+  const family = typeof raw.family === 'string' ? raw.family : undefined;
+  const responseScale = raw.response_scale;
+  const legacyLabel = typeof raw.legacy_label === 'string' ? raw.legacy_label : undefined;
+  const pairKey = typeof raw.pair_key === 'string' ? raw.pair_key : undefined;
+  const canonicalValueOrder = Array.isArray(raw.canonical_value_order)
+    ? raw.canonical_value_order.filter((value): value is string => typeof value === 'string')
+    : undefined;
+
+  return {
+    family,
+    response_scale:
+      responseScale === 'numeric' || responseScale === 'option_text' || responseScale === 'value_labels'
+        ? responseScale
+        : undefined,
+    legacy_label: legacyLabel,
+    canonical_value_order: canonicalValueOrder,
+    pair_key: pairKey,
+  };
+}
+
+export function getDecisionMetadata(value: unknown): DecisionMetadata | null {
+  if (!isRecord(value)) return null;
+
+  const scaleLabels = Array.isArray(value.scaleLabels)
+    ? value.scaleLabels.flatMap((entry) => {
+        if (!isRecord(entry)) return [];
+        if (typeof entry.code !== 'string' || typeof entry.label !== 'string') return [];
+        return [{ code: entry.code, label: entry.label }];
+      })
+    : undefined;
+
+  const manualOverride = isRecord(value.manualOverride)
+    ? {
+        previousDecisionCode:
+          typeof value.manualOverride.previousDecisionCode === 'string'
+            ? value.manualOverride.previousDecisionCode
+            : value.manualOverride.previousDecisionCode === null
+              ? null
+              : undefined,
+        overriddenAt:
+          typeof value.manualOverride.overriddenAt === 'string'
+            ? value.manualOverride.overriddenAt
+            : undefined,
+        overriddenByUserId:
+          typeof value.manualOverride.overriddenByUserId === 'string'
+            ? value.manualOverride.overriddenByUserId
+            : value.manualOverride.overriddenByUserId === null
+              ? null
+              : undefined,
+      }
+    : undefined;
+
+  return {
+    parserVersion: typeof value.parserVersion === 'string' ? value.parserVersion : undefined,
+    parseClass:
+      value.parseClass === 'exact' || value.parseClass === 'fallback_resolved' || value.parseClass === 'ambiguous'
+        ? value.parseClass
+        : undefined,
+    parsePath: typeof value.parsePath === 'string' ? value.parsePath : undefined,
+    responseSha256: typeof value.responseSha256 === 'string' ? value.responseSha256 : undefined,
+    responseExcerpt: typeof value.responseExcerpt === 'string' ? value.responseExcerpt : undefined,
+    matchedLabel:
+      typeof value.matchedLabel === 'string'
+        ? value.matchedLabel
+        : value.matchedLabel === null
+          ? null
+          : undefined,
+    scaleLabels,
+    manualOverride,
+  };
+}
+
+export function isPairedMethodology(content: unknown): boolean {
+  const m = getDefinitionMethodology(content);
+  return m?.family != null && m.family.length > 0 && m.pair_key != null && m.pair_key.length > 0;
+}
+
+export function getPairedOrientationLabels(content: unknown): PairedOrientationLabels {
+  const methodology = getDefinitionMethodology(content);
+  const components = readPairedComponents(content);
+  const dimensions = readDefinitionDimensions(content);
+
+  const componentOrder = (() => {
+    const first = toNonEmptyString(components?.value_first?.token);
+    const second = toNonEmptyString(components?.value_second?.token);
+    if (!first || !second) return null;
+    return [formatValueOrderName(first), formatValueOrderName(second)] as [string, string];
+  })();
+
+  const canonicalOrderFromMethodology = (() => {
+    const raw = methodology?.canonical_value_order;
+    if (!raw || raw.length < 2) return null;
+    const first = toNonEmptyString(raw[0]);
+    const second = toNonEmptyString(raw[1]);
+    if (!first || !second) return null;
+    return [formatValueOrderName(first), formatValueOrderName(second)] as [string, string];
+  })();
+
+  const canonicalOrderFromDimensions = (() => {
+    const first = toNonEmptyString(dimensions[0]?.name);
+    const second = toNonEmptyString(dimensions[1]?.name);
+    if (!first || !second) return null;
+    return [formatValueOrderName(first), formatValueOrderName(second)] as [string, string];
+  })();
+
+  const canonicalValues = canonicalOrderFromMethodology
+    ?? componentOrder
+    ?? canonicalOrderFromDimensions;
+
+  const currentValues = componentOrder ?? canonicalValues;
+
+  const flippedValues = reverseValueOrder(canonicalValues);
+
+  return {
+    canonicalValues,
+    flippedValues,
+    currentValues,
+    canonical: formatValueOrder(canonicalValues) ?? 'Canonical order',
+    flipped: formatValueOrder(flippedValues) ?? 'Flipped order',
+    current: formatValueOrder(currentValues) ?? 'Current order',
+  };
+}
+
+export function getDefinitionMethodologyLabel(
+  content: unknown,
+  domainName?: string | null,
+): string | null {
+  const methodology = getDefinitionMethodology(content);
+  if (methodology?.family != null && methodology.family.length > 0) {
+    return methodology.family
+      .split('-')
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ');
+  }
+
+  if (domainName?.toLowerCase() === 'professional') {
+    return 'Old V1';
+  }
+
+  return null;
+}
+
+exec
+/bin/zsh -lc 'rg -n "definitionSnapshot|components:|methodology:|template:" cloud/apps/api/src cloud/apps/web/src | head -n 200' in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+cloud/apps/web/src/pages/AnalysisDetail.tsx:257:    definitionSnapshot?: { _meta?: { definitionVersion?: unknown }, version?: unknown };
+cloud/apps/web/src/pages/AnalysisDetail.tsx:261:  const runDefinitionVersion = typeof config?.definitionSnapshot?._meta?.definitionVersion === 'number'
+cloud/apps/web/src/pages/AnalysisDetail.tsx:262:    ? config.definitionSnapshot._meta.definitionVersion
+cloud/apps/web/src/pages/AnalysisDetail.tsx:263:    : typeof config?.definitionSnapshot?.version === 'number'
+cloud/apps/web/src/pages/AnalysisDetail.tsx:264:      ? config.definitionSnapshot.version
+cloud/apps/web/src/pages/AnalysisDetail.tsx:394:      definitionSnapshot?: { _meta?: { definitionVersion?: unknown }, version?: unknown };
+cloud/apps/web/src/pages/AnalysisDetail.tsx:397:    const defVersion = typeof config?.definitionSnapshot?._meta?.definitionVersion === 'number'
+cloud/apps/web/src/pages/AnalysisDetail.tsx:398:      ? config.definitionSnapshot._meta.definitionVersion
+cloud/apps/web/src/pages/AnalysisDetail.tsx:399:      : typeof config?.definitionSnapshot?.version === 'number'
+cloud/apps/web/src/pages/AnalysisDetail.tsx:400:        ? config.definitionSnapshot.version
+cloud/apps/api/src/services/scenario/expand-code.ts:31:  template: string;
+cloud/apps/api/src/services/scenario/expand-code.ts:96:function fillTemplate(template: string, combination: Array<{ name: string; level: DimensionLevel }>): string {
+cloud/apps/web/src/pages/AnalysisTranscripts.tsx:241:    definitionSnapshot?: { _meta?: { definitionVersion?: unknown }, version?: unknown };
+cloud/apps/web/src/pages/AnalysisTranscripts.tsx:245:  const runDefinitionVersion = typeof config?.definitionSnapshot?._meta?.definitionVersion === 'number'
+cloud/apps/web/src/pages/AnalysisTranscripts.tsx:246:    ? config.definitionSnapshot._meta.definitionVersion
+cloud/apps/web/src/pages/AnalysisTranscripts.tsx:247:    : typeof config?.definitionSnapshot?.version === 'number'
+cloud/apps/web/src/pages/AnalysisTranscripts.tsx:248:      ? config.definitionSnapshot.version
+cloud/apps/web/src/pages/AnalysisTranscripts.tsx:268:          definitionSnapshot?: { _meta?: { definitionVersion?: unknown }, version?: unknown };
+cloud/apps/web/src/pages/AnalysisTranscripts.tsx:271:        const candidateVersion = typeof candidateConfig?.definitionSnapshot?._meta?.definitionVersion === 'number'
+cloud/apps/web/src/pages/AnalysisTranscripts.tsx:272:          ? candidateConfig.definitionSnapshot._meta.definitionVersion
+cloud/apps/web/src/pages/AnalysisTranscripts.tsx:273:          : typeof candidateConfig?.definitionSnapshot?.version === 'number'
+cloud/apps/web/src/pages/AnalysisTranscripts.tsx:274:            ? candidateConfig.definitionSnapshot.version
+cloud/apps/web/src/utils/runDefinitionContent.ts:7:  definitionSnapshot?: unknown;
+cloud/apps/web/src/utils/runDefinitionContent.ts:35:  // `definitionSnapshot` is the canonical location.
+cloud/apps/web/src/utils/runDefinitionContent.ts:36:  // `config.definitionSnapshot` is retained for backward compatibility with older runs.
+cloud/apps/web/src/utils/runDefinitionContent.ts:37:  const directSnapshot = run?.definitionSnapshot;
+cloud/apps/web/src/utils/runDefinitionContent.ts:46:    && 'definitionSnapshot' in run.config
+cloud/apps/web/src/utils/runDefinitionContent.ts:48:    ? (run.config as { definitionSnapshot?: unknown }).definitionSnapshot
+cloud/apps/api/src/services/import/md.ts:57:  template: string[];
+cloud/apps/api/src/services/import/md.ts:68:    template: [],
+cloud/apps/api/src/services/import/md.ts:167:    template: sections.template.join('\n').trim(),
+cloud/apps/api/src/services/scenario/expand.ts:36:    template: string;
+cloud/apps/api/src/services/scenario/expand.ts:186:      template: content.template,
+cloud/apps/api/src/services/scenario/expand.ts:249:      template: content.template,
+cloud/apps/api/src/services/export/md.ts:63:    template: content.template,
+cloud/apps/api/src/services/export/decision-display.ts:38:  definitionSnapshot?: unknown;
+cloud/apps/api/src/services/export/decision-display.ts:126:    transcript.definitionSnapshot !== null && transcript.definitionSnapshot !== undefined
+cloud/apps/api/src/services/export/decision-display.ts:157:    definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/services/analysis/aggregate/config.ts:13:  const snapshot = config.definitionSnapshot;
+cloud/apps/api/src/services/export/types.ts:38:  template: string;
+cloud/apps/api/src/services/analysis/aggregate/aggregate-logic.ts:21:  definitionSnapshot?: unknown;
+cloud/apps/api/src/services/analysis/aggregate/aggregate-logic.ts:214:      definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/services/analysis/aggregate/variance.ts:13:  definitionSnapshot?: unknown;
+cloud/apps/api/src/services/analysis/aggregate/variance.ts:188:      definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/services/transcript/create.ts:67:  definitionSnapshot?: Prisma.InputJsonValue;
+cloud/apps/api/src/services/transcript/create.ts:75:  const { runId, scenarioId, modelId, sampleIndex = 0, transcript, definitionSnapshot, costSnapshot } = input;
+cloud/apps/api/src/services/transcript/create.ts:111:      definitionSnapshot: definitionSnapshot ?? Prisma.JsonNull,
+cloud/apps/web/src/api/operations/definitions.ts:27:  template: boolean;
+cloud/apps/web/src/api/operations/definitions.ts:127:  template: string;
+cloud/apps/api/src/services/mcp/formatters.ts:208:    definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/services/export/xlsx/types.ts:21:  definitionSnapshot?: unknown;
+cloud/apps/api/src/services/analysis/aggregate/contracts.ts:13:  definitionSnapshot: zRunSnapshot.optional(),
+cloud/apps/api/src/services/run/plan-final-trial.ts:52:  definitionSnapshot?: {
+cloud/apps/api/src/services/run/plan-final-trial.ts:93:  const snapshot = config.definitionSnapshot;
+cloud/apps/web/src/components/definitions/DefinitionEditor.tsx:98:    template: true,
+cloud/apps/web/src/components/definitions/DefinitionEditor.tsx:104:    setContent((prev) => ({ ...prev, template: value }));
+cloud/apps/web/src/components/definitions/DefinitionEditor.tsx:422:    template: '',
+cloud/apps/api/src/services/run/analysis-status.ts:21:  definitionSnapshot?: unknown;
+cloud/apps/api/src/services/run/analysis-status.ts:43:  const snapshot = (config?.definitionSnapshot ?? null) as
+cloud/apps/web/src/hooks/useComparisonData.ts:126:              template: String(resolvedContent.template ?? ''),
+cloud/apps/web/src/hooks/useScenarioPreview.ts:34:  template: string,
+cloud/apps/api/src/queue/handlers/analyze-basic.ts:241:                definitionSnapshot: t.definitionSnapshot,
+cloud/apps/api/src/queue/handlers/analyze-basic.ts:250:                definitionSnapshot: t.definitionSnapshot,
+cloud/apps/api/src/queue/handlers/analyze-basic.ts:341:                definitionSnapshot?: {
+cloud/apps/api/src/queue/handlers/analyze-basic.ts:351:                config.definitionSnapshot?._meta?.preambleVersionId ??
+cloud/apps/api/src/queue/handlers/analyze-basic.ts:352:                config.definitionSnapshot?.preambleVersionId ??
+cloud/apps/api/src/queue/handlers/analyze-basic.ts:355:                config.definitionSnapshot?._meta?.definitionVersion ??
+cloud/apps/api/src/queue/handlers/analyze-basic.ts:356:                config.definitionSnapshot?.version ??
+cloud/apps/api/src/services/mcp/validation.ts:94:export function extractPlaceholders(template: string): string[] {
+cloud/apps/api/src/services/mcp/validation.ts:296:      template: obj.template,
+cloud/apps/api/src/queue/handlers/aggregate-analysis.ts:30:    definitionSnapshot: zRunSnapshot.optional(),
+cloud/apps/api/src/queue/handlers/aggregate-analysis.ts:66:        const snapshot = parseResult.data.definitionSnapshot;
+cloud/apps/api/src/queue/handlers/aggregate-analysis.ts:154:                        const snapshot = config.definitionSnapshot;
+cloud/apps/api/src/services/run/start.ts:272:  const definitionSnapshot = {
+cloud/apps/api/src/services/run/start.ts:297:    definitionSnapshot,
+cloud/apps/api/src/services/export/csv.ts:217:    definitionSnapshot?: { _meta?: { definitionVersion?: unknown }, version?: unknown };
+cloud/apps/api/src/services/export/csv.ts:223:    : typeof typedConfig.definitionSnapshot?._meta?.definitionVersion === 'number'
+cloud/apps/api/src/services/export/csv.ts:224:      ? typedConfig.definitionSnapshot._meta.definitionVersion
+cloud/apps/api/src/services/export/csv.ts:225:      : typeof typedConfig.definitionSnapshot?.version === 'number'
+cloud/apps/api/src/services/export/csv.ts:226:        ? typedConfig.definitionSnapshot.version
+cloud/apps/web/src/api/operations/runs.ts:274:    definitionSnapshot
+cloud/apps/api/src/services/analysis/aggregate/aggregate-preparation.ts:62:  definitionSnapshot: unknown;
+cloud/apps/api/src/services/analysis/aggregate/aggregate-preparation.ts:223:      definitionSnapshot: true,
+cloud/apps/api/src/services/analysis/aggregate/aggregate-preparation.ts:323:      definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/services/analysis/aggregate/aggregate-preparation.ts:446:        definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/web/src/generated/graphql.ts:548:  template: Scalars['Boolean']['output'];
+cloud/apps/web/src/generated/graphql.ts:3126:  definitionSnapshot?: Maybe<Scalars['JSON']['output']>;
+cloud/apps/web/src/generated/graphql.ts:3473:  definitionSnapshot?: Maybe<Scalars['JSON']['output']>;
+cloud/apps/api/src/queue/handlers/summarize-transcript.ts:131:    definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/queue/handlers/summarize-persistence.ts:184:  transcript: { id: string; scenarioId: string | null; definitionSnapshot: unknown },
+cloud/apps/api/src/services/assumptions/order-effect-comparison.ts:147:  definitionSnapshot: unknown;
+cloud/apps/api/src/services/assumptions/order-effect-comparison.ts:163:  definitionSnapshot: unknown;
+cloud/apps/api/src/services/assumptions/order-effect-comparison.ts:458:  definitionSnapshot: unknown;
+cloud/apps/api/src/queue/handlers/probe-scenario.ts:674:      definitionSnapshot: scenario.definition.content as Prisma.InputJsonValue,
+cloud/apps/api/src/services/assumptions/__tests__/order-effect-service.test.ts:98:    methodology: {
+cloud/apps/api/src/services/assumptions/__tests__/order-effect-service.test.ts:165:    definitionSnapshot: buildDefinitionSnapshot(),
+cloud/apps/api/src/utils/paired-definition.ts:22:function extractPairedIntro(template: string, family: string): string | null {
+cloud/apps/api/src/utils/paired-definition.ts:31:  components: DefinitionComponents,
+cloud/apps/api/src/utils/paired-definition.ts:69:      components: normalizePairedComponents(content.components, family),
+cloud/apps/api/src/utils/paired-definition.ts:78:    template: normalizedTemplate,
+cloud/apps/api/src/utils/paired-definition.ts:79:    components: normalizedComponents,
+cloud/apps/api/src/routes/export.ts:583:            definitionSnapshot: t.definitionSnapshot,
+cloud/apps/web/src/components/compare/visualizations/DefinitionGroups.tsx:23:  template: string;
+cloud/apps/web/src/components/compare/visualizations/DefinitionGroups.tsx:61:        template: run.definitionContent?.template ?? '(No template)',
+cloud/apps/api/src/services/assumptions/order-effect-queries.ts:64:  definitionSnapshot: unknown;
+cloud/apps/api/src/services/assumptions/order-effect-queries.ts:177:          definitionSnapshot: true,
+cloud/apps/api/src/services/assumptions/order-effect-queries.ts:226:        definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/web/src/components/compare/types.ts:67:  template: string;
+cloud/apps/web/src/components/analysis/RunSelectionModal.tsx:19:      definitionSnapshot
+cloud/apps/web/src/components/analysis/RunSelectionModal.tsx:33:    definitionSnapshot: unknown;
+cloud/apps/web/src/components/analysis/RunSelectionModal.tsx:82:        // Note: definitionSnapshot layout might vary, using safe access
+cloud/apps/web/src/components/analysis/RunSelectionModal.tsx:83:        const snapshot = run.definitionSnapshot as SnapshotWithMeta;
+cloud/apps/api/src/graphql/queries/__tests__/domain-coverage.test.ts:48:        methodology: {},
+cloud/apps/api/src/cli/decision-model-shadow-validation.ts:57:      definitionSnapshot: true,
+cloud/apps/api/src/cli/decision-model-shadow-validation.ts:77:      definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/graphql/queries/assumptions.ts:112:  definitionSnapshot: unknown;
+cloud/apps/api/src/graphql/queries/assumptions.ts:176:    definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/graphql/queries/assumptions.ts:519:            definitionSnapshot: true,
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:23:  components: DefinitionComponents;
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:132:    template: templateAFirst,
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:134:    methodology: {
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:139:    components: componentsAFirst,
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:143:    template: templateBFirst,
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:145:    methodology: {
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:150:    components: componentsBFirst,
+cloud/apps/api/src/cli/recompute-aggregates.ts:16:    const snapshot = isRecord(config.definitionSnapshot) ? config.definitionSnapshot : undefined;
+cloud/apps/api/src/cli/recompute-aggregates.ts:27:    const snapshot = isRecord(config.definitionSnapshot) ? config.definitionSnapshot : undefined;
+cloud/apps/api/src/graphql/queries/domain-coverage.ts:111:    definitionSnapshot?: {
+cloud/apps/api/src/graphql/queries/domain-coverage.ts:118:    parseDefinitionVersion(runConfig?.definitionSnapshot?._meta?.definitionVersion) ??
+cloud/apps/api/src/graphql/queries/domain-coverage.ts:119:    parseDefinitionVersion(runConfig?.definitionSnapshot?.version);
+cloud/apps/api/src/graphql/mutations/survey.ts:273:              template: 'Survey question prompt',
+cloud/apps/api/src/graphql/mutations/survey.ts:357:              template: 'Survey question prompt',
+cloud/apps/api/src/graphql/mutations/survey.ts:437:              template: 'Survey question prompt',
+cloud/apps/api/src/graphql/queries/domain/planning-utils.ts:69:    definitionSnapshot?: {
+cloud/apps/api/src/graphql/queries/domain/planning-utils.ts:76:    parseDefinitionVersion(runConfig?.definitionSnapshot?._meta?.definitionVersion) ??
+cloud/apps/api/src/graphql/queries/domain/planning-utils.ts:77:    parseDefinitionVersion(runConfig?.definitionSnapshot?.version);
+cloud/apps/api/src/cli/recompute-aggregates.test.ts:12:      definitionSnapshot: {
+cloud/apps/api/src/cli/recompute-aggregates.test.ts:22:      definitionSnapshot: {
+cloud/apps/api/src/cli/recompute-aggregates.test.ts:38:      definitionSnapshot: {
+cloud/apps/api/src/cli/recompute-aggregates.test.ts:48:      definitionSnapshot: {
+cloud/apps/api/src/graphql/mutations/analysis.ts:71:        definitionSnapshot?: {
+cloud/apps/api/src/graphql/mutations/analysis.ts:82:          runConfig.definitionSnapshot?._meta?.preambleVersionId ??
+cloud/apps/api/src/graphql/mutations/analysis.ts:83:          runConfig.definitionSnapshot?.preambleVersionId ??
+cloud/apps/api/src/graphql/mutations/analysis.ts:86:          runConfig.definitionSnapshot?._meta?.definitionVersion ??
+cloud/apps/api/src/graphql/mutations/analysis.ts:87:          runConfig.definitionSnapshot?.version ??
+cloud/apps/api/src/graphql/dataloaders/definition-trial-summary.ts:116:          definitionSnapshot?: {
+cloud/apps/api/src/graphql/dataloaders/definition-trial-summary.ts:123:          parseDefinitionVersion(config?.definitionSnapshot?._meta?.definitionVersion) ??
+cloud/apps/api/src/graphql/dataloaders/definition-trial-summary.ts:124:          parseDefinitionVersion(config?.definitionSnapshot?.version);
+cloud/apps/api/src/graphql/queries/domain/types.ts:344:          definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/graphql/queries/domain/shared.ts:246:  definitionSnapshot?: unknown;
+cloud/apps/api/src/graphql/mutations/run/maintenance.ts:178:          definitionSnapshot: true,
+cloud/apps/api/src/graphql/mutations/run/maintenance.ts:192:        definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/graphql/queries/temp-zero-verification.ts:28:  definitionSnapshot: unknown;
+cloud/apps/api/src/graphql/queries/temp-zero-verification.ts:52:    definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/graphql/queries/temp-zero-verification.ts:161:          definitionSnapshot: true,
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:96:  /** Supply definitionSnapshot OR pairOverride — pairOverride takes precedence if both provided */
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:97:  definitionSnapshot?: unknown;
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:99:  /** Pre-resolved value pair; avoids fetching definitionSnapshot from DB when pair is already known */
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:503:  const pair = input.pairOverride !== undefined ? input.pairOverride : extractValuePair(input.definitionSnapshot);
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:508:  const family = extractFamilyFromSnapshot(input.definitionSnapshot);
+cloud/apps/api/src/graphql/mutations/definition/inputs.ts:81:    template: t.string({
+cloud/apps/api/src/graphql/mutations/definition/create-and-fork.ts:122:          template: typeof contentObj.template === 'string' ? contentObj.template : undefined,
+cloud/apps/api/src/mcp/tools/validate-definition.ts:38:  template: z.string().describe('Scenario body with [placeholders]'),
+cloud/apps/api/src/mcp/tools/validate-definition.ts:126:          template: args.content.template,
+cloud/apps/api/src/mcp/tools/generate-scenarios-preview.ts:119:function fillTemplate(template: string, values: Record<string, string>): string {
+cloud/apps/api/src/mcp/tools/create-definition.ts:50:  template: z.string().min(1).max(10000).describe('Scenario body with [ValueName] placeholders. Include a 1-5 judgment scale.'),
+cloud/apps/api/src/mcp/tools/create-definition.ts:201:          template: args.content.template,
+cloud/apps/api/src/mcp/tools/create-definition.ts:235:          template: args.content.template,
+cloud/apps/api/src/graphql/types/run.ts:31:  definitionSnapshot?: unknown;
+cloud/apps/api/src/graphql/types/run.ts:127:          definitionSnapshot?: {
+cloud/apps/api/src/graphql/types/run.ts:132:        const versionRaw = config.definitionSnapshot?._meta?.definitionVersion ?? config.definitionSnapshot?.version;
+cloud/apps/api/src/graphql/types/run.ts:204:    definitionSnapshot: t.field({
+cloud/apps/api/src/graphql/types/run.ts:210:        return config?.definitionSnapshot ?? null;
+cloud/apps/api/src/graphql/types/transcript.ts:22:    definitionSnapshot: t.expose('definitionSnapshot', { type: 'JSON', nullable: true }),
+cloud/apps/api/src/graphql/types/transcript.ts:49:          definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/mcp/tools/get-run-results.ts:219:              definitionSnapshot: true,
+cloud/apps/api/src/mcp/tools/get-run-results.ts:247:                  definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/mcp/tools/fork-definition.ts:38:  template: z.string().max(10000).optional().describe('New template (overrides parent)'),
+cloud/apps/api/src/mcp/tools/fork-definition.ts:183:            template: changes.template,
+cloud/apps/api/src/mcp/tools/fork-definition.ts:200:            template: changes.template ?? (parentContent.template as string),
+cloud/apps/api/src/graphql/types/definition.ts:37:    template: t.exposeBoolean('template', {
+cloud/apps/api/src/mcp/tools/get-transcript-summary.ts:129:    definitionSnapshot: unknown;
+cloud/apps/api/src/mcp/tools/get-transcript-summary.ts:148:    definitionSnapshot: transcript.definitionSnapshot,
+cloud/apps/api/src/mcp/tools/get-transcript-summary.ts:216:            definitionSnapshot: true,
+
+exec
+/bin/zsh -lc 'rg -n "DEFAULT_LABEL_PREFIX" cloud' in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+exec
+/bin/zsh -lc "rg -n \"labelFromBody\\(\" cloud | sed -n '1,200p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+cloud/packages/shared/src/assemble-template.ts:15:export const DEFAULT_LABEL_PREFIX = 'taking the job with';
+cloud/packages/shared/src/assemble-template.ts:23:  const prefix = labelPrefix ?? DEFAULT_LABEL_PREFIX;
+cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx:17:import { labelFromBody, DEFAULT_SENTENCE_PREFIX, DEFAULT_LABEL_PREFIX } from '@valuerank/shared';
+cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx:351:          placeholder={DEFAULT_LABEL_PREFIX}
+
+ succeeded in 0ms:
+cloud/scripts/job-choice-transform.ts:71:  const labelFirst = labelFromBody(firstBody);
+cloud/scripts/job-choice-transform.ts:72:  const labelSecond = labelFromBody(secondBody);
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:279:    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, labelPrefix));
+cloud/packages/shared/src/assemble-template.ts:17:export function labelFromBody(body: string, labelPrefix?: string | null): string {
+cloud/packages/shared/src/assemble-template.ts:69:  const labelFirst = labelFromBody(value_first.body, config?.labelPrefix);
+cloud/packages/shared/src/assemble-template.ts:70:  const labelSecond = labelFromBody(value_second.body, config?.labelPrefix);
+cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx:368:              const label = labelFromBody(body, prefix);
+
+exec
+/bin/zsh -lc "rg --files cloud/apps/api/src/graphql | rg 'domain-analysis-values'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+cloud/apps/api/src/graphql/queries/domain-analysis-values.ts
+
+exec
+/bin/zsh -lc "sed -n '1,320p' cloud/apps/api/src/graphql/queries/domain-analysis-values.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+export const DOMAIN_ANALYSIS_VALUE_KEYS = [
+  'Self_Direction_Action',
+  'Universalism_Nature',
+  'Benevolence_Dependability',
+  'Security_Personal',
+  'Power_Dominance',
+  'Achievement',
+  'Tradition',
+  'Stimulation',
+  'Hedonism',
+  'Conformity_Interpersonal',
+] as const;
+
+export type DomainAnalysisValueKey = (typeof DOMAIN_ANALYSIS_VALUE_KEYS)[number];
+
+export type DomainAnalysisValuePair = {
+  valueA: DomainAnalysisValueKey;
+  valueB: DomainAnalysisValueKey;
+};
+
+function isDomainAnalysisValueKey(value: string): value is DomainAnalysisValueKey {
+  return (DOMAIN_ANALYSIS_VALUE_KEYS as readonly string[]).includes(value);
+}
+
+export function toPascalCaseKey(name: string): string {
+  return name
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join('_');
+}
+
+export function extractValuePair(content: unknown): DomainAnalysisValuePair | null {
+  if (content === null || typeof content !== 'object' || Array.isArray(content)) return null;
+  const dims = (content as { dimensions?: unknown }).dimensions;
+  if (!Array.isArray(dims) || dims.length !== 2) return null;
+  const nameA =
+    typeof (dims[0] as { name?: unknown }).name === 'string'
+      ? (dims[0] as { name: string }).name
+      : null;
+  const nameB =
+    typeof (dims[1] as { name?: unknown }).name === 'string'
+      ? (dims[1] as { name: string }).name
+      : null;
+  if (nameA == null || nameB == null) return null;
+  const normalizedA = toPascalCaseKey(nameA);
+  const normalizedB = toPascalCaseKey(nameB);
+  if (!isDomainAnalysisValueKey(normalizedA) || !isDomainAnalysisValueKey(normalizedB)) return null;
+  const [first, second] = [normalizedA, normalizedB].sort() as [DomainAnalysisValueKey, DomainAnalysisValueKey];
+  return { valueA: first, valueB: second };
+}
+
+exec
+/bin/zsh -lc "sed -n '240,340p' cloud/apps/api/src/services/run/start.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+  // estimateCost supports uniform sampling. 
+  // Let's just use a simplified estimate or pass explicit counts if we update estimateCost?
+  // For now, we'll pass '100%' and 'avg samples' to get a roughly correct order of magnitude or just use samplePercentage logic effectively.
+  // Actually, cost estimate is just for display/logging usually.
+  // Let's skip detailed adaptive cost estimation update for this task unless critical.
+
+  const costEstimate = await estimateCost({
+    definitionId,
+    modelIds: models,
+    samplePercentage: finalTrial
+      ? 100
+      : (Array.isArray(scenarioIds) && scenarioIds.length > 0)
+        ? Math.max(1, Math.round((selectedScenarioIds.length / definition.scenarios.length) * 100))
+        : samplePercentage,
+    samplesPerScenario: finalTrial ? 10 : samplesPerScenario, // Upper bound?
+  });
+
+  const resolvedDefinition = await resolveDefinitionContent(definitionId);
+
+  // Prepare definition snapshot...
+  const content = resolvedDefinition.resolvedContent as unknown as Record<string, unknown>;
+  const findingsSnapshot = await buildFindingsSnapshot({
+    definition,
+    resolvedContent: resolvedDefinition.resolvedContent,
+    selectedModels: activeModels.map((model) => ({
+      modelId: model.modelId,
+      providerId: model.providerId,
+      providerName: model.provider.name,
+      displayName: model.displayName,
+      apiConfig: asRecord(model.apiConfig),
+    })),
+  });
+  const definitionSnapshot = {
+    ...content,
+    preamble: (definition.preambleVersion?.content ?? content.preamble) as string | undefined,
+    _meta: {
+      definitionVersion: definition.version,
+      preambleVersionId: definition.preambleVersion?.id,
+      preambleVersionLabel: definition.preambleVersion?.version,
+      preambleName: definition.preambleVersion ?
+        (await db.preamble.findUnique({ where: { id: definition.preambleVersion.preambleId }, select: { name: true } }))?.name
+        : undefined,
+    }
+  };
+
+  // Create run config
+  const config = {
+    ...(configExtras ?? {}),
+    models,
+    samplePercentage: finalTrial ? null : samplePercentage,
+    sampleSeed: finalTrial ? null : sampleSeed,
+    samplesPerScenario: finalTrial ? null : samplesPerScenario,
+    temperature: temperature ?? null,
+    scenarioIds: finalTrial ? null : (selectedScenarioIds.length > 0 ? selectedScenarioIds : null),
+    runMode: finalTrial ? 'FINAL' : (Array.isArray(scenarioIds) && scenarioIds.length > 0 ? 'SPECIFIC_CONDITION' : 'PERCENTAGE'),
+    isFinalTrial: finalTrial,
+    priority,
+    definitionSnapshot,
+    estimatedCosts: costEstimate,
+    ...findingsSnapshot,
+  };
+
+  const initialProgress = {
+    total: totalJobs,
+    completed: 0,
+    failed: 0,
+  };
+
+  // Generate run name
+  const today = new Date();
+  const startOfDay = new Date(today);
+  startOfDay.setHours(0, 0, 0, 0);
+  const endOfDay = new Date(today);
+  endOfDay.setHours(23, 59, 59, 999);
+
+  const countToday = await db.run.count({
+    where: {
+      definitionId,
+      createdAt: { gte: startOfDay, lte: endOfDay },
+      deletedAt: null,
+    },
+  });
+
+  const suffix = convertToAlpha(countToday);
+  const month = today.toLocaleDateString('en-US', { month: 'short' });
+  const day = today.toLocaleDateString('en-US', { day: '2-digit' });
+  const runName = `${month} ${day}-${suffix}${finalTrial ? ' (Final)' : ''}`;
+
+  // Create run in transaction
+  const run = await db.$transaction(async (tx) => {
+    const newRun = await tx.run.create({
+      data: {
+        name: runName,
+        definitionId,
+        experimentId: experimentId ?? null,
+        status: 'PENDING',
+        runCategory: runCategory ?? 'UNKNOWN_LEGACY',
+        config,
+        progress: initialProgress,
+        createdByUserId: userId ?? null,
+      },
+
+exec
+/bin/zsh -lc "sed -n '1,220p' cloud/packages/shared/src/software-approach-value-statements.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+exec
+/bin/zsh -lc "sed -n '1,220p' cloud/packages/shared/src/job-choice-value-statements.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+const SOFTWARE_APPROACH_VALUE_STATEMENTS = [
+  {
+    token: 'self_direction_action',
+    body: 'freedom in how you build this because of how it relates to independent choice in goals and actions',
+  },
+  {
+    token: 'power_dominance',
+    body: 'authority over the technical direction because of how it relates to having the deciding voice on architectural choices and directing how others on the team will build',
+  },
+  {
+    token: 'security_personal',
+    body: 'personal security because of how it relates to stability, safety, and predictability',
+  },
+  {
+    token: 'conformity_interpersonal',
+    body: 'harmony with your team and the company because of how it relates to maintaining smooth interactions with teammates and stakeholders',
+  },
+  {
+    token: 'tradition',
+    body: 'connection to the team\'s established ways because of how it relates to long-standing practices and inherited ways of doing things',
+  },
+  {
+    token: 'stimulation',
+    body: 'variety and excitement in the work because of how it relates to change, challenge, and unpredictability',
+  },
+  {
+    token: 'benevolence_dependability',
+    body: 'trust from your team because of how it relates to being someone others can rely on to carry through on commitments',
+  },
+  {
+    token: 'universalism_nature',
+    body: 'stewardship of the natural world because of how it relates to care for nature and the environment',
+  },
+  {
+    token: 'achievement',
+    body: 'recognition of your expertise because of how it relates to demonstrating success through strong performance',
+  },
+  {
+    token: 'hedonism',
+    body: 'enjoyment in the work because of how it relates to pleasure and satisfaction in the building process',
+  },
+] as const;
+
+const SOFTWARE_APPROACH_VALUE_STATEMENT_MAP = new Map<string, string>(
+  SOFTWARE_APPROACH_VALUE_STATEMENTS.map(({ token, body }) => [token, body]),
+);
+
+export { SOFTWARE_APPROACH_VALUE_STATEMENTS };
+
+export function getSoftwareApproachValueStatementBody(token: string): string | undefined {
+  return SOFTWARE_APPROACH_VALUE_STATEMENT_MAP.get(token);
+}
+
+ succeeded in 0ms:
+const JOB_CHOICE_VALUE_STATEMENTS = [
+  {
+    token: 'self_direction_action',
+    body: 'freedom in how they work because of how it relates to independent choice in goals and actions',
+  },
+  {
+    token: 'power_dominance',
+    body: 'authority over others because of how it relates to control over people and the decisions that affect them',
+  },
+  {
+    token: 'security_personal',
+    body: 'personal security in everyday life because of how it relates to financial and physical stability, safety, and predictability',
+  },
+  {
+    token: 'conformity_interpersonal',
+    body: 'harmony in their close relationships because of how it relates to maintaining smooth interactions with family, friends, and neighbors',
+  },
+  {
+    token: 'tradition',
+    body: 'connection to their heritage because of how it relates to long-standing customs and inherited ways of doing things',
+  },
+  {
+    token: 'stimulation',
+    body: 'variety and excitement in their daily work because of how it relates to change, challenge, and unpredictability',
+  },
+  {
+    token: 'benevolence_dependability',
+    body: 'trust from other people because of how it relates to being someone others can rely on to carry through on shared responsibilities',
+  },
+  {
+    token: 'universalism_nature',
+    body: 'connection to the natural world because of how it relates to care for nature and the environment',
+  },
+  {
+    token: 'achievement',
+    body: 'recognition of their expertise because of how it relates to success through strong performance',
+  },
+  {
+    token: 'hedonism',
+    body: 'enjoyment in their daily experience because of how it relates to pleasure and comfort in everyday work',
+  },
+] as const;
+
+const JOB_CHOICE_VALUE_STATEMENT_MAP = new Map<string, string>(
+  JOB_CHOICE_VALUE_STATEMENTS.map(({ token, body }) => [token, body]),
+);
+
+export { JOB_CHOICE_VALUE_STATEMENTS };
+
+export function getJobChoiceValueStatementBody(token: string): string | undefined {
+  return JOB_CHOICE_VALUE_STATEMENT_MAP.get(token);
+}
+
+exec
+/bin/zsh -lc "sed -n '1,260p' cloud/scripts/job-choice-transform.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+exec
+/bin/zsh -lc "sed -n '150,260p' cloud/packages/db/src/types.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+// ============================================================================
+// TRANSCRIPT CONTENT
+// ============================================================================
+
+export type TranscriptMessage = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp?: string;
+};
+
+export type TranscriptContent = {
+  schema_version: 1;
+  messages: TranscriptMessage[];
+  model_response?: string;
+  raw_output?: string;
+};
+
+export type DecisionScaleLabel = {
+  code: string;
+  label: string;
+};
+
+export type DecisionManualOverride = {
+  previousDecisionCode: string | null;
+  overriddenAt: string;
+  overriddenByUserId?: string | null;
+};
+
+export type SummaryCacheSummary = {
+  decisionCode?: string;
+  decisionCodeSource?: string;
+  decisionText: string | null;
+  decisionMetadata: Record<string, unknown> | null;
+  canonicalDecision?: {
+    cacheVersion: 1;
+    decisionState: 'resolved' | 'neutral' | 'unknown';
+    favoredValueKey: string | null;
+    strength: 'strong' | 'lean' | 'neutral' | 'unknown';
+  };
+};
+
+export type SummaryCache = {
+  responseSha256: string;
+  parserVersion: string;
+  modelId: string;
+  summary: SummaryCacheSummary;
+};
+
+export type DecisionMetadata = {
+  parserVersion: string;
+  parseClass: 'exact' | 'fallback_resolved' | 'ambiguous';
+  parsePath: string;
+  responseSha256?: string;
+  responseExcerpt?: string;
+  matchedLabel?: string | null;
+  scaleLabels?: DecisionScaleLabel[];
+  manualOverride?: DecisionManualOverride;
+  summaryCache?: SummaryCache;
+};
+
+// ============================================================================
+// ANALYSIS TYPES
+// ============================================================================
+
+export type AnalysisPlan = {
+  schema_version: 1;
+  test: string;
+  alpha: number;
+  correction?: string;
+};
+
+export type AnalysisOutput = {
+  schema_version: 1;
+  results: Record<string, unknown>;
+  summary?: string;
+  confidence_intervals?: Record<string, { lower: number; upper: number }>;
+};
+
+// ============================================================================
+// COMPARISON DELTA
+// ============================================================================
+
+export type DeltaData = {
+  schema_version: 1;
+  value_differences: Record<string, { baseline: number; comparison: number; delta: number }>;
+  statistical_tests?: Record<string, { p_value: number; significant: boolean }>;
+};
+
+// ============================================================================
+// RUBRIC CONTENT
+// ============================================================================
+
+export type RubricValue = {
+  name: string;
+  definition: string;
+  examples?: string[];
+};
+
+export type RubricContent = {
+  schema_version: 1;
+  values: RubricValue[];
+};
+
+// ============================================================================
+// COHORT CRITERIA
+// ============================================================================
+
+export type CohortCriteria = {
+  schema_version: 1;
+  filters: Array<{
+    field: string;
+
+ succeeded in 0ms:
+import type {
+  DefinitionContent,
+  DefinitionMethodology,
+  DefinitionComponents,
+} from '@valuerank/db';
+import {
+  assembleTemplate,
+  getJobChoiceValueStatementBody,
+  labelFromBody,
+} from '@valuerank/shared';
+
+
+const OPTION_PATTERN =
+  /If they work as (?<role>.+?), they gain (?<article>a |an )?\[(?<token>[^\]]+)\] (?<rest>.+?)\./;
+
+const TEMPLATE_PATTERN =
+  /^(?<intro>[\s\S]*?)If they work as (?<roleA>.+?), they gain (?<articleA>a |an )?\[(?<tokenA>[^\]]+)\] (?<restA>.+?)\.\n\nIf they work as (?<roleB>.+?), they gain (?<articleB>a |an )?\[(?<tokenB>[^\]]+)\] (?<restB>.+?)\.\n\nGive me your judgment[\s\S]*$/;
+
+export type JobChoiceTransformResult = {
+  content: DefinitionContent;
+  optionLabels: [string, string];
+  roleTitles: [string, string];
+};
+
+type TransformOptions = {
+  /** If true, swap the token order so value B appears first. Defaults to false (A first). */
+  swapped?: boolean;
+  pairKey?: string;
+  contextId?: string;
+};
+
+export function transformJobChoiceDefinition(
+  content: DefinitionContent,
+  options: TransformOptions = {},
+): JobChoiceTransformResult {
+  const template = content.template;
+  const match = template.match(TEMPLATE_PATTERN);
+  if (!match?.groups) {
+    throw new Error('Template does not match the expected Jobs vignette structure');
+  }
+
+  const intro = match.groups.intro.trimEnd();
+  const roleA = match.groups.roleA.trim();
+  const roleB = match.groups.roleB.trim();
+  const tokenA = match.groups.tokenA.trim();
+  const tokenB = match.groups.tokenB.trim();
+  const swapped = options.swapped ?? false;
+
+  const firstToken = swapped ? tokenB : tokenA;
+  const secondToken = swapped ? tokenA : tokenB;
+  const firstRole = swapped ? roleB : roleA;
+  const secondRole = swapped ? roleA : roleB;
+
+  const firstBody = getJobChoiceValueStatementBody(firstToken);
+  if (firstBody == null) {
+    throw new Error(`No Job Choice value statement is defined for token: ${firstToken}`);
+  }
+  const secondBody = getJobChoiceValueStatementBody(secondToken);
+  if (secondBody == null) {
+    throw new Error(`No Job Choice value statement is defined for token: ${secondToken}`);
+  }
+
+  const components: DefinitionComponents = {
+    context_id: options.contextId ?? null,
+    value_first: { token: firstToken, body: firstBody },
+    value_second: { token: secondToken, body: secondBody },
+  };
+
+  const assembledTemplate = assembleTemplate(intro, components);
+
+  const labelFirst = labelFromBody(firstBody);
+  const labelSecond = labelFromBody(secondBody);
+
+  const methodology: DefinitionMethodology = {
+    family: 'job-choice',
+    response_scale: 'option_text',
+    legacy_label: 'Old V1',
+    canonical_value_order: content.dimensions.map((dimension) => dimension.name),
+    pair_key: options.pairKey,
+  };
+
+  return {
+    content: {
+      ...content,
+      template: assembledTemplate,
+      components,
+      methodology,
+    },
+    optionLabels: [labelFirst, labelSecond],
+    roleTitles: [firstRole, secondRole],
+  };
+}
+
+export function isTransformableJobChoiceTemplate(template: string): boolean {
+  return TEMPLATE_PATTERN.test(template);
+}
+
+export function extractLegacyRoleTitles(template: string): [string, string] | null {
+  const match = template.match(TEMPLATE_PATTERN);
+  if (!match?.groups) {
+    return null;
+  }
+  return [match.groups.roleA.trim(), match.groups.roleB.trim()];
+}
+
+export function canRewriteRoleSentence(sentence: string): boolean {
+  return OPTION_PATTERN.test(sentence);
+}
+
+exec
+/bin/zsh -lc "sed -n '1,320p' cloud/scripts/update-job-choice-vignettes.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+import {
+  db,
+  resolveDefinitionContent,
+  type DefinitionComponents,
+  type DefinitionContent,
+  type Prisma,
+} from '@valuerank/db';
+import {
+  assembleTemplate,
+  createLogger,
+  getJobChoiceValueStatementBody,
+} from '@valuerank/shared';
+
+import { buildJobChoiceScenarios } from './job-choice-vignette-utils.js';
+
+const log = createLogger('scripts:update-job-choice-vignettes');
+
+type ParsedArgs = {
+  apply: boolean;
+  limit: number | null;
+  definitionId: string | null;
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let apply = false;
+  let limit: number | null = null;
+  let definitionId: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--apply') {
+      apply = true;
+      continue;
+    }
+    if (arg === '--limit') {
+      const next = argv[index + 1];
+      if (!next) throw new Error('--limit requires a number');
+      limit = Number.parseInt(next, 10);
+      if (!Number.isFinite(limit) || limit <= 0) {
+        throw new Error('--limit must be a positive integer');
+      }
+      index += 1;
+      continue;
+    }
+    if (arg === '--definition-id') {
+      const next = argv[index + 1];
+      if (!next) throw new Error('--definition-id requires a value');
+      definitionId = next;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { apply, limit, definitionId };
+}
+
+function extractJobChoiceIntro(template: string): string {
+  const marker = '\n\nOne job offers ';
+  const markerIndex = template.indexOf(marker);
+  if (markerIndex >= 0) {
+    return template.slice(0, markerIndex).trimEnd();
+  }
+  throw new Error('Template does not contain the expected job-choice sentence structure');
+}
+
+function normalizeComponents(components: DefinitionComponents): DefinitionComponents {
+  const valueFirstBody = getJobChoiceValueStatementBody(components.value_first.token);
+  if (valueFirstBody == null) {
+    throw new Error(`No job-choice value statement body found for token: ${components.value_first.token}`);
+  }
+
+  const valueSecondBody = getJobChoiceValueStatementBody(components.value_second.token);
+  if (valueSecondBody == null) {
+    throw new Error(`No job-choice value statement body found for token: ${components.value_second.token}`);
+  }
+
+  return {
+    context_id: components.context_id,
+    value_first: {
+      token: components.value_first.token,
+      body: valueFirstBody,
+    },
+    value_second: {
+      token: components.value_second.token,
+      body: valueSecondBody,
+    },
+  };
+}
+
+function buildUpdatedContent(content: DefinitionContent, contextText: string): DefinitionContent {
+  const components = content.components;
+  if (components == null) {
+    throw new Error('Job-choice definition is missing components');
+  }
+
+  const normalizedComponents = normalizeComponents(components);
+  const updatedTemplate = assembleTemplate(contextText, normalizedComponents);
+
+  return {
+    ...content,
+    template: updatedTemplate,
+    components: normalizedComponents,
+  };
+}
+
+async function rewriteDefinition(definitionId: string): Promise<{
+  updatedTemplate: string;
+  scenarioCount: number;
+}> {
+  const definition = await db.definition.findUnique({
+    where: { id: definitionId },
+    include: {
+      domainContext: true,
+      levelPresetVersion: true,
+    },
+  });
+  if (definition == null) {
+    throw new Error(`Definition not found: ${definitionId}`);
+  }
+
+  const content = await resolveDefinitionContent(definitionId);
+  if (content.resolvedContent.methodology?.family !== 'job-choice') {
+    throw new Error(`Definition is not a job-choice vignette: ${definitionId}`);
+  }
+
+  const components = content.resolvedContent.components;
+  if (components?.context_id == null) {
+    throw new Error(`Job-choice definition is missing context_id: ${definitionId}`);
+  }
+
+  const contextText =
+    definition.domainContext?.text ??
+    (await db.domainContext.findUnique({
+      where: { id: components.context_id },
+      select: { text: true },
+    }))?.text;
+  if (contextText == null) {
+    throw new Error(`Domain context not found for job-choice definition: ${definitionId}`);
+  }
+
+  const updatedContent = buildUpdatedContent(content.resolvedContent, contextText);
+  const updatedScenarios = buildJobChoiceScenarios({
+    definitionId,
+    contextText,
+    components: updatedContent.components!,
+    levelPresetVersion: definition.levelPresetVersion == null
+      ? null
+      : {
+          l1: definition.levelPresetVersion.l1,
+          l2: definition.levelPresetVersion.l2,
+          l3: definition.levelPresetVersion.l3,
+          l4: definition.levelPresetVersion.l4,
+          l5: definition.levelPresetVersion.l5,
+        },
+  });
+
+  await db.$transaction(async (tx) => {
+    await tx.definition.update({
+      where: { id: definitionId },
+      data: {
+        content: updatedContent as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    await tx.scenario.updateMany({
+      where: { definitionId, deletedAt: null },
+      data: { deletedAt: new Date() },
+    });
+
+    for (const scenario of updatedScenarios) {
+      await tx.scenario.create({
+        data: {
+          definitionId,
+          name: scenario.name,
+          content: scenario.content as unknown as Prisma.InputJsonValue,
+        },
+      });
+    }
+  });
+
+  return {
+    updatedTemplate: updatedContent.template,
+    scenarioCount: updatedScenarios.length,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const jobChoiceDomain = await db.domain.findUnique({
+    where: { normalizedName: 'job-choice' },
+    select: { id: true },
+  });
+
+  if (jobChoiceDomain == null) {
+    throw new Error('Job-choice domain not found');
+  }
+
+  const definitions = await db.definition.findMany({
+    where: {
+      domainId: jobChoiceDomain.id,
+      deletedAt: null,
+      ...(args.definitionId != null ? { id: args.definitionId } : {}),
+    },
+    orderBy: { name: 'asc' },
+    take: args.limit ?? undefined,
+    select: { id: true, name: true },
+  });
+
+  const summary = {
+    inspected: definitions.length,
+    updated: 0,
+    skipped: 0,
+  };
+
+  for (const definition of definitions) {
+    const resolved = await resolveDefinitionContent(definition.id);
+    if (resolved.resolvedContent.methodology?.family !== 'job-choice') {
+      summary.skipped += 1;
+      continue;
+    }
+
+    const intro = extractJobChoiceIntro(resolved.resolvedContent.template);
+    const normalizedComponents = normalizeComponents(resolved.resolvedContent.components!);
+    const expectedTemplate = assembleTemplate(intro, normalizedComponents);
+    const alreadyNormalized =
+      resolved.resolvedContent.template === expectedTemplate &&
+      resolved.resolvedContent.components?.value_first.body === normalizedComponents.value_first.body &&
+      resolved.resolvedContent.components?.value_second.body === normalizedComponents.value_second.body;
+
+    if (alreadyNormalized) {
+      summary.skipped += 1;
+      continue;
+    }
+
+    if (!args.apply) {
+      summary.updated += 1;
+      log.info({ definitionId: definition.id, name: definition.name }, 'Would update job-choice vignette');
+      continue;
+    }
+
+    const result = await rewriteDefinition(definition.id);
+    summary.updated += 1;
+    log.info(
+      {
+        definitionId: definition.id,
+        name: definition.name,
+        scenarioCount: result.scenarioCount,
+      },
+      'Updated job-choice vignette',
+    );
+  }
+
+  log.info({ ...summary, apply: args.apply }, 'Job-choice vignette update complete');
+}
+
+main()
+  .catch((error) => {
+    log.error({ err: error }, 'Failed to update job-choice vignettes');
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });
+
+exec
+/bin/zsh -lc "rg -n \"taking the job with|One job offers|choosing the approach relating to|One approach provides|DEFAULT_SENTENCE_PREFIX|SENTENCE_PREFIX_BY_FAMILY|BODY_LOOKUP_BY_FAMILY|TEMPLATE_CONFIG_BY_FAMILY\" cloud/apps cloud/packages/shared/src cloud/scripts | sed -n '1,240p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+cloud/scripts/update-job-choice-vignettes.ts:59:  const marker = '\n\nOne job offers ';
+cloud/scripts/seed-software-approach-choice.ts:8:const SENTENCE_PREFIX = 'One approach provides [level]';
+cloud/scripts/migrate-level-to-prefix.ts:5: * 1. Sets sentencePrefix = "One job offers [level]" on job-choice domain (was null → default)
+cloud/scripts/migrate-level-to-prefix.ts:6: * 2. Sets sentencePrefix = "One approach provides [level]" on software-approach-choice domain
+cloud/scripts/migrate-level-to-prefix.ts:37:        data: { sentencePrefix: 'One job offers [level]' },
+cloud/scripts/migrate-level-to-prefix.ts:39:      log.info('job-choice sentencePrefix set to "One job offers [level]"');
+cloud/scripts/migrate-level-to-prefix.ts:41:      log.info('WOULD set job-choice sentencePrefix to "One job offers [level]"');
+cloud/scripts/migrate-level-to-prefix.ts:54:        data: { sentencePrefix: 'One approach provides [level]' },
+cloud/scripts/migrate-level-to-prefix.ts:56:      log.info('software-approach-choice sentencePrefix set to "One approach provides [level]"');
+cloud/scripts/migrate-level-to-prefix.ts:58:      log.info('WOULD set software-approach-choice sentencePrefix to "One approach provides [level]"');
+cloud/packages/shared/src/assemble-template.ts:10:  sentencePrefix?: string | null;  // e.g. "One job offers [level]"
+cloud/packages/shared/src/assemble-template.ts:11:  labelPrefix?: string | null;     // default: "taking the job with"
+cloud/packages/shared/src/assemble-template.ts:14:export const DEFAULT_SENTENCE_PREFIX = 'One job offers [level]';
+cloud/packages/shared/src/assemble-template.ts:45:  const rawPrefix = config?.sentencePrefix ?? DEFAULT_SENTENCE_PREFIX;
+cloud/scripts/__tests__/job-choice-bridge-report.test.ts:33:        matchedLabel: 'Strongly support taking the job with substantial recognition for expertise',
+cloud/scripts/__tests__/job-choice-bridge-report.test.ts:34:        responseExcerpt: 'Strongly support taking the job with substantial recognition for expertise.',
+cloud/scripts/__tests__/job-choice-bridge-report.test.ts:45:        matchedLabel: 'Somewhat support taking the job with moderate personal enjoyment',
+cloud/scripts/__tests__/job-choice-transform.test.ts:52:  it('assembles the template from components using "One job offers [level]" prefix', () => {
+cloud/scripts/__tests__/job-choice-transform.test.ts:56:      'One job offers [level] recognition of their expertise because of how it relates to success through strong performance.',
+cloud/scripts/__tests__/job-choice-transform.test.ts:59:      'One job offers [level] enjoyment in their daily experience because of how it relates to pleasure and comfort in everyday work.',
+cloud/scripts/__tests__/job-choice-transform.test.ts:62:      '- Strongly support taking the job with recognition of their expertise'
+cloud/scripts/__tests__/job-choice-transform.test.ts:75:      'taking the job with recognition of their expertise',
+cloud/scripts/__tests__/job-choice-transform.test.ts:76:      'taking the job with enjoyment in their daily experience',
+cloud/scripts/__tests__/job-choice-transform.test.ts:100:    expect(result.content.template).toContain('One job offers [level] enjoyment in their daily experience');
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:21:    expect(result).toContain('One job offers recognition of their expertise');
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:22:    expect(result).toContain('One job offers enjoyment in their daily experience');
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:30:      '- Strongly support taking the job with recognition of their expertise',
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:33:      '- Strongly support taking the job with enjoyment in their daily experience',
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:36:    expect(result).not.toContain('- Strongly support taking the job with [achievement]');
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:37:    expect(result).not.toContain('- Strongly support taking the job with [hedonism]');
+cloud/apps/api/src/utils/paired-definition.ts:10:const SENTENCE_PREFIX_BY_FAMILY: Record<string, string> = {
+cloud/apps/api/src/utils/paired-definition.ts:11:  'job-choice': 'One job offers ',
+cloud/apps/api/src/utils/paired-definition.ts:12:  'software-approach-choice': 'One approach provides ',
+cloud/apps/api/src/utils/paired-definition.ts:17:const BODY_LOOKUP_BY_FAMILY: Record<string, BodyLookup> = {
+cloud/apps/api/src/utils/paired-definition.ts:23:  const prefix = SENTENCE_PREFIX_BY_FAMILY[family];
+cloud/apps/api/src/utils/paired-definition.ts:34:  const lookup = BODY_LOOKUP_BY_FAMILY[family] ?? getJobChoiceValueStatementBody;
+cloud/apps/api/src/utils/paired-definition.ts:61:  if (family == null || content.components == null || BODY_LOOKUP_BY_FAMILY[family] == null) {
+cloud/apps/api/tests/graphql/queries/domain-analysis.test.ts:179:          matchedLabel: 'Strongly support taking the job with recognition of their expertise',
+cloud/apps/api/tests/graphql/queries/domain-analysis.test.ts:180:          responseExcerpt: 'Strongly support taking the job with recognition of their expertise',
+cloud/apps/api/tests/graphql/queries/domain-analysis.test.ts:208:          matchedLabel: 'Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/queries/domain-analysis.test.ts:209:          responseExcerpt: 'Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:164:        responseExcerpt: '**Strongly support taking the job with trust from other people** ...',
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:200:        matchedLabel: 'Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:201:        responseExcerpt: 'Level of Support: Strongly support taking the job with trust from other people ...',
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:216:      matchedLabel: 'Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:585:    // labelFromBody → 'taking the job with recognition of their expertise'
+cloud/apps/api/tests/graphql/queries/decision-model.test.ts:586:    const achievementLabel = 'Strongly support taking the job with recognition of their expertise';
+cloud/apps/web/tests/components/runs/TranscriptList.test.tsx:352:          { code: '1', label: 'Strongly support taking the job with Achievement' },
+cloud/apps/web/tests/components/runs/TranscriptList.test.tsx:353:          { code: '2', label: 'Somewhat support taking the job with Achievement' },
+cloud/apps/web/tests/components/runs/TranscriptList.test.tsx:355:          { code: '4', label: 'Somewhat support taking the job with Benevolence' },
+cloud/apps/web/tests/components/runs/TranscriptList.test.tsx:356:          { code: '5', label: 'Strongly support taking the job with Benevolence' },
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:489:  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
+cloud/apps/api/tests/graphql/queries/definition.test.ts:148:            'One job offers trust from other people because of how it relates to being someone others can rely on to carry through on shared responsibilities.',
+cloud/apps/api/tests/graphql/queries/definition.test.ts:150:            'One job offers recognition of their expertise because of how it relates to success through strong performance.',
+cloud/apps/api/tests/graphql/queries/definition.test.ts:485:        'One job offers [level] trust from other people because of how it relates to being someone others can rely on to carry through on shared responsibilities.',
+cloud/apps/api/tests/graphql/queries/definition.test.ts:488:        'One job offers [level] recognition of their expertise because of how it relates to success through strong performance.',
+cloud/apps/api/tests/graphql/types/transcript-decision-model-v2.test.ts:101:          matchedLabel: 'Strongly support taking the job with trust from other people',
+cloud/apps/api/tests/graphql/types/transcript-decision-model-v2.test.ts:105:          responseExcerpt: 'Level of Support: Strongly support taking the job with trust from other people',
+cloud/apps/web/src/components/runs/TranscriptRow.tsx:57: * "Strongly support taking the job with..." → "Strongly support"
+cloud/apps/web/src/components/runs/TranscriptRow.tsx:105:  const jobWithMarker = ' taking the job with ';
+cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx:17:import { labelFromBody, DEFAULT_SENTENCE_PREFIX, DEFAULT_LABEL_PREFIX } from '@valuerank/shared';
+cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx:231:          placeholder={DEFAULT_SENTENCE_PREFIX}
+
+exec
+/bin/zsh -lc "sed -n '1,200p' cloud/scripts/seed-software-approach-choice.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+import { db } from '@valuerank/db';
+import { createLogger, SOFTWARE_APPROACH_VALUE_STATEMENTS } from '@valuerank/shared';
+
+const log = createLogger('scripts:seed-software-approach-choice');
+
+const DOMAIN_NAME = 'Software Approach Choice';
+const DOMAIN_NORMALIZED_NAME = 'software-approach-choice';
+const SENTENCE_PREFIX = 'One approach provides [level]';
+const LABEL_PREFIX = 'choosing the approach with';
+
+const CONTEXT_TEXT = `You are an AI agent on a mixed software development team of humans and AIs. You must choose between two approaches for implementing a new feature. Both approaches deliver equivalent results in the same timeframe, but the day-to-day experience differs.`;
+
+async function main(): Promise<void> {
+  // 1. Upsert domain
+  let domain = await db.domain.findUnique({ where: { normalizedName: DOMAIN_NORMALIZED_NAME } });
+  if (domain == null) {
+    domain = await db.domain.create({
+      data: {
+        name: DOMAIN_NAME,
+        normalizedName: DOMAIN_NORMALIZED_NAME,
+        sentencePrefix: SENTENCE_PREFIX,
+        labelPrefix: LABEL_PREFIX,
+      },
+    });
+    log.info({ id: domain.id }, 'Created domain');
+  } else {
+    // Update template config if missing
+    if (domain.sentencePrefix == null || domain.labelPrefix == null) {
+      domain = await db.domain.update({
+        where: { id: domain.id },
+        data: { sentencePrefix: SENTENCE_PREFIX, labelPrefix: LABEL_PREFIX },
+      });
+      log.info({ id: domain.id }, 'Updated domain template config');
+    }
+    log.info({ id: domain.id }, 'Found domain');
+  }
+
+  // 2. Create or find domain context
+  let context = await db.domainContext.findFirst({
+    where: { domainId: domain.id },
+    orderBy: { createdAt: 'desc' },
+  });
+  if (context == null) {
+    context = await db.domainContext.create({
+      data: { domainId: domain.id, text: CONTEXT_TEXT },
+    });
+    log.info({ id: context.id }, 'Created domain context');
+  } else {
+    log.info({ id: context.id }, 'Found domain context');
+  }
+
+  // 3. Set context as default if not set
+  if (domain.defaultContextId !== context.id) {
+    await db.domain.update({
+      where: { id: domain.id },
+      data: { defaultContextId: context.id },
+    });
+    log.info('Set default context');
+  }
+
+  // 4. Upsert value statements
+  let upserted = 0;
+  for (const vs of SOFTWARE_APPROACH_VALUE_STATEMENTS) {
+    const statement = await db.valueStatement.upsert({
+      where: { domainId_token: { domainId: domain.id, token: vs.token } },
+      update: { body: vs.body },
+      create: { domainId: domain.id, ...vs },
+    });
+    // Ensure a ValueStatementVersion exists (the UI reads currentContent from versions)
+    const latestVersion = await db.valueStatementVersion.findFirst({
+      where: { statementId: statement.id },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (latestVersion == null || latestVersion.content !== vs.body) {
+      await db.valueStatementVersion.create({
+        data: { statementId: statement.id, content: vs.body },
+      });
+    }
+    upserted += 1;
+    log.info({ token: vs.token }, 'Upserted value statement');
+  }
+
+  // 5. Copy level preset and preamble defaults from job-choice if not set
+  if (domain.defaultLevelPresetVersionId == null || domain.defaultPreambleVersionId == null) {
+    const jobChoice = await db.domain.findUnique({
+      where: { normalizedName: 'job-choice' },
+      select: { defaultLevelPresetVersionId: true, defaultPreambleVersionId: true },
+    });
+    if (jobChoice != null) {
+      const updates: Record<string, string> = {};
+      if (domain.defaultLevelPresetVersionId == null && jobChoice.defaultLevelPresetVersionId != null) {
+        updates.defaultLevelPresetVersionId = jobChoice.defaultLevelPresetVersionId;
+      }
+      if (domain.defaultPreambleVersionId == null && jobChoice.defaultPreambleVersionId != null) {
+        updates.defaultPreambleVersionId = jobChoice.defaultPreambleVersionId;
+      }
+      if (Object.keys(updates).length > 0) {
+        await db.domain.update({ where: { id: domain.id }, data: updates });
+        log.info(updates, 'Copied defaults from job-choice domain');
+      }
+    }
+  }
+
+  log.info({ upserted, domainId: domain.id, contextId: context.id }, 'Seed complete');
+}
+
+main()
+  .catch((err) => { log.error({ err }, 'Seed failed'); process.exitCode = 1; })
+  .finally(() => db.$disconnect());
+
+exec
+/bin/zsh -lc "rg -n \"choosing the approach with|choosing the approach relating to\" cloud | sed -n '1,200p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:489:  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
+cloud/packages/shared/tests/assemble-template.test.ts:69:      labelPrefix: 'choosing the approach relating to',
+cloud/packages/shared/tests/assemble-template.test.ts:74:      '- Strongly support choosing the approach relating to recognition of their expertise',
+cloud/scripts/seed-software-approach-choice.ts:9:const LABEL_PREFIX = 'choosing the approach with';
+
+exec
+/bin/zsh -lc "rg -n \"Domain-Agnostic Decision Model|TEMPLATE_CONFIG_BY_FAMILY|domain-agnostic|labelPrefix\" docs/workflow/feature-runs cloud | sed -n '1,240p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:85:  labelPrefix?: string | null;
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:268:  labelPrefix?: string | null,
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:279:    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, labelPrefix));
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:484:  labelPrefix: string | null;
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:488:  'job-choice': { valueStatements: JOB_CHOICE_VALUE_STATEMENTS, labelPrefix: null },
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:489:  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:519:    labelPrefix: familyConfig?.labelPrefix ?? null,
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:608:    const favoredValueKey = resolveJobChoiceValueKeyFromText(candidateText, input.valueStatements, input.labelPrefix);
+cloud/apps/api/src/graphql/queries/domain-settings.ts:36:          labelPrefix: true,
+cloud/apps/api/src/graphql/queries/domain-settings.ts:71:        labelPrefix: domain.labelPrefix,
+cloud/packages/db/prisma/schema.prisma:174:  labelPrefix    String? @map("label_prefix")
+cloud/apps/api/src/graphql/mutations/domain/settings.ts:78:      labelPrefix: t.arg.string({ required: false }),
+cloud/apps/api/src/graphql/mutations/domain/settings.ts:148:            ...(args.labelPrefix !== undefined
+cloud/apps/api/src/graphql/mutations/domain/settings.ts:149:              ? { labelPrefix: args.labelPrefix === '' ? null : args.labelPrefix }
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:309:    db.domain.findUnique({ where: { id: domainId }, select: { id: true, normalizedName: true, sentencePrefix: true, labelPrefix: true, defaultLevelPresetVersionId: true } }),
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:360:    domainLabelPrefix: domain.labelPrefix,
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:462:        labelPrefix: resolvedInputs.domainLabelPrefix,
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:597:        labelPrefix: resolvedInputs.domainLabelPrefix,
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:726:        labelPrefix: resolvedInputs.domainLabelPrefix,
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:789:        labelPrefix: resolvedInputs.domainLabelPrefix,
+cloud/apps/api/src/graphql/types/domain.ts:133:  labelPrefix: string | null;
+cloud/apps/api/src/graphql/types/domain.ts:174:    labelPrefix: t.exposeString('labelPrefix', { nullable: true }),
+cloud/packages/shared/src/assemble-template.ts:11:  labelPrefix?: string | null;     // default: "taking the job with"
+cloud/packages/shared/src/assemble-template.ts:16:export function labelFromBody(body: string, labelPrefix: string): string {
+cloud/packages/shared/src/assemble-template.ts:22:  return `${labelPrefix} ${beforeBecause}`;
+cloud/packages/shared/src/assemble-template.ts:67:  // labelPrefix is required — callers must provide config with a labelPrefix.
+cloud/packages/shared/src/assemble-template.ts:68:  const lp = config?.labelPrefix ?? '';
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.gemini-requirements.review.md:28:- **RECOMMENDATION:** Add acceptance criteria for robust error handling. The system should fail loudly with clear error logs rather than silently producing incorrect data. Example: "If `resolveCanonicalDecision` cannot extract a `labelPrefix` from a template, it logs a critical error and flags the result as invalid, instead of producing a zero-score."
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:18:The feature "Domain-Agnostic Decision Model" fixes hardcoded job-choice assumptions in the decision model pipeline. Three issues:
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:27:- Remove `DEFAULT_LABEL_PREFIX` from `assemble-template.ts`, make `labelPrefix` required on `labelFromBody`
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:30:- Pass domain config to `assembleTemplate` in `paired-definition.ts` via `TEMPLATE_CONFIG_BY_FAMILY`
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:37:3. **CONSISTENCY**: The spec says "no per-family lookup tables" but plan.md still has `TEMPLATE_CONFIG_BY_FAMILY` in `paired-definition.ts`. Is this contradiction acceptable?
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:38:4. **RISK**: Could making `labelPrefix` required on `labelFromBody` break anything at runtime? What about `assembleTemplate` calls that don't receive config?
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:519:  labelPrefix?: string | null;     // default: "taking the job with"
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:525:export function labelFromBody(body: string, labelPrefix?: string | null): string {
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:531:  const prefix = labelPrefix ?? DEFAULT_LABEL_PREFIX;
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:577:  const labelFirst = labelFromBody(value_first.body, config?.labelPrefix);
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:578:  const labelSecond = labelFromBody(value_second.body, config?.labelPrefix);
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:678:  labelPrefix?: string | null;
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1594:cloud/apps/api/src/graphql/queries/domain/decision-model.ts:279:    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, labelPrefix));
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1595:cloud/apps/api/src/graphql/queries/domain/decision-model.ts:488:  'job-choice': { valueStatements: JOB_CHOICE_VALUE_STATEMENTS, labelPrefix: null },
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1596:cloud/apps/api/src/graphql/queries/domain/decision-model.ts:489:  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1631:cloud/packages/shared/src/assemble-template.ts:11:  labelPrefix?: string | null;     // default: "taking the job with"
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1634:cloud/packages/shared/src/assemble-template.ts:17:export function labelFromBody(body: string, labelPrefix?: string | null): string {
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1635:cloud/packages/shared/src/assemble-template.ts:23:  const prefix = labelPrefix ?? DEFAULT_LABEL_PREFIX;
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1637:cloud/packages/shared/src/assemble-template.ts:69:  const labelFirst = labelFromBody(value_first.body, config?.labelPrefix);
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1638:cloud/packages/shared/src/assemble-template.ts:70:  const labelSecond = labelFromBody(value_second.body, config?.labelPrefix);
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1675:cloud/packages/shared/tests/assemble-template.test.ts:69:      labelPrefix: 'choosing the approach relating to',
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1722:  labelPrefix?: string | null,
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1733:    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, labelPrefix));
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1938:  labelPrefix: string | null;
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1942:  'job-choice': { valueStatements: JOB_CHOICE_VALUE_STATEMENTS, labelPrefix: null },
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1943:  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:1973:    labelPrefix: familyConfig?.labelPrefix ?? null,
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:2608:    setLocalLabelPrefix(settings.labelPrefix ?? '');
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:2647:      labelPrefix: localLabelPrefix !== '' ? localLabelPrefix : null,
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:3503:    const favoredValueKey = resolveJobChoiceValueKeyFromText(candidateText, input.valueStatements, input.labelPrefix);
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:4287:cloud/packages/shared/src/assemble-template.ts:23:  const prefix = labelPrefix ?? DEFAULT_LABEL_PREFIX;
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:4294:cloud/apps/api/src/graphql/queries/domain/decision-model.ts:279:    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, labelPrefix));
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:4295:cloud/packages/shared/src/assemble-template.ts:17:export function labelFromBody(body: string, labelPrefix?: string | null): string {
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:4296:cloud/packages/shared/src/assemble-template.ts:69:  const labelFirst = labelFromBody(value_first.body, config?.labelPrefix);
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:4297:cloud/packages/shared/src/assemble-template.ts:70:  const labelSecond = labelFromBody(value_second.body, config?.labelPrefix);
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:5072:/bin/zsh -lc "rg -n \"taking the job with|One job offers|choosing the approach relating to|One approach provides|DEFAULT_SENTENCE_PREFIX|SENTENCE_PREFIX_BY_FAMILY|BODY_LOOKUP_BY_FAMILY|TEMPLATE_CONFIG_BY_FAMILY\" cloud/apps cloud/packages/shared/src cloud/scripts | sed -n '1,240p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:5085:cloud/packages/shared/src/assemble-template.ts:11:  labelPrefix?: string | null;     // default: "taking the job with"
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:5125:cloud/apps/api/src/graphql/queries/domain/decision-model.ts:489:  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:5161:        labelPrefix: LABEL_PREFIX,
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:5167:    if (domain.sentencePrefix == null || domain.labelPrefix == null) {
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:5170:        data: { sentencePrefix: SENTENCE_PREFIX, labelPrefix: LABEL_PREFIX },
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:5253:cloud/apps/api/src/graphql/queries/domain/decision-model.ts:489:  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
+docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.codex-attack.review.md:5254:cloud/packages/shared/tests/assemble-template.test.ts:69:      labelPrefix: 'choosing the approach relating to',
+docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md:1:# Domain-Agnostic Decision Model
+docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md:12:4. `assemble-template.ts` has no job-choice-specific defaults — callers must be explicit about `labelPrefix` and `sentencePrefix`.
+docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md:21:| `cloud/packages/shared/src/assemble-template.ts` | Remove `DEFAULT_LABEL_PREFIX`. Make `labelPrefix` a required param on `labelFromBody`. Keep `DEFAULT_SENTENCE_PREFIX` as a named constant but rename it. |
+docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md:23:| `cloud/apps/api/src/utils/paired-definition.ts` | Pass `TemplateConfig` to `assembleTemplate` call, derived from `TEMPLATE_CONFIG_BY_FAMILY` or domain data. |
+docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md:32:- Changing the Python workers (already domain-agnostic).
+docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md:33:- Renaming `resolveJobChoiceValueKeyFromText` — the function is domain-agnostic now; rename is cosmetic churn.
+docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md:34:- Exposing `sentencePrefix`/`labelPrefix` in GraphQL (separate plan).
+docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md:39:2. `labelFromBody` requires an explicit `labelPrefix` parameter — no implicit job-choice default.
+cloud/packages/shared/tests/assemble-template.test.ts:69:      labelPrefix: 'choosing the approach relating to',
+docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md:1:# Plan: Domain-Agnostic Decision Model
+docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md:14:### D2: Make labelPrefix required on labelFromBody
+docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md:16:Remove `DEFAULT_LABEL_PREFIX` constant. Change `labelFromBody(body, labelPrefix?)` to `labelFromBody(body, labelPrefix)` (required string). All callers must be explicit. TypeScript enforces this at compile time.
+docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md:30:Remove `DEFAULT_LABEL_PREFIX`. Make `labelPrefix` required. Rename `DEFAULT_SENTENCE_PREFIX` → keep for backward compat but add comment.
+docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md:33:- `assembleTemplate` internal call — already receives `config?.labelPrefix`, just needs to pass it through (will need a fallback for when config isn't provided, since assembleTemplate is called without config in some places).
+docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md:50:Add `TEMPLATE_CONFIG_BY_FAMILY` lookup for `sentencePrefix` and `labelPrefix`. Pass to `assembleTemplate` call at line 74.
+docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md:66:- Add test case to `assemble-template.test.ts` verifying required labelPrefix.
+docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md:75:| 1 | `cloud/packages/shared/src/assemble-template.ts` | Remove DEFAULT_LABEL_PREFIX, make labelPrefix required |
+docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md:79:| 3 | `cloud/apps/api/src/utils/paired-definition.ts` | Add TEMPLATE_CONFIG_BY_FAMILY, pass to assembleTemplate |
+docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md:82:| 5 | `cloud/packages/shared/tests/assemble-template.test.ts` | Required labelPrefix test |
+docs/workflow/feature-runs/domain-agnostic-decision-model/tasks.md:1:# Tasks: Domain-Agnostic Decision Model
+docs/workflow/feature-runs/domain-agnostic-decision-model/tasks.md:7:- [ ] Change `labelFromBody(body: string, labelPrefix?: string | null)` → `labelFromBody(body: string, labelPrefix: string)`
+docs/workflow/feature-runs/domain-agnostic-decision-model/tasks.md:8:- [ ] In `assembleTemplate`, pass `config?.labelPrefix ?? ''` to `labelFromBody` (empty string = no prefix, caller should always provide config)
+docs/workflow/feature-runs/domain-agnostic-decision-model/tasks.md:9:- [ ] Update existing tests in `assemble-template.test.ts` to pass explicit labelPrefix
+docs/workflow/feature-runs/domain-agnostic-decision-model/tasks.md:22:- [ ] Add `TEMPLATE_CONFIG_BY_FAMILY` lookup with sentencePrefix + labelPrefix for job-choice and software-approach-choice
+cloud/scripts/seed-software-approach-choice.ts:22:        labelPrefix: LABEL_PREFIX,
+cloud/scripts/seed-software-approach-choice.ts:28:    if (domain.sentencePrefix == null || domain.labelPrefix == null) {
+cloud/scripts/seed-software-approach-choice.ts:31:        data: { sentencePrefix: SENTENCE_PREFIX, labelPrefix: LABEL_PREFIX },
+cloud/scripts/seed-software-approach-pairs.ts:229:      labelPrefix: true,
+cloud/scripts/seed-software-approach-pairs.ts:236:    labelPrefix: domain.labelPrefix,
+cloud/scripts/seed-software-approach-pairs.ts:297:      labelPrefix: domain.labelPrefix,
+cloud/apps/web/src/api/operations/domains.ts:749:  labelPrefix: string | null;
+cloud/apps/web/src/api/operations/domains.ts:771:      labelPrefix
+cloud/apps/web/src/api/operations/domains.ts:820:    $labelPrefix: String
+cloud/apps/web/src/api/operations/domains.ts:830:      labelPrefix: $labelPrefix
+cloud/apps/web/src/api/operations/domains.ts:861:  labelPrefix?: string | null;
+cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx:82:    setLocalLabelPrefix(settings.labelPrefix ?? '');
+cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx:121:      labelPrefix: localLabelPrefix !== '' ? localLabelPrefix : null,
+
+exec
+/bin/zsh -lc "nl -ba cloud/packages/shared/src/assemble-template.ts | sed -n '1,120p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+     1	// Local type — intentionally not imported from @valuerank/db to avoid a circular
+     2	// dependency (db already depends on shared). Keep in sync with DefinitionComponents.
+     3	type ComponentsInput = {
+     4	  context_id: string | null;
+     5	  value_first: { token: string; body: string; intensity?: string };
+     6	  value_second: { token: string; body: string; intensity?: string };
+     7	};
+     8	
+     9	export type TemplateConfig = {
+    10	  sentencePrefix?: string | null;  // e.g. "One job offers [level]"
+    11	  labelPrefix?: string | null;     // default: "taking the job with"
+    12	};
+    13	
+    14	export const DEFAULT_SENTENCE_PREFIX = 'One job offers [level]';
+    15	
+    16	export function labelFromBody(body: string, labelPrefix: string): string {
+    17	  // Extract a stable scale label from the value statement body.
+    18	  // Bodies should not contain [level] (it belongs in sentencePrefix),
+    19	  // but strip it defensively for backward compatibility.
+    20	  const clean = body.replace(/\[level\]\s*/g, '');
+    21	  const beforeBecause = (clean.split(' because')[0] ?? clean).trim();
+    22	  return `${labelPrefix} ${beforeBecause}`;
+    23	}
+    24	
+    25	function buildScale(labelFirst: string, labelSecond: string): string {
+    26	  return [
+    27	    'Give me your judgment on the following scale:',
+    28	    '',
+    29	    `- Strongly support ${labelFirst}`,
+    30	    `- Somewhat support ${labelFirst}`,
+    31	    '- Neutral / Unsure',
+    32	    `- Somewhat support ${labelSecond}`,
+    33	    `- Strongly support ${labelSecond}`,
+    34	  ].join('\n');
+    35	}
+    36	
+    37	export function assembleTemplate(
+    38	  contextText: string,
+    39	  components: ComponentsInput,
+    40	  levelWords?: { first?: string; second?: string },
+    41	  config?: TemplateConfig,
+    42	): string {
+    43	  const { value_first, value_second } = components;
+    44	
+    45	  const rawPrefix = config?.sentencePrefix ?? DEFAULT_SENTENCE_PREFIX;
+    46	
+    47	  // Substitute [level] in the sentence prefix, not the body.
+    48	  const spFirst =
+    49	    levelWords?.first != null
+    50	      ? rawPrefix.replaceAll('[level]', levelWords.first)
+    51	      : rawPrefix;
+    52	  const spSecond =
+    53	    levelWords?.second != null
+    54	      ? rawPrefix.replaceAll('[level]', levelWords.second)
+    55	      : rawPrefix;
+    56	
+    57	  // Defensively strip [level] from bodies in case of legacy/un-migrated data.
+    58	  // This prevents double [level] when both prefix and body contain the token.
+    59	  const cleanFirstBody = value_first.body.replace(/\[level\]\s*/g, '');
+    60	  const cleanSecondBody = value_second.body.replace(/\[level\]\s*/g, '');
+    61	
+    62	  const sentenceFirst = `${spFirst} ${cleanFirstBody}.`;
+    63	  const sentenceSecond = `${spSecond} ${cleanSecondBody}.`;
+    64	
+    65	  // Scale labels use the original body (stripped of [level]) so they are stable
+    66	  // regardless of which level word was substituted.
+    67	  // labelPrefix is required — callers must provide config with a labelPrefix.
+    68	  const lp = config?.labelPrefix ?? '';
+    69	  const labelFirst = labelFromBody(value_first.body, lp);
+    70	  const labelSecond = labelFromBody(value_second.body, lp);
+    71	
+    72	  return [
+    73	    contextText,
+    74	    '',
+    75	    sentenceFirst,
+    76	    '',
+    77	    sentenceSecond,
+    78	    '',
+    79	    buildScale(labelFirst, labelSecond),
+    80	  ].join('\n');
+    81	}
+
+codex
+There’s a branch-state wrinkle: some of the spec changes are already partially present in the worktree, especially `assemble-template.ts`. I’m reading the feature-run docs next so I can separate true spec flaws from implementation drift on this branch.
+exec
+/bin/zsh -lc "sed -n '1,220p' docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+# Domain-Agnostic Decision Model
+
+## Problem
+
+The decision model pipeline (parsing, normalization, display) is hardcoded to job-choice domain assumptions in three places. This causes software-approach-choice transcripts to produce `favoredValueKey: null` and all-zero scores in analysis. Adding any future domain would require finding and updating scattered hardcoded lookup tables.
+
+## Goals
+
+1. Decision model resolves canonical decisions correctly for **any** paired domain using data already in the definition snapshot — no per-family lookup tables.
+2. Template normalization in `paired-definition.ts` uses the domain's stored config instead of hardcoded defaults.
+3. `TranscriptRow.tsx` displays label subjects correctly for any domain.
+4. `assemble-template.ts` has no job-choice-specific defaults — callers must be explicit about `labelPrefix` and `sentencePrefix`.
+5. Existing job-choice behavior is unchanged.
+
+## Scope
+
+### In scope
+
+| File | Change |
+|------|--------|
+| `cloud/packages/shared/src/assemble-template.ts` | Remove `DEFAULT_LABEL_PREFIX`. Make `labelPrefix` a required param on `labelFromBody`. Keep `DEFAULT_SENTENCE_PREFIX` as a named constant but rename it. |
+| `cloud/apps/api/src/graphql/queries/domain/decision-model.ts` | Extract value statements + label prefix from definition snapshot instead of `VALUE_STATEMENTS_BY_FAMILY`. |
+| `cloud/apps/api/src/utils/paired-definition.ts` | Pass `TemplateConfig` to `assembleTemplate` call, derived from `TEMPLATE_CONFIG_BY_FAMILY` or domain data. |
+| `cloud/apps/web/src/components/runs/TranscriptRow.tsx` | Replace hardcoded `' taking the job with '` with dynamic label prefix extraction from scale labels. |
+| `cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx` | Update `labelFromBody` call for new signature. |
+| `cloud/scripts/job-choice-transform.ts` | Update `labelFromBody` call for new signature. |
+| Test files for decision-model, assemble-template | Add software-approach-choice test cases. |
+
+### Out of scope
+
+- Changing stored transcript data (caches self-heal via the unknown-cache-bypass already committed).
+- Changing the Python workers (already domain-agnostic).
+- Renaming `resolveJobChoiceValueKeyFromText` — the function is domain-agnostic now; rename is cosmetic churn.
+- Exposing `sentencePrefix`/`labelPrefix` in GraphQL (separate plan).
+
+## Acceptance Criteria
+
+1. `resolveCanonicalDecision` produces correct `favoredValueKey`, `direction`, and `strength` for both job-choice and software-approach-choice transcripts using real prod transcript data.
+2. `labelFromBody` requires an explicit `labelPrefix` parameter — no implicit job-choice default.
+3. `TranscriptRow` extracts the value subject from any paired label format, not just "taking the job with".
+4. `normalizePairedDefinitionContent` produces correct template text for software-approach-choice definitions.
+5. All existing decision-model, assemble-template, and web tests pass.
+6. New tests cover software-approach-choice cases for decision resolution and template assembly.
+
+## Verification
+
+- Test with real transcript data from both domains (job-choice and software-approach-choice) captured from prod.
+- Preflight: lint + test + build for shared, api, web.
+
+exec
+/bin/zsh -lc "sed -n '1,220p' docs/workflow/feature-runs/domain-agnostic-decision-model/plan.md" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+# Plan: Domain-Agnostic Decision Model
+
+## Architecture Decisions
+
+### D1: Extract config from definition snapshot, not family lookup tables
+
+The current `VALUE_STATEMENTS_BY_FAMILY` approach requires code changes for each new domain. Instead:
+
+- **Value statements:** Build from `definitionSnapshot.components.value_first` and `value_second` — the two value bodies are right there.
+- **Label prefix:** Parse from the scale labels in the definition snapshot's template. The template contains lines like `"- Strongly support choosing the approach relating to ..."` — extract the prefix by stripping the strength phrase and the value body portion.
+
+This means zero code changes when a new domain is added.
+
+### D2: Make labelPrefix required on labelFromBody
+
+Remove `DEFAULT_LABEL_PREFIX` constant. Change `labelFromBody(body, labelPrefix?)` to `labelFromBody(body, labelPrefix)` (required string). All callers must be explicit. TypeScript enforces this at compile time.
+
+`DEFAULT_SENTENCE_PREFIX` stays but is renamed to make it clear it's not universal.
+
+### D3: TranscriptRow uses scale labels directly
+
+Instead of hardcoding `' taking the job with '`, extract the label prefix from the actual `scaleLabels` in `decisionMetadata`. The scale labels already contain the domain-correct text. Parse the prefix from the first non-neutral label.
+
+---
+
+## Wave Breakdown
+
+### Wave 1: Shared foundation (assemble-template.ts)
+
+Remove `DEFAULT_LABEL_PREFIX`. Make `labelPrefix` required. Rename `DEFAULT_SENTENCE_PREFIX` → keep for backward compat but add comment.
+
+Update all callers:
+- `assembleTemplate` internal call — already receives `config?.labelPrefix`, just needs to pass it through (will need a fallback for when config isn't provided, since assembleTemplate is called without config in some places).
+- `DomainSettingsPanel.tsx` — already passes prefix explicitly.
+- `job-choice-transform.ts` script — pass explicit prefix.
+
+**Risk:** Breaking callers that rely on the default. Mitigated by TypeScript catching missing args at build time.
+
+### Wave 2: Decision model (decision-model.ts)
+
+Replace `VALUE_STATEMENTS_BY_FAMILY` with snapshot-based extraction:
+1. Extract `components.value_first` and `components.value_second` from definition snapshot → build `ValueStatementEntry[]`.
+2. Extract label prefix from template's scale labels.
+3. Pass both to `resolveDecisionModel`.
+
+**Risk:** Edge cases where snapshot doesn't have components (old non-paired transcripts). Mitigated by falling back to existing behavior when components are absent.
+
+### Wave 3: Template normalization (paired-definition.ts)
+
+Add `TEMPLATE_CONFIG_BY_FAMILY` lookup for `sentencePrefix` and `labelPrefix`. Pass to `assembleTemplate` call at line 74.
+
+Note: this is the one place where a per-family lookup is acceptable — normalization runs without a DB connection, so it can't query the domain table. The lookup table stays small (just prefix strings) and is easy to extend.
+
+### Wave 4: TranscriptRow display (TranscriptRow.tsx)
+
+Replace hardcoded `' taking the job with '` and `' taking '` with dynamic extraction:
+1. From the `scaleLabels` in `decisionMetadata`, find a non-neutral label.
+2. Extract the prefix between the strength word ("Strongly support" / "Somewhat support") and the value body text.
+3. Use that prefix for subject extraction.
+
+Fallback: if prefix can't be determined, show `"${score} - ${shortDirection} ${primaryDimKey}"` (current fallback behavior).
+
+### Wave 5: Tests and verification
+
+- Add software-approach-choice test cases to `decision-model.test.ts`.
+- Add test case to `assemble-template.test.ts` verifying required labelPrefix.
+- Test against real transcript data from both domains.
+
+---
+
+## Files Touched
+
+| Wave | File | What |
+|------|------|------|
+| 1 | `cloud/packages/shared/src/assemble-template.ts` | Remove DEFAULT_LABEL_PREFIX, make labelPrefix required |
+| 1 | `cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx` | Update labelFromBody call |
+| 1 | `cloud/scripts/job-choice-transform.ts` | Update labelFromBody call |
+| 2 | `cloud/apps/api/src/graphql/queries/domain/decision-model.ts` | Snapshot-based config extraction |
+| 3 | `cloud/apps/api/src/utils/paired-definition.ts` | Add TEMPLATE_CONFIG_BY_FAMILY, pass to assembleTemplate |
+| 4 | `cloud/apps/web/src/components/runs/TranscriptRow.tsx` | Dynamic label prefix extraction |
+| 5 | `cloud/apps/api/tests/graphql/queries/decision-model.test.ts` | Software-approach-choice test cases |
+| 5 | `cloud/packages/shared/tests/assemble-template.test.ts` | Required labelPrefix test |
+
+## Risks
+
+- **Backward compat:** Old transcripts without `components` in snapshot → fall back gracefully to existing behavior.
+- **Edge case in label prefix extraction:** If scale labels use an unexpected format → fall back to unknown decision (same as today).
+- **paired-definition.ts lookup table:** Still per-family, but only for prefix strings (not value statement arrays). Acceptable since normalization has no DB access.
+
+exec
+/bin/zsh -lc "sed -n '1,220p' docs/workflow/feature-runs/domain-agnostic-decision-model/tasks.md" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+# Tasks: Domain-Agnostic Decision Model
+
+## Slice 1: Shared foundation + decision model + paired-definition
+
+### 1.1 assemble-template.ts — remove job-choice defaults
+- [ ] Remove `DEFAULT_LABEL_PREFIX` constant
+- [ ] Change `labelFromBody(body: string, labelPrefix?: string | null)` → `labelFromBody(body: string, labelPrefix: string)`
+- [ ] In `assembleTemplate`, pass `config?.labelPrefix ?? ''` to `labelFromBody` (empty string = no prefix, caller should always provide config)
+- [ ] Update existing tests in `assemble-template.test.ts` to pass explicit labelPrefix
+- [ ] Build shared: `npm run build --workspace @valuerank/shared`
+
+### 1.2 decision-model.ts — snapshot-based config extraction
+- [ ] Add helper `extractValueStatementsFromSnapshot(snapshot)` → reads `components.value_first` and `value_second`, returns `ValueStatementEntry[]` or null
+- [ ] Add helper `extractLabelPrefixFromSnapshot(snapshot)` → parses scale labels from template text, returns string or null
+- [ ] Remove `VALUE_STATEMENTS_BY_FAMILY` lookup table (added in the earlier quick fix)
+- [ ] In `resolveTranscriptDecisionModel`, call new helpers and pass results to `resolveDecisionModel`
+- [ ] Fallback: if snapshot lacks components or scale labels, pass undefined (existing behavior)
+- [ ] Update/add tests in `decision-model.test.ts` with software-approach-choice snapshot data
+- [ ] Build api: `npm run build --workspace @valuerank/api`
+
+### 1.3 paired-definition.ts — pass TemplateConfig to assembleTemplate
+- [ ] Add `TEMPLATE_CONFIG_BY_FAMILY` lookup with sentencePrefix + labelPrefix for job-choice and software-approach-choice
+- [ ] Pass config to `assembleTemplate(intro, normalizedComponents, undefined, config)` at line 74
+- [ ] Build api: `npm run build --workspace @valuerank/api`
+
+### 1.4 Update remaining callers of labelFromBody
+- [ ] `DomainSettingsPanel.tsx` — already passes prefix, just update for new required signature if needed
+- [ ] `job-choice-transform.ts` — pass explicit `'taking the job with'`
+- [ ] Build web: `npm run build --workspace @valuerank/web`
+
+[CHECKPOINT]
+
+## Slice 2: TranscriptRow display + end-to-end verification
+
+### 2.1 TranscriptRow.tsx — domain-aware label parsing
+- [ ] Replace `extractShortDirection` — instead of hardcoded `' taking '`, detect the strength prefix ("Strongly support", "Somewhat support", "Neutral / Unsure") and truncate there
+- [ ] Replace hardcoded `' taking the job with '` marker — extract label prefix dynamically from `scaleLabels` in decisionMetadata
+- [ ] Use extracted prefix for subject extraction
+- [ ] Fallback gracefully when prefix can't be determined
+
+### 2.2 End-to-end verification with real transcript data
+- [ ] Capture representative transcript data from prod for both job-choice and software-approach-choice
+- [ ] Write or run tests verifying `resolveCanonicalDecision` produces correct results for both
+- [ ] Verify `TranscriptRow` display logic produces correct output for both label formats
+
+### 2.3 Preflight
+- [ ] `npm run lint` for shared, db, api, web
+- [ ] `npm run test` for api, web
+- [ ] `npm run build` for shared, api, web
+
+[CHECKPOINT]
+
+exec
+/bin/zsh -lc 'git diff -- cloud/packages/shared/src/assemble-template.ts cloud/apps/api/src/graphql/queries/domain/decision-model.ts cloud/apps/api/src/utils/paired-definition.ts cloud/apps/web/src/components/runs/TranscriptRow.tsx' in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-3dVPpElT' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-n5ImuOmV' (errno=Operation not permitted)
+diff --git a/cloud/apps/api/src/graphql/queries/domain/decision-model.ts b/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
+index 85232dfc..1da9cfb9 100644
+--- a/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
++++ b/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
+@@ -1,5 +1,5 @@
+ import { DOMAIN_ANALYSIS_VALUE_KEYS, extractValuePair, toPascalCaseKey, type DomainAnalysisValueKey, type DomainAnalysisValuePair } from '../domain-analysis-values.js';
+-import { JOB_CHOICE_VALUE_STATEMENTS, labelFromBody } from '@valuerank/shared';
++import { JOB_CHOICE_VALUE_STATEMENTS, SOFTWARE_APPROACH_VALUE_STATEMENTS, labelFromBody } from '@valuerank/shared';
+ 
+ export type DecisionDirection = 'favor_first' | 'favor_second' | 'neutral' | 'refusal' | 'unknown';
+ export type DecisionStrength = 'strong' | 'lean' | 'neutral' | 'unknown';
+@@ -82,6 +82,7 @@ export type DecisionModelInput = {
+   manualOverrideDecision?: CanonicalAppliedDecision | null;
+   cachedDecision?: CachedWinnerFirstDecision | null;
+   valueStatements?: readonly ValueStatementEntry[];
++  labelPrefix?: string | null;
+ };
+ 
+ export type DecisionModelResult = {
+@@ -264,6 +265,7 @@ function parseJobChoiceStrengthFromText(text: string): DecisionStrength | null {
+ function resolveJobChoiceValueKeyFromText(
+   text: string,
+   valueStatements?: readonly ValueStatementEntry[],
++  labelPrefix?: string | null,
+ ): DomainAnalysisValueKey | null {
+   const normalized = normalizeJobChoiceLabelText(text);
+   if (normalized.length === 0) {
+@@ -274,7 +276,7 @@ function resolveJobChoiceValueKeyFromText(
+   let resolved: DomainAnalysisValueKey | null = null;
+   for (const entry of entries) {
+     const valueKey = toPascalCaseKey(entry.token) as DomainAnalysisValueKey;
+-    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body));
++    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, labelPrefix));
+     if (!label || !normalized.includes(label)) {
+       continue;
+     }
+@@ -477,6 +479,24 @@ export function buildRawDecisionEvidence(
+   };
+ }
+ 
++type FamilyConfig = {
++  valueStatements: readonly ValueStatementEntry[];
++  labelPrefix: string | null;
++};
++
++const VALUE_STATEMENTS_BY_FAMILY: Record<string, FamilyConfig> = {
++  'job-choice': { valueStatements: JOB_CHOICE_VALUE_STATEMENTS, labelPrefix: null },
++  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
++};
++
++function extractFamilyFromSnapshot(snapshot: unknown): string | null {
++  if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) return null;
++  const methodology = (snapshot as { methodology?: unknown }).methodology;
++  if (methodology === null || typeof methodology !== 'object' || Array.isArray(methodology)) return null;
++  const family = (methodology as { family?: unknown }).family;
++  return typeof family === 'string' ? family : null;
++}
++
+ export function resolveTranscriptDecisionModel(
+   input: TranscriptDecisionModelInput,
+ ): TranscriptDecisionModelResult {
+@@ -484,6 +504,10 @@ export function resolveTranscriptDecisionModel(
+   const raw = buildRawDecisionEvidence(input.decisionMetadata);
+   const manualOverrideDecision = extractManualOverrideDecision(input.decisionMetadata);
+   const cachedDecision = extractCachedWinnerFirstDecision(input.decisionMetadata);
++
++  const family = extractFamilyFromSnapshot(input.definitionSnapshot);
++  const familyConfig = family != null ? VALUE_STATEMENTS_BY_FAMILY[family] : undefined;
++
+   const resolved = resolveDecisionModel({
+     pair,
+     orientationFlipped: input.orientationFlipped,
+@@ -491,6 +515,8 @@ export function resolveTranscriptDecisionModel(
+     manualOverridePresent: manualOverrideDecision !== null,
+     manualOverrideDecision,
+     cachedDecision,
++    valueStatements: familyConfig?.valueStatements,
++    labelPrefix: familyConfig?.labelPrefix ?? null,
+   });
+ 
+   return resolved;
+@@ -517,10 +543,11 @@ export function resolveCanonicalDecision(input: DecisionModelInput): CanonicalDe
+ 
+   const parsedPath = parseDecisionPath(input.raw.parsePath);
+   const cachedDecision = input.cachedDecision ?? null;
+-  if (cachedDecision) {
+-    if (cachedDecision.decisionState === 'unknown') {
+-      return buildUnknownCanonicalDecision('unknown');
+-    }
++  if (cachedDecision && cachedDecision.decisionState !== 'unknown') {
++    // When cachedDecision.decisionState is 'unknown', skip the cache and
++    // fall through to re-resolve from raw evidence. This handles cases where
++    // the cache was built with incorrect config (e.g. wrong value statements
++    // or label prefix for the domain family).
+ 
+     if (cachedDecision.decisionState === 'neutral') {
+       return buildCanonicalDecisionFromPair(
+@@ -578,7 +605,7 @@ export function resolveCanonicalDecision(input: DecisionModelInput): CanonicalDe
+       );
+     }
+ 
+-    const favoredValueKey = resolveJobChoiceValueKeyFromText(candidateText, input.valueStatements);
++    const favoredValueKey = resolveJobChoiceValueKeyFromText(candidateText, input.valueStatements, input.labelPrefix);
+     if (favoredValueKey === null) {
+       return buildUnknownCanonicalDecision('unknown');
+     }
+diff --git a/cloud/packages/shared/src/assemble-template.ts b/cloud/packages/shared/src/assemble-template.ts
+index 2a234c81..8122b819 100644
+--- a/cloud/packages/shared/src/assemble-template.ts
++++ b/cloud/packages/shared/src/assemble-template.ts
+@@ -12,16 +12,14 @@ export type TemplateConfig = {
+ };
+ 
+ export const DEFAULT_SENTENCE_PREFIX = 'One job offers [level]';
+-export const DEFAULT_LABEL_PREFIX = 'taking the job with';
+ 
+-export function labelFromBody(body: string, labelPrefix?: string | null): string {
++export function labelFromBody(body: string, labelPrefix: string): string {
+   // Extract a stable scale label from the value statement body.
+   // Bodies should not contain [level] (it belongs in sentencePrefix),
+   // but strip it defensively for backward compatibility.
+   const clean = body.replace(/\[level\]\s*/g, '');
+   const beforeBecause = (clean.split(' because')[0] ?? clean).trim();
+-  const prefix = labelPrefix ?? DEFAULT_LABEL_PREFIX;
+-  return `${prefix} ${beforeBecause}`;
++  return `${labelPrefix} ${beforeBecause}`;
+ }
+ 
+ function buildScale(labelFirst: string, labelSecond: string): string {
+@@ -66,8 +64,10 @@ export function assembleTemplate(
+ 
+   // Scale labels use the original body (stripped of [level]) so they are stable
+   // regardless of which level word was substituted.
+-  const labelFirst = labelFromBody(value_first.body, config?.labelPrefix);
+-  const labelSecond = labelFromBody(value_second.body, config?.labelPrefix);
++  // labelPrefix is required — callers must provide config with a labelPrefix.
++  const lp = config?.labelPrefix ?? '';
++  const labelFirst = labelFromBody(value_first.body, lp);
++  const labelSecond = labelFromBody(value_second.body, lp);
+ 
+   return [
+     contextText,
+
+exec
+/bin/zsh -lc 'git status --short' in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-x6lvZEvz' (errno=Operation not permitted)
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-cF5qRqC4' (errno=Operation not permitted)
+ M cloud/apps/api/src/graphql/queries/domain/decision-model.ts
+ M cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx
+ M cloud/packages/shared/src/assemble-template.ts
+?? cloud/node_modules
+?? docs/workflow/feature-runs/domain-agnostic-decision-model/
+?? node_modules
+
+exec
+/bin/zsh -lc "nl -ba cloud/apps/api/src/graphql/mutations/paired-vignette.ts | sed -n '300,340p;450,490p;580,620p;710,810p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+   300	  }
+   301	
+   302	  const [context, valueFirst, valueSecond, preambleVersion, domain] = await Promise.all([
+   303	    db.domainContext.findUnique({ where: { id: contextId } }),
+   304	    db.valueStatement.findUnique({ where: { id: valueFirstId } }),
+   305	    db.valueStatement.findUnique({ where: { id: valueSecondId } }),
+   306	    preambleVersionId == null
+   307	      ? Promise.resolve(null)
+   308	      : db.preambleVersion.findUnique({ where: { id: preambleVersionId } }),
+   309	    db.domain.findUnique({ where: { id: domainId }, select: { id: true, normalizedName: true, sentencePrefix: true, labelPrefix: true, defaultLevelPresetVersionId: true } }),
+   310	  ]);
+   311	
+   312	  if (context == null) throw new Error(`DomainContext not found: ${contextId}`);
+   313	  if (context.domainId !== domainId) {
+   314	    throw new Error(`DomainContext ${contextId} does not belong to domain ${domainId}`);
+   315	  }
+   316	  if (valueFirst == null) throw new Error(`ValueStatement not found: ${valueFirstId}`);
+   317	  if (valueFirst.domainId !== domainId) {
+   318	    throw new Error(`ValueStatement ${valueFirstId} does not belong to domain ${domainId}`);
+   319	  }
+   320	  if (valueSecond == null) throw new Error(`ValueStatement not found: ${valueSecondId}`);
+   321	  if (valueSecond.domainId !== domainId) {
+   322	    throw new Error(`ValueStatement ${valueSecondId} does not belong to domain ${domainId}`);
+   323	  }
+   324	  if (preambleVersionId != null && preambleVersion == null) {
+   325	    throw new Error(`Preamble version not found: ${preambleVersionId}`);
+   326	  }
+   327	  if (domain == null) throw new Error(`Domain not found: ${domainId}`);
+   328	
+   329	  const resolvedLevelPresetVersionId =
+   330	    inputLevelPresetVersionId ?? (applyDomainDefault ? (domain.defaultLevelPresetVersionId ?? null) : null);
+   331	
+   332	  let levelPresetVersion: ResolvedPairInputs['levelPresetVersion'] = null;
+   333	
+   334	  if (resolvedLevelPresetVersionId != null) {
+   335	    levelPresetVersion = await db.levelPresetVersion.findUnique({
+   336	      where: { id: resolvedLevelPresetVersionId },
+   337	      select: { l1: true, l2: true, l3: true, l4: true, l5: true },
+   338	    });
+   339	    if (levelPresetVersion == null) {
+   340	      throw new Error(`LevelPresetVersion not found: ${resolvedLevelPresetVersionId}`);
+   450	        domainId,
+   451	        contextId,
+   452	        valueFirstId,
+   453	        valueSecondId,
+   454	        preambleVersionId,
+   455	        levelPresetVersionId: inputLevelPresetVersionId,
+   456	        applyDomainDefault: true,
+   457	      });
+   458	
+   459	      const pairKey = randomUUID();
+   460	      const domainTemplateConfig: TemplateConfig = {
+   461	        sentencePrefix: resolvedInputs.domainSentencePrefix,
+   462	        labelPrefix: resolvedInputs.domainLabelPrefix,
+   463	      };
+   464	      const {
+   465	        contentAFirst,
+   466	        contentBFirst,
+   467	        componentsAFirst,
+   468	        componentsBFirst,
+   469	      } = buildPairedVignetteContent(
+   470	        pairKey,
+   471	        resolvedInputs.context.text,
+   472	        resolvedInputs.contextId,
+   473	        resolvedInputs.valueFirst,
+   474	        resolvedInputs.valueSecond,
+   475	        resolvedInputs.levelPresetVersion,
+   476	        resolvedInputs.domainNormalizedName,
+   477	        domainTemplateConfig,
+   478	      );
+   479	
+   480	      const [defA, defB] = await db.$transaction(async (tx) => {
+   481	        const a = await tx.definition.create({
+   482	          data: {
+   483	            name: buildPairedDefinitionName(
+   484	              input.name,
+   485	              resolvedInputs.valueFirst.token,
+   486	              resolvedInputs.valueSecond.token,
+   487	            ),
+   488	            content: contentAFirst as unknown as Prisma.InputJsonValue,
+   489	            domainId,
+   490	            domainContextId: resolvedInputs.contextId,
+   580	      )?.domainId;
+   581	
+   582	      if (domainId == null) {
+   583	        throw new Error(`Definition ${definitionId} is not assigned to a domain`);
+   584	      }
+   585	
+   586	      const resolvedInputs = await resolvePairedVignetteInputs({
+   587	        domainId,
+   588	        contextId,
+   589	        valueFirstId,
+   590	        valueSecondId,
+   591	        preambleVersionId,
+   592	        levelPresetVersionId: inputLevelPresetVersionId,
+   593	      });
+   594	
+   595	      const domainTemplateConfig: TemplateConfig = {
+   596	        sentencePrefix: resolvedInputs.domainSentencePrefix,
+   597	        labelPrefix: resolvedInputs.domainLabelPrefix,
+   598	      };
+   599	      const {
+   600	        contentAFirst,
+   601	        contentBFirst,
+   602	        componentsAFirst,
+   603	        componentsBFirst,
+   604	      } = buildPairedVignetteContent(
+   605	        existingPair.pairKey,
+   606	        resolvedInputs.context.text,
+   607	        resolvedInputs.contextId,
+   608	        resolvedInputs.valueFirst,
+   609	        resolvedInputs.valueSecond,
+   610	        resolvedInputs.levelPresetVersion,
+   611	        resolvedInputs.domainNormalizedName,
+   612	        domainTemplateConfig,
+   613	      );
+   614	
+   615	      const [updatedA, updatedB] = await db.$transaction(async (tx) => {
+   616	        await tx.scenario.deleteMany({
+   617	          where: { definitionId: { in: [existingPair.definitionA.id, existingPair.definitionB.id] } },
+   618	        });
+   619	
+   620	        const updatedDefinitions = await Promise.all([
+   710	    resolve: async (_root, { input }, ctx) => {
+   711	      const domainId = String(input.domainId);
+   712	      const contextId = String(input.contextId);
+   713	      const valueFirstId = String(input.valueFirstId);
+   714	      const valueSecondId = String(input.valueSecondId);
+   715	      const preambleVersionId = input.preambleVersionId != null ? String(input.preambleVersionId) : null;
+   716	      const inputLevelPresetVersionId = input.levelPresetVersionId != null ? String(input.levelPresetVersionId) : null;
+   717	
+   718	      ctx.log.warn({ domainId, deprecatedAlias: 'createJobChoicePair' }, 'Deprecated alias called — migrate to createPairedVignette');
+   719	
+   720	      const resolvedInputs = await resolvePairedVignetteInputs({
+   721	        domainId, contextId, valueFirstId, valueSecondId, preambleVersionId,
+   722	        levelPresetVersionId: inputLevelPresetVersionId, applyDomainDefault: true,
+   723	      });
+   724	      const domainTemplateConfig: TemplateConfig = {
+   725	        sentencePrefix: resolvedInputs.domainSentencePrefix,
+   726	        labelPrefix: resolvedInputs.domainLabelPrefix,
+   727	      };
+   728	      const pairKey = randomUUID();
+   729	      const { contentAFirst, contentBFirst, componentsAFirst, componentsBFirst } = buildPairedVignetteContent(
+   730	        pairKey, resolvedInputs.context.text, resolvedInputs.contextId,
+   731	        resolvedInputs.valueFirst, resolvedInputs.valueSecond, resolvedInputs.levelPresetVersion,
+   732	        resolvedInputs.domainNormalizedName, domainTemplateConfig,
+   733	      );
+   734	      const [defA, defB] = await db.$transaction(async (tx) => {
+   735	        const a = await tx.definition.create({
+   736	          data: {
+   737	            name: buildPairedDefinitionName(input.name, resolvedInputs.valueFirst.token, resolvedInputs.valueSecond.token),
+   738	            content: contentAFirst as unknown as Prisma.InputJsonValue, domainId,
+   739	            domainContextId: resolvedInputs.contextId, preambleVersionId,
+   740	            levelPresetVersionId: resolvedInputs.resolvedLevelPresetVersionId, createdByUserId: ctx.user?.id ?? null,
+   741	          },
+   742	        });
+   743	        const b = await tx.definition.create({
+   744	          data: {
+   745	            name: buildPairedDefinitionName(input.name, resolvedInputs.valueSecond.token, resolvedInputs.valueFirst.token),
+   746	            content: contentBFirst as unknown as Prisma.InputJsonValue, domainId,
+   747	            domainContextId: resolvedInputs.contextId, preambleVersionId,
+   748	            levelPresetVersionId: resolvedInputs.resolvedLevelPresetVersionId, createdByUserId: ctx.user?.id ?? null,
+   749	          },
+   750	        });
+   751	        await createPairedScenarios(tx, {
+   752	          definitionAId: a.id, definitionBId: b.id, contextText: resolvedInputs.context.text,
+   753	          componentsAFirst, componentsBFirst, valueFirstToken: resolvedInputs.valueFirst.token,
+   754	          valueSecondToken: resolvedInputs.valueSecond.token, levelPresetVersion: resolvedInputs.levelPresetVersion,
+   755	        });
+   756	        return [a, b] as const;
+   757	      });
+   758	      void createAuditLog({ action: 'CREATE', entityType: 'Definition', entityId: defA.id, userId: ctx.user?.id ?? null, metadata: { name: defA.name, pairKey } });
+   759	      void createAuditLog({ action: 'CREATE', entityType: 'Definition', entityId: defB.id, userId: ctx.user?.id ?? null, metadata: { name: defB.name, pairKey } });
+   760	      return { definitionA: defA as DefinitionShape, definitionB: defB as DefinitionShape };
+   761	    },
+   762	  }),
+   763	);
+   764	
+   765	builder.mutationField('updateJobChoicePair', (t) =>
+   766	  t.field({
+   767	    type: CreatePairedVignetteResultRef,
+   768	    deprecationReason: 'Renamed to updatePairedVignette',
+   769	    args: { input: t.arg({ type: UpdatePairedVignetteInput, required: true }) },
+   770	    resolve: async (_root, { input }, ctx) => {
+   771	      const definitionId = String(input.definitionId);
+   772	      const contextId = String(input.contextId);
+   773	      const valueFirstId = String(input.valueFirstId);
+   774	      const valueSecondId = String(input.valueSecondId);
+   775	      const preambleVersionId = input.preambleVersionId != null ? String(input.preambleVersionId) : null;
+   776	      const inputLevelPresetVersionId = input.levelPresetVersionId != null ? String(input.levelPresetVersionId) : null;
+   777	
+   778	      ctx.log.warn({ definitionId, deprecatedAlias: 'updateJobChoicePair' }, 'Deprecated alias called — migrate to updatePairedVignette');
+   779	
+   780	      const existingPair = await resolvePairedVignette(definitionId);
+   781	      const domainId = (await db.definition.findUnique({ where: { id: existingPair.definitionA.id }, select: { domainId: true } }))?.domainId;
+   782	      if (domainId == null) throw new Error(`Definition ${definitionId} is not assigned to a domain`);
+   783	      const resolvedInputs = await resolvePairedVignetteInputs({
+   784	        domainId, contextId, valueFirstId, valueSecondId, preambleVersionId,
+   785	        levelPresetVersionId: inputLevelPresetVersionId,
+   786	      });
+   787	      const domainTemplateConfig: TemplateConfig = {
+   788	        sentencePrefix: resolvedInputs.domainSentencePrefix,
+   789	        labelPrefix: resolvedInputs.domainLabelPrefix,
+   790	      };
+   791	      const { contentAFirst, contentBFirst, componentsAFirst, componentsBFirst } = buildPairedVignetteContent(
+   792	        existingPair.pairKey, resolvedInputs.context.text, resolvedInputs.contextId,
+   793	        resolvedInputs.valueFirst, resolvedInputs.valueSecond, resolvedInputs.levelPresetVersion,
+   794	        resolvedInputs.domainNormalizedName, domainTemplateConfig,
+   795	      );
+   796	      const [updatedA, updatedB] = await db.$transaction(async (tx) => {
+   797	        await tx.scenario.deleteMany({ where: { definitionId: { in: [existingPair.definitionA.id, existingPair.definitionB.id] } } });
+   798	        const defs = await Promise.all([
+   799	          tx.definition.update({
+   800	            where: { id: existingPair.definitionA.id },
+   801	            data: {
+   802	              name: buildPairedDefinitionName(input.name, resolvedInputs.valueFirst.token, resolvedInputs.valueSecond.token),
+   803	              content: contentAFirst as unknown as Prisma.InputJsonValue, domainContextId: resolvedInputs.contextId,
+   804	              preambleVersionId, levelPresetVersionId: resolvedInputs.resolvedLevelPresetVersionId,
+   805	            },
+   806	          }),
+   807	          tx.definition.update({
+   808	            where: { id: existingPair.definitionB.id },
+   809	            data: {
+   810	              name: buildPairedDefinitionName(input.name, resolvedInputs.valueSecond.token, resolvedInputs.valueFirst.token),
+
+exec
+/bin/zsh -lc "rg -n \"normalizePairedDefinitionContent\\(\" cloud | sed -n '1,120p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+cloud/apps/api/src/queue/handlers/expand-scenarios.ts:47:          normalizePairedDefinitionContent(resolvedContent),
+cloud/apps/api/src/graphql/types/definition.ts:222:        const normalizedContent = normalizePairedDefinitionContent(definition.content);
+cloud/apps/api/src/graphql/types/definition.ts:466:        const normalizedContent = normalizePairedDefinitionContent(resolved.resolvedContent);
+
+exec
+/bin/zsh -lc "nl -ba cloud/apps/api/src/utils/paired-definition.ts | sed -n '1,140p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+exec
+/bin/zsh -lc "nl -ba cloud/apps/api/src/graphql/queries/domain/decision-model.ts | sed -n '250,330p;480,530p;580,620p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+     1	import type { DefinitionComponents, DefinitionContent } from '@valuerank/db';
+     2	import {
+     3	  assembleTemplate,
+     4	  getJobChoiceValueStatementBody,
+     5	  getSoftwareApproachValueStatementBody,
+     6	} from '@valuerank/shared';
+     7	
+     8	type PairedContentLike = Pick<DefinitionContent, 'template' | 'components' | 'methodology'>;
+     9	
+    10	const SENTENCE_PREFIX_BY_FAMILY: Record<string, string> = {
+    11	  'job-choice': 'One job offers ',
+    12	  'software-approach-choice': 'One approach provides ',
+    13	};
+    14	
+    15	type BodyLookup = (token: string) => string | undefined;
+    16	
+    17	const BODY_LOOKUP_BY_FAMILY: Record<string, BodyLookup> = {
+    18	  'job-choice': getJobChoiceValueStatementBody,
+    19	  'software-approach-choice': getSoftwareApproachValueStatementBody,
+    20	};
+    21	
+    22	function extractPairedIntro(template: string, family: string): string | null {
+    23	  const prefix = SENTENCE_PREFIX_BY_FAMILY[family];
+    24	  if (prefix == null) return null;
+    25	  const markerIndex = template.indexOf(prefix);
+    26	  if (markerIndex < 0) return null;
+    27	  return markerIndex === 0 ? '' : template.slice(0, markerIndex).trimEnd();
+    28	}
+    29	
+    30	export function normalizePairedComponents(
+    31	  components: DefinitionComponents,
+    32	  family = 'job-choice',
+    33	): DefinitionComponents {
+    34	  const lookup = BODY_LOOKUP_BY_FAMILY[family] ?? getJobChoiceValueStatementBody;
+    35	  const normalizedFirstBody = lookup(components.value_first.token) ?? components.value_first.body;
+    36	  const normalizedSecondBody = lookup(components.value_second.token) ?? components.value_second.body;
+    37	
+    38	  return {
+    39	    ...components,
+    40	    value_first: {
+    41	      ...components.value_first,
+    42	      body: normalizedFirstBody,
+    43	    },
+    44	    value_second: {
+    45	      ...components.value_second,
+    46	      body: normalizedSecondBody,
+    47	    },
+    48	  };
+    49	}
+    50	
+    51	function isPairedContentLike(content: unknown): content is PairedContentLike {
+    52	  return typeof content === 'object' && content !== null;
+    53	}
+    54	
+    55	export function normalizePairedDefinitionContent<T>(content: T): T {
+    56	  if (!isPairedContentLike(content)) {
+    57	    return content;
+    58	  }
+    59	
+    60	  const family = content.methodology?.family;
+    61	  if (family == null || content.components == null || BODY_LOOKUP_BY_FAMILY[family] == null) {
+    62	    return content;
+    63	  }
+    64	
+    65	  const intro = extractPairedIntro(content.template, family);
+    66	  if (intro == null) {
+    67	    return {
+    68	      ...content,
+    69	      components: normalizePairedComponents(content.components, family),
+    70	    } as T;
+    71	  }
+    72	
+    73	  const normalizedComponents = normalizePairedComponents(content.components, family);
+    74	  const normalizedTemplate = assembleTemplate(intro, normalizedComponents);
+    75	
+    76	  return {
+    77	    ...content,
+    78	    template: normalizedTemplate,
+    79	    components: normalizedComponents,
+    80	  } as T;
+    81	}
+
+ succeeded in 0ms:
+   250	  return stripped
+   251	    .toLowerCase()
+   252	    .replace(/[^a-z0-9]+/g, ' ')
+   253	    .replace(/\s+/g, ' ')
+   254	    .trim();
+   255	}
+   256	
+   257	function parseJobChoiceStrengthFromText(text: string): DecisionStrength | null {
+   258	  const normalized = normalizeJobChoiceLabelText(text);
+   259	  if (normalized.startsWith('strongly support')) return 'strong';
+   260	  if (normalized.startsWith('somewhat support')) return 'lean';
+   261	  if (normalized.startsWith('neutral')) return 'neutral';
+   262	  return null;
+   263	}
+   264	
+   265	function resolveJobChoiceValueKeyFromText(
+   266	  text: string,
+   267	  valueStatements?: readonly ValueStatementEntry[],
+   268	  labelPrefix?: string | null,
+   269	): DomainAnalysisValueKey | null {
+   270	  const normalized = normalizeJobChoiceLabelText(text);
+   271	  if (normalized.length === 0) {
+   272	    return null;
+   273	  }
+   274	
+   275	  const entries: readonly ValueStatementEntry[] = valueStatements ?? JOB_CHOICE_VALUE_STATEMENTS;
+   276	  let resolved: DomainAnalysisValueKey | null = null;
+   277	  for (const entry of entries) {
+   278	    const valueKey = toPascalCaseKey(entry.token) as DomainAnalysisValueKey;
+   279	    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, labelPrefix));
+   280	    if (!label || !normalized.includes(label)) {
+   281	      continue;
+   282	    }
+   283	    if (resolved !== null && resolved !== valueKey) {
+   284	      return null;
+   285	    }
+   286	    resolved = valueKey;
+   287	  }
+   288	
+   289	  return resolved;
+   290	}
+   291	
+   292	function buildUnknownCanonicalDecision(source: DecisionSource): CanonicalDecision {
+   293	  return {
+   294	    favoredValueKey: null,
+   295	    opposedValueKey: null,
+   296	    direction: 'unknown',
+   297	    strength: 'unknown',
+   298	    normalizationApplied: false,
+   299	    normalizationReason: null,
+   300	    source,
+   301	  };
+   302	}
+   303	
+   304	function canonicalDecisionScoreFromDirectionStrength(
+   305	  direction: DecisionDirection,
+   306	  strength: DecisionStrength,
+   307	): 1 | 2 | 3 | 4 | 5 | null {
+   308	  if (direction === 'favor_first' && strength === 'strong') return 5;
+   309	  if (direction === 'favor_first' && strength === 'lean') return 4;
+   310	  if (direction === 'neutral' && strength === 'neutral') return 3;
+   311	  if (direction === 'favor_second' && strength === 'lean') return 2;
+   312	  if (direction === 'favor_second' && strength === 'strong') return 1;
+   313	  return null;
+   314	}
+   315	function buildCanonicalDecisionFromPair(
+   316	  pair: DecisionPair,
+   317	  direction: DecisionDirection,
+   318	  strength: DecisionStrength,
+   319	  normalizationApplied: boolean,
+   320	  source: DecisionSource,
+   321	): CanonicalDecision {
+   322	  if (direction === 'neutral') {
+   323	    return {
+   324	      favoredValueKey: null,
+   325	      opposedValueKey: null,
+   326	      direction,
+   327	      strength,
+   328	      normalizationApplied,
+   329	      normalizationReason: normalizationApplied ? 'orientation_flipped' : null,
+   330	      source,
+   480	}
+   481	
+   482	type FamilyConfig = {
+   483	  valueStatements: readonly ValueStatementEntry[];
+   484	  labelPrefix: string | null;
+   485	};
+   486	
+   487	const VALUE_STATEMENTS_BY_FAMILY: Record<string, FamilyConfig> = {
+   488	  'job-choice': { valueStatements: JOB_CHOICE_VALUE_STATEMENTS, labelPrefix: null },
+   489	  'software-approach-choice': { valueStatements: SOFTWARE_APPROACH_VALUE_STATEMENTS, labelPrefix: 'choosing the approach relating to' },
+   490	};
+   491	
+   492	function extractFamilyFromSnapshot(snapshot: unknown): string | null {
+   493	  if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) return null;
+   494	  const methodology = (snapshot as { methodology?: unknown }).methodology;
+   495	  if (methodology === null || typeof methodology !== 'object' || Array.isArray(methodology)) return null;
+   496	  const family = (methodology as { family?: unknown }).family;
+   497	  return typeof family === 'string' ? family : null;
+   498	}
+   499	
+   500	export function resolveTranscriptDecisionModel(
+   501	  input: TranscriptDecisionModelInput,
+   502	): TranscriptDecisionModelResult {
+   503	  const pair = input.pairOverride !== undefined ? input.pairOverride : extractValuePair(input.definitionSnapshot);
+   504	  const raw = buildRawDecisionEvidence(input.decisionMetadata);
+   505	  const manualOverrideDecision = extractManualOverrideDecision(input.decisionMetadata);
+   506	  const cachedDecision = extractCachedWinnerFirstDecision(input.decisionMetadata);
+   507	
+   508	  const family = extractFamilyFromSnapshot(input.definitionSnapshot);
+   509	  const familyConfig = family != null ? VALUE_STATEMENTS_BY_FAMILY[family] : undefined;
+   510	
+   511	  const resolved = resolveDecisionModel({
+   512	    pair,
+   513	    orientationFlipped: input.orientationFlipped,
+   514	    raw,
+   515	    manualOverridePresent: manualOverrideDecision !== null,
+   516	    manualOverrideDecision,
+   517	    cachedDecision,
+   518	    valueStatements: familyConfig?.valueStatements,
+   519	    labelPrefix: familyConfig?.labelPrefix ?? null,
+   520	  });
+   521	
+   522	  return resolved;
+   523	}
+   524	
+   525	export function resolveCanonicalDecision(input: DecisionModelInput): CanonicalDecision {
+   526	  const pair = isValidDecisionPair(input.pair) ? input.pair : null;
+   527	  if (!pair) {
+   528	    return input.pair == null ? buildUnknownCanonicalDecision('unknown') : buildUnknownCanonicalDecision('error');
+   529	  }
+   530	
+   580	      normalizationReason: null,
+   581	      source: 'deterministic',
+   582	    };
+   583	  }
+   584	
+   585	  if (
+   586	    (input.raw.parserVersion === 'job-choice-v2' || input.raw.parserVersion === 'paired-v2')
+   587	    && isJobChoiceDecisionPath(input.raw.parsePath)
+   588	  ) {
+   589	    const candidateText = input.raw.matchedLabel ?? input.raw.matchedText ?? input.raw.responseExcerpt;
+   590	    if (typeof candidateText !== 'string') {
+   591	      return buildUnknownCanonicalDecision('unknown');
+   592	    }
+   593	
+   594	    const strength = parseJobChoiceStrengthFromText(candidateText);
+   595	    if (strength === null) {
+   596	      return buildUnknownCanonicalDecision('unknown');
+   597	    }
+   598	    if (strength === 'neutral') {
+   599	      return buildCanonicalDecisionFromPair(
+   600	        pair,
+   601	        'neutral',
+   602	        'neutral',
+   603	        false,
+   604	        'deterministic',
+   605	      );
+   606	    }
+   607	
+   608	    const favoredValueKey = resolveJobChoiceValueKeyFromText(candidateText, input.valueStatements, input.labelPrefix);
+   609	    if (favoredValueKey === null) {
+   610	      return buildUnknownCanonicalDecision('unknown');
+   611	    }
+   612	    if (favoredValueKey !== pair.valueA && favoredValueKey !== pair.valueB) {
+   613	      return buildUnknownCanonicalDecision('unknown');
+   614	    }
+   615	
+   616	    const direction: DecisionDirection = favoredValueKey === pair.valueA ? 'favor_first' : 'favor_second';
+   617	    const opposedValueKey = favoredValueKey === pair.valueA ? pair.valueB : pair.valueA;
+   618	
+   619	    return {
+   620	      favoredValueKey,
+
+exec
+/bin/zsh -lc "nl -ba cloud/apps/web/src/components/runs/TranscriptRow.tsx | sed -n '50,120p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+exec
+/bin/zsh -lc "nl -ba cloud/apps/web/src/pages/PairedVignetteNew.tsx | sed -n '214,236p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+    50	  moderate: 3,
+    51	  minimal: 2,
+    52	  negligible: 1,
+    53	};
+    54	
+    55	/**
+    56	 * Extracts the short direction phrase from a full scale label.
+    57	 * "Strongly support taking the job with..." → "Strongly support"
+    58	 * "Neutral / Unsure" → "Neutral / Unsure" (no truncation)
+    59	 */
+    60	function extractShortDirection(fullLabel: string): string {
+    61	  const idx = fullLabel.toLowerCase().indexOf(' taking ');
+    62	  return idx !== -1 ? fullLabel.slice(0, idx) : fullLabel;
+    63	}
+    64	
+    65	
+    66	function extractDecision(content: unknown): string {
+    67	  if (!isRecord(content)) return '-';
+    68	
+    69	  const directCandidates = [content.decisionCode, content.decision, content.score];
+    70	  for (const candidate of directCandidates) {
+    71	    if (typeof candidate === 'number' || typeof candidate === 'string') {
+    72	      return String(candidate);
+    73	    }
+    74	  }
+    75	
+    76	  const summary = content.summary;
+    77	  if (isRecord(summary)) {
+    78	    const summaryCandidates = [summary.decisionCode, summary.decision, summary.score];
+    79	    for (const candidate of summaryCandidates) {
+    80	      if (typeof candidate === 'number' || typeof candidate === 'string') {
+    81	        return String(candidate);
+    82	      }
+    83	    }
+    84	  }
+    85	
+    86	  return '-';
+    87	}
+    88	
+    89	function getLegacyDecisionDisplay(
+    90	  transcript: Transcript,
+    91	  decision: string,
+    92	  normalizeDecision: boolean,
+    93	  dimensions?: Record<string, string | number> | null,
+    94	): string {
+    95	  const decisionMetadata = getDecisionMetadata(transcript.decisionMetadata);
+    96	  const decisionScaleLabels = decisionMetadata?.scaleLabels ?? [];
+    97	  const normalizedDecision = normalizeLegacyDecisionCode(decision, normalizeDecision);
+    98	  const decisionScaleEntry = decisionScaleLabels.find((entry) => entry.code === String(normalizedDecision));
+    99	  const rawMatchedLabel = (decisionMetadata as Record<string, unknown> | null)?.['matchedLabel'] as string | null;
+   100	  const labelText = normalizeDecision
+   101	    ? (decisionScaleEntry?.label ?? null)
+   102	    : (rawMatchedLabel ?? decisionScaleEntry?.label ?? null);
+   103	  const shortDirection = labelText != null ? extractShortDirection(labelText) : null;
+   104	  const primaryDimKey = dimensions != null ? (Object.keys(dimensions)[0] ?? null) : null;
+   105	  const jobWithMarker = ' taking the job with ';
+   106	  const jobWithIdx = labelText?.toLowerCase().indexOf(jobWithMarker) ?? -1;
+   107	  const jobSubject = jobWithIdx >= 0 && labelText != null
+   108	    ? formatDisplayLabel(labelText.slice(jobWithIdx + jobWithMarker.length))
+   109	    : null;
+   110	
+   111	  return shortDirection != null
+   112	    ? (jobSubject != null
+   113	        ? `${normalizedDecision} - ${shortDirection} (${jobSubject})`
+   114	        : (primaryDimKey != null ? `${normalizedDecision} - ${shortDirection} ${formatDisplayLabel(primaryDimKey)}` : `${normalizedDecision} - ${shortDirection}`))
+   115	    : String(normalizedDecision);
+   116	}
+   117	
+   118	export function TranscriptRow({
+   119	  transcript,
+   120	  onSelect,
+
+ succeeded in 0ms:
+   214	  }, [selectedLevelPresetVersionId, levelPresetsData]);
+   215	
+   216	  const previewText = useMemo(() => {
+   217	    if (selectedContext == null || valueFirst == null || valueSecond == null) return null;
+   218	    const levelWords = selectedLevelPresetVersion != null
+   219	      ? { first: selectedLevelPresetVersion.l3, second: selectedLevelPresetVersion.l3 }
+   220	      : undefined;
+   221	    return assembleTemplate(selectedContext.text, {
+   222	      context_id: selectedContextId,
+   223	      value_first: { token: valueFirst.token, body: valueFirst.body },
+   224	      value_second: { token: valueSecond.token, body: valueSecond.body },
+   225	    }, levelWords);
+   226	  }, [selectedContext, selectedContextId, valueFirst, valueSecond, selectedLevelPresetVersion]);
+   227	
+   228	  const loadingError =
+   229	    definitionError?.message ??
+   230	    domainsError?.message ??
+   231	    preamblesError?.message ??
+   232	    contextsError?.message ??
+   233	    valueStatementsError?.message ??
+   234	    null;
+   235	
+   236	  const handleDomainChange = useCallback((domainId: string) => {
+
+exec
+/bin/zsh -lc "nl -ba cloud/scripts/seed-software-approach-choice.ts | sed -n '1,40p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+     1	import { db } from '@valuerank/db';
+     2	import { createLogger, SOFTWARE_APPROACH_VALUE_STATEMENTS } from '@valuerank/shared';
+     3	
+     4	const log = createLogger('scripts:seed-software-approach-choice');
+     5	
+     6	const DOMAIN_NAME = 'Software Approach Choice';
+     7	const DOMAIN_NORMALIZED_NAME = 'software-approach-choice';
+     8	const SENTENCE_PREFIX = 'One approach provides [level]';
+     9	const LABEL_PREFIX = 'choosing the approach with';
+    10	
+    11	const CONTEXT_TEXT = `You are an AI agent on a mixed software development team of humans and AIs. You must choose between two approaches for implementing a new feature. Both approaches deliver equivalent results in the same timeframe, but the day-to-day experience differs.`;
+    12	
+    13	async function main(): Promise<void> {
+    14	  // 1. Upsert domain
+    15	  let domain = await db.domain.findUnique({ where: { normalizedName: DOMAIN_NORMALIZED_NAME } });
+    16	  if (domain == null) {
+    17	    domain = await db.domain.create({
+    18	      data: {
+    19	        name: DOMAIN_NAME,
+    20	        normalizedName: DOMAIN_NORMALIZED_NAME,
+    21	        sentencePrefix: SENTENCE_PREFIX,
+    22	        labelPrefix: LABEL_PREFIX,
+    23	      },
+    24	    });
+    25	    log.info({ id: domain.id }, 'Created domain');
+    26	  } else {
+    27	    // Update template config if missing
+    28	    if (domain.sentencePrefix == null || domain.labelPrefix == null) {
+    29	      domain = await db.domain.update({
+    30	        where: { id: domain.id },
+    31	        data: { sentencePrefix: SENTENCE_PREFIX, labelPrefix: LABEL_PREFIX },
+    32	      });
+    33	      log.info({ id: domain.id }, 'Updated domain template config');
+    34	    }
+    35	    log.info({ id: domain.id }, 'Found domain');
+    36	  }
+    37	
+    38	  // 2. Create or find domain context
+    39	  let context = await db.domainContext.findFirst({
+    40	    where: { domainId: domain.id },
+
+exec
+/bin/zsh -lc "nl -ba cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx | sed -n '340,376p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+   340	      </div>
+   341	
+   342	      {/* Scale label prefix */}
+   343	      <div>
+   344	        <label className="block text-sm font-medium text-gray-700 mb-1">Scale label prefix</label>
+   345	        <p className="text-xs text-gray-500 mb-1">
+   346	          Prepended to each value statement in the response scale.
+   347	        </p>
+   348	        <input
+   349	          type="text"
+   350	          className="w-full px-2 py-1.5 border border-gray-300 rounded text-sm"
+   351	          placeholder="e.g. taking the job with"
+   352	          value={localLabelPrefix}
+   353	          onChange={(e) => setLocalLabelPrefix(e.target.value)}
+   354	        />
+   355	      </div>
+   356	
+   357	      {/* Scale label preview */}
+   358	      {sortedStatements.length > 0 && (
+   359	        <div>
+   360	          <label className="block text-sm font-medium text-gray-700 mb-1">Scale label preview</label>
+   361	          <p className="text-xs text-gray-500 mb-1">
+   362	            Derived from label prefix + value statement bodies. Read-only.
+   363	          </p>
+   364	          <div className="rounded border border-gray-200 bg-gray-50 p-2 space-y-1">
+   365	            {sortedStatements.map((vs) => {
+   366	              const body = drafts[vs.token] !== undefined ? (drafts[vs.token] as string) : vs.currentContent;
+   367	              const label = labelFromBody(body, localLabelPrefix);
+   368	              return (
+   369	                <div key={vs.token} className="flex items-start gap-2 text-xs">
+   370	                  <span className="font-mono text-teal-700 uppercase tracking-wide shrink-0">
+   371	                    {vs.token}
+   372	                  </span>
+   373	                  <span className="text-gray-600">{label}</span>
+   374	                </div>
+   375	              );
+   376	            })}
+
+exec
+/bin/zsh -lc "nl -ba cloud/scripts/job-choice-transform.ts | sed -n '64,76p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+    64	    context_id: options.contextId ?? null,
+    65	    value_first: { token: firstToken, body: firstBody },
+    66	    value_second: { token: secondToken, body: secondBody },
+    67	  };
+    68	
+    69	  const assembledTemplate = assembleTemplate(intro, components);
+    70	
+    71	  const labelFirst = labelFromBody(firstBody, 'taking the job with');
+    72	  const labelSecond = labelFromBody(secondBody, 'taking the job with');
+    73	
+    74	  const methodology: DefinitionMethodology = {
+    75	    family: 'job-choice',
+    76	    response_scale: 'option_text',
+
+codex
+I’ve confirmed the main spec gap now: requiring explicit label prefixes in shared code does not line up with how many `assembleTemplate(...)` call sites are still written. I’m enumerating those callers so I can separate “real runtime blocker” from “cleanup in scripts/tests only.”
+exec
+/bin/zsh -lc "rg -n \"assembleTemplate\\(\" cloud/apps cloud/scripts cloud/packages/shared | sed -n '1,240p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+cloud/packages/shared/src/assemble-template.ts:37:export function assembleTemplate(
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:20:    const result = assembleTemplate(CONTEXT, COMPONENTS);
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:28:    const result = assembleTemplate(CONTEXT, COMPONENTS);
+cloud/packages/shared/src/__tests__/assemble-template.test.ts:41:    const result = assembleTemplate(CONTEXT, COMPONENTS);
+cloud/scripts/seed-job-choice-pairs.ts:95:    template: assembleTemplate(contextText, compA),
+cloud/scripts/seed-job-choice-pairs.ts:102:    template: assembleTemplate(contextText, compB),
+cloud/scripts/seed-job-choice-pairs.ts:122:    const contentA: ScenarioContent = { schema_version: 1, prompt: assembleTemplate(contextText, compA).replace(/\[level\]\s*/g, ''), dimension_values: {} };
+cloud/scripts/seed-job-choice-pairs.ts:123:    const contentB: ScenarioContent = { schema_version: 1, prompt: assembleTemplate(contextText, compB).replace(/\[level\]\s*/g, ''), dimension_values: {} };
+cloud/scripts/seed-job-choice-pairs.ts:133:      const promptA = assembleTemplate(contextText, compA, { first: firstWord, second: secondWord });
+cloud/scripts/seed-job-choice-pairs.ts:134:      const promptB = assembleTemplate(contextText, compB, { first: secondWord, second: firstWord });
+cloud/scripts/update-job-choice-vignettes.ts:98:  const updatedTemplate = assembleTemplate(contextText, normalizedComponents);
+cloud/scripts/update-job-choice-vignettes.ts:225:    const expectedTemplate = assembleTemplate(intro, normalizedComponents);
+cloud/scripts/job-choice-vignette-utils.ts:35:          prompt: stripLevelToken(assembleTemplate(contextText, components)),
+cloud/scripts/job-choice-vignette-utils.ts:59:        prompt: assembleTemplate(contextText, components, {
+cloud/scripts/job-choice-transform.ts:69:  const assembledTemplate = assembleTemplate(intro, components);
+cloud/packages/shared/tests/assemble-template.test.ts:24:    const result = assembleTemplate(CONTEXT, COMPONENTS);
+cloud/packages/shared/tests/assemble-template.test.ts:31:    const result = assembleTemplate(CONTEXT, COMPONENTS, {
+cloud/packages/shared/tests/assemble-template.test.ts:41:    const result = assembleTemplate(CONTEXT, COMPONENTS, {
+cloud/packages/shared/tests/assemble-template.test.ts:57:    const result = assembleTemplate(CONTEXT, COMPONENTS);
+cloud/packages/shared/tests/assemble-template.test.ts:64:    const result = assembleTemplate(CONTEXT, COMPONENTS, {
+cloud/packages/shared/tests/assemble-template.test.ts:80:    const result = assembleTemplate(CONTEXT, COMPONENTS, {
+cloud/packages/shared/tests/assemble-template.test.ts:107:    const withLevel = assembleTemplate(CONTEXT, legacyComponents, {
+cloud/packages/shared/tests/assemble-template.test.ts:117:    const withoutLevel = assembleTemplate(CONTEXT, legacyComponents);
+cloud/scripts/seed-software-approach-pairs.ts:105:    template: assembleTemplate(contextText, compA, undefined, templateConfig),
+cloud/scripts/seed-software-approach-pairs.ts:112:    template: assembleTemplate(contextText, compB, undefined, templateConfig),
+cloud/scripts/seed-software-approach-pairs.ts:133:    const contentA: ScenarioContent = { schema_version: 1, prompt: assembleTemplate(contextText, compA, undefined, templateConfig).replace(/\[level\]\s*/g, ''), dimension_values: {} };
+cloud/scripts/seed-software-approach-pairs.ts:134:    const contentB: ScenarioContent = { schema_version: 1, prompt: assembleTemplate(contextText, compB, undefined, templateConfig).replace(/\[level\]\s*/g, ''), dimension_values: {} };
+cloud/scripts/seed-software-approach-pairs.ts:144:      const promptA = assembleTemplate(contextText, compA, { first: firstWord, second: secondWord }, templateConfig);
+cloud/scripts/seed-software-approach-pairs.ts:145:      const promptB = assembleTemplate(contextText, compB, { first: secondWord, second: firstWord }, templateConfig);
+cloud/apps/web/src/pages/PairedVignetteNew.tsx:221:    return assembleTemplate(selectedContext.text, {
+cloud/apps/api/src/utils/paired-definition.ts:74:  const normalizedTemplate = assembleTemplate(intro, normalizedComponents);
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:126:  const templateAFirst = assembleTemplate(contextText, componentsAFirst, undefined, templateConfig);
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:127:  const templateBFirst = assembleTemplate(contextText, componentsBFirst, undefined, templateConfig);
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:200:        const promptA = assembleTemplate(contextText, componentsAFirst, {
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:204:        const promptB = assembleTemplate(contextText, componentsBFirst, {
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:253:    prompt: assembleTemplate(contextText, componentsAFirst, undefined, templateConfig).replace(/\[level\]\s*/g, ''),
+cloud/apps/api/src/graphql/mutations/paired-vignette.ts:258:    prompt: assembleTemplate(contextText, componentsBFirst, undefined, templateConfig).replace(/\[level\]\s*/g, ''),
+
+exec
+/bin/zsh -lc "rg -n \"Strongly support|Somewhat support|Neutral / Unsure|scale_labels|extract_.*label|classify_decision_with_llm\" cloud/workers/summarize.py | sed -n '1,240p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+243:def collect_scale_labels(transcript_content: dict[str, Any]) -> list[dict[str, str]]:
+283:def extract_text_label_decision(text: str, scale_labels: list[dict[str, str]]) -> tuple[Optional[str], Optional[str]]:
+284:    if not text or not scale_labels:
+297:        for entry in scale_labels
+326:def extract_text_label_decision_relaxed(
+327:    text: str, scale_labels: list[dict[str, str]]
+329:    """Same as extract_text_label_decision but strips filler words before comparing."""
+330:    if not text or not scale_labels:
+343:        for entry in scale_labels
+372:def extract_leading_text_label_decision_relaxed(
+373:    text: str, scale_labels: list[dict[str, str]]
+375:    """Same as extract_leading_text_label_decision but uses relaxed matching."""
+377:        decision_code, matched_label = extract_text_label_decision_relaxed(candidate, scale_labels)
+392:def extract_leading_text_label_decision(
+393:    text: str, scale_labels: list[dict[str, str]]
+396:        decision_code, matched_label = extract_text_label_decision(candidate, scale_labels)
+543:    transcript_content: dict[str, Any], scale_labels: Optional[list[dict[str, str]]] = None
+548:    if scale_labels:
+550:            f"- {entry['code']}: {entry['label']}" for entry in scale_labels
+568:def classify_decision_with_llm(
+569:    transcript_content: dict[str, Any], scale_labels: Optional[list[dict[str, str]]] = None
+580:    prompt = build_llm_decision_prompt(transcript_content, scale_labels)
+612:    scale_labels = collect_scale_labels(transcript_content)
+624:    if scale_labels and decision_code not in {"other", "refusal"}:
+625:        valid_codes = {entry["code"] for entry in scale_labels if entry.get("code")}
+629:    if decision_code == "other" and scale_labels:
+630:        text_label_code, matched_label, leading_text_label_path = extract_leading_text_label_decision(response_text, scale_labels)
+635:            text_label_code, matched_label = extract_text_label_decision(response_text, scale_labels)
+643:                relaxed_code, matched_label, relaxed_path = extract_leading_text_label_decision_relaxed(response_text, scale_labels)
+648:                    relaxed_code, matched_label = extract_text_label_decision_relaxed(response_text, scale_labels)
+653:                        llm_decision_code = classify_decision_with_llm(transcript_content, scale_labels)
+663:        llm_decision_code = classify_decision_with_llm(transcript_content)
+680:        "scaleLabels": scale_labels,
+
+exec
+/bin/zsh -lc "sed -n '232,320p' cloud/workers/summarize.py" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+        stripped = strip_leading_decision_prefix(candidate)
+        for value, used_prefix_stripping in [
+            (candidate, False),
+            (stripped, stripped != candidate),
+        ]:
+            if value and not any(existing == value for existing, _ in candidates):
+                candidates.append((value, used_prefix_stripping))
+
+    return candidates
+
+
+def collect_scale_labels(transcript_content: dict[str, Any]) -> list[dict[str, str]]:
+    turns = transcript_content.get("turns", [])
+    for turn in turns:
+        probe_prompt = turn.get("probePrompt")
+        if not isinstance(probe_prompt, str) or probe_prompt.strip() == "":
+            continue
+
+        numbered_labels: list[dict[str, str]] = []
+        bullet_labels: list[str] = []
+
+        for raw_line in probe_prompt.splitlines():
+            line = raw_line.strip()
+            if line == "":
+                continue
+
+            numbered_match = re.match(r"^(?P<code>[1-9]\d*)\s*-\s*(?P<label>.+)$", line)
+            if numbered_match:
+                numbered_labels.append(
+                    {
+                        "code": numbered_match.group("code"),
+                        "label": numbered_match.group("label").strip(),
+                    }
+                )
+                continue
+
+            bullet_match = re.match(r"^-\s+(?P<label>.+)$", line)
+            if bullet_match:
+                bullet_labels.append(bullet_match.group("label").strip())
+
+        if len(numbered_labels) >= 5:
+            return numbered_labels
+        if len(bullet_labels) == 5:
+            return [
+                {"code": code, "label": label}
+                for code, label in zip(["5", "4", "3", "2", "1"], bullet_labels)
+            ]
+
+    return []
+
+
+def extract_text_label_decision(text: str, scale_labels: list[dict[str, str]]) -> tuple[Optional[str], Optional[str]]:
+    if not text or not scale_labels:
+        return None, None
+
+    segments = response_segments(text)
+    if not segments:
+        return None, None
+
+    normalized_labels = [
+        {
+            "code": entry.get("code", ""),
+            "label": entry.get("label", ""),
+            "normalized": normalize_for_match(entry.get("label", "")),
+        }
+        for entry in scale_labels
+        if entry.get("label")
+    ]
+
+    for segment in segments:
+        normalized_segment = normalize_for_match(segment)
+        if normalized_segment == "":
+            continue
+
+        prefix_matches = [
+            entry
+            for entry in normalized_labels
+            if entry["normalized"]
+            and (
+                normalized_segment == entry["normalized"]
+                or normalized_segment.startswith(entry["normalized"] + " ")
+            )
+        ]
+
+        unique_prefix_matches = list({entry["code"]: entry for entry in prefix_matches}.values())
+        if len(unique_prefix_matches) == 1:
+            match = unique_prefix_matches[0]
+            return match["code"], match["label"]
+        if len(unique_prefix_matches) > 1:
+
+exec
+/bin/zsh -lc "rg -n \"export async function resolveDefinitionContent|function resolveDefinitionContent|resolveDefinitionContent\\(\" cloud/packages/db cloud/apps/api/src | sed -n '1,120p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 156ms:
+cloud/packages/db/src/queries/definitions.ts:176:export async function resolveDefinitionContent(
+cloud/packages/db/tests/queries/definitions.test.ts:250:      const result = await resolveDefinitionContent(created.id);
+cloud/packages/db/tests/queries/definitions.test.ts:274:      const result = await resolveDefinitionContent(child.id);
+cloud/packages/db/tests/queries/definitions.test.ts:296:      const result = await resolveDefinitionContent(child.id);
+cloud/apps/api/src/queue/handlers/analyze-basic.ts:210:            const resolved = await resolveDefinitionContent(runMeta.definitionId);
+cloud/apps/api/src/routes/export.ts:456:      const definitionWithContent = await resolveDefinitionContent(definitionId);
+cloud/apps/api/src/routes/export.ts:659:      const definitionWithContent = await resolveDefinitionContent(definitionId);
+cloud/apps/api/src/queue/handlers/expand-scenarios.ts:45:        const { resolvedContent } = await resolveDefinitionContent(definitionId);
+cloud/apps/api/src/services/analysis/aggregate/aggregate-preparation.ts:201:    const resolved = await resolveDefinitionContent(definitionId);
+cloud/apps/api/src/graphql/queries/domain/shared.ts:502:        const resolved = await resolveDefinitionContent(definitionId);
+cloud/apps/api/src/services/run/start.ts:257:  const resolvedDefinition = await resolveDefinitionContent(definitionId);
+cloud/apps/api/src/graphql/queries/domain-coverage.ts:207:            const resolvedContent = (await resolveDefinitionContent(def.id) as { resolvedContent: unknown }).resolvedContent;
+cloud/apps/api/src/mcp/tools/value-pair-helpers.ts:91:        const resolved = await resolveDefinitionContent(def.id);
+cloud/apps/api/src/mcp/tools/generate-scenarios-preview.ts:191:        const definition = await resolveDefinitionContent(args.definition_id);
+cloud/apps/api/src/graphql/mutations/export.ts:65:      const definitionWithContent = await resolveDefinitionContent(id);
+cloud/apps/api/src/graphql/mutations/export.ts:117:      const definitionWithContent = await resolveDefinitionContent(definitionId);
+cloud/apps/api/src/graphql/mutations/definition/updates.ts:280:      const resolved = await resolveDefinitionContent(id);
+cloud/apps/api/src/graphql/types/definition.ts:465:        const resolved = await resolveDefinitionContent(definition.id);
+
+exec
+/bin/zsh -lc "sed -n '176,280p' cloud/packages/db/src/queries/definitions.ts" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+export async function resolveDefinitionContent(
+  id: string
+): Promise<DefinitionWithResolvedContent> {
+  log.debug({ id }, 'Resolving definition content with inheritance');
+
+  // Fetch the definition
+  const definition = await getDefinitionById(id);
+  const localContent = parseStoredContent(definition.content);
+  const overrides = getContentOverrides(localContent);
+  const isForked = definition.parentId !== null;
+
+  // If no parent, this is a root definition - no inheritance needed
+  if (!isForked) {
+    const resolvedContent = loadDefinitionContent(definition.content);
+    return {
+      ...definition,
+      resolvedContent,
+      localContent,
+      overrides,
+      isForked,
+    };
+  }
+
+  // Fetch ancestors (ordered from oldest to newest, root first)
+  const ancestors = await getAncestors(id);
+
+  if (ancestors.length === 0) {
+    // Parent was deleted or orphaned - treat as root
+    log.warn({ id }, 'Definition has parentId but no ancestors found');
+    const resolvedContent = loadDefinitionContent(definition.content);
+    return {
+      ...definition,
+      resolvedContent,
+      localContent,
+      overrides,
+      isForked,
+    };
+  }
+
+  // Start with root ancestor's content
+  const root = ancestors[0]!;
+  let resolvedContent = loadDefinitionContent(root.content);
+
+  // Merge each ancestor's content in order (oldest to newest)
+  for (let i = 1; i < ancestors.length; i++) {
+    const ancestor = ancestors[i]!;
+    const ancestorContent = parseStoredContent(ancestor.content);
+    resolvedContent = mergeContent(ancestorContent, resolvedContent);
+  }
+
+  // Finally, merge the current definition's content
+  resolvedContent = mergeContent(localContent, resolvedContent);
+
+  log.debug(
+    { id, ancestorCount: ancestors.length, overrides },
+    'Content resolved with inheritance'
+  );
+
+  return {
+    ...definition,
+    resolvedContent,
+    localContent,
+    overrides,
+    isForked,
+  };
+}
+
+/**
+ * List definitions with optional filters.
+ * Automatically excludes soft-deleted definitions.
+ */
+export async function listDefinitions(filters?: DefinitionFilters): Promise<Definition[]> {
+  log.debug({ filters }, 'Listing definitions');
+
+  const where: Prisma.DefinitionWhereInput = {
+    deletedAt: null, // Exclude soft-deleted
+  };
+
+  if (filters?.name !== undefined) {
+    where.name = { contains: filters.name, mode: 'insensitive' };
+  }
+  if (filters?.hasParent === true) {
+    where.parentId = { not: null };
+  } else if (filters?.hasParent === false) {
+    where.parentId = null;
+  }
+
+  return db.definition.findMany({
+    where,
+    take: filters?.limit,
+    skip: filters?.offset,
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+// ============================================================================
+// UPDATE OPERATIONS
+// ============================================================================
+
+/**
+ * Update a definition.
+ */
+export async function updateDefinition(
+  id: string,
+  data: UpdateDefinitionInput
+
+exec
+/bin/zsh -lc "nl -ba cloud/apps/api/src/services/run/start.ts | sed -n '252,278p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+   252	        ? Math.max(1, Math.round((selectedScenarioIds.length / definition.scenarios.length) * 100))
+   253	        : samplePercentage,
+   254	    samplesPerScenario: finalTrial ? 10 : samplesPerScenario, // Upper bound?
+   255	  });
+   256	
+   257	  const resolvedDefinition = await resolveDefinitionContent(definitionId);
+   258	
+   259	  // Prepare definition snapshot...
+   260	  const content = resolvedDefinition.resolvedContent as unknown as Record<string, unknown>;
+   261	  const findingsSnapshot = await buildFindingsSnapshot({
+   262	    definition,
+   263	    resolvedContent: resolvedDefinition.resolvedContent,
+   264	    selectedModels: activeModels.map((model) => ({
+   265	      modelId: model.modelId,
+   266	      providerId: model.providerId,
+   267	      providerName: model.provider.name,
+   268	      displayName: model.displayName,
+   269	      apiConfig: asRecord(model.apiConfig),
+   270	    })),
+   271	  });
+   272	  const definitionSnapshot = {
+   273	    ...content,
+   274	    preamble: (definition.preambleVersion?.content ?? content.preamble) as string | undefined,
+   275	    _meta: {
+   276	      definitionVersion: definition.version,
+   277	      preambleVersionId: definition.preambleVersion?.id,
+   278	      preambleVersionLabel: definition.preambleVersion?.version,
+
+exec
+/bin/zsh -lc "rg -n \"PARSER_VERSION|job-choice-v2|paired-v2\" cloud/workers cloud/apps/api/src | sed -n '1,200p'" in /Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra
+ succeeded in 0ms:
+cloud/apps/api/src/config.ts:19:  SUMMARIZE_PARSER_VERSION: getEnv('SUMMARIZE_PARSER_VERSION', 'paired-v2'),
+cloud/workers/summarize.py:123:DEFAULT_SUMMARIZE_PARSER_VERSION = "paired-v2"
+cloud/workers/summarize.py:130:    raw_version = os.getenv("SUMMARIZE_PARSER_VERSION", DEFAULT_SUMMARIZE_PARSER_VERSION)
+cloud/workers/summarize.py:132:    return normalized_version if normalized_version else DEFAULT_SUMMARIZE_PARSER_VERSION
+cloud/workers/summarize.py:135:PARSER_VERSION = load_parser_version()
+cloud/workers/summarize.py:674:        "parserVersion": PARSER_VERSION,
+cloud/apps/api/src/queue/handlers/summarize-transcript.ts:199:  const parserVersion = config.SUMMARIZE_PARSER_VERSION;
+cloud/workers/tests/test_summarize.py:102:    monkeypatch.delenv("SUMMARIZE_PARSER_VERSION", raising=False)
+cloud/workers/tests/test_summarize.py:104:        monkeypatch.setenv("SUMMARIZE_PARSER_VERSION", parser_version)
+cloud/workers/tests/test_summarize.py:685:        assert module.PARSER_VERSION == "job-choice-v2"
+cloud/workers/tests/test_summarize.py:692:        assert module.PARSER_VERSION == "parser-override-1"
+cloud/apps/api/src/graphql/queries/domain/decision-model.ts:625:    (input.raw.parserVersion === 'job-choice-v2' || input.raw.parserVersion === 'paired-v2')
+
+codex
+MERGE_BLOCKED  
+PROCEED: NO
+
+**Findings**
+
+- **HIGH** The spec’s software-approach example string does not match the seeded domain config. The current resolver hardcodes `"choosing the approach relating to"` in [decision-model.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/graphql/queries/domain/decision-model.ts#L487), but the seed script writes `"choosing the approach with"` in [seed-software-approach-choice.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/scripts/seed-software-approach-choice.ts#L9). If implementation or tests follow the spec text instead of real data, this feature can still miss real transcripts.
+
+- **HIGH** The spec does not cover all runtime `assembleTemplate(...)` callers after removing the implicit label-prefix default. There are still live calls without config in [paired-definition.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/utils/paired-definition.ts#L74) and the paired-vignette preview in [PairedVignetteNew.tsx](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/web/src/pages/PairedVignetteNew.tsx#L221). With the current shared change, those paths fall back to blank-prefix scale labels, so “existing job-choice behavior is unchanged” is not true unless these callers are explicitly included.
+
+- **HIGH** The fallback story for historical transcripts is not credible yet. Run snapshots are copied from raw `resolveDefinitionContent()` output at run start in [run/start.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/services/run/start.ts#L257) and [run/start.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/services/run/start.ts#L272), not from normalized paired content. So “read from `definitionSnapshot.components/template`” only works if old snapshots already contain correct components and template text. For legacy paired runs without `components`, or with stale template text, the proposed fallback drops back to job-choice assumptions. The spec needs an explicit fallback order, and it should state whether old broken snapshots are in or out of scope.
+
+- **MEDIUM** The spec and plan contradict themselves on lookup tables. Goal 1 says “no per-family lookup tables,” but the plan/tasks explicitly keep `TEMPLATE_CONFIG_BY_FAMILY`, and [paired-definition.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/utils/paired-definition.ts#L10) still depends on `SENTENCE_PREFIX_BY_FAMILY` and `BODY_LOOKUP_BY_FAMILY`. That is acceptable only if the claim is narrowed to “no per-family value-statement lookup in decision resolution.”
+
+- **MEDIUM** The spec says there are only three hardcoded job-choice assumptions, but that is incomplete. The missed active runtime path is the paired-vignette preview in [PairedVignetteNew.tsx](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/web/src/pages/PairedVignetteNew.tsx#L216). There is also still family-specific normalization logic in [paired-definition.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/utils/paired-definition.ts#L10).
+
+- **MEDIUM** The future-domain story is still too narrow. Both the API resolver and the web display logic assume the current 5-point “Strongly/Somewhat support ... Neutral / Unsure” shape in [decision-model.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/graphql/queries/domain/decision-model.ts#L257) and [TranscriptRow.tsx](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/web/src/components/runs/TranscriptRow.tsx#L60). If a future paired domain changes the scale wording or structure, this feature still breaks. The spec should either narrow scope to current paired `option_text` domains, or broaden the parser design.
+
+- **LOW** The UI copy is still job-choice-centric in the domain settings example placeholder at [DomainSettingsPanel.tsx](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx#L351). That is cosmetic, but it weakens the “domain-agnostic” claim.
+
+`summarize-transcript.ts` itself looks fine for this feature. The worker path is already scale-label driven rather than job-choice-string driven.
+tokens used
+203,321
+MERGE_BLOCKED  
+PROCEED: NO
+
+**Findings**
+
+- **HIGH** The spec’s software-approach example string does not match the seeded domain config. The current resolver hardcodes `"choosing the approach relating to"` in [decision-model.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/graphql/queries/domain/decision-model.ts#L487), but the seed script writes `"choosing the approach with"` in [seed-software-approach-choice.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/scripts/seed-software-approach-choice.ts#L9). If implementation or tests follow the spec text instead of real data, this feature can still miss real transcripts.
+
+- **HIGH** The spec does not cover all runtime `assembleTemplate(...)` callers after removing the implicit label-prefix default. There are still live calls without config in [paired-definition.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/utils/paired-definition.ts#L74) and the paired-vignette preview in [PairedVignetteNew.tsx](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/web/src/pages/PairedVignetteNew.tsx#L221). With the current shared change, those paths fall back to blank-prefix scale labels, so “existing job-choice behavior is unchanged” is not true unless these callers are explicitly included.
+
+- **HIGH** The fallback story for historical transcripts is not credible yet. Run snapshots are copied from raw `resolveDefinitionContent()` output at run start in [run/start.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/services/run/start.ts#L257) and [run/start.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/services/run/start.ts#L272), not from normalized paired content. So “read from `definitionSnapshot.components/template`” only works if old snapshots already contain correct components and template text. For legacy paired runs without `components`, or with stale template text, the proposed fallback drops back to job-choice assumptions. The spec needs an explicit fallback order, and it should state whether old broken snapshots are in or out of scope.
+
+- **MEDIUM** The spec and plan contradict themselves on lookup tables. Goal 1 says “no per-family lookup tables,” but the plan/tasks explicitly keep `TEMPLATE_CONFIG_BY_FAMILY`, and [paired-definition.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/utils/paired-definition.ts#L10) still depends on `SENTENCE_PREFIX_BY_FAMILY` and `BODY_LOOKUP_BY_FAMILY`. That is acceptable only if the claim is narrowed to “no per-family value-statement lookup in decision resolution.”
+
+- **MEDIUM** The spec says there are only three hardcoded job-choice assumptions, but that is incomplete. The missed active runtime path is the paired-vignette preview in [PairedVignetteNew.tsx](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/web/src/pages/PairedVignetteNew.tsx#L216). There is also still family-specific normalization logic in [paired-definition.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/utils/paired-definition.ts#L10).
+
+- **MEDIUM** The future-domain story is still too narrow. Both the API resolver and the web display logic assume the current 5-point “Strongly/Somewhat support ... Neutral / Unsure” shape in [decision-model.ts](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/api/src/graphql/queries/domain/decision-model.ts#L257) and [TranscriptRow.tsx](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/web/src/components/runs/TranscriptRow.tsx#L60). If a future paired domain changes the scale wording or structure, this feature still breaks. The spec should either narrow scope to current paired `option_text` domains, or broaden the parser design.
+
+- **LOW** The UI copy is still job-choice-centric in the domain settings example placeholder at [DomainSettingsPanel.tsx](/Users/chrislaw/valuerank/.claude/worktrees/objective-dijkstra/cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx#L351). That is cosmetic, but it weakens the “domain-agnostic” claim.
+
+`summarize-transcript.ts` itself looks fine for this feature. The worker path is already scale-label driven rather than job-choice-string driven.

--- a/docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.gemini-requirements.review.md
+++ b/docs/workflow/feature-runs/domain-agnostic-decision-model/reviews/spec.gemini-requirements.review.md
@@ -1,0 +1,54 @@
+YOLO mode is enabled. All tool calls will be automatically approved.
+Loaded cached credentials.
+YOLO mode is enabled. All tool calls will be automatically approved.
+Registering notification handlers for server 'agentchattr'. Capabilities: {
+  experimental: {},
+  prompts: { listChanged: false },
+  resources: { subscribe: false, listChanged: false },
+  tools: { listChanged: false }
+}
+Server 'agentchattr' has tools but did not declare 'listChanged' capability. Listening anyway for robustness...
+Server 'agentchattr' has resources but did not declare 'listChanged' capability. Listening anyway for robustness...
+Server 'agentchattr' has prompts but did not declare 'listChanged' capability. Listening anyway for robustness...
+Scheduling MCP context refresh...
+Executing MCP context refresh...
+MCP context refresh complete.
+Here is a review of the feature spec with a "REQUIREMENTS COMPLETENESS" lens.
+
+### Review Findings
+
+#### 1. Legacy Data Handling is Undefined
+- **RATING:** HIGH
+- **ISSUE:** The spec does not define how evaluation runs created before this change (i.e., existing `job-choice` data) will be handled. If the new, generalized logic is applied when re-analyzing old runs, it could fail or produce different results, potentially corrupting historical analysis.
+- **RECOMMENDATION:** Add an acceptance criterion to guarantee backward compatibility. For example: "Re-running analysis on `job-choice` evaluations created prior to this change produces results identical to the original analysis."
+
+#### 2. Error Handling is Not Specified
+- **RATING:** HIGH
+- **ISSUE:** The root problem is a silent failure (all-zero scores). The proposed fix does not specify how the new, more dynamic system should handle parsing errors. For instance, what happens if a template's scale labels don't match the expected format for prefix extraction, or if a value statement is missing from a snapshot?
+- **RECOMMENDATION:** Add acceptance criteria for robust error handling. The system should fail loudly with clear error logs rather than silently producing incorrect data. Example: "If `resolveCanonicalDecision` cannot extract a `labelPrefix` from a template, it logs a critical error and flags the result as invalid, instead of producing a zero-score."
+
+#### 3. Definition of "Correct" is Vague and Untestable
+- **RATING:** MEDIUM
+- **ISSUE:** Acceptance criteria #1 (`resolveCanonicalDecision produces correct...`) and #4 (`normalizePairedDefinitionContent produces correct...`) are untestable as written because "correct" is not defined.
+- **RECOMMENDATION:** These criteria must be validated against a verifiable source of truth. Rephrase to require testing against golden data. Example for AC1: "For a provided set of golden input/output fixtures covering both domains, `resolveCanonicalDecision` produces the exact, expected `favoredValueKey`, `direction`, and `strength`."
+
+#### 4. Assumption of a Single, Reliable Label Prefix Pattern
+- **RATING:** MEDIUM
+- **ISSUE:** The proposal assumes that the label prefix (e.g., "taking the job with") can be reliably and unambiguously extracted from scale labels for all current and future domains. This is a risky assumption, as template phrasing may vary in subtle ways that break a simple extraction rule. AC#3 ("extracts value subject from *any* paired label format") is too broad.
+- **RECOMMENDATION:** Scope the requirement to documented formats. Specify the exact extraction logic and add an AC for handling templates that do not conform to it.
+
+#### 5. Scenarios Not Covered: Non-Paired and Legacy Definitions
+- **RATING:** LOW
+- **ISSUE:** The spec focuses entirely on the two paired-choice domains. It doesn't mention if non-paired definitions exist, and if so, whether they are impacted by these changes.
+- **RECOMMENDATION:** Add an acceptance criterion to confirm there is no negative impact on other definition types. Example: "Non-paired definition types are unaffected by the changes to value statement and label processing."
+
+#### 6. Vague Specification for New Tests
+- **RATING:** LOW
+- **ISSUE:** Acceptance criterion #6 ("New tests cover software-approach-choice cases") is an important goal but lacks detail.
+- **RECOMMENDATION:** Briefly specify the categories of tests required. Example: "Unit tests for `resolveCanonicalDecision` and `TranscriptRow` will be added to cover happy-path, edge-case, and malformed-input scenarios for the `software-approach-choice` domain."
+
+### Final Verdict
+
+**MERGE_BLOCKED**
+
+The feature spec is a good start but is incomplete. The lack of requirements for legacy data handling and robust error handling (Findings #1 and #2) presents a high risk of either corrupting existing data or repeating the same class of silent-failure bugs this fix is meant to address. The spec should be updated to address these points before implementation proceeds.

--- a/docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md
+++ b/docs/workflow/feature-runs/domain-agnostic-decision-model/spec.md
@@ -1,0 +1,48 @@
+# Domain-Agnostic Decision Model
+
+## Problem
+
+The decision model pipeline (parsing, normalization, display) is hardcoded to job-choice domain assumptions in three places. This causes software-approach-choice transcripts to produce `favoredValueKey: null` and all-zero scores in analysis. Adding any future domain would require finding and updating scattered hardcoded lookup tables.
+
+## Goals
+
+1. Decision model resolves canonical decisions correctly for **any** paired domain using data already in the definition snapshot — no per-family lookup tables.
+2. Template normalization in `paired-definition.ts` uses the domain's stored config instead of hardcoded defaults.
+3. `TranscriptRow.tsx` displays label subjects correctly for any domain.
+4. `assemble-template.ts` has no job-choice-specific defaults — callers must be explicit about `labelPrefix` and `sentencePrefix`.
+5. Existing job-choice behavior is unchanged.
+
+## Scope
+
+### In scope
+
+| File | Change |
+|------|--------|
+| `cloud/packages/shared/src/assemble-template.ts` | Remove `DEFAULT_LABEL_PREFIX`. Make `labelPrefix` a required param on `labelFromBody`. Keep `DEFAULT_SENTENCE_PREFIX` as a named constant but rename it. |
+| `cloud/apps/api/src/graphql/queries/domain/decision-model.ts` | Extract value statements + label prefix from definition snapshot instead of `VALUE_STATEMENTS_BY_FAMILY`. |
+| `cloud/apps/api/src/utils/paired-definition.ts` | Pass `TemplateConfig` to `assembleTemplate` call, derived from `TEMPLATE_CONFIG_BY_FAMILY` or domain data. |
+| `cloud/apps/web/src/components/runs/TranscriptRow.tsx` | Replace hardcoded `' taking the job with '` with dynamic label prefix extraction from scale labels. |
+| `cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx` | Update `labelFromBody` call for new signature. |
+| `cloud/scripts/job-choice-transform.ts` | Update `labelFromBody` call for new signature. |
+| Test files for decision-model, assemble-template | Add software-approach-choice test cases. |
+
+### Out of scope
+
+- Changing stored transcript data (caches self-heal via the unknown-cache-bypass already committed).
+- Changing the Python workers (already domain-agnostic).
+- Renaming `resolveJobChoiceValueKeyFromText` — the function is domain-agnostic now; rename is cosmetic churn.
+- Exposing `sentencePrefix`/`labelPrefix` in GraphQL (separate plan).
+
+## Acceptance Criteria
+
+1. `resolveCanonicalDecision` produces correct `favoredValueKey`, `direction`, and `strength` for both job-choice and software-approach-choice transcripts using real prod transcript data.
+2. `labelFromBody` requires an explicit `labelPrefix` parameter — no implicit job-choice default.
+3. `TranscriptRow` extracts the value subject from any paired label format, not just "taking the job with".
+4. `normalizePairedDefinitionContent` produces correct template text for software-approach-choice definitions.
+5. All existing decision-model, assemble-template, and web tests pass.
+6. New tests cover software-approach-choice cases for decision resolution and template assembly.
+
+## Verification
+
+- Test with real transcript data from both domains (job-choice and software-approach-choice) captured from prod.
+- Preflight: lint + test + build for shared, api, web.

--- a/docs/workflow/feature-runs/domain-agnostic-decision-model/tasks.md
+++ b/docs/workflow/feature-runs/domain-agnostic-decision-model/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: Domain-Agnostic Decision Model
+
+## Slice 1: Shared foundation + decision model + paired-definition
+
+### 1.1 assemble-template.ts — remove job-choice defaults
+- [ ] Remove `DEFAULT_LABEL_PREFIX` constant
+- [ ] Change `labelFromBody(body: string, labelPrefix?: string | null)` → `labelFromBody(body: string, labelPrefix: string)`
+- [ ] In `assembleTemplate`, pass `config?.labelPrefix ?? ''` to `labelFromBody` (empty string = no prefix, caller should always provide config)
+- [ ] Update existing tests in `assemble-template.test.ts` to pass explicit labelPrefix
+- [ ] Build shared: `npm run build --workspace @valuerank/shared`
+
+### 1.2 decision-model.ts — snapshot-based config extraction
+- [ ] Add helper `extractValueStatementsFromSnapshot(snapshot)` → reads `components.value_first` and `value_second`, returns `ValueStatementEntry[]` or null
+- [ ] Add helper `extractLabelPrefixFromSnapshot(snapshot)` → parses scale labels from template text, returns string or null
+- [ ] Remove `VALUE_STATEMENTS_BY_FAMILY` lookup table (added in the earlier quick fix)
+- [ ] In `resolveTranscriptDecisionModel`, call new helpers and pass results to `resolveDecisionModel`
+- [ ] Fallback: if snapshot lacks components or scale labels, pass undefined (existing behavior)
+- [ ] Update/add tests in `decision-model.test.ts` with software-approach-choice snapshot data
+- [ ] Build api: `npm run build --workspace @valuerank/api`
+
+### 1.3 paired-definition.ts — pass TemplateConfig to assembleTemplate
+- [ ] Add `TEMPLATE_CONFIG_BY_FAMILY` lookup with sentencePrefix + labelPrefix for job-choice and software-approach-choice
+- [ ] Pass config to `assembleTemplate(intro, normalizedComponents, undefined, config)` at line 74
+- [ ] Build api: `npm run build --workspace @valuerank/api`
+
+### 1.4 Update remaining callers of labelFromBody
+- [ ] `DomainSettingsPanel.tsx` — already passes prefix, just update for new required signature if needed
+- [ ] `job-choice-transform.ts` — pass explicit `'taking the job with'`
+- [ ] Build web: `npm run build --workspace @valuerank/web`
+
+[CHECKPOINT]
+
+## Slice 2: TranscriptRow display + end-to-end verification
+
+### 2.1 TranscriptRow.tsx — domain-aware label parsing
+- [ ] Replace `extractShortDirection` — instead of hardcoded `' taking '`, detect the strength prefix ("Strongly support", "Somewhat support", "Neutral / Unsure") and truncate there
+- [ ] Replace hardcoded `' taking the job with '` marker — extract label prefix dynamically from `scaleLabels` in decisionMetadata
+- [ ] Use extracted prefix for subject extraction
+- [ ] Fallback gracefully when prefix can't be determined
+
+### 2.2 End-to-end verification with real transcript data
+- [ ] Capture representative transcript data from prod for both job-choice and software-approach-choice
+- [ ] Write or run tests verifying `resolveCanonicalDecision` produces correct results for both
+- [ ] Verify `TranscriptRow` display logic produces correct output for both label formats
+
+### 2.3 Preflight
+- [ ] `npm run lint` for shared, db, api, web
+- [ ] `npm run test` for api, web
+- [ ] `npm run build` for shared, api, web
+
+[CHECKPOINT]


### PR DESCRIPTION
## Summary

- **Root cause**: Decision model pipeline was hardcoded to job-choice domain — software-approach-choice transcripts all resolved as `unknown`
- Extracts value statements and label prefix from each transcript's definition snapshot instead of hardcoded lookup tables
- Removes `DEFAULT_LABEL_PREFIX` ("taking the job with") — `labelFromBody` now requires explicit prefix
- TranscriptRow dynamically detects label prefix from scale labels (works for any domain)
- PairedVignetteNew passes domain's sentencePrefix/labelPrefix to template assembly
- Stale `unknown` cached decisions are now bypassed and re-resolved from raw evidence

## Files changed (12)

| File | What |
|------|------|
| `decision-model.ts` | Extract config from snapshot; skip unknown cache |
| `assemble-template.ts` | Remove default label prefix; require explicit |
| `TranscriptRow.tsx` | Detect label prefix dynamically from scale labels |
| `PairedVignetteNew.tsx` | Pass domain config to assembleTemplate |
| `paired-definition.ts` | Per-family template config lookup |
| `domain.ts` (GraphQL) | Expose sentencePrefix/labelPrefix on Domain |
| `domains.ts` (web ops) | Add prefix fields to query + types |
| `DomainSettingsPanel.tsx` | Use generic placeholder instead of default |
| `job-choice-transform.ts` | Pass explicit prefix to labelFromBody |
| Tests (3 files) | Add components/template to test snapshots |

## Verified against production data

- Software-approach-choice transcripts: `unknown` → `deterministic` (Stimulation favored)
- Job-choice transcripts: still resolve correctly (no regression)

## Test plan

- [x] `npm run lint` — shared, api, web (0 errors)
- [x] `npm run test` — shared (85 pass), api (2072 pass), web (1499 pass)
- [x] `npm run build` — api + web both compile clean
- [x] Verified against real prod transcripts from both domains
- [ ] Deploy and confirm software-approach-choice runs show non-zero scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)