### PR TITLE
fix: prevent duplicate budget deductions via atomic status transition

### DIFF
--- a/cloud/apps/api/src/queue/handlers/summarize-persistence.ts
+++ b/cloud/apps/api/src/queue/handlers/summarize-persistence.ts
@@ -115,7 +115,7 @@ export async function maybeCompleteRun(runId: string): Promise<void> {
       UPDATE "runs"
       SET "status" = 'COMPLETED',
           "completed_at" = NOW(),
-          "stalled_models" = '[]'::jsonb
+          "stalled_models" = '{}'::text[]
       WHERE "id" = ${runId}
         AND "status" = 'SUMMARIZING'
     `;

--- a/cloud/apps/api/src/queue/handlers/summarize-persistence.ts
+++ b/cloud/apps/api/src/queue/handlers/summarize-persistence.ts
@@ -97,20 +97,34 @@ export async function checkAllSummarized(runId: string): Promise<boolean> {
 
 /**
  * Update run status to COMPLETED if all transcripts are summarized.
- * Also triggers basic analysis and token statistics computation for the completed run.
+ * Also triggers basic analysis, token statistics computation, and budget deduction.
+ *
+ * Uses an atomic status transition (SUMMARIZING → COMPLETED) to prevent
+ * duplicate side effects when multiple summarization jobs finish concurrently.
+ * Only the first caller that successfully transitions the status will run
+ * the completion side effects (analysis, token stats, budget deduction).
  */
 export async function maybeCompleteRun(runId: string): Promise<void> {
   const allDone = await checkAllSummarized(runId);
 
   if (allDone) {
-    await db.run.update({
-      where: { id: runId },
-      data: {
-        status: 'COMPLETED',
-        completedAt: new Date(),
-        stalledModels: [],
-      },
-    });
+    // Atomic transition: only update if status is still SUMMARIZING.
+    // If another caller already moved it to COMPLETED, this returns 0 rows
+    // and we skip all side effects to avoid duplicates (e.g., double deductions).
+    const transitioned = await db.$executeRaw`
+      UPDATE "runs"
+      SET "status" = 'COMPLETED',
+          "completed_at" = NOW(),
+          "stalled_models" = '[]'::jsonb
+      WHERE "id" = ${runId}
+        AND "status" = 'SUMMARIZING'
+    `;
+
+    if (transitioned === 0) {
+      log.debug({ runId }, 'Run already completed by another worker — skipping side effects');
+      return;
+    }
+
     log.info({ runId }, 'Run completed - all transcripts summarized');
 
     try {


### PR DESCRIPTION
## Summary

- `maybeCompleteRun()` had a race condition: multiple summarization jobs finishing concurrently would all pass the "are all transcripts done?" check and each independently deduct provider balances
- This caused budget balances to be deducted 2-3× per run, leading to balances going negative (e.g., Anthropic showed -$6.37 when the real dashboard balance was $3.20)
- Fix: replace `db.run.update()` with an atomic `UPDATE ... WHERE status = 'SUMMARIZING'` — only the first caller transitions the status and runs side effects; subsequent callers see 0 rows affected and skip

## Test plan

- [x] All 19 budget deduction tests pass
- [x] No new build errors (pre-existing errors in unrelated files)
- [ ] After deploy: run a batch, verify each provider balance decreases by exactly the run's actual cost (not 2-3×)
- [ ] Re-sync provider balances from dashboards to correct accumulated over-deductions

🤖 Generated with [Claude Code](https://claude.com/claude-code)