### PR TITLE
feat(export): rename domain CSV to domain name + PT datetime

### DIFF
--- a/cloud/apps/api/src/routes/export/domains.ts
+++ b/cloud/apps/api/src/routes/export/domains.ts
@@ -50,11 +50,14 @@ domainsExportRouter.get(
 
       const { domain, filteredSourceRunIds, resolvedSignature } = resolved;
 
-      const safeName = domain.name.replace(/[^a-z0-9-]/gi, '_').toLowerCase();
-      const date = new Date().toISOString().slice(0, 10);
-      const filename = resolvedSignature !== null
-        ? `domain-${safeName}-${resolvedSignature.replace(/[^a-z0-9-]/gi, '_').toLowerCase()}-transcripts-${date}.csv`
-        : `domain-${safeName}-transcripts-${date}.csv`;
+      // Format datetime in PT, replacing colons with dashes for filename safety
+      // e.g. "2026-04-13 14-32-05"
+      const ptDateTime = new Date()
+        .toLocaleString('sv-SE', { timeZone: 'America/Los_Angeles' })
+        .replace(/:/g, '-');
+      // Strip characters invalid in filenames (keep spaces, dashes, alphanumeric)
+      const safeDomainName = domain.name.replace(/[/\\:*?"<>|]/g, '_');
+      const filename = `${safeDomainName} domain export - ${ptDateTime}.csv`;
 
       res.setHeader('Content-Type', 'text/csv; charset=utf-8');
       res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);


### PR DESCRIPTION
## Summary
- Changes domain CSV export filename from the old slug format to a human-readable format
- New format: `Job Choice domain export - 2026-04-13 14-32-05.csv`
- Datetime is in PT (America/Los_Angeles), colons replaced with dashes for Windows compatibility

## Test plan
- [ ] Download a domain CSV and verify the filename matches the format above
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)