### PR TITLE
fix(queue): prevent premature run completion when probes are missing

### DIFF
--- a/cloud/apps/api/src/cli/reopen-premature-runs.ts
+++ b/cloud/apps/api/src/cli/reopen-premature-runs.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env npx tsx
+/**
+ * One-time backfill: re-open COMPLETED runs that completed prematurely due to
+ * AUTH_ERROR failures leaving some probes without transcripts.
+ *
+ * Usage:
+ *   npx tsx src/cli/reopen-premature-runs.ts [--dry-run] [--after YYYY-MM-DD]
+ *
+ * Prerequisites:
+ *   1. Confirm the provider quota/auth issue is resolved before running in live mode.
+ *   2. Use --after to limit scope (e.g., --after 2025-11-01).
+ *   3. Always run --dry-run first and review the output.
+ *
+ * Crash recovery: if the script crashes after the transaction commits (run is
+ * now RUNNING) but before recoverOrphanedRun completes, the scheduled
+ * detectOrphanedRuns service (every 5 min) will re-queue the missing probes.
+ */
+
+import { fileURLToPath } from 'url';
+import readline from 'readline';
+
+import { db } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+
+import { findMissingProbes } from '../services/run/coverage-completeness.js';
+import { reverseDeductionForRun } from '../services/budget/deduct.js';
+import { recoverOrphanedRun } from '../services/run/recovery.js';
+import { createBoss, startBoss, stopBoss } from '../queue/boss.js';
+
+const log = createLogger('cli:reopen-premature-runs');
+
+type ParsedArgs = {
+  dryRun: boolean;
+  afterDate: Date | null;
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args = argv.slice(2);
+  let dryRun = false;
+  let afterDate: Date | null = null;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg === '--after') {
+      const value = args[i + 1];
+      if (value === undefined || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        throw new Error('--after requires a YYYY-MM-DD date');
+      }
+      afterDate = new Date(`${value}T00:00:00Z`);
+      i += 1;
+    }
+  }
+
+  return { dryRun, afterDate };
+}
+
+async function promptConfirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim() === 'YES');
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const { dryRun, afterDate } = parseArgs(process.argv);
+
+  log.info({ dryRun, afterDate }, 'Starting reopen-premature-runs');
+
+  // Query all COMPLETED runs within the optional time window
+  const completedRuns = await db.run.findMany({
+    where: {
+      status: 'COMPLETED',
+      deletedAt: null,
+      ...(afterDate != null ? { completedAt: { gte: afterDate } } : {}),
+    },
+    select: { id: true, completedAt: true },
+    orderBy: { completedAt: 'asc' },
+  });
+
+  log.info({ count: completedRuns.length }, 'Scanning completed runs for missing probes');
+
+  const toReopen: Array<{ runId: string; missingCount: number }> = [];
+  let skipped = 0;
+
+  for (const run of completedRuns) {
+    const missing = await findMissingProbes(run.id);
+    if (missing.length === 0) {
+      skipped++;
+      continue;
+    }
+    toReopen.push({ runId: run.id, missingCount: missing.length });
+    if (dryRun) {
+      console.log(`[DRY RUN] Would reopen run ${run.id} — ${missing.length} missing probe(s)`);
+    }
+  }
+
+  console.log(
+    `\nScan complete: ${completedRuns.length} runs scanned, ${skipped} OK, ${toReopen.length} need reopening`,
+  );
+
+  if (toReopen.length === 0) {
+    log.info('No runs to reopen — exiting');
+    return;
+  }
+
+  if (dryRun) {
+    console.log('\nRe-run without --dry-run to apply changes.');
+    return;
+  }
+
+  // Live mode: confirm before proceeding (unless --after was specified)
+  console.log('\nRuns that will be reopened:');
+  for (const { runId, missingCount } of toReopen) {
+    console.log(`  ${runId} (${missingCount} missing probes)`);
+  }
+
+  if (afterDate === null) {
+    const confirmed = await promptConfirm(
+      '\nThis will modify ALL completed runs with missing probes. Type YES to continue: ',
+    );
+    if (!confirmed) {
+      console.log('Aborted.');
+      return;
+    }
+  }
+
+  console.log(
+    '\nNote: Ensure the provider quota/auth issue is resolved before proceeding.\n',
+  );
+
+  // Initialize PgBoss (required by recoverOrphanedRun)
+  createBoss();
+  await startBoss();
+
+  let reopened = 0;
+  let totalProbesQueued = 0;
+  let errors = 0;
+
+  for (const { runId } of toReopen) {
+    try {
+      // Reverse budget deduction and reset status atomically
+      await db.$transaction(async (tx) => {
+        await reverseDeductionForRun(runId, tx);
+        await tx.run.update({
+          where: { id: runId },
+          data: { status: 'RUNNING', completedAt: null, stalledModels: [] },
+        });
+      });
+
+      // Re-queue missing probes (uses PgBoss)
+      const result = await recoverOrphanedRun(runId);
+      const requeuedCount = result.requeuedCount ?? 0;
+
+      log.info({ runId, requeuedCount, action: result.action }, 'Reopened run');
+      reopened++;
+      totalProbesQueued += requeuedCount;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.error({ runId, error: errorMessage }, 'Failed to reopen run');
+      errors++;
+    }
+  }
+
+  await stopBoss();
+
+  console.log(
+    `\nDone: ${completedRuns.length} scanned, ${skipped} skipped, ${reopened} reopened, ${totalProbesQueued} probes re-queued, ${errors} errors`,
+  );
+
+  if (errors > 0) {
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  void main().catch((error: unknown) => {
+    log.error({ err: error }, 'reopen-premature-runs failed');
+    process.exit(1);
+  });
+}

