### PR TITLE
fix: prevent duplicate transcripts and fix summarization denominator race

### DIFF
--- a/cloud/apps/api/src/services/run/progress.ts
+++ b/cloud/apps/api/src/services/run/progress.ts
@@ -206,6 +206,44 @@ async function transitionStatus(
 }
 
 /**
+ * Wait for transcript rows to settle before counting.
+ *
+ * When the last probe job triggers SUMMARIZING, other probe jobs may still
+ * be committing their transcript rows. This polls briefly (up to 5 seconds)
+ * until the DB transcript count matches the expected total from probe progress,
+ * so the summarization denominator is accurate.
+ */
+const SETTLE_POLL_INTERVAL_MS = 500;
+const SETTLE_MAX_WAIT_MS = 5_000;
+
+async function waitForTranscriptSettle(
+  runId: string,
+  expectedCompleted: number,
+): Promise<number> {
+  const deadline = Date.now() + SETTLE_MAX_WAIT_MS;
+
+  while (Date.now() < deadline) {
+    const count = await db.transcript.count({ where: { runId } });
+    if (count >= expectedCompleted) {
+      return count;
+    }
+    log.debug(
+      { runId, dbCount: count, expected: expectedCompleted },
+      'Waiting for in-flight transcript commits to settle'
+    );
+    await new Promise((resolve) => setTimeout(resolve, SETTLE_POLL_INTERVAL_MS));
+  }
+
+  // Timed out — return whatever we have
+  const finalCount = await db.transcript.count({ where: { runId } });
+  log.warn(
+    { runId, dbCount: finalCount, expected: expectedCompleted },
+    'Transcript settle timed out — proceeding with current count'
+  );
+  return finalCount;
+}
+
+/**
  * Queues summarize jobs for all transcripts in a run.
  */
 async function queueSummarizeJobs(runId: string): Promise<void> {
@@ -214,6 +252,19 @@ async function queueSummarizeJobs(runId: string): Promise<void> {
   const { DEFAULT_JOB_OPTIONS } = await import('../../queue/types.js');
 
   const boss = getBoss();
+
+  // Read the probe progress to know how many successful transcripts to expect
+  const run = await db.run.findUnique({
+    where: { id: runId },
+    select: { progress: true },
+  });
+  const probeProgress = run?.progress as ProgressData | null;
+  const expectedCompleted = probeProgress?.completed ?? 0;
+
+  // Wait for in-flight transcript commits before counting
+  if (expectedCompleted > 0) {
+    await waitForTranscriptSettle(runId, expectedCompleted);
+  }
 
   // Get all transcripts for this run
   const transcripts = await db.transcript.findMany({

--- a/cloud/apps/api/tests/services/run/progress.test.ts
+++ b/cloud/apps/api/tests/services/run/progress.test.ts
@@ -28,8 +28,11 @@ describe('progress service', () => {
   const createdRunIds: string[] = [];
 
   afterEach(async () => {
-    // Clean up runs first
+    // Clean up transcripts, run selections, runs, scenarios, definitions (order matters for FK)
     if (createdRunIds.length > 0) {
+      await db.transcript.deleteMany({
+        where: { runId: { in: createdRunIds } },
+      });
       await db.runScenarioSelection.deleteMany({
         where: { runId: { in: createdRunIds } },
       });
@@ -39,7 +42,13 @@ describe('progress service', () => {
       createdRunIds.length = 0;
     }
 
-    // Clean up definitions
+    if (createdScenarioIds.length > 0) {
+      await db.scenario.deleteMany({
+        where: { id: { in: createdScenarioIds } },
+      });
+      createdScenarioIds.length = 0;
+    }
+
     if (createdDefinitionIds.length > 0) {
       await db.definition.deleteMany({
         where: { id: { in: createdDefinitionIds } },
@@ -48,7 +57,12 @@ describe('progress service', () => {
     }
   });
 
-  async function createTestRun(progress: { total: number; completed: number; failed: number }) {
+  const createdScenarioIds: string[] = [];
+
+  async function createTestRun(
+    progress: { total: number; completed: number; failed: number },
+    opts?: { transcriptCount?: number },
+  ) {
     const definition = await db.definition.create({
       data: {
         name: 'Test Definition',
@@ -66,6 +80,32 @@ describe('progress service', () => {
       },
     });
     createdRunIds.push(run.id);
+
+    // Create transcripts if requested (needed for tests that trigger SUMMARIZING)
+    if (opts?.transcriptCount != null && opts.transcriptCount > 0) {
+      const scenario = await db.scenario.create({
+        data: {
+          definitionId: definition.id,
+          name: 'test-scenario-' + Date.now(),
+          content: { schema_version: 1, prompt: 'Test', dimension_values: { test: 'value' } },
+        },
+      });
+      createdScenarioIds.push(scenario.id);
+
+      for (let i = 0; i < opts.transcriptCount; i++) {
+        await db.transcript.create({
+          data: {
+            runId: run.id,
+            scenarioId: scenario.id,
+            modelId: 'openai:gpt-4',
+            content: { schema_version: 1, messages: [] },
+            turnCount: 1,
+            tokenCount: 100,
+            durationMs: 1000,
+          },
+        });
+      }
+    }
 
     return run;
   }
@@ -141,7 +181,8 @@ describe('progress service', () => {
     });
 
     it('transitions RUNNING to SUMMARIZING when all jobs done', async () => {
-      const run = await createTestRun({ total: 3, completed: 2, failed: 0 });
+      // Create 3 transcripts so waitForTranscriptSettle resolves immediately
+      const run = await createTestRun({ total: 3, completed: 2, failed: 0 }, { transcriptCount: 3 });
       // Update to RUNNING first
       await db.run.update({
         where: { id: run.id },
@@ -156,7 +197,8 @@ describe('progress service', () => {
     });
 
     it('transitions to SUMMARIZING even with failures', async () => {
-      const run = await createTestRun({ total: 3, completed: 1, failed: 1 });
+      // Create 1 transcript matching completed count so settle resolves immediately
+      const run = await createTestRun({ total: 3, completed: 1, failed: 1 }, { transcriptCount: 1 });
       await db.run.update({
         where: { id: run.id },
         data: { status: 'RUNNING', startedAt: new Date() },


### PR DESCRIPTION
## Summary
- **Prevent duplicate transcripts** from concurrent probe retries using `pg_advisory_xact_lock` — locks on `runId:scenarioId:modelId:sampleIndex` and checks for existing transcript before inserting
- **Fix summarization denominator race** — when the last probe triggers SUMMARIZING, other probes may still be committing transcript rows. Adds `waitForTranscriptSettle()` that polls briefly (up to 5s) until the DB transcript count matches `progress.completed` before setting `summarizeProgress.total`

## Test plan
- [x] All 174 API test files pass (2076 tests)
- [x] Lint passes (0 errors)
- [x] Build passes
- [x] Progress tests updated with transcript rows so settle function resolves immediately
- [ ] Monitor next production run for correct summarization denominator

🤖 Generated with [Claude Code](https://claude.com/claude-code)