### PR TITLE
fix: correct budget estimate to multiply by remaining batches

### DIFF
--- a/cloud/apps/web/src/components/domains/domainTrials/launch-state.ts
+++ b/cloud/apps/web/src/components/domains/domainTrials/launch-state.ts
@@ -103,7 +103,9 @@ export function buildProviderBudgetEstimates(input: {
     const key = provider.id || provider.name;
     const existing = providerRows.get(key);
     const remainingBatchCount = Math.max(0, targetCount - (existingBatchCountByDefinitionId.get(cell.definitionId) ?? 0));
-    const nextSpend = cell.estimatedCost * (remainingBatchCount / targetCount);
+    // cellEstimates represent 1-batch cost (backend uses samplesPerScenario=1).
+    // Multiply by remaining batches to get total expected spend.
+    const nextSpend = cell.estimatedCost * remainingBatchCount;
     const expectedSpendUsd = (existing?.expectedSpendUsd ?? 0) + nextSpend;
     const budgetBalanceUsd = existing?.budgetBalanceUsd ?? provider.balance ?? null;
 

--- a/cloud/apps/web/tests/components/domains/domainTrials/launch-state.test.ts
+++ b/cloud/apps/web/tests/components/domains/domainTrials/launch-state.test.ts
@@ -34,7 +34,7 @@ function makeModel(overrides: Partial<LlmModel> = {}): LlmModel {
 }
 
 describe('buildProviderBudgetEstimates', () => {
-  it('scales spend by batches still needed for each vignette', () => {
+  it('multiplies per-batch cost by remaining batches needed for each vignette', () => {
     const estimates = buildProviderBudgetEstimates({
       selectedModels: [
         makeModel({
@@ -87,17 +87,20 @@ describe('buildProviderBudgetEstimates', () => {
     });
 
     expect(estimates).toHaveLength(2);
+    // cellEstimates are per-batch costs (backend uses samplesPerScenario=1).
+    // def-1: existing=2, target=5, remaining=3 → Anthropic: 50*3=150, OpenAI: 100*3=300
+    // def-2: existing=5, target=5, remaining=0 → OpenAI: 40*0=0
     expect(estimates[0]).toMatchObject({
       providerDisplayName: 'Anthropic',
-      expectedSpendUsd: 30,
+      expectedSpendUsd: 150,
       budgetBalanceUsd: 50,
-      budgetReady: true,
+      budgetReady: false,
     });
     expect(estimates[1]).toMatchObject({
       providerDisplayName: 'OpenAI',
-      expectedSpendUsd: 60,
+      expectedSpendUsd: 300,
       budgetBalanceUsd: 100,
-      budgetReady: true,
+      budgetReady: false,
     });
   });
 });


### PR DESCRIPTION
## Summary

- Budget estimate on domain launch page showed ~$8 for Anthropic when the actual cost was ~$36
- Root cause: `cellEstimates` represent per-batch cost (backend uses `samplesPerScenario=1`), but the formula divided by `targetBatchCount` instead of multiplying by remaining batches
- `cell.estimatedCost * (remaining / target)` → `cell.estimatedCost * remaining`
- This caused launches to proceed without warning when provider balance was insufficient

## Test plan

- [x] Updated launch-state test to match correct math
- [x] Web test passes
- [x] No new build errors
- [ ] After deploy: set target batch count > 1 on launch page, verify estimate matches `per-batch cost × remaining batches`

🤖 Generated with [Claude Code](https://claude.com/claude-code)