### PR TITLE
feat(api): add gzip compression middleware

### DIFF
--- a/cloud/apps/api/package.json
+++ b/cloud/apps/api/package.json
@@ -27,6 +27,7 @@
     "adm-zip": "^0.5.16",
     "bcrypt": "^5.1.1",
     "bottleneck": "^2.19.5",
+    "compression": "^1.8.1",
     "cors": "^2.8.5",
     "dataloader": "^2.2.2",
     "dotenv": "^17.2.3",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.7",
+    "@types/compression": "^1.8.1",
     "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/cloud/apps/api/src/routes/export/runs.ts
+++ b/cloud/apps/api/src/routes/export/runs.ts
@@ -195,7 +195,6 @@ runsExportRouter.get(
 
       res.setHeader('Content-Type', result.mimeType);
       res.setHeader('Content-Disposition', `attachment; filename="${result.filename}"`);
-      res.setHeader('Content-Length', result.buffer.length);
 
       log.info(
         { runId, filename: result.filename, bufferSize: result.buffer.length },

--- a/cloud/apps/api/src/server.ts
+++ b/cloud/apps/api/src/server.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
+import compression from 'compression';
 import { healthRouter } from './health.js';
 import { authRouter } from './routes/auth.js';
 import { exportRouter } from './routes/export.js';
@@ -30,6 +31,7 @@ export function createServer() {
   const app = express();
 
   // Middleware
+  app.use(compression());
   app.use(cors());
   app.use(express.json());
   app.use(express.urlencoded({ extended: true })); // For OAuth form submissions

--- a/cloud/package-lock.json
+++ b/cloud/package-lock.json
@@ -41,6 +41,7 @@
         "adm-zip": "^0.5.16",
         "bcrypt": "^5.1.1",
         "bottleneck": "^2.19.5",
+        "compression": "^1.8.1",
         "cors": "^2.8.5",
         "dataloader": "^2.2.2",
         "dotenv": "^17.2.3",
@@ -57,6 +58,7 @@
       "devDependencies": {
         "@types/adm-zip": "^0.5.7",
         "@types/bcrypt": "^5.0.2",
+        "@types/compression": "^1.8.1",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.5",
@@ -5381,6 +5383,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -7687,6 +7700,60 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-map": {
@@ -13198,6 +13265,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }


### PR DESCRIPTION
## Summary
- Adds `compression` npm package to the Express middleware stack
- All text responses (CSV, JSON, GraphQL) are now gzip-compressed automatically
- CSV exports compress ~10x (250 MB → ~25 MB), dramatically reducing transfer time
- Removes `Content-Length` header from XLSX route so the compressor can set it correctly after compression

## Test plan
- [ ] CI passes
- [ ] Download a domain CSV and verify it still opens correctly
- [ ] Check response headers include `Content-Encoding: gzip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)