--- a/cloud/apps/api/src/queue/handlers/__tests__/summarize-persistence.test.ts
+++ b/cloud/apps/api/src/queue/handlers/__tests__/summarize-persistence.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock @valuerank/db before importing the module under test
+vi.mock('@valuerank/db', () => ({
+  db: {
+    transcript: {
+      count: vi.fn(),
+    },
+  },
+  Prisma: { DbNull: null },
+}));
+
+// Mock findMissingProbes from coverage-completeness
+vi.mock('../../../services/run/coverage-completeness.js', () => ({
+  findMissingProbes: vi.fn(),
+}));
+
+import { db } from '@valuerank/db';
+import { findMissingProbes } from '../../../services/run/coverage-completeness.js';
+import { checkAllSummarized } from '../summarize-persistence.js';
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const mockCount = vi.mocked(db.transcript.count);
+const mockFindMissingProbes = vi.mocked(findMissingProbes);
+
+describe('checkAllSummarized', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false when there are unsummarized transcripts', async () => {
+    mockCount.mockResolvedValueOnce(2);
+    // findMissingProbes should not be called since we short-circuit
+    const result = await checkAllSummarized('run-1');
+    expect(result).toBe(false);
+    expect(mockFindMissingProbes).not.toHaveBeenCalled();
+  });
+
+  it('returns false when all transcripts are summarized but some probes are missing', async () => {
+    mockCount.mockResolvedValueOnce(0);
+    mockFindMissingProbes.mockResolvedValueOnce([
+      { scenarioId: 'sc-1', modelId: 'model-a', sampleIndex: 0 },
+    ]);
+    const result = await checkAllSummarized('run-1');
+    expect(result).toBe(false);
+  });
+
+  it('returns true when all transcripts are summarized and no probes are missing', async () => {
+    mockCount.mockResolvedValueOnce(0);
+    mockFindMissingProbes.mockResolvedValueOnce([]);
+    const result = await checkAllSummarized('run-1');
+    expect(result).toBe(true);
+  });
+
+  it('returns true when run has no expected probes (findMissingProbes returns [])', async () => {
+    mockCount.mockResolvedValueOnce(0);
+    mockFindMissingProbes.mockResolvedValueOnce([]);
+    const result = await checkAllSummarized('run-no-config');
+    expect(result).toBe(true);
+  });
+
+  it('propagates errors from findMissingProbes so the job can retry', async () => {
+    mockCount.mockResolvedValueOnce(0);
+    mockFindMissingProbes.mockRejectedValueOnce(new Error('DB connection lost'));
+    await expect(checkAllSummarized('run-1')).rejects.toThrow('DB connection lost');
+  });
+});

--- a/cloud/apps/api/src/queue/handlers/summarize-persistence.ts
+++ b/cloud/apps/api/src/queue/handlers/summarize-persistence.ts
@@ -1,4 +1,5 @@
 import { db, Prisma, type SummaryCache } from '@valuerank/db';
