### PR TITLE
feat: remember last selected domain and fetch fresh coverage data

### DIFF
--- a/cloud/apps/web/src/components/domains/CoverageMatrix.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageMatrix.tsx
@@ -45,7 +45,7 @@ export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
     query: DOMAIN_AVAILABLE_SIGNATURES_QUERY,
     variables: { domainId },
     pause: domainId === '',
-    requestPolicy: 'cache-and-network',
+    requestPolicy: 'network-only',
   });
 
   const signatureOptions = useMemo<DomainAvailableSignature[]>(
@@ -93,7 +93,7 @@ export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
       signature: selectedSignature === '' ? undefined : selectedSignature,
     },
     pause: domainId === '' || !signatureSelectionReady || useLegacyQuery,
-    requestPolicy: 'cache-and-network',
+    requestPolicy: 'network-only',
   });
 
   const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<
@@ -105,7 +105,7 @@ export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
       domainId,
     },
     pause: domainId === '' || !signatureSelectionReady || !useLegacyQuery,
-    requestPolicy: 'cache-and-network',
+    requestPolicy: 'network-only',
   });
 
   useEffect(() => {

--- a/cloud/apps/web/src/pages/Domains.tsx
+++ b/cloud/apps/web/src/pages/Domains.tsx
@@ -7,10 +7,12 @@ import { useDomains } from '../hooks/useDomains';
 
 type FolderKey = string;
 
+const LAST_DOMAIN_KEY = 'valuerank:lastSelectedDomainId';
+
 export function Domains() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const initialSelectedFolder = searchParams.get('domainId');
-  const [selectedFolder, setSelectedFolder] = useState<FolderKey>(initialSelectedFolder ?? '');
+  const initialSelectedFolder = searchParams.get('domainId') ?? localStorage.getItem(LAST_DOMAIN_KEY) ?? '';
+  const [selectedFolder, setSelectedFolder] = useState<FolderKey>(initialSelectedFolder);
   const coverageRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -20,11 +22,13 @@ export function Domains() {
 
   const selectedDomain = domains.find((d) => d.id === selectedFolder) ?? null;
 
-  // Auto-select first domain when list loads
+  // Auto-select best domain when list loads: last picked > first in list
   useEffect(() => {
-    if (selectedFolder === '' && domains.length > 0 && domains[0] != null) {
-      setSelectedFolder(domains[0].id);
-    }
+    if (domains.length === 0) return;
+    if (selectedFolder !== '' && domains.some((d) => d.id === selectedFolder)) return;
+    const lastId = localStorage.getItem(LAST_DOMAIN_KEY);
+    const lastDomain = lastId != null ? domains.find((d) => d.id === lastId) : null;
+    setSelectedFolder(lastDomain?.id ?? domains[0]?.id ?? '');
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [domains]);
 
@@ -54,7 +58,10 @@ export function Domains() {
           <div className="flex flex-col gap-2 md:flex-row md:items-center md:flex-1">
             <select
               value={selectedFolder}
-              onChange={(e) => setSelectedFolder(e.target.value)}
+              onChange={(e) => {
+                setSelectedFolder(e.target.value);
+                localStorage.setItem(LAST_DOMAIN_KEY, e.target.value);
+              }}
               className="min-w-[220px] border border-gray-300 rounded px-3 py-2 text-sm bg-white"
             >
               {domains.map((d) => (


### PR DESCRIPTION
## Summary
- Domains page now restores the last-picked domain (via localStorage) instead of always defaulting to the first domain in the list
- CoverageMatrix request policy changed from `cache-and-network` to `network-only` so batch counts are always accurate on page load (fixes stale zero counts after running a batch)

## Test plan
- [ ] Preflight passed (lint + tests + build)
- [ ] Pick a non-first domain, navigate away, come back — it should restore to that domain
- [ ] Run a batch, navigate to Domains page — coverage count should show the updated value immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)