### PR TITLE
feat(db): add soft delete to ProbeResult and domain evaluation models

### DIFF
--- a/cloud/packages/db/prisma/migrations/20260412140114_add_soft_delete_probe_result_domain_evaluation/migration.sql
+++ b/cloud/packages/db/prisma/migrations/20260412140114_add_soft_delete_probe_result_domain_evaluation/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable: Add soft delete to ProbeResult
+ALTER TABLE "probe_results" ADD COLUMN "deleted_at" TIMESTAMP(3);
+
+-- AlterTable: Add soft delete to DomainEvaluation
+ALTER TABLE "domain_evaluations" ADD COLUMN "deleted_at" TIMESTAMP(3);
+
+-- AlterTable: Add soft delete to DomainEvaluationRun
+ALTER TABLE "domain_evaluation_runs" ADD COLUMN "deleted_at" TIMESTAMP(3);

--- a/cloud/packages/db/prisma/schema.prisma
+++ b/cloud/packages/db/prisma/schema.prisma
@@ -420,6 +420,7 @@ model DomainEvaluation {
   startedAt        DateTime?                     @map("started_at")
   completedAt      DateTime?                     @map("completed_at")
   createdByUserId  String?                       @map("created_by_user_id")
+  deletedAt        DateTime?                     @map("deleted_at")
 
   domain    Domain               @relation(fields: [domainId], references: [id], onDelete: Cascade)
   createdBy User?                @relation("DomainEvaluationCreator", fields: [createdByUserId], references: [id])
@@ -440,6 +441,7 @@ model DomainEvaluationRun {
   definitionNameAtLaunch String  @map("definition_name_at_launch")
   domainIdAtLaunch      String   @map("domain_id_at_launch")
   createdAt             DateTime @default(now()) @map("created_at")
+  deletedAt             DateTime? @map("deleted_at")
 
   domainEvaluation DomainEvaluation @relation(fields: [domainEvaluationId], references: [id], onDelete: Cascade)
   run              Run              @relation(fields: [runId], references: [id], onDelete: Cascade)
@@ -620,6 +622,7 @@ model ProbeResult {
   // Timestamps
   createdAt    DateTime         @default(now()) @map("created_at")
   completedAt  DateTime?        @map("completed_at")
+  deletedAt    DateTime?        @map("deleted_at")
 
   run      Run      @relation(fields: [runId], references: [id], onDelete: Cascade)
   scenario Scenario @relation(fields: [scenarioId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary
Add `deletedAt DateTime?` to ProbeResult, DomainEvaluation, and DomainEvaluationRun. Migration-only, no app code changes.

## Migration
`ALTER TABLE ... ADD COLUMN "deleted_at" TIMESTAMP(3)` for all 3 tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)