+import { findMissingProbes } from '../../services/run/coverage-completeness.js';
 import { createLogger } from '@valuerank/shared';
 import { DEFAULT_JOB_OPTIONS } from '../types.js';
 import { triggerBasicAnalysis } from '../../services/analysis/index.js';
@@ -83,7 +84,15 @@ export async function queueComputeTokenStats(runId: string): Promise<void> {
 }
 
 /**
- * Check if all transcripts for a run have been summarized.
+ * Check if all transcripts for a run have been summarized AND all expected probes
+ * have produced transcripts (or been accounted for).
+ *
+ * Returns false if:
+ * - Any transcript is still unsummarized (existing behavior), OR
+ * - Any expected (scenarioId × modelId × sampleIndex) tuple lacks a transcript
+ *   (new guard: prevents premature completion when AUTH_ERROR probes are re-queued)
+ *
+ * Returns true only when both conditions are satisfied.
  */
 export async function checkAllSummarized(runId: string): Promise<boolean> {
   const unsummarized = await db.transcript.count({
@@ -92,7 +101,11 @@ export async function checkAllSummarized(runId: string): Promise<boolean> {
       summarizedAt: null,
     },
   });
-  return unsummarized === 0;
+  if (unsummarized > 0) {
+    return false;
+  }
+  const missing = await findMissingProbes(runId);
+  return missing.length === 0;
 }
 
 /**

--- a/cloud/apps/api/src/services/budget/deduct.ts
+++ b/cloud/apps/api/src/services/budget/deduct.ts
@@ -132,6 +132,64 @@ export async function deductActualProviderBalancesForRun(runId: string): Promise
 }
 
 /**
+ * Reverse the budget deduction for a run by crediting back the costs
+ * stored in each transcript's costSnapshot. Used by the backfill script
+ * before re-opening a prematurely completed run.
+ *
+ * Costs are read from transcript.content.costSnapshot.estimatedCost.
+ * Accepts an optional Prisma transaction client for atomic execution with
+ * status updates.
+ */
+export async function reverseDeductionForRun(
+  runId: string,
+  tx?: Prisma.TransactionClient,
+): Promise<void> {
+  const client = tx ?? db;
+  const transcripts = await client.transcript.findMany({
+    where: { runId },
+    select: { modelId: true, content: true },
+  });
+  if (transcripts.length === 0) return;
+
+  const costByModel = new Map<string, number>();
+  for (const t of transcripts) {
+    const cost = extractTranscriptCost(t.content);
+    if (cost > 0) {
+      costByModel.set(t.modelId, (costByModel.get(t.modelId) ?? 0) + cost);
+    }
+  }
+  if (costByModel.size === 0) return;
+
+  const modelIds = [...costByModel.keys()];
+  const models = await client.llmModel.findMany({
+    where: { modelId: { in: modelIds } },
+    select: { modelId: true, provider: { select: { name: true, balance: true } } },
+  });
+  const modelToProvider = new Map(models.map((m) => [m.modelId, m.provider]));
+
+  const costByProvider = new Map<string, number>();
+  for (const [modelId, cost] of costByModel) {
+    const provider = modelToProvider.get(modelId);
+    if (provider == null) continue;
+    costByProvider.set(provider.name, (costByProvider.get(provider.name) ?? 0) + cost);
+  }
+
+  for (const [providerName, cost] of costByProvider) {
+    if (tx != null) {
+      await tx.$executeRaw`
+        UPDATE "llm_providers"
+        SET "balance" = "balance" + ${new Prisma.Decimal(cost)}
+        WHERE "name" = ${providerName}
+          AND "balance" IS NOT NULL
+      `;
+    } else {
+      await atomicDeduct(providerName, -cost);
+    }
+    log.info({ runId, providerName, cost }, 'Reversed provider balance (backfill)');
+  }
+}
+
+/**
  * Deduct provider balances for a completed run.
  *
  * Reads `estimatedCosts.perModel` from the run's JSON config, groups costs by

--- a/cloud/apps/api/src/services/run/coverage-completeness.ts
+++ b/cloud/apps/api/src/services/run/coverage-completeness.ts
@@ -1,3 +1,5 @@
+import { db } from '@valuerank/db';
+
 export type TranscriptKey = {
   scenarioId: string;
   modelId: string;
@@ -44,4 +46,50 @@ export function findMissingTranscriptKeys({
   }
 
   return missing;
+}
+
+/**
+ * Finds which (scenarioId × modelId × sampleIndex) tuples are missing transcripts
+ * for a given run, by reading the run's config and scenario selections from the DB.
+ *
+ * Returns [] if the run does not exist or has no expected probes.
+ */
+export async function findMissingProbes(runId: string): Promise<TranscriptKey[]> {
+  const run = await db.run.findUnique({
+    where: { id: runId },
+    select: {
+      config: true,
+      scenarioSelections: {
+        select: { scenarioId: true },
+      },
+    },
+  });
+
+  if (run === null) {
+    return [];
+  }
+
+  const config =
+    run.config != null && typeof run.config === 'object'
+      ? (run.config as { models?: string[]; samplesPerScenario?: number })
+      : {};
+  const models = config.models ?? [];
+  const samplesPerScenario = normalizeSamplesPerScenario(config.samplesPerScenario);
+  const scenarioIds = run.scenarioSelections.map((s) => s.scenarioId);
+
+  const existingTranscripts = await db.transcript.findMany({
+    where: { runId },
+    select: { scenarioId: true, modelId: true, sampleIndex: true },
+  });
+
+  const existing = existingTranscripts
+    .filter((t): t is TranscriptKey => t.scenarioId !== null)
+    .map(({ scenarioId, modelId, sampleIndex }) => ({ scenarioId, modelId, sampleIndex }));
+
+  return findMissingTranscriptKeys({
+    scenarioIds,
+    models,
+    samplesPerScenario,
+    existingTranscripts: existing,
+  });
 }

