### PR TITLE
fix: domain analysis falls back to global default models

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/analysis.ts
@@ -20,6 +20,7 @@ import {
   incrementPairwiseWin,
   isDomainAnalysisValueKey,
   parseDomainAnalysisScoreMethod,
+  resolveEffectiveDefaultModelIds,
   resolveSignatureRuns,
   resolveValuePairsInChunks,
   resolveTranscriptDecisionModel,
@@ -101,7 +102,7 @@ builder.queryField('domainAnalysis', (t) =>
       );
 
       const valuePairByDefinition = await resolveValuePairsInChunks(latestDefinitionIds);
-      const resolvedSignatureRuns = await resolveSignatureRuns(latestDefinitionIds, requestedSignature, domain.defaultModelIds);
+      const resolvedSignatureRuns = await resolveSignatureRuns(latestDefinitionIds, requestedSignature, await resolveEffectiveDefaultModelIds(domain.defaultModelIds));
       const filteredSourceRunIds = resolvedSignatureRuns.filteredSourceRunIds;
       const filteredSourceRunDefinitionById = resolvedSignatureRuns.filteredSourceRunDefinitionById;
 
@@ -375,7 +376,7 @@ builder.queryField('domainAnalysisValueDetail', (t) =>
         latestRunByDefinition.set(run.definitionId, { id: run.id });
       }
 
-      const resolvedSignatureRuns = await resolveSignatureRuns(scoreDefinitionIds, requestedSignature, domain.defaultModelIds);
+      const resolvedSignatureRuns = await resolveSignatureRuns(scoreDefinitionIds, requestedSignature, await resolveEffectiveDefaultModelIds(domain.defaultModelIds));
       const filteredSourceRunIds = resolvedSignatureRuns.filteredSourceRunIds;
       const filteredSourceRunDefinitionById = resolvedSignatureRuns.filteredSourceRunDefinitionById;
       const targetDefinitionIdSet = new Set(targetDefinitionIds);
@@ -703,7 +704,7 @@ builder.queryField('domainAnalysisConditionTranscripts', (t) =>
       if (!pair) return [];
       if (pair.valueA !== valueKey && pair.valueB !== valueKey) return [];
 
-      const resolvedSignatureRuns = await resolveSignatureRuns([definitionId], requestedSignature, domain.defaultModelIds);
+      const resolvedSignatureRuns = await resolveSignatureRuns([definitionId], requestedSignature, await resolveEffectiveDefaultModelIds(domain.defaultModelIds));
       const sourceRunIds = resolvedSignatureRuns.filteredSourceRunIds;
       if (sourceRunIds.length === 0) return [];
 

--- a/cloud/apps/api/tests/graphql/queries/domain-analysis.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/domain-analysis.test.ts
@@ -50,6 +50,7 @@ describe('GraphQL domain analysis', () => {
       data: {
         name: `Job Choice Analysis Fix ${Date.now()}`,
         normalizedName: `job-choice-analysis-fix-${Date.now()}`,
+        defaultModelIds: ['job-choice-analysis-model'],
       },
     });
     createdDomainIds.push(domain.id);
@@ -126,7 +127,7 @@ describe('GraphQL domain analysis', () => {
       data: {
         definitionId: aFirstDefinition.id,
         status: 'COMPLETED',
-        config: { temperature: null },
+        config: { temperature: null, models: ['job-choice-analysis-model'] },
         progress: { completed: 1, total: 1 },
         startedAt: new Date(),
         completedAt: new Date(),
@@ -154,7 +155,7 @@ describe('GraphQL domain analysis', () => {
       data: {
         definitionId: bFirstDefinition.id,
         status: 'COMPLETED',
-        config: { temperature: null },
+        config: { temperature: null, models: ['job-choice-analysis-model'] },
         progress: { completed: 1, total: 1 },
         startedAt: new Date(),
         completedAt: new Date(),


### PR DESCRIPTION
## Summary
- `domainAnalysis` query was passing `domain.defaultModelIds` directly to `resolveSignatureRuns()` — when empty, this skipped model filtering entirely, letting stale models from old partial runs appear with mostly-zero cells
- Now calls `resolveEffectiveDefaultModelIds()` (same as `domainValueCoverage` already does) to fall back to global default models when the domain has no explicit list
- Fixes all 3 call sites in `analysis.ts`
- Updates domain-analysis test to set explicit `defaultModelIds` and `config.models`

## Test plan
- [x] `domain-analysis.test.ts` passes
- [x] Full API test suite passes (171/171, 1 pre-existing flaky)
- [x] Lint passes (0 errors)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)