### PR TITLE
fix: prevent duplicate transcripts from concurrent probe retries

### DIFF
--- a/cloud/apps/api/src/queue/handlers/probe-scenario.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-scenario.ts
@@ -667,14 +667,37 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
       };
     }
 
-    const transcriptRecord = await createTranscript({
-      runId,
-      scenarioId,
-      modelId,
-      sampleIndex,
-      transcript: output.transcript,
-      definitionSnapshot: scenario.definition.content as Prisma.InputJsonValue,
-      costSnapshot,
+    // Use an advisory lock to prevent concurrent probe jobs from creating
+    // duplicate transcripts for the same (runId, scenarioId, modelId, sampleIndex).
+    // Without this, two retries can both pass the "existing transcript?" check
+    // before either finishes inserting, producing duplicate rows.
+    const probeKey = `${runId}:${scenarioId}:${modelId}:${sampleIndex}`;
+    const transcriptRecord = await db.$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${probeKey}))`;
+
+      // Re-check inside the lock — another job may have inserted while we waited
+      const alreadyCreated = await tx.transcript.findFirst({
+        where: { runId, scenarioId, modelId, sampleIndex, deletedAt: null },
+        select: { id: true, durationMs: true, tokenCount: true, content: true },
+      });
+
+      if (alreadyCreated !== null) {
+        log.info(
+          { runId, scenarioId, modelId, sampleIndex, existingId: alreadyCreated.id },
+          'Transcript already created by concurrent job — skipping duplicate insert'
+        );
+        return alreadyCreated;
+      }
+
+      return createTranscript({
+        runId,
+        scenarioId,
+        modelId,
+        sampleIndex,
+        transcript: output.transcript,
+        definitionSnapshot: scenario.definition.content as Prisma.InputJsonValue,
+        costSnapshot,
+      }, tx);
     });
 
     // Record probe success in results table

--- a/cloud/apps/api/src/services/transcript/create.ts
+++ b/cloud/apps/api/src/services/transcript/create.ts
@@ -73,7 +73,7 @@ export type CreateTranscriptInput = {
 /**
  * Create a transcript record from probe worker output.
  */
-export async function createTranscript(input: CreateTranscriptInput) {
+export async function createTranscript(input: CreateTranscriptInput, txClient?: Prisma.TransactionClient) {
   const { runId, scenarioId, modelId, sampleIndex = 0, transcript, definitionSnapshot, costSnapshot } = input;
 
   // Calculate duration from timestamps
@@ -107,7 +107,8 @@ export async function createTranscript(input: CreateTranscriptInput) {
     'Creating transcript'
   );
 
-  const record = await db.transcript.create({
+  const client = txClient ?? db;
+  const record = await client.transcript.create({
     data: {
       runId,
       scenarioId,


### PR DESCRIPTION
## Summary
- Concurrent probe retries could create duplicate transcript rows for the same (runId, scenarioId, modelId, sampleIndex) due to a race condition between the existence check and the insert
- Wraps transcript creation in a `pg_advisory_xact_lock` transaction — if another job already inserted while waiting for the lock, reuses the existing transcript instead of creating a duplicate
- Most commonly affected flaky providers: Grok 4 (10 dupes), Grok 4.1 (4 dupes), Gemini Flash (3 dupes)

## Test plan
- [x] Full API test suite passes (174 files, 2078 tests)
- [x] Build passes
- [x] Advisory lock pattern matches existing usage in aggregate-run-workflow.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)