### PR TITLE
feat(findings): UI cleanup — freshness, model groups, support-win cells

### DIFF
--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -114,9 +114,6 @@ export function ModelGroupsSection({ clusterAnalysis }: ModelGroupsSectionProps)
               return (
                 <div key={cluster.id} className={`min-w-[280px] max-w-[520px] rounded-lg border ${style.border} ${style.light} p-3`}>
                   <p className={`text-sm font-semibold ${style.text}`}>
-                    <span className="font-medium">Model Group:</span> {personality.title}
-                  </p>
-                  <p className="mt-1 text-xs text-gray-700">
                     <span className="font-medium">Members:</span> {cluster.members.map((member) => member.label).join(', ')}
                   </p>
                   <p className="mt-2 text-xs text-gray-700">
@@ -124,9 +121,6 @@ export function ModelGroupsSection({ clusterAnalysis }: ModelGroupsSectionProps)
                   </p>
                   <p className="mt-1 text-xs text-gray-700">
                     <span className="font-medium">De-prioritizes:</span> {personality.bottomValues.join(', ')}
-                  </p>
-                  <p className="mt-2 text-xs text-gray-700 italic">
-                    <span className="font-medium not-italic">Advising tendency:</span> &ldquo;{personality.tendency}&rdquo;
                   </p>
                 </div>
               );

--- a/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
@@ -361,9 +361,9 @@ export function ValuePrioritiesSection({
                                 const supportRate = model.supportRates?.[value] ?? null;
                                 const winRate = model.winRates?.[value] ?? null;
                                 if (supportRate === null && winRate === null) return 'n/a / n/a';
-                                if (winRate === null) return `Support ${Math.round(supportRate ?? 0)}% / Win n/a`;
-                                if (supportRate === null) return `n/a / Win ${Math.round(winRate)}%`;
-                                return `Support ${Math.round(supportRate)}% / Win ${Math.round(winRate)}%`;
+                                if (winRate === null) return `${Math.round(supportRate ?? 0)}% / n/a`;
+                                if (supportRate === null) return `n/a / ${Math.round(winRate)}%`;
+                                return `${Math.round(supportRate)}% / ${Math.round(winRate)}%`;
                               }
                               if (cellValue === null) return 'n/a';
                               if (scoreMode === 'WIN_RATE') return `${cellValue.toFixed(1)}%`;

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -8,13 +8,10 @@ import {
   DOMAIN_AVAILABLE_SIGNATURES_QUERY,
   DOMAIN_ANALYSIS_QUERY,
   DOMAIN_ANALYSIS_QUERY_LEGACY,
-  DOMAIN_FINDINGS_ELIGIBILITY_QUERY,
   REFRESH_DOMAIN_ANALYSIS_MUTATION,
   type DomainAvailableSignature,
   type DomainAvailableSignaturesQueryResult,
   type DomainAvailableSignaturesQueryVariables,
-  type DomainFindingsEligibilityQueryResult,
-  type DomainFindingsEligibilityQueryVariables,
   type DomainAnalysisQueryResult,
   type DomainAnalysisQueryVariables,
   type RefreshDomainAnalysisMutationResult,
@@ -24,7 +21,6 @@ import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
 import { DominanceSection } from '../components/domains/DominanceSection';
 import { SimilaritySection } from '../components/domains/SimilaritySection';
 import { ValuePrioritiesSection } from '../components/domains/ValuePrioritiesSection';
-import { EvidenceScopeDisclosure, getEvidenceScopeState } from '../components/domains/EvidenceScopeDisclosure';
 import {
   VALUES,
   type DomainAnalysisModelAvailability,
@@ -71,15 +67,6 @@ export function DomainAnalysis() {
       })
       .map(({ option }) => option);
   }, [signatureData]);
