### PR TITLE
fix(snapshot): case-insensitive value key lookup — restores win rates on domain analysis page

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
@@ -78,7 +78,13 @@ function getValueCountsFromAnalysis(output: unknown, modelId: string, valueKey: 
   if (values == null || typeof values !== 'object' || Array.isArray(values)) {
     return { prioritized: 0, deprioritized: 0, neutral: 0 };
   }
-  const valueData = (values as Record<string, unknown>)[valueKey];
+  // Analysis outputs store value keys in lowercase (e.g. "power_dominance") while
+  // the canonical ValueKey type uses PascalCase (e.g. "Power_Dominance"). Do a
+  // case-insensitive lookup so both conventions are handled.
+  const valuesRecord = values as Record<string, unknown>;
+  const keyLower = valueKey.toLowerCase();
+  const valueData = valuesRecord[valueKey]
+    ?? Object.entries(valuesRecord).find(([k]) => k.toLowerCase() === keyLower)?.[1];
   if (valueData == null || typeof valueData !== 'object' || Array.isArray(valueData)) {
     return { prioritized: 0, deprioritized: 0, neutral: 0 };
   }


### PR DESCRIPTION
## Summary

- **Root cause**: `getValueCountsFromAnalysis` looked up value keys with PascalCase (e.g. `Power_Dominance`) but the analysis result outputs store them in lowercase (`power_dominance`). Every lookup returned zeros → all win rates showed as n/a.
- **Why now**: PR #620 introduced the snapshot-based domain analysis path. The old transcript-based path was case-blind (it aggregated by iterating all transcript decisions). The new analysis-result path does a direct dict lookup, which is case-sensitive.
- **Fix**: After trying the exact key, fall back to a case-insensitive search over the values dict. Exact match is tried first so there's no perf regression if keys are already normalized.

After deploy, existing stale snapshots need to be invalidated so they rebuild with correct counts. The "Refresh" button on the domain analysis page (also added in #620) will trigger this.

## Test plan

- [ ] CI passes
- [ ] After deploy: visit a domain analysis page and verify win rates are non-zero
- [ ] Click "Refresh" on any domain that was cached with zeros to rebuild its snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)