### PR TITLE
fix: compute pooled overall stats in aggregate analysis

### DIFF
--- a/cloud/apps/api/src/services/analysis/aggregate/aggregate-logic.ts
+++ b/cloud/apps/api/src/services/analysis/aggregate/aggregate-logic.ts
@@ -178,10 +178,58 @@ export function aggregateAnalysesLogic(
       };
     });
 
+    // Aggregate overall stats from source runs using sample-weighted pooling
+    const overallMeans: number[] = [];
+    const overallWeights: number[] = [];
+    let overallMin = Infinity;
+    let overallMax = -Infinity;
+
+    validAnalyses.forEach((analysis) => {
+      const stats = analysis.perModel[modelId];
+      if (stats?.overall == null) return;
+      const n = stats.sampleSize ?? 0;
+      if (n <= 0) return;
+      if (!Number.isFinite(stats.overall.mean) || !Number.isFinite(stats.overall.stdDev)) return;
+      overallMeans.push(stats.overall.mean);
+      overallWeights.push(n);
+      if (Number.isFinite(stats.overall.min) && stats.overall.min < overallMin) overallMin = stats.overall.min;
+      if (Number.isFinite(stats.overall.max) && stats.overall.max > overallMax) overallMax = stats.overall.max;
+    });
+
+    let pooledMean = 0;
+    let pooledStdDev = 0;
+    const totalWeight = overallWeights.reduce((s, w) => s + w, 0);
+
+    if (totalWeight > 0 && overallMeans.length > 0) {
+      // Sample-weighted mean
+      pooledMean = overallMeans.reduce((s, m, i) => s + m * overallWeights[i]!, 0) / totalWeight;
+
+      // Pooled stdDev: combine within-run variance + between-run variance of means
+      let pooledVariance = 0;
+      validAnalyses.forEach((analysis) => {
+        const stats = analysis.perModel[modelId];
+        if (stats?.overall == null) return;
+        const n = stats.sampleSize ?? 0;
+        if (n <= 0) return;
+        if (!Number.isFinite(stats.overall.mean) || !Number.isFinite(stats.overall.stdDev)) return;
+        const w = n / totalWeight;
+        // Within-run variance contribution
+        pooledVariance += w * (stats.overall.stdDev * stats.overall.stdDev);
+        // Between-run mean deviation contribution
+        pooledVariance += w * Math.pow(stats.overall.mean - pooledMean, 2);
+      });
+      pooledStdDev = Math.sqrt(pooledVariance);
+    }
+
     aggregatedPerModel[modelId] = {
       sampleSize: totalModelSamples,
       values: aggregatedValues,
-      overall: { mean: 0, stdDev: 0, min: 0, max: 0 },
+      overall: {
+        mean: pooledMean,
+        stdDev: pooledStdDev,
+        min: overallMin === Infinity ? 0 : overallMin,
+        max: overallMax === -Infinity ? 0 : overallMax,
+      },
     };
   });
 

