### PR TITLE
feat: clean URL pattern, domain switcher, last-used domain redirect

### DIFF
--- a/cloud/apps/web/src/App.tsx
+++ b/cloud/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 // NOTE: The term "Vignette" is used throughout the UI for user-friendliness.
 // However, the underlying codebase, API, and database still use the term "Definition".
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { Provider } from 'urql';
 import { AuthProvider } from './auth/context';
 import { ProtectedRoute } from './components/ProtectedRoute';
@@ -55,6 +55,10 @@ function ProtectedLayout({ children, fullWidth = false }: { children: React.Reac
   );
 }
 
+function RedirectPreservingParams({ to }: { to: string }) {
+  const { search, hash } = useLocation();
+  return <Navigate to={`${to}${search}${hash}`} replace />;
+}
 
 function App() {
   return (
@@ -302,8 +306,8 @@ function App() {
                 </ProtectedLayout>
               }
             />
-            <Route path="/survey" element={<Navigate to="/archive/surveys" replace />} />
-            <Route path="/survey-results" element={<Navigate to="/archive/survey-results" replace />} />
+            <Route path="/survey" element={<RedirectPreservingParams to="/archive/surveys" />} />
+            <Route path="/survey-results" element={<RedirectPreservingParams to="/archive/survey-results" />} />
             <Route path="/experiments" element={<Navigate to="/archive" replace />} />
             <Route path="/settings" element={<Navigate to="/settings/account" replace />} />
             <Route
@@ -381,14 +385,7 @@ function App() {
             {['/paired/new', '/paired/:id/edit'].map((path) => (
               <Route key={path} path={path} element={<ProtectedLayout><PairedVignetteNew /></ProtectedLayout>} />
             ))}
-            <Route
-              path="*"
-              element={
-                <ProtectedLayout>
-                  <NotFound />
-                </ProtectedLayout>
-              }
-            />
+            <Route path="*" element={<ProtectedLayout><NotFound /></ProtectedLayout>} />
           </Routes>
         </AuthProvider>
       </Provider>

--- a/cloud/apps/web/src/App.tsx
+++ b/cloud/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 // NOTE: The term "Vignette" is used throughout the UI for user-friendliness.
 // However, the underlying codebase, API, and database still use the term "Definition".
-import { BrowserRouter, Routes, Route, Navigate, useLocation, useParams } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Provider } from 'urql';
 import { AuthProvider } from './auth/context';
 import { ProtectedRoute } from './components/ProtectedRoute';
@@ -41,6 +41,7 @@ import { LevelPresets } from './pages/LevelPresets';
 import { DomainContexts } from './pages/DomainContexts';
 import { ValueStatements } from './pages/ValueStatements';
 import { PairedVignetteNew } from './pages/PairedVignetteNew';
+import { StartRedirect } from './pages/StartRedirect';
 import { StatusRedirect } from './pages/StatusRedirect';
 import { NotFound } from './pages/NotFound';
 import { client } from './api/client';
@@ -54,12 +55,6 @@ function ProtectedLayout({ children, fullWidth = false }: { children: React.Reac
   );
 }
 
-function LegacyRouteRedirect({ to }: { to: string }) {
-  const params = useParams();
-  const location = useLocation();
-  const resolved = Object.entries(params).reduce((path, [key, val]) => path.replace(`:${key}`, val ?? ''), to);
-  return <Navigate to={`${resolved}${location.search}${location.hash}`} replace />;
-}
 
 function App() {
   return (
@@ -128,7 +123,7 @@ function App() {
               }
             />
             <Route
-              path="/domains/:domainId/start"
+              path="/domains/start/:domainId"
               element={
                 <ProtectedLayout>
                   <DomainStartBatches />
@@ -136,7 +131,15 @@ function App() {
               }
             />
             <Route
-              path="/domains/:domainId/status"
+              path="/domains/start"
+              element={
+                <ProtectedLayout>
+                  <StartRedirect />
+                </ProtectedLayout>
+              }
+            />
+            <Route
+              path="/domains/status/:domainId"
               element={
                 <ProtectedLayout>
                   <DomainStatus />
@@ -144,8 +147,12 @@ function App() {
               }
             />
             <Route
-              path="/domains/:domainId/run-trials"
-              element={<LegacyRouteRedirect to="/domains/:domainId/status" />}
+              path="/domains/status"
+              element={
+                <ProtectedLayout>
+                  <StatusRedirect />
+                </ProtectedLayout>
+              }
             />
             <Route
               path="/domains/analysis"

--- a/cloud/apps/web/src/App.tsx
+++ b/cloud/apps/web/src/App.tsx
@@ -302,8 +302,8 @@ function App() {
                 </ProtectedLayout>
               }
             />
-            <Route path="/survey" element={<LegacyRouteRedirect to="/archive/surveys" />} />
-            <Route path="/survey-results" element={<LegacyRouteRedirect to="/archive/survey-results" />} />
+            <Route path="/survey" element={<Navigate to="/archive/surveys" replace />} />
+            <Route path="/survey-results" element={<Navigate to="/archive/survey-results" replace />} />
             <Route path="/experiments" element={<Navigate to="/archive" replace />} />
             <Route path="/settings" element={<Navigate to="/settings/account" replace />} />
             <Route

--- a/cloud/apps/web/src/components/domains/DomainSwitcher.tsx
+++ b/cloud/apps/web/src/components/domains/DomainSwitcher.tsx
@@ -1,0 +1,37 @@
+import { useNavigate } from 'react-router-dom';
+import { useDomains } from '../../hooks/useDomains';
+
+const LAST_DOMAIN_KEY = 'valuerank:lastSelectedDomainId';
+
+type DomainSwitcherProps = {
+  currentDomainId: string;
+  /** Path prefix before the domain ID, e.g. "/domains/status" */
+  basePath: string;
+};
+
+export function DomainSwitcher({ currentDomainId, basePath }: DomainSwitcherProps) {
+  const { domains } = useDomains();
+  const navigate = useNavigate();
+
+  if (domains.length <= 1) {
+    const name = domains.find((d) => d.id === currentDomainId)?.name ?? currentDomainId;
+    return <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">{name}</h1>;
+  }
+
+  return (
+    <select
+      value={currentDomainId}
+      onChange={(e) => {
+        const newId = e.target.value;
+        localStorage.setItem(LAST_DOMAIN_KEY, newId);
+        navigate(`${basePath}/${newId}`);
+      }}
+      className="text-2xl font-serif font-medium text-[#1A1A1A] bg-transparent border-none cursor-pointer pr-8 appearance-none"
+      style={{ backgroundImage: 'url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'12\' height=\'12\' viewBox=\'0 0 12 12\'%3E%3Cpath fill=\'%23666\' d=\'M6 8L1 3h10z\'/%3E%3C/svg%3E")', backgroundRepeat: 'no-repeat', backgroundPosition: 'right 0 center' }}
+    >
+      {domains.map((d) => (
+        <option key={d.id} value={d.id}>{d.name}</option>
+      ))}
+    </select>
+  );
+}

--- a/cloud/apps/web/src/components/layout/NavTabs.tsx
+++ b/cloud/apps/web/src/components/layout/NavTabs.tsx
@@ -5,7 +5,7 @@ import { Button } from '../ui/Button';
 import { useClickOutside } from '../../hooks/useClickOutside';
 
 const utilityTabs: { name: string; path: string; icon: React.ComponentType<{ className?: string }>; aliases?: string[] }[] = [
-  { name: 'Status', path: '/status', icon: Activity, aliases: ['/run-trials', '/status'] },
+  { name: 'Status', path: '/status', icon: Activity, aliases: ['/domains/status'] },
 ];
 
 type MenuLinkItem = {

--- a/cloud/apps/web/src/pages/Dashboard.tsx
+++ b/cloud/apps/web/src/pages/Dashboard.tsx
@@ -86,7 +86,7 @@ export function Dashboard() {
           </p>
           <div className="mt-4 grid gap-3 md:grid-cols-3">
             <Link
-              to={`/domains/${activeDomain.id}/status`}
+              to={`/domains/status/${activeDomain.id}`}
               className="rounded-lg border border-gray-200 bg-gray-50 p-4 hover:bg-gray-100"
             >
               <div className="text-xs font-medium uppercase tracking-wide text-gray-500">Resume batches</div>

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -211,7 +211,7 @@ export function DomainAnalysis() {
       const t = parseTemperatureFromSignature(selectedSignature);
       if (t !== null) query.set('temperature', String(t));
     }
-    navigate(`/domains/${selectedDomainId}/status?${query.toString()}`);
+    navigate(`/domains/status/${selectedDomainId}?${query.toString()}`);
   };
 
   return (

--- a/cloud/apps/web/src/pages/DomainStartBatches.tsx
+++ b/cloud/apps/web/src/pages/DomainStartBatches.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery } from 'urql';
+import { DomainSwitcher } from '../components/domains/DomainSwitcher';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { LaunchConfirmModal } from '../components/domains/domainTrials/LaunchConfirmModal';
 import { LaunchControlsPanel } from '../components/domains/domainTrials/LaunchControlsPanel';
@@ -217,7 +218,7 @@ export function DomainStartBatches() {
       }
 
       setShowLaunchConfirm(false);
-      navigate(`/domains/${domainId}/status?evaluationId=${backfillEvaluationId}`);
+      navigate(`/domains/status/${domainId}?evaluationId=${backfillEvaluationId}`);
 
       if (payload.startedRuns === 0) {
         setRunError('No new runs were started. The gap may already be filled or still in flight.');
@@ -264,7 +265,7 @@ export function DomainStartBatches() {
     }
 
     setShowLaunchConfirm(false);
-    navigate(`/domains/${domainId}/status?evaluationId=${payload.domainEvaluationId}`);
+    navigate(`/domains/status/${domainId}?evaluationId=${payload.domainEvaluationId}`);
   };
 
   // --- Render ---
@@ -277,7 +278,7 @@ export function DomainStartBatches() {
     <div className="space-y-6">
       <div className="space-y-2">
         <div className="text-xs font-medium uppercase tracking-wide text-gray-500">Start Paired Batches</div>
-        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">{domainName}</h1>
+        <DomainSwitcher currentDomainId={domainId} basePath="/domains/start" />
       </div>
 
       {displayError != null && <ErrorMessage message={`Failed to load launch data: ${displayError.message ?? 'Unknown error'}`} />}

--- a/cloud/apps/web/src/pages/DomainStatus.tsx
+++ b/cloud/apps/web/src/pages/DomainStatus.tsx
@@ -3,6 +3,7 @@ import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useQuery } from 'urql';
 import { Plus } from 'lucide-react';
 import { Badge } from '../components/ui/Badge';
+import { DomainSwitcher } from '../components/domains/DomainSwitcher';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { DomainEvaluationStatusPanel } from '../components/domains/domainTrials/DomainEvaluationStatusPanel';
 import { DomainEvaluationStatusDrawer } from '../components/domains/domainTrials/DomainEvaluationStatusDrawer';
@@ -204,7 +205,7 @@ export function DomainStatus() {
         <div className="space-y-2">
           <div className="text-xs font-medium uppercase tracking-wide text-gray-500">Domain Status</div>
           <div className="flex flex-wrap items-center gap-2">
-            <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">{domainName}</h1>
+            <DomainSwitcher currentDomainId={domainId} basePath="/domains/status" />
             {statusHeader != null && (
               <Badge variant={hasLiveRows ? 'warning' : 'success'} size="count">
                 {statusHeader}
@@ -213,7 +214,7 @@ export function DomainStatus() {
           </div>
         </div>
         <Link
-          to={`/domains/${domainId}/start`}
+          to={`/domains/start/${domainId}`}
           className="inline-flex items-center gap-1.5 rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-white hover:bg-gray-800"
         >
           <Plus className="h-4 w-4" />
@@ -230,7 +231,7 @@ export function DomainStatus() {
             {modelGaps.map((gap) => (
               <Link
                 key={gap.modelId}
-                to={`/domains/${domainId}/start?evaluationId=${currentEvaluation.id}&models=${encodeURIComponent(gap.modelId)}&depth=${currentEvaluation.targetBatchCount ?? 1}`}
+                to={`/domains/start/${domainId}?evaluationId=${currentEvaluation.id}&models=${encodeURIComponent(gap.modelId)}&depth=${currentEvaluation.targetBatchCount ?? 1}`}
                 className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2.5 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
               >
                 {gap.modelName}: {gap.missing} missing

--- a/cloud/apps/web/src/pages/Domains.tsx
+++ b/cloud/apps/web/src/pages/Domains.tsx
@@ -70,7 +70,7 @@ export function Domains() {
             </select>
             {selectedDomain != null && (
               <Link
-                to={`/domains/${selectedDomain.id}/start`}
+                to={`/domains/start/${selectedDomain.id}`}
                 className="inline-flex items-center justify-center rounded-lg border border-teal-600 bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 md:ml-auto"
               >
                 Add Paired Batches for all Vignettes

--- a/cloud/apps/web/src/pages/StartRedirect.tsx
+++ b/cloud/apps/web/src/pages/StartRedirect.tsx
@@ -5,10 +5,10 @@ import { useDomains } from '../hooks/useDomains';
 const LAST_DOMAIN_KEY = 'valuerank:lastSelectedDomainId';
 
 /**
- * Redirects /status (or /domains/status) to the last-used domain's status page.
+ * Redirects /domains/start to the last-used domain's start page.
  * Falls back to the first domain if no last-used domain is stored.
  */
-export function StatusRedirect() {
+export function StartRedirect() {
   const { domains, queryLoading } = useDomains();
   const navigate = useNavigate();
 
@@ -18,7 +18,7 @@ export function StatusRedirect() {
     const lastDomain = lastId != null ? domains.find((d) => d.id === lastId) : null;
     const domain = lastDomain ?? domains[0];
     if (domain != null) {
-      navigate(`/domains/status/${domain.id}`, { replace: true });
+      navigate(`/domains/start/${domain.id}`, { replace: true });
     }
   }, [domains, queryLoading, navigate]);
 

--- a/cloud/apps/web/tests/pages/Dashboard.test.tsx
+++ b/cloud/apps/web/tests/pages/Dashboard.test.tsx
@@ -22,7 +22,7 @@ describe('Dashboard', () => {
     expect(screen.getByRole('link', { name: /validation/i })).toHaveAttribute('href', '/validation');
     expect(screen.getByRole('link', { name: /archive/i })).toHaveAttribute('href', '/archive');
     expect(screen.getByRole('heading', { name: /resume active domain work/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /open domain level batches/i })).toHaveAttribute('href', '/domains/domain-a/status');
+    expect(screen.getByRole('link', { name: /open domain level batches/i })).toHaveAttribute('href', '/domains/status/domain-a');
     expect(screen.getByRole('link', { name: /open findings for this domain/i })).toHaveAttribute('href', '/domains/analysis?domainId=domain-a');
     expect(screen.getByRole('link', { name: /review setup coverage/i })).toHaveAttribute('href', '/domains?domainId=domain-a&tab=setup&setupTab=contexts');
   });

--- a/cloud/apps/web/tests/pages/Domains.test.tsx
+++ b/cloud/apps/web/tests/pages/Domains.test.tsx
@@ -99,7 +99,7 @@ describe('Domains page', () => {
     renderDomainsPage();
 
     const launchLink = screen.getByRole('link', { name: /add paired batches for all vignettes/i });
-    expect(launchLink).toHaveAttribute('href', '/domains/domain-a/start');
+    expect(launchLink).toHaveAttribute('href', '/domains/start/domain-a');
   });
 
   it('renders the coverage copy control beside the value coverage header', () => {
@@ -116,7 +116,7 @@ describe('Domains page', () => {
     await user.selectOptions(screen.getAllByRole('combobox')[0]!, 'domain-b');
 
     expect(screen.getByRole('link', { name: /add paired batches for all vignettes/i }))
-      .toHaveAttribute('href', '/domains/domain-b/start');
+      .toHaveAttribute('href', '/domains/start/domain-b');
   });
 
   it('does not show a manage domains action', () => {


### PR DESCRIPTION
## Summary
- Routes changed from `/domains/:id/start` → `/domains/start/:id` (and `/status`)
- Removed legacy `/run-trials` redirect — clean break
- Added `DomainSwitcher` dropdown to Start and Status pages for quick domain switching
- `StatusRedirect` and new `StartRedirect` use `localStorage` last-used domain instead of arbitrary `domains[0]`
- `/domains/start` and `/domains/status` bare paths redirect to last-used domain

## Test plan
- [ ] TypeScript compiles with no new errors
- [ ] Dashboard and Domains tests updated and pass
- [ ] All file sizes under 400 lines
- [ ] No remaining references to old `/domains/:id/start` or `/run-trials` patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)