### PR TITLE
feat(db): add Prisma soft-delete client extension

### DIFF
--- a/cloud/apps/api/tests/services/scenario/expand.test.ts
+++ b/cloud/apps/api/tests/services/scenario/expand.test.ts
@@ -276,10 +276,15 @@ describe('Scenario Expansion Service', () => {
         expect(result.created).toBe(1);
 
         // Verify old scenario is soft deleted
-        const allScenarios = await db.scenario.findMany({
+        // Query active and deleted separately (soft-delete extension auto-filters)
+        const activeCount = await db.scenario.count({
           where: { definitionId: testDefinitionId },
         });
-        expect(allScenarios).toHaveLength(2);
+        const deletedCount = await db.scenario.count({
+          where: { definitionId: testDefinitionId, deletedAt: { not: null } },
+        });
+        expect(activeCount).toBe(1); // new scenario
+        expect(deletedCount).toBe(1); // old scenario soft-deleted
 
         const activeScenarios = await db.scenario.findMany({
           where: { definitionId: testDefinitionId, deletedAt: null },

--- a/cloud/packages/db/src/client.ts
+++ b/cloud/packages/db/src/client.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { softDeleteExtension } from './extensions/soft-delete.js';
 
 /**
  * CRITICAL SAFEGUARD: Prevent tests from accidentally using production database
@@ -45,12 +46,18 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
-export const db =
+const basePrisma =
   globalForPrisma.prisma ??
   new PrismaClient({
     log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
   });
 
 if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = db;
+  globalForPrisma.prisma = basePrisma;
 }
+
+// Apply soft-delete extension at runtime. The cast preserves the PrismaClient type
+// for consumers — $extends changes the type in ways that break $transaction callbacks
+// and TransactionClient parameters across the codebase. The runtime behavior is correct;
+// only the type is widened back to PrismaClient.
+export const db = basePrisma.$extends(softDeleteExtension) as unknown as PrismaClient;

--- a/cloud/packages/db/src/extensions/soft-delete.ts
+++ b/cloud/packages/db/src/extensions/soft-delete.ts
@@ -1,0 +1,86 @@
+/**
+ * Prisma Soft-Delete Client Extension
+ *
+ * Auto-injects `deletedAt: null` into where clauses for soft-deletable models.
+ * Callers can bypass by explicitly setting `deletedAt` in their where clause.
+ */
+
+import { Prisma } from '@prisma/client';
+
+/**
+ * Models that use soft delete (have a `deletedAt` column).
+ * Uses PascalCase Prisma model names as they appear in $allModels handlers.
+ */
+export const SOFT_DELETABLE_MODELS = new Set([
+  'Definition',
+  'DefinitionTag',
+  'Scenario',
+  'Transcript',
+  'AnalysisResult',
+  'AssumptionAnalysisSnapshot',
+  'ProbeResult',
+  'DomainEvaluation',
+  'DomainEvaluationRun',
+]);
+
+/**
+ * Inject `deletedAt: null` into a where clause unless the caller
+ * has already specified `deletedAt` (bypass for admin/audit queries).
+ */
+export function injectDeletedAtNull(
+  where: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (where == null) return { deletedAt: null };
+  if ('deletedAt' in where) return where;
+  return { ...where, deletedAt: null };
+}
+
+/**
+ * Prisma client extension that auto-filters soft-deleted records.
+ *
+ * Intercepts findMany, findFirst, findFirstOrThrow, count, aggregate,
+ * and groupBy for soft-deletable models. Skips findUnique/findUniqueOrThrow
+ * because Prisma requires unique-field-only where clauses for those.
+ */
+export const softDeleteExtension = Prisma.defineExtension({
+  query: {
+    $allModels: {
+      async findMany({ model, args, query }) {
+        if (SOFT_DELETABLE_MODELS.has(model)) {
+          args.where = injectDeletedAtNull(args.where as Record<string, unknown> | undefined);
+        }
+        return query(args);
+      },
+      async findFirst({ model, args, query }) {
+        if (SOFT_DELETABLE_MODELS.has(model)) {
+          args.where = injectDeletedAtNull(args.where as Record<string, unknown> | undefined);
+        }
+        return query(args);
+      },
+      async findFirstOrThrow({ model, args, query }) {
+        if (SOFT_DELETABLE_MODELS.has(model)) {
+          args.where = injectDeletedAtNull(args.where as Record<string, unknown> | undefined);
+        }
+        return query(args);
+      },
+      async count({ model, args, query }) {
+        if (SOFT_DELETABLE_MODELS.has(model)) {
+          args.where = injectDeletedAtNull(args.where as Record<string, unknown> | undefined);
+        }
+        return query(args);
+      },
+      async aggregate({ model, args, query }) {
+        if (SOFT_DELETABLE_MODELS.has(model)) {
+          args.where = injectDeletedAtNull(args.where as Record<string, unknown> | undefined);
+        }
+        return query(args);
+      },
+      async groupBy({ model, args, query }) {
+        if (SOFT_DELETABLE_MODELS.has(model)) {
+          args.where = injectDeletedAtNull(args.where as Record<string, unknown> | undefined);
+        }
+        return query(args);
+      },
+    },
+  },
+});

--- a/cloud/packages/db/tests/extensions/soft-delete.test.ts
+++ b/cloud/packages/db/tests/extensions/soft-delete.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SOFT_DELETABLE_MODELS,
+  injectDeletedAtNull,
+} from '../../src/extensions/soft-delete.js';
+
+describe('softDeleteExtension', () => {
+  describe('SOFT_DELETABLE_MODELS', () => {
+    it('includes all expected models', () => {
+      const expected = [
+        'Definition',
+        'DefinitionTag',
+        'Scenario',
+        'Transcript',
+        'AnalysisResult',
+        'AssumptionAnalysisSnapshot',
+        'ProbeResult',
+        'DomainEvaluation',
+        'DomainEvaluationRun',
+      ];
+      for (const model of expected) {
+        expect(SOFT_DELETABLE_MODELS.has(model)).toBe(true);
+      }
+      expect(SOFT_DELETABLE_MODELS.size).toBe(expected.length);
+    });
+
+    it('does not include non-soft-deletable models', () => {
+      expect(SOFT_DELETABLE_MODELS.has('User')).toBe(false);
+      expect(SOFT_DELETABLE_MODELS.has('Run')).toBe(false);
+      expect(SOFT_DELETABLE_MODELS.has('LlmModel')).toBe(false);
+      expect(SOFT_DELETABLE_MODELS.has('Domain')).toBe(false);
+    });
+  });
+
+  describe('injectDeletedAtNull', () => {
+    it('returns { deletedAt: null } when where is undefined', () => {
+      expect(injectDeletedAtNull(undefined)).toEqual({ deletedAt: null });
+    });
+
+    it('returns { deletedAt: null } when where is null', () => {
+      expect(injectDeletedAtNull(null as unknown as undefined)).toEqual({ deletedAt: null });
+    });
+
+    it('adds deletedAt: null to existing where clause', () => {
+      const where = { domainId: 'abc', status: 'COMPLETED' };
+      expect(injectDeletedAtNull(where)).toEqual({
+        domainId: 'abc',
+        status: 'COMPLETED',
+        deletedAt: null,
+      });
+    });
+
+    it('preserves caller-specified deletedAt (bypass)', () => {
+      const where = { domainId: 'abc', deletedAt: { not: null } };
+      expect(injectDeletedAtNull(where)).toEqual({
+        domainId: 'abc',
+        deletedAt: { not: null },
+      });
+    });
+
+    it('preserves deletedAt: null (idempotent with existing manual filters)', () => {
+      const where = { domainId: 'abc', deletedAt: null };
+      expect(injectDeletedAtNull(where)).toEqual({
+        domainId: 'abc',
+        deletedAt: null,
+      });
+    });
+
+    it('preserves deletedAt when set to a Date (query for deleted-at-specific-time)', () => {
+      const date = new Date('2026-01-01');
+      const where = { deletedAt: date };
+      expect(injectDeletedAtNull(where)).toEqual({ deletedAt: date });
+    });
+
+    it('does not mutate the original where object', () => {
+      const where = { domainId: 'abc' };
+      const result = injectDeletedAtNull(where);
+      expect(result).not.toBe(where);
+      expect(where).toEqual({ domainId: 'abc' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Auto-injects `deletedAt: null` for 9 soft-deletable models. Bypass by setting `deletedAt` explicitly.

## Covered models
Definition, DefinitionTag, Scenario, Transcript, AnalysisResult, AssumptionAnalysisSnapshot, ProbeResult, DomainEvaluation, DomainEvaluationRun

## Intercepted operations
findMany, findFirst, findFirstOrThrow, count, aggregate, groupBy

## Bypass mechanism
```typescript
// Normal query — auto-filtered
db.definition.findMany({ where: { domainId: 'abc' } })
// → WHERE domain_id = 'abc' AND deleted_at IS NULL

// Bypass — see deleted records
db.definition.findMany({ where: { deletedAt: { not: null } } })
// → WHERE deleted_at IS NOT NULL
```

## Adversarial reviews
- Codex: 5/6 PASS
- Gemini: 4/5 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)