--- a/cloud/apps/api/src/services/run/recovery-jobs.ts
+++ b/cloud/apps/api/src/services/run/recovery-jobs.ts
@@ -1,0 +1,108 @@
+/**
+ * Low-level job queue operations for run recovery.
+ * Extracted from recovery.ts to keep that file under the 400-line limit.
+ */
+
+import { db } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
+import { getBoss } from '../../queue/boss.js';
+import { DEFAULT_JOB_OPTIONS } from '../../queue/types.js';
+import { getQueueNameForModel } from '../parallelism/index.js';
+import type { TranscriptKey } from './coverage-completeness.js';
+
+const log = createLogger('services:run:recovery');
+
+/**
+ * Counts pending and active jobs for a specific run across all probe queues.
+ */
+export async function countJobsForRun(runId: string): Promise<{ pending: number; active: number }> {
+  // Query PgBoss job table directly for accurate counts
+  const result = await db.$queryRaw<Array<{ state: string; count: bigint }>>`
+    SELECT state, COUNT(*) as count
+    FROM pgboss.job
+    WHERE (name = 'probe_scenario' OR name LIKE 'probe_scenario_%')
+      AND state IN ('created', 'retry', 'active')
+      AND data->>'runId' = ${runId}
+    GROUP BY state
+  `;
+
+  let pending = 0;
+  let active = 0;
+
+  for (const row of result) {
+    const count = Number(row.count);
+    if (row.state === 'active') {
+      active = count;
+    } else {
+      pending += count; // 'created' and 'retry' are both pending
+    }
+  }
+
+  return { pending, active };
+}
+
+/**
+ * Re-queues missing probe jobs for an orphaned run.
+ * Handles multi-sample runs by including sampleIndex in job data.
+ */
+export async function requeueMissingProbes(
+  runId: string,
+  missingProbes: TranscriptKey[]
+): Promise<number> {
+  const boss = getBoss();
+
+  const jobOptions = DEFAULT_JOB_OPTIONS['probe_scenario'];
+  let queuedCount = 0;
+
+  for (const { scenarioId, modelId, sampleIndex } of missingProbes) {
+    const queueName = await getQueueNameForModel(modelId);
+
+    await boss.send(
+      queueName,
+      {
+        runId,
+        scenarioId,
+        modelId,
+        sampleIndex,
+        config: {
+          maxTurns: 10,
+        },
+      },
+      jobOptions
+    );
+
+    queuedCount++;
+  }
+
+  log.info({ runId, queuedCount }, 'Re-queued missing probe jobs');
+  return queuedCount;
+}
+
+/**
+ * Queues summarize jobs for all unsummarized transcripts in a run.
+ * Duplicated from progress.ts since that function is private.
+ */
+export async function queueSummarizeJobsForRecovery(runId: string): Promise<number> {
+  const boss = getBoss();
+
+  const transcripts = await db.transcript.findMany({
+    where: { runId, summarizedAt: null },
+    select: { id: true },
+  });
+
+  if (transcripts.length === 0) {
+    return 0;
+  }
+
+  const jobOptions = DEFAULT_JOB_OPTIONS['summarize_transcript'];
+
+  for (const transcript of transcripts) {
+    await boss.send('summarize_transcript', {
+      runId,
+      transcriptId: transcript.id,
+    }, jobOptions);
+  }
+
+  log.info({ runId, jobCount: transcripts.length }, 'Queued summarize jobs for recovery');
+  return transcripts.length;
+}

