### PR TITLE
fix(analysis): defer model filter until globalDefaultModelIds resolves

### DIFF
--- a/cloud/apps/web/src/components/analysis/AnalysisPanel.tsx
+++ b/cloud/apps/web/src/components/analysis/AnalysisPanel.tsx
@@ -46,8 +46,11 @@ type AnalysisPanelProps = {
   companionAnalysis?: AnalysisResult | null;
   currentRun?: Run | null;
   companionRun?: Run | null;
-  /** Model IDs with isDefault=true from the global LLM model list (Settings → Models). */
-  globalDefaultModelIds?: string[];
+  /**
+   * Model IDs with isDefault=true from the global LLM model list (Settings → Models).
+   * `null` means the list is still loading — defer model filtering until it resolves.
+   */
+  globalDefaultModelIds?: string[] | null;
 };
 
 export function AnalysisPanel({
@@ -278,12 +281,14 @@ export function AnalysisPanel({
         </div>
       )}
 
-      {/* Model filter — above tab bar */}
-      {transcriptModelIds.length > 0 && (
+      {/* Model filter — above tab bar.
+          selectedModels is null while globalDefaultModelIds is still loading;
+          skip rendering the filter (and the tabs below it guard on filteredSemantics != null). */}
+      {transcriptModelIds.length > 0 && selectedModels !== null && (
         <ModelFilter
           transcriptModelIds={transcriptModelIds}
           noTranscriptModelIds={noTranscriptModelIds}
-          defaultModelIds={defaultSelectedModels}
+          defaultModelIds={defaultSelectedModels ?? undefined}
           selectedModels={selectedModels}
           onSelectedModelsChange={setSelectedModels}
         />

--- a/cloud/apps/web/src/components/analysis/useAnalysisState.ts
+++ b/cloud/apps/web/src/components/analysis/useAnalysisState.ts
@@ -27,7 +27,12 @@ type UseAnalysisStateParams = {
   companionAnalysis: AnalysisResult | null | undefined;
   currentRun: Run | null | undefined;
   companionRun: Run | null | undefined;
-  globalDefaultModelIds: string[] | undefined;
+  /**
+   * `undefined` = caller doesn't manage defaults (e.g. tests / embedded usage).
+   * `null`      = caller is still fetching — defer model filtering.
+   * `string[]`  = resolved list (may be empty if no defaults configured).
+   */
+  globalDefaultModelIds: string[] | null | undefined;
   coverageBatchCount: number | null | undefined;
   coveragePairedBatchCount: number | null | undefined;
 };
@@ -84,21 +89,25 @@ export function useAnalysisState({
   );
 
   const defaultSelectedModels = useMemo(() => {
+    // null = still fetching; signal the filter to defer rather than fall back to all models
+    if (globalDefaultModelIds === null) return null;
     const defaults = globalDefaultModelIds ?? [];
     if (defaults.length === 0) return [...transcriptModelIds];
     const intersection = transcriptModelIds.filter((id) => defaults.includes(id));
     return intersection.length > 0 ? intersection : [...transcriptModelIds];
   }, [globalDefaultModelIds, transcriptModelIds]);
 
-  const [selectedModels, setSelectedModels] = useState<string[]>(defaultSelectedModels);
+  const [selectedModels, setSelectedModels] = useState<string[] | null>(defaultSelectedModels);
 
-  // When the run changes, reset filter to the new default
+  // When the run changes (or defaults finish loading), reset filter to the new default.
+  // Skip when defaultSelectedModels is null — the llmModels query hasn't resolved yet.
   useEffect(() => {
+    if (defaultSelectedModels === null) return;
     setSelectedModels(defaultSelectedModels);
   }, [runId, defaultSelectedModels]);
 
   const effectiveModels = useMemo(
-    () => (selectedModels.length > 0 ? selectedModels : transcriptModelIds),
+    () => (selectedModels != null && selectedModels.length > 0 ? selectedModels : transcriptModelIds),
     [selectedModels, transcriptModelIds],
   );
 
@@ -112,8 +121,11 @@ export function useAnalysisState({
   // Must be defined AFTER effectiveModels.
   // Only filter when there are transcript-based models to filter by; if effectiveModels
   // is empty (no transcripts for this run), show all models rather than nothing.
+  // If selectedModels is null, the llmModels query is still loading — return null so the
+  // chart doesn't flash with non-default models before defaults are known.
   const filteredDecisionsVisualizationData = useMemo(() => {
     if (decisionsVisualizationData == null) return null;
+    if (selectedModels === null) return null;
     if (effectiveModels.length === 0) return decisionsVisualizationData;
     return {
       ...decisionsVisualizationData,
@@ -126,22 +138,24 @@ export function useAnalysisState({
           .filter(([modelId]) => effectiveModels.includes(modelId)),
       ),
     };
-  }, [decisionsVisualizationData, effectiveModels]);
+  }, [decisionsVisualizationData, effectiveModels, selectedModels]);
 
   const filteredSemantics = useMemo(() => {
     if (analysis == null) return null;
+    if (selectedModels === null) return null; // llmModels still loading
     const modelFilter = effectiveModels.length > 0 ? effectiveModels : undefined;
     return buildAnalysisSemanticsView(analysis, isAggregateAnalysis, modelFilter);
-  }, [analysis, isAggregateAnalysis, effectiveModels]);
+  }, [analysis, isAggregateAnalysis, effectiveModels, selectedModels]);
 
   const filteredOverviewSemantics = useMemo(() => {
     if (analysis == null) return null;
+    if (selectedModels === null) return null; // llmModels still loading
     const modelFilter = effectiveModels.length > 0 ? effectiveModels : undefined;
     if (analysisMode === 'paired' && companionAnalysis != null) {
       return buildPairedAnalysisSemanticsView(analysis, companionAnalysis, isAggregateAnalysis, modelFilter);
     }
     return buildAnalysisSemanticsView(analysis, isAggregateAnalysis, modelFilter);
-  }, [analysis, analysisMode, companionAnalysis, isAggregateAnalysis, effectiveModels]);
+  }, [analysis, analysisMode, companionAnalysis, isAggregateAnalysis, effectiveModels, selectedModels]);
 
   const scenariosTranscripts = useMemo(() => {
     const currentTranscripts = transcripts ?? currentRun?.transcripts ?? [];

--- a/cloud/apps/web/src/pages/AnalysisDetail.tsx
+++ b/cloud/apps/web/src/pages/AnalysisDetail.tsx
@@ -138,11 +138,16 @@ export function AnalysisDetail() {
   const [llmModelsResult] = useQuery<LlmModelsQueryResult>({
     query: LLM_MODELS_QUERY,
   });
+  // Pass null while fetching so useAnalysisState knows to defer model filtering
+  // (an empty array would look like "no defaults configured" and cause the filter
+  // to fall back to showing all transcript models before the query resolves).
   const globalDefaultModelIds = useMemo(
-    () => (llmModelsResult.data?.llmModels ?? [])
-      .filter((m) => m.isDefault)
-      .map((m) => m.modelId),
-    [llmModelsResult.data],
+    () => llmModelsResult.fetching
+      ? null
+      : (llmModelsResult.data?.llmModels ?? [])
+          .filter((m) => m.isDefault)
+          .map((m) => m.modelId),
+    [llmModelsResult.fetching, llmModelsResult.data],
   );
 
   const { analysis } = useAnalysis({

--- a/cloud/apps/web/src/pages/AnalysisDetail.tsx
+++ b/cloud/apps/web/src/pages/AnalysisDetail.tsx
@@ -5,9 +5,9 @@
  */
 
 import { useEffect, useMemo } from 'react';
-import { useParams, useNavigate, Link, useSearchParams } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from 'urql';
-import { ArrowLeft, Play } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { formatTrialSignature } from '@valuerank/shared/trial-signature';
 import { Button } from '../components/ui/Button';
 import { Loading } from '../components/ui/Loading';
@@ -17,12 +17,15 @@ import { findCompanionPairedRun } from '../components/analysis/PairedRunComparis
 import { useAnalysis } from '../hooks/useAnalysis';
 import { useInfiniteRuns } from '../hooks/useInfiniteRuns';
 import { useRun } from '../hooks/useRun';
-import { useRuns } from '../hooks/useRuns';
 import { getRunDefinitionContent } from '../utils/runDefinitionContent';
 import type { AnalysisTab } from '../components/analysis/tabs';
 import { ANALYSIS_BASE_PATH, buildAnalysisDetailPath, isAggregateAnalysis } from '../utils/analysisRouting';
 import { getDefinitionMethodology, getDefinitionMethodologyLabel } from '../utils/methodology';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
+import {
+  AnalysisDetailHeader,
+  COVERAGE_CONTEXT_QUERY_KEYS,
+} from './AnalysisDetailHeader';
 
 function parseAnalysisTab(value: string | null): AnalysisTab {
   if (value === 'overview' || value === 'decisions' || value === 'scenarios') {
@@ -36,8 +39,6 @@ type AnalysisDetailMode = 'single' | 'paired';
 function parseAnalysisDetailMode(value: string | null): AnalysisDetailMode {
   return value === 'paired' ? 'paired' : 'single';
 }
-
-const COVERAGE_CONTEXT_QUERY_KEYS = ['coverageBatchCount', 'coveragePairedBatchCount'] as const;
 
 function parseCoverageCountParam(value: string | null): number | null {
   if (value == null) {
@@ -68,10 +69,6 @@ function buildAnalysisDetailParams(
     }
   }
   return next;
-}
-
-function getDisplaySignature(signature: string | null | undefined): string {
-  return signature && signature !== 'v?td' ? signature : 'Unknown Signature';
 }
 
 export function AnalysisDetail() {
@@ -314,7 +311,7 @@ export function AnalysisDetail() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <Header
+        <AnalysisDetailHeader
           runId={run.id}
           definitionId={run.definition?.id}
           definitionName={run.definition?.name}
@@ -364,147 +361,3 @@ export function AnalysisDetail() {
   );
 }
 
-/**
- * Header component with navigation.
- */
-function Header({
-  runId,
-  definitionId,
-  definitionName,
-  methodologyLabel,
-  launchModeLabel,
-  isAggregate,
-  currentSignature,
-}: {
-  runId: string;
-  definitionId?: string | null;
-  definitionName?: string | null;
-  methodologyLabel?: string | null;
-  launchModeLabel?: string | null;
-  isAggregate?: boolean;
-  currentSignature?: string | null;
-}) {
-  const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-
-  const { runs } = useRuns({
-    definitionId: isAggregate ? (definitionId || undefined) : undefined,
-    status: 'COMPLETED',
-    limit: 1000,
-    pause: !isAggregate || !definitionId,
-  });
-
-  const aggregateRuns = runs.filter(r => (r.tags ?? []).some(t => t.name === 'Aggregate')).map(r => {
-    const config = r.config as {
-      definitionSnapshot?: { _meta?: { definitionVersion?: unknown }, version?: unknown };
-      temperature?: unknown;
-    } | null;
-    const defVersion = typeof config?.definitionSnapshot?._meta?.definitionVersion === 'number'
-      ? config.definitionSnapshot._meta.definitionVersion
-      : typeof config?.definitionSnapshot?.version === 'number'
-        ? config.definitionSnapshot.version
-        : typeof r.definitionVersion === 'number'
-          ? r.definitionVersion
-          : null;
-    const temp = typeof config?.temperature === 'number' ? config.temperature : null;
-    return { id: r.id, signature: formatTrialSignature(defVersion, temp) };
-  }).reduce<Array<{ id: string; signature: string; count: number }>>((acc, run) => {
-    const existing = acc.find((item) => item.signature === run.signature);
-    if (existing) {
-      existing.count += 1;
-      if (run.id === runId) {
-        existing.id = run.id;
-      }
-      return acc;
-    }
-    acc.push({ ...run, count: 1 });
-    return acc;
-  }, []);
-
-  const selectedAggregateSignature = aggregateRuns.find((run) => run.id === runId)?.signature ?? currentSignature ?? 'v?td';
-  const currentSearch = searchParams.toString();
-
-  return (
-    <div className="flex items-start justify-between flex-1 mr-4 gap-4">
-      <div className="flex items-center gap-4">
-        <Button variant="ghost" size="sm" onClick={() => navigate('/analysis')}>
-          <ArrowLeft className="w-4 h-4 mr-1" />
-          Back to Analysis
-        </Button>
-        <span className="text-gray-300">|</span>
-        <div className="text-sm text-gray-500 flex items-center gap-2">
-          {definitionName || 'Unnamed Definition'}
-          {methodologyLabel && (
-            <span className="rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800">
-              {methodologyLabel}
-            </span>
-          )}
-          {launchModeLabel && (
-            <span
-              className={`rounded-full px-2 py-1 text-xs font-medium ${
-                launchModeLabel === 'Paired Batch'
-                  ? 'bg-teal-100 text-teal-800'
-                  : 'bg-gray-100 text-gray-700'
-              }`}
-            >
-              {launchModeLabel}
-            </span>
-          )}
-          <span className="mx-1">•</span>
-          {isAggregate ? (
-            <div className="flex items-center gap-2">
-              <span className="bg-indigo-100 text-indigo-800 text-xs px-2 py-0.5 rounded-full font-medium flex items-center">
-                Aggregate View
-              </span>
-              <span className="font-mono bg-gray-100 text-gray-800 text-xs px-2 py-0.5 rounded border border-gray-200">
-                {aggregateRuns.length > 1 ? (
-                  <select
-                    className="bg-transparent border-none p-0 pr-4 text-xs font-mono cursor-pointer focus:ring-0 focus:outline-none focus:bg-gray-200"
-                    value={selectedAggregateSignature}
-                    onChange={(e) => {
-                      const nextRun = aggregateRuns.find((run) => run.signature === e.target.value);
-                      if (nextRun) {
-                        const nextSearchParams = new URLSearchParams(currentSearch);
-                        for (const key of COVERAGE_CONTEXT_QUERY_KEYS) {
-                          nextSearchParams.delete(key);
-                        }
-                        navigate({
-                          pathname: buildAnalysisDetailPath(ANALYSIS_BASE_PATH, nextRun.id),
-                          search: nextSearchParams.toString().length > 0 ? `?${nextSearchParams.toString()}` : '',
-                        });
-                      }
-                    }}
-                  >
-                    {aggregateRuns.map(r => (
-                      <option key={r.signature} value={r.signature}>
-                        {getDisplaySignature(r.signature)}{r.count > 1 ? ` (${r.count} runs)` : ''}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  getDisplaySignature(currentSignature)
-                )}
-              </span>
-            </div>
-          ) : (
-            <div className="flex items-center gap-2">
-              <span className="font-mono">Trial {runId.slice(0, 8)}...</span>
-              <span className="font-mono bg-gray-100 text-gray-800 text-xs px-2 py-0.5 rounded border border-gray-200">
-                {getDisplaySignature(currentSignature)}
-              </span>
-            </div>
-          )}
-        </div>
-      </div>
-      {!isAggregate && (
-        <Link
-          to={`/runs/${runId}`}
-          className="inline-flex items-center gap-1 text-sm text-teal-600 hover:text-teal-700"
-        >
-          <Play className="w-4 h-4" />
-          View Trial
-        </Link>
-      )}
-    </div>
-  );
-}

--- a/cloud/apps/web/src/pages/AnalysisDetailHeader.tsx
+++ b/cloud/apps/web/src/pages/AnalysisDetailHeader.tsx
@@ -1,0 +1,165 @@
+/**
+ * AnalysisDetailHeader
+ *
+ * Page header for AnalysisDetail. Shows navigation, vignette name,
+ * methodology/launch-mode badges, and an aggregate-run selector.
+ *
+ * Extracted from AnalysisDetail.tsx to keep that file under the 400-line limit.
+ */
+
+import { useNavigate, Link, useSearchParams } from 'react-router-dom';
+import { ArrowLeft, Play } from 'lucide-react';
+import { formatTrialSignature } from '@valuerank/shared/trial-signature';
+import { Button } from '../components/ui/Button';
+import { useRuns } from '../hooks/useRuns';
+import { ANALYSIS_BASE_PATH, buildAnalysisDetailPath } from '../utils/analysisRouting';
+
+export const COVERAGE_CONTEXT_QUERY_KEYS = ['coverageBatchCount', 'coveragePairedBatchCount'] as const;
+
+function getDisplaySignature(signature: string | null | undefined): string {
+  return signature && signature !== 'v?td' ? signature : 'Unknown Signature';
+}
+
+export type AnalysisDetailHeaderProps = {
+  runId: string;
+  definitionId?: string | null;
+  definitionName?: string | null;
+  methodologyLabel?: string | null;
+  launchModeLabel?: string | null;
+  isAggregate?: boolean;
+  currentSignature?: string | null;
+};
+
+export function AnalysisDetailHeader({
+  runId,
+  definitionId,
+  definitionName,
+  methodologyLabel,
+  launchModeLabel,
+  isAggregate,
+  currentSignature,
+}: AnalysisDetailHeaderProps) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const { runs } = useRuns({
+    definitionId: isAggregate ? (definitionId || undefined) : undefined,
+    status: 'COMPLETED',
+    limit: 1000,
+    pause: !isAggregate || !definitionId,
+  });
+
+  const aggregateRuns = runs.filter(r => (r.tags ?? []).some(t => t.name === 'Aggregate')).map(r => {
+    const config = r.config as {
+      definitionSnapshot?: { _meta?: { definitionVersion?: unknown }, version?: unknown };
+      temperature?: unknown;
+    } | null;
+    const defVersion = typeof config?.definitionSnapshot?._meta?.definitionVersion === 'number'
+      ? config.definitionSnapshot._meta.definitionVersion
+      : typeof config?.definitionSnapshot?.version === 'number'
+        ? config.definitionSnapshot.version
+        : typeof r.definitionVersion === 'number'
+          ? r.definitionVersion
+          : null;
+    const temp = typeof config?.temperature === 'number' ? config.temperature : null;
+    return { id: r.id, signature: formatTrialSignature(defVersion, temp) };
+  }).reduce<Array<{ id: string; signature: string; count: number }>>((acc, run) => {
+    const existing = acc.find((item) => item.signature === run.signature);
+    if (existing) {
+      existing.count += 1;
+      if (run.id === runId) {
+        existing.id = run.id;
+      }
+      return acc;
+    }
+    acc.push({ ...run, count: 1 });
+    return acc;
+  }, []);
+
+  const selectedAggregateSignature = aggregateRuns.find((run) => run.id === runId)?.signature ?? currentSignature ?? 'v?td';
+  const currentSearch = searchParams.toString();
+
+  return (
+    <div className="flex items-start justify-between flex-1 mr-4 gap-4">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" onClick={() => navigate('/analysis')}>
+          <ArrowLeft className="w-4 h-4 mr-1" />
+          Back to Analysis
+        </Button>
+        <span className="text-gray-300">|</span>
+        <div className="text-sm text-gray-500 flex items-center gap-2">
+          {definitionName || 'Unnamed Definition'}
+          {methodologyLabel && (
+            <span className="rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800">
+              {methodologyLabel}
+            </span>
+          )}
+          {launchModeLabel && (
+            <span
+              className={`rounded-full px-2 py-1 text-xs font-medium ${
+                launchModeLabel === 'Paired Batch'
+                  ? 'bg-teal-100 text-teal-800'
+                  : 'bg-gray-100 text-gray-700'
+              }`}
+            >
+              {launchModeLabel}
+            </span>
+          )}
+          <span className="mx-1">•</span>
+          {isAggregate ? (
+            <div className="flex items-center gap-2">
+              <span className="bg-indigo-100 text-indigo-800 text-xs px-2 py-0.5 rounded-full font-medium flex items-center">
+                Aggregate View
+              </span>
+              <span className="font-mono bg-gray-100 text-gray-800 text-xs px-2 py-0.5 rounded border border-gray-200">
+                {aggregateRuns.length > 1 ? (
+                  <select
+                    className="bg-transparent border-none p-0 pr-4 text-xs font-mono cursor-pointer focus:ring-0 focus:outline-none focus:bg-gray-200"
+                    value={selectedAggregateSignature}
+                    onChange={(e) => {
+                      const nextRun = aggregateRuns.find((run) => run.signature === e.target.value);
+                      if (nextRun) {
+                        const nextSearchParams = new URLSearchParams(currentSearch);
+                        for (const key of COVERAGE_CONTEXT_QUERY_KEYS) {
+                          nextSearchParams.delete(key);
+                        }
+                        navigate({
+                          pathname: buildAnalysisDetailPath(ANALYSIS_BASE_PATH, nextRun.id),
+                          search: nextSearchParams.toString().length > 0 ? `?${nextSearchParams.toString()}` : '',
+                        });
+                      }
+                    }}
+                  >
+                    {aggregateRuns.map(r => (
+                      <option key={r.signature} value={r.signature}>
+                        {getDisplaySignature(r.signature)}{r.count > 1 ? ` (${r.count} runs)` : ''}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  getDisplaySignature(currentSignature)
+                )}
+              </span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="font-mono">Trial {runId.slice(0, 8)}...</span>
+              <span className="font-mono bg-gray-100 text-gray-800 text-xs px-2 py-0.5 rounded border border-gray-200">
+                {getDisplaySignature(currentSignature)}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+      {!isAggregate && (
+        <Link
+          to={`/runs/${runId}`}
+          className="inline-flex items-center gap-1 text-sm text-teal-600 hover:text-teal-700"
+        >
+          <Play className="w-4 h-4" />
+          View Trial
+        </Link>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Fixes a regression from PR #621: the Decision Distribution chart was showing non-default models (e.g. `gemini-2.5-pro`, `grok-4-0709`) on every page load because `AnalysisDetail` passed `[]` for `globalDefaultModelIds` while the `llmModels` query was still in flight
- `useAnalysisState` treated `[]` as "no defaults configured" and fell back to ALL transcript model IDs, so `selectedModels` was initialised with all models before defaults were known
- **Fix**: `AnalysisDetail` now passes `null` while fetching (not `[]`); `useAnalysisState` treats `null` as a loading signal — the filtered data memos return `null` until defaults resolve, and the tabs already guard on `filteredSemantics != null` so they simply don't render during the brief loading window
- Once `llmModels` resolves, `defaultSelectedModels` computes the correct intersection and a `useEffect` resets `selectedModels` to the right 8 models

## Test plan

- [x] Preflight passed (lint + tests + build on `@valuerank/web`)
- [x] All 27 `AnalysisPanel` tests pass (including zero-transcript edge cases)
- [ ] Manual smoke test: navigate to a run with non-default models — chart should show only default models immediately, not flash all models first

🤖 Generated with [Claude Code](https://claude.com/claude-code)