--- a/cloud/apps/api/src/services/mcp/formatters.ts
+++ b/cloud/apps/api/src/services/mcp/formatters.ts
@@ -231,7 +231,14 @@ export function formatTranscriptSummary(
  * Analysis output structure (stored in AnalysisResult.output)
  */
 type AnalysisOutput = {
-  perModel?: Record<string, { sampleSize?: number; meanScore?: number; stdDev?: number }>;
+  perModel?: Record<string, {
+    sampleSize?: number;
+    overall?: { mean?: number; stdDev?: number; min?: number; max?: number };
+    /** @deprecated Legacy field — use overall.mean instead */
+    meanScore?: number;
+    /** @deprecated Legacy field — use overall.stdDev instead */
+    stdDev?: number;
+  }>;
   modelAgreement?: { averageCorrelation?: number; outlierModels?: string[] };
   mostContestedScenarios?: Array<{ scenarioId: string; variance: number }>;
   insights?: string[];
@@ -302,10 +309,13 @@ export function formatRunSummary(
   if (output.perModel) {
     for (const [modelId, stats] of Object.entries(output.perModel)) {
       if (stats !== undefined) {
+        const overall = stats.overall;
         perModel[modelId] = {
           sampleSize: typeof stats.sampleSize === 'number' ? stats.sampleSize : 0,
-          meanScore: typeof stats.meanScore === 'number' ? stats.meanScore : 0,
-          stdDev: typeof stats.stdDev === 'number' ? stats.stdDev : 0,
+          meanScore: typeof overall?.mean === 'number' ? overall.mean
+            : typeof stats.meanScore === 'number' ? stats.meanScore : 0,
+          stdDev: typeof overall?.stdDev === 'number' ? overall.stdDev
+            : typeof stats.stdDev === 'number' ? stats.stdDev : 0,
         };
       }
     }

--- a/cloud/apps/api/tests/services/analysis/aggregate.test.ts
+++ b/cloud/apps/api/tests/services/analysis/aggregate.test.ts
@@ -869,4 +869,110 @@ describe('updateAggregateRun same-signature aggregate eligibility', () => {
       strongly: 1,
     });
   });
+
+  it('computes pooled overall stats from multiple source runs', () => {
+    const analyses: AnalysisOutput[] = [
+      {
+        perModel: {
+          'gpt-4': {
+            sampleSize: 10,
+            values: {},
+            overall: { mean: 2, stdDev: 0.5, min: 1, max: 3 },
+          },
+        },
+        modelAgreement: {},
+      },
+      {
+        perModel: {
+          'gpt-4': {
+            sampleSize: 20,
+            values: {},
+            overall: { mean: 4, stdDev: 0.8, min: 2, max: 5 },
+          },
+        },
+        modelAgreement: {},
+      },
+    ];
+
+    const scenarios = [{ id: 's1', name: 'S1', content: { name: 'S1' } }];
+
+    const result = aggregateAnalysesLogic(analyses, [], scenarios);
+    const overall = result.perModel['gpt-4']?.overall;
+
+    expect(overall).toBeDefined();
+    // Weighted mean: (2*10 + 4*20) / 30 = 100/30 ≈ 3.333
+    expect(overall!.mean).toBeCloseTo(3.333, 2);
+    // min/max across sources
+    expect(overall!.min).toBe(1);
+    expect(overall!.max).toBe(5);
+    // stdDev should be positive and incorporate both within-run and between-run variance
+    expect(overall!.stdDev).toBeGreaterThan(0);
+    // Pooled variance = w1*(σ1² + (μ1-μ̄)²) + w2*(σ2² + (μ2-μ̄)²)
+    // = (10/30)*(0.25 + 1.778) + (20/30)*(0.64 + 0.444)
+    // = 0.333*2.028 + 0.667*1.084 ≈ 0.676 + 0.723 = 1.399
+    // stdDev = √1.399 ≈ 1.183
+    expect(overall!.stdDev).toBeCloseTo(1.183, 2);
+    // Total sample size
+    expect(result.perModel['gpt-4']?.sampleSize).toBe(30);
+  });
+
+  it('handles single source run overall stats correctly', () => {
+    const analyses: AnalysisOutput[] = [
+      {
+        perModel: {
+          'gpt-4': {
+            sampleSize: 25,
+            values: {},
+            overall: { mean: 1.5, stdDev: 0.9, min: -2, max: 2 },
+          },
+        },
+        modelAgreement: {},
+      },
+    ];
+
+    const scenarios = [{ id: 's1', name: 'S1', content: { name: 'S1' } }];
+    const result = aggregateAnalysesLogic(analyses, [], scenarios);
+    const overall = result.perModel['gpt-4']?.overall;
+
+    // Single source: overall should pass through unchanged
+    expect(overall!.mean).toBe(1.5);
+    expect(overall!.stdDev).toBe(0.9);
+    expect(overall!.min).toBe(-2);
+    expect(overall!.max).toBe(2);
+  });
+
+  it('skips NaN overall stats without poisoning aggregate', () => {
+    const analyses: AnalysisOutput[] = [
+      {
+        perModel: {
+          'gpt-4': {
+            sampleSize: 10,
+            values: {},
+            overall: { mean: NaN, stdDev: 0.5, min: 1, max: 3 },
+          },
+        },
+        modelAgreement: {},
+      },
+      {
+        perModel: {
+          'gpt-4': {
+            sampleSize: 20,
+            values: {},
+            overall: { mean: 1.5, stdDev: 0.8, min: 0, max: 2 },
+          },
+        },
+        modelAgreement: {},
+      },
+    ];
+
+    const scenarios = [{ id: 's1', name: 'S1', content: { name: 'S1' } }];
+    const result = aggregateAnalysesLogic(analyses, [], scenarios);
+    const overall = result.perModel['gpt-4']?.overall;
+
+    // NaN source skipped; only the second run contributes
+    expect(overall!.mean).toBe(1.5);
+    expect(overall!.stdDev).toBe(0.8);
+    expect(Number.isFinite(overall!.mean)).toBe(true);
+    expect(Number.isFinite(overall!.stdDev)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Aggregate analysis hardcoded `overall: { mean: 0, stdDev: 0, min: 0, max: 0 }` instead of computing from source runs — this caused the analysis page to show zero scores for all aggregate runs
- MCP formatter read `stats.meanScore` (nonexistent) instead of `stats.overall.mean` — caused `get_run_summary` to always return zeros
- Added NaN guards to prevent corrupted source data from poisoning aggregates

## Test plan
- [x] 3 new unit tests: multi-run pooling, single-run passthrough, NaN resilience
- [x] Full API test suite passes (174 files, 2075 tests)
- [x] Build passes
- [ ] After deploy: re-trigger `recomputeAnalysis` on aggregate runs to populate correct scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)