-
-  const [{ data: findingsEligibilityData, fetching: findingsEligibilityLoading, error: findingsEligibilityError }] = useQuery<
-    DomainFindingsEligibilityQueryResult, DomainFindingsEligibilityQueryVariables
-  >({
-    query: DOMAIN_FINDINGS_ELIGIBILITY_QUERY,
-    variables: { domainId: selectedDomainId },
-    pause: selectedDomainId === '',
-    requestPolicy: 'cache-and-network',
-  });
 
   useEffect(() => {
     if (domains.length === 0) return;
@@ -143,11 +130,6 @@ export function DomainAnalysis() {
   const data = useLegacyQuery ? legacyData : scoredData;
   const fetching = useLegacyQuery ? legacyFetching : scoredFetching;
   const error = useLegacyQuery ? legacyError : scoredError;
-  const findingsEligibility = findingsEligibilityData?.domainFindingsEligibility;
-  const evidenceScopeState = useMemo(
-    () => getEvidenceScopeState(findingsEligibility, findingsEligibilityLoading, findingsEligibilityError),
-    [findingsEligibility, findingsEligibilityLoading, findingsEligibilityError],
-  );
   const cacheStatusCopy = useMemo(
     () => getCacheStatusCopy(data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt),
     [data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt],
@@ -251,6 +233,30 @@ export function DomainAnalysis() {
         <p className="mt-1 text-sm text-gray-600">
           Structured domain interpretation across priorities, ranking behavior, and similarity for the selected domain.
         </p>
+        {data?.domainAnalysis != null && cacheStatusCopy != null && (
+          <div className="mt-2 space-y-1 text-xs text-gray-500">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${cacheStatusCopy.badgeClassName}`}>
+                {cacheStatusCopy.badgeLabel}
+              </span>
+              <span>{cacheStatusCopy.detail}</span>
+              {!useLegacyQuery && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  className="h-auto px-2.5 py-1 text-xs"
+                  onClick={handleRefreshAnalysis}
+                  disabled={refreshFetching}
+                >
+                  {refreshFetching ? 'Refreshing\u2026' : 'Refresh now'}
+                </Button>
+              )}
+            </div>
+            {refreshNotice !== null && <p className="text-green-700">{refreshNotice}</p>}
+            {refreshError !== null && <p className="text-amber-700">{refreshError}</p>}
+          </div>
+        )}
       </div>
 
       {(domainsError != null || signaturesError != null || error != null) && (
@@ -292,37 +298,8 @@ export function DomainAnalysis() {
           </div>
           {exportError !== null && <p className="mt-1 text-xs text-amber-700">{exportError}</p>}
         </div>
-        {data?.domainAnalysis != null && (
+        {data?.domainAnalysis != null && missingDefinitionCount > 0 && (
           <div className="mt-2 space-y-1 text-xs text-gray-500">
-            {cacheStatusCopy != null && (
-              <div className="flex flex-wrap items-center gap-2">
-                <span className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${cacheStatusCopy.badgeClassName}`}>
-                  {cacheStatusCopy.badgeLabel}
-                </span>
-                <span>{cacheStatusCopy.detail}</span>
-                {!useLegacyQuery && (
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    size="sm"
-                    onClick={handleRefreshAnalysis}
-                    disabled={refreshFetching}
-                  >
-                    {refreshFetching ? 'Refreshing\u2026' : 'Refresh now'}
-                  </Button>
-                )}
-              </div>
-            )}
-            {refreshNotice !== null && (
-              <p className="text-green-700">{refreshNotice}</p>
-            )}
-            {refreshError !== null && (
-              <p className="text-amber-700">{refreshError}</p>
-            )}
-            <p>{data.domainAnalysis.definitionsWithAnalysis} of {data.domainAnalysis.targetedDefinitions} latest vignettes currently have aggregate analysis data.</p>
-            {data.domainAnalysis.definitionsWithAnalysis === 0 && data.domainAnalysis.targetedDefinitions > 0 && (
-              <p className="text-amber-700">No latest vignettes produced analyzable transcript data for the selected signature.</p>
-            )}
             {missingDefinitionCount > 0 && (
               <>
                 <div className="flex flex-wrap items-center gap-2">
@@ -344,7 +321,6 @@ export function DomainAnalysis() {
         )}
       </section>
 
-      {selectedDomainId !== '' && <EvidenceScopeDisclosure state={evidenceScopeState} />}
 
       {showPageLoader ? (
         <Loading size="lg" text="Loading domain analysis..." />

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -161,29 +161,6 @@ describe('DomainAnalysis', () => {
     installQueryResponses();
   });
 
-  it('shows the compact scope chip and expands the details panel', async () => {
-    const user = userEvent.setup();
-    render(
-      <MemoryRouter>
-        <DomainAnalysis />
-      </MemoryRouter>,
-    );
-
-    const disclosure = await screen.findByRole('button', { name: /show evidence scope details/i });
-    expect(screen.getByText(/current evidence scope: diagnostic evidence only/i)).toBeInTheDocument();
-
-    await user.click(disclosure);
-
-    expect(disclosure).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.getByText(/this domain can show diagnostic signals/i)).toBeInTheDocument();
-    expect(screen.getByText(/launch snapshot boundary is not complete/i)).toBeInTheDocument();
-
-    disclosure.focus();
-    await user.keyboard('{Enter}');
-
-    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
-  });
-
   it('shows the freshness badge for saved analysis', async () => {
     render(
       <MemoryRouter>
@@ -193,48 +170,6 @@ describe('DomainAnalysis', () => {
 
     expect(await screen.findByText(/^Fresh$/)).toBeInTheDocument();
     expect(screen.getByText(/updated 3\/15\/2026/i)).toBeInTheDocument();
-  });
-
-  it('shows a loading chip while the eligibility query is unresolved', async () => {
-    installQueryResponses({
-      findingsData: undefined,
-      findingsFetching: true,
-      findingsError: undefined,
-    });
-
-    render(
-      <MemoryRouter>
-        <DomainAnalysis />
-      </MemoryRouter>,
-    );
-
-    await screen.findByText(/loading scope/i);
-    expect(screen.queryByRole('button', { name: /show evidence scope details/i })).not.toBeInTheDocument();
-  });
-
-  it('keeps the report visible when the eligibility query fails', async () => {
-    installQueryResponses({
-      findingsData: undefined,
-      findingsFetching: false,
-      findingsError: new Error('Eligibility data could not load'),
-    });
-
-    render(
-      <MemoryRouter>
-        <DomainAnalysis />
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /show evidence scope details/i })).toBeInTheDocument();
-    });
-
-    expect(screen.getByText(/scope unavailable/i)).toBeInTheDocument();
-    expect(screen.getByText(/eligibility data could not load/i)).toBeInTheDocument();
-    expect(screen.getByText(/Mock model groups section/i)).toBeInTheDocument();
-    expect(screen.getByText(/Mock value priorities section/i)).toBeInTheDocument();
-    expect(screen.getByText(/Mock dominance section/i)).toBeInTheDocument();
-    expect(screen.getByText(/Mock similarity section/i)).toBeInTheDocument();
   });
 
   it('renders the report sections in the requested order', async () => {


### PR DESCRIPTION
## Summary

- **Freshness section moved** to sit directly under the page title/subtitle — it applies to the whole page, not just Domain Selection
- **Refresh now button** shrunk to match the size of the Fresh/Stale badge (same `px-2.5 py-1 text-xs` sizing)
- **Removed** the "90 of 90 vignettes currently have aggregate analysis data" line
- **Removed** the Evidence Scope section (entire `EvidenceScopeDisclosure` component and its query)
- **Model Groups cards**: Members line is now the card title (colored, bold); "Model Group: Values-Driven Advisors" label and "Advising tendency" paragraph removed
- **Support Rate / Win Rate cells**: bare percentages only — `72% / 85%` instead of `Support 72% / Win 85%`

## Test plan
- [ ] Preflight passed (lint 0 errors, build clean)
- [ ] Manual smoke test on Findings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)