### PR TITLE
fix(overview): show win rate for neutral preferred values

### DIFF
--- a/cloud/apps/web/src/components/analysis/tabs/OverviewSummaryTable.tsx
+++ b/cloud/apps/web/src/components/analysis/tabs/OverviewSummaryTable.tsx
@@ -199,7 +199,11 @@ export function OverviewSummaryTable({
           <tbody>
             {models.map(({ modelId, preference, reliability }) => {
               const preferredValue = getPreferredValueName(preference);
-              const preferredValueWinRate = preference.topPrioritizedValues[0]?.winRate ?? null;
+              const preferredValueWinRate = (
+                preference.topPrioritizedValues[0]
+                ?? preference.neutralValues[0]
+                ?? preference.topDeprioritizedValues[0]
+              )?.winRate ?? null;
               const perSourceMetricsList = repeatPatternSources.map(
                 (source) => getRepeatPatternMetrics(modelId, source.varianceAnalysis, source.conditionRows),
               );

--- a/cloud/apps/web/tests/components/analysis/AnalysisPanel.test.tsx
+++ b/cloud/apps/web/tests/components/analysis/AnalysisPanel.test.tsx
@@ -648,7 +648,7 @@ describe('AnalysisPanel', () => {
     expect(claudeRow).not.toBeNull();
     expect(gptRow).not.toBeNull();
     expect(within(claudeRow as HTMLTableRowElement).getByText('Achievement')).toBeInTheDocument();
-    expect(within(claudeRow as HTMLTableRowElement).getAllByText('—').length).toBeGreaterThan(0);
+    expect(within(claudeRow as HTMLTableRowElement).getByText('50%')).toBeInTheDocument();
     expect(within(gptRow as HTMLTableRowElement).getByText('Care')).toBeInTheDocument();
     expect(within(gptRow as HTMLTableRowElement).getByText('60%')).toBeInTheDocument();
     expect(screen.getByText('Run-level evidence: pooled across 2 companion runs')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Fix win rate column showing "—" when a model's top values are all neutral (≤50% win rate)
- Win rate now uses the same priority fallback chain as the Preferred Value column: prioritized → neutral → deprioritized
- Previously, a model with no clearly prioritized value would show a value name in "Preferred Value" but "—" in "Win Rate" — now both are consistent

## Test plan
- [ ] Preflight passed (lint + build)
- [ ] Manual smoke test done — analysis page with a neutral-preference model now shows 50% instead of —

🤖 Generated with [Claude Code](https://claude.com/claude-code)