--- a/cloud/apps/api/src/services/run/recovery.ts
+++ b/cloud/apps/api/src/services/run/recovery.ts
@@ -16,8 +16,7 @@ import { getBoss } from '../../queue/boss.js';
 import { DEFAULT_JOB_OPTIONS } from '../../queue/types.js';
 import { getQueueNameForModel } from '../parallelism/index.js';
 import {
-  findMissingTranscriptKeys,
-  normalizeSamplesPerScenario,
+  findMissingProbes,
   type TranscriptKey,
 } from './coverage-completeness.js';
 
@@ -148,54 +147,6 @@ async function countJobsForRun(runId: string): Promise<{ pending: number; active
   }
 
   return { pending, active };
-}
-
-/**
- * Finds which scenario+model+sampleIndex combinations are missing transcripts for a run.
- * Handles multi-sample runs where samplesPerScenario > 1.
- */
-async function findMissingProbes(
-  runId: string
-): Promise<TranscriptKey[]> {
-  // Get run config to know which models were requested and samples per scenario
-  const run = await db.run.findUnique({
-    where: { id: runId },
-    select: {
-      config: true,
-      scenarioSelections: {
-        select: { scenarioId: true },
-      },
-    },
-  });
-
-  if (run === null) {
-    return [];
-  }
-
-  const config = run.config as { models: string[]; samplesPerScenario?: number };
-  const models = config.models ?? [];
-  const samplesPerScenario = normalizeSamplesPerScenario(config.samplesPerScenario);
-  const scenarioIds = run.scenarioSelections.map((s) => s.scenarioId);
-
-  // Get existing transcripts for this run (include sampleIndex for multi-sample runs)
-  const existingTranscripts = await db.transcript.findMany({
-    where: { runId },
-    select: { scenarioId: true, modelId: true, sampleIndex: true },
-  });
-  const existingTranscriptKeys = existingTranscripts
-    .filter((transcript): transcript is TranscriptKey => transcript.scenarioId !== null)
-    .map((transcript) => ({
-      scenarioId: transcript.scenarioId,
-      modelId: transcript.modelId,
-      sampleIndex: transcript.sampleIndex,
-    }));
-
-  return findMissingTranscriptKeys({
-    scenarioIds,
-    models,
-    samplesPerScenario,
-    existingTranscripts: existingTranscriptKeys,
-  });
 }
 
 /**

--- a/cloud/apps/api/src/services/run/recovery.ts
+++ b/cloud/apps/api/src/services/run/recovery.ts
@@ -12,13 +12,12 @@
 
 import { db } from '@valuerank/db';
 import { createLogger } from '@valuerank/shared';
-import { getBoss } from '../../queue/boss.js';
-import { DEFAULT_JOB_OPTIONS } from '../../queue/types.js';
-import { getQueueNameForModel } from '../parallelism/index.js';
+import { findMissingProbes } from './coverage-completeness.js';
 import {
-  findMissingProbes,
-  type TranscriptKey,
-} from './coverage-completeness.js';
+  countJobsForRun,
+  requeueMissingProbes,
+  queueSummarizeJobsForRecovery,
+} from './recovery-jobs.js';
 
 const log = createLogger('services:run:recovery');
 
@@ -118,104 +117,6 @@ export async function detectOrphanedRuns(): Promise<OrphanedRunInfo[]> {
   }
 
   return orphaned;
-}
-
-/**
- * Counts pending and active jobs for a specific run across all probe queues.
- */
-async function countJobsForRun(runId: string): Promise<{ pending: number; active: number }> {
-  // Query PgBoss job table directly for accurate counts
-  const result = await db.$queryRaw<Array<{ state: string; count: bigint }>>`
-    SELECT state, COUNT(*) as count
-    FROM pgboss.job
-    WHERE (name = 'probe_scenario' OR name LIKE 'probe_scenario_%')
-      AND state IN ('created', 'retry', 'active')
-      AND data->>'runId' = ${runId}
-    GROUP BY state
-  `;
-
-  let pending = 0;
-  let active = 0;
-
-  for (const row of result) {
-    const count = Number(row.count);
-    if (row.state === 'active') {
-      active = count;
-    } else {
-      pending += count; // 'created' and 'retry' are both pending
-    }
-  }
-
-  return { pending, active };
-}
-
-/**
- * Re-queues missing probe jobs for an orphaned run.
- * Handles multi-sample runs by including sampleIndex in job data.
- */
-async function requeueMissingProbes(
-  runId: string,
-  missingProbes: TranscriptKey[]
-): Promise<number> {
-  const boss = getBoss();
-
-
-  const jobOptions = DEFAULT_JOB_OPTIONS['probe_scenario'];
-  let queuedCount = 0;
-
-  for (const { scenarioId, modelId, sampleIndex } of missingProbes) {
-    const queueName = await getQueueNameForModel(modelId);
-
-    await boss.send(
-      queueName,
-      {
-        runId,
-        scenarioId,
-        modelId,
-        sampleIndex,
-        config: {
-          maxTurns: 10,
-        },
-      },
-      jobOptions
-    );
-
-    queuedCount++;
-  }
-
-  log.info({ runId, queuedCount }, 'Re-queued missing probe jobs');
-  return queuedCount;
-}
-
-/**
- * Queues summarize jobs for all transcripts in a run.
- * Duplicated from progress.ts since that function is private.
- */
-async function queueSummarizeJobsForRecovery(runId: string): Promise<number> {
-  const boss = getBoss();
-
-
-  // Get all transcripts for this run that haven't been summarized
-  const transcripts = await db.transcript.findMany({
-    where: { runId, summarizedAt: null },
-    select: { id: true },
-  });
-
-  if (transcripts.length === 0) {
-    return 0;
-  }
-
-  const jobOptions = DEFAULT_JOB_OPTIONS['summarize_transcript'];
-
-  for (const transcript of transcripts) {
-    await boss.send('summarize_transcript', {
-      runId,
-      transcriptId: transcript.id,
-    }, jobOptions);
-  }
-
-  log.info({ runId, jobCount: transcripts.length }, 'Queued summarize jobs for recovery');
-  return transcripts.length;
 }
 
 /**


### PR DESCRIPTION
## Problem

When probes fail with AUTH_ERROR (quota exhausted), they never create transcripts. `checkAllSummarized()` only checked `unsummarized === 0` — it didn't verify whether all *expected* probes had produced transcripts. So a run could transition to COMPLETED while recovery was still pending re-queued probes. Those probes would then arrive, see a terminal COMPLETED run, and skip.

## Solution

### Slice 1: Guard in `checkAllSummarized`

- Extracts `findMissingProbes` from `recovery.ts` into `coverage-completeness.ts` so it can be shared
- Updates `checkAllSummarized` to two-step check: unsummarized transcripts AND no missing (scenarioId × modelId × sampleIndex) tuples
- Adds unit tests for all five cases (unsummarized > 0; missing > 0; both 0; no config; DB error propagation)

### Slice 2: Backfill for already-affected runs

- Adds `reverseDeductionForRun(runId, tx?)` to `deduct.ts` — credits back costs stored in transcript `costSnapshot` before re-opening, preventing double-charging
- Adds `src/cli/reopen-premature-runs.ts` — finds COMPLETED runs with missing probes, atomically reverses budget deduction + resets to RUNNING in a Prisma transaction, then calls `recoverOrphanedRun` to re-queue missing probes
- Supports `--dry-run` (review first) and `--after YYYY-MM-DD` (blast-radius control)

## Validation

Run from `cloud/` in the worktree:

- `npx turbo lint --filter=@valuerank/api` — 0 errors, 127 pre-existing warnings ✓
- `npx vitest run src/queue/handlers/__tests__/summarize-persistence.test.ts` — 5/5 tests pass ✓
- `npx turbo build --filter=@valuerank/api` — TypeScript compilation clean ✓

Pre-existing test failures (unrelated to these changes, also fail on main):
- `tests/graphql/mutations/domain.test.ts`
- `tests/graphql/queries/domain.test.ts`
- `tests/graphql/queries/run-progress.test.ts`
- `tests/services/scenario/expand.test.ts` (soft-delete extension interaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)