### PR TITLE
feat(coverage): domain coverage completeness guard

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-coverage-gql-types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-coverage-gql-types.ts
@@ -1,0 +1,131 @@
+/**
+ * Domain Coverage GQL Types
+ *
+ * Pothos objectRef implementations and shared types for the domainValueCoverage
+ * query. Extracted to keep domain-coverage.ts under the 400-line limit.
+ */
+
+import { builder } from '../builder.js';
+import {
+  formatTrialSignature,
+  isVnewSignature,
+  parseVnewTemperature,
+} from '@valuerank/shared/trial-signature';
+import { parseDefinitionVersion } from '../../utils/definition-version.js';
+import { parseTemperature } from '../../utils/temperature.js';
+import type { CoverageModelBreakdown } from './domain-coverage-utils.js';
+
+// ─── TypeScript types ─────────────────────────────────────────────────────────
+
+export type DomainValueCoverageCell = {
+  valueA: string;
+  valueB: string;
+  batchCount: number;
+  pairedBatchCount: number;
+  /** Number of non-aggregate runs whose transcript count is less than expected. */
+  incompleteBatchCount: number;
+  definitionId: string | null;
+  definitionName: string | null;
+  aggregateRunId: string | null;
+  minTrialCount: number | null;
+  maxTrialCount: number | null;
+  modelBreakdown: CoverageModelBreakdown[] | null;
+};
+
+export type CoverageModelOption = {
+  modelId: string;
+  label: string;
+};
+
+export type DomainValueCoverageResult = {
+  domainId: string;
+  values: string[];
+  cells: DomainValueCoverageCell[];
+  availableModels: CoverageModelOption[];
+};
+
+// ─── Pothos GQL objectRefs ────────────────────────────────────────────────────
+
+const CoverageModelOptionRef = builder
+  .objectRef<CoverageModelOption>('CoverageModelOption')
+  .implement({
+    fields: (t) => ({
+      modelId: t.exposeString('modelId'),
+      label: t.exposeString('label'),
+    }),
+  });
+
+const CoverageModelBreakdownRef = builder
+  .objectRef<CoverageModelBreakdown>('CoverageModelBreakdown')
+  .implement({
+    fields: (t) => ({
+      modelId: t.exposeString('modelId'),
+      label: t.exposeString('label'),
+      trialCount: t.exposeInt('trialCount'),
+    }),
+  });
+
+const DomainValueCoverageCellRef = builder
+  .objectRef<DomainValueCoverageCell>('DomainValueCoverageCell')
+  .implement({
+    fields: (t) => ({
+      valueA: t.exposeString('valueA'),
+      valueB: t.exposeString('valueB'),
+      batchCount: t.exposeInt('batchCount'),
+      pairedBatchCount: t.exposeInt('pairedBatchCount'),
+      incompleteBatchCount: t.exposeInt('incompleteBatchCount'),
+      definitionId: t.exposeString('definitionId', { nullable: true }),
+      definitionName: t.exposeString('definitionName', { nullable: true }),
+      aggregateRunId: t.exposeString('aggregateRunId', { nullable: true }),
+      minTrialCount: t.exposeInt('minTrialCount', { nullable: true }),
+      maxTrialCount: t.exposeInt('maxTrialCount', { nullable: true }),
+      modelBreakdown: t.expose('modelBreakdown', {
+        type: [CoverageModelBreakdownRef],
+        nullable: true,
+      }),
+    }),
+  });
+
+export const DomainValueCoverageResultRef = builder
+  .objectRef<DomainValueCoverageResult>('DomainValueCoverageResult')
+  .implement({
+    fields: (t) => ({
+      domainId: t.exposeString('domainId'),
+      values: t.exposeStringList('values'),
+      cells: t.field({
+        type: [DomainValueCoverageCellRef],
+        resolve: (parent) => parent.cells,
+      }),
+      availableModels: t.field({
+        type: [CoverageModelOptionRef],
+        resolve: (parent) => parent.availableModels,
+      }),
+    }),
+  });
+
+// ─── Signature helpers ────────────────────────────────────────────────────────
+
+export function formatRunSignature(config: unknown): string {
+  const runConfig = config as {
+    definitionSnapshot?: {
+      _meta?: { definitionVersion?: unknown };
+      version?: unknown;
+    };
+    temperature?: unknown;
+  } | null;
+  const definitionVersion =
+    parseDefinitionVersion(runConfig?.definitionSnapshot?._meta?.definitionVersion) ??
+    parseDefinitionVersion(runConfig?.definitionSnapshot?.version);
+  const temperature = parseTemperature(runConfig?.temperature);
+  return formatTrialSignature(definitionVersion, temperature);
+}
+
+export function runMatchesSignature(runConfig: unknown, signature: string): boolean {
+  if (isVnewSignature(signature)) {
+    return (
+      parseTemperature((runConfig as { temperature?: unknown } | null)?.temperature) ===
+      parseVnewTemperature(signature)
+    );
+  }
+  return formatRunSignature(runConfig) === signature;
+}

--- a/cloud/apps/api/src/graphql/queries/domain-coverage.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-coverage.ts
@@ -8,14 +8,10 @@
 
 import { builder } from '../builder.js';
 import { db, resolveDefinitionContent } from '@valuerank/db';
-import { formatTrialSignature, isVnewSignature, parseVnewTemperature } from '@valuerank/shared/trial-signature';
-import { parseDefinitionVersion } from '../../utils/definition-version.js';
-import { parseTemperature } from '../../utils/temperature.js';
 
 import {
   COVERAGE_VALUE_KEYS,
   type CoverageValueKey,
-  type CoverageModelBreakdown,
   extractValuePair,
   getCoverageBatchGroupId,
   getCoverageBatchIncrement,
@@ -24,109 +20,12 @@ import {
   deduplicateRunsByGroupId,
 } from './domain-coverage-utils.js';
 import { resolveEffectiveDefaultModelIds } from './domain/shared.js';
-
-type DomainValueCoverageCell = {
-  valueA: string;
-  valueB: string;
-  batchCount: number;
-  pairedBatchCount: number;
-  definitionId: string | null;
-  definitionName: string | null;
-  aggregateRunId: string | null;
-  minTrialCount: number | null;
-  maxTrialCount: number | null;
-  modelBreakdown: CoverageModelBreakdown[] | null;
-};
-
-type CoverageModelOption = {
-  modelId: string;
-  label: string;
-};
-
-type DomainValueCoverageResult = {
-  domainId: string;
-  values: string[];
-  cells: DomainValueCoverageCell[];
-  availableModels: CoverageModelOption[];
-};
-
-const CoverageModelOptionRef = builder
-  .objectRef<CoverageModelOption>('CoverageModelOption')
-  .implement({
-    fields: (t) => ({
-      modelId: t.exposeString('modelId'),
-      label: t.exposeString('label'),
-    }),
-  });
-
-const CoverageModelBreakdownRef = builder
-  .objectRef<CoverageModelBreakdown>('CoverageModelBreakdown')
-  .implement({
-    fields: (t) => ({
-      modelId: t.exposeString('modelId'),
-      label: t.exposeString('label'),
-      trialCount: t.exposeInt('trialCount'),
-    }),
-  });
-
-const DomainValueCoverageCellRef = builder
-  .objectRef<DomainValueCoverageCell>('DomainValueCoverageCell')
-  .implement({
-    fields: (t) => ({
-      valueA: t.exposeString('valueA'),
-      valueB: t.exposeString('valueB'),
-      batchCount: t.exposeInt('batchCount'),
-      pairedBatchCount: t.exposeInt('pairedBatchCount'),
-      definitionId: t.exposeString('definitionId', { nullable: true }),
-      definitionName: t.exposeString('definitionName', { nullable: true }),
-      aggregateRunId: t.exposeString('aggregateRunId', { nullable: true }),
-      minTrialCount: t.exposeInt('minTrialCount', { nullable: true }),
-      maxTrialCount: t.exposeInt('maxTrialCount', { nullable: true }),
-      modelBreakdown: t.expose('modelBreakdown', {
-        type: [CoverageModelBreakdownRef],
-        nullable: true,
-      }),
-    }),
-  });
-
-const DomainValueCoverageResultRef = builder
-  .objectRef<DomainValueCoverageResult>('DomainValueCoverageResult')
-  .implement({
-    fields: (t) => ({
-      domainId: t.exposeString('domainId'),
-      values: t.exposeStringList('values'),
-      cells: t.field({
-        type: [DomainValueCoverageCellRef],
-        resolve: (parent) => parent.cells,
-      }),
-      availableModels: t.field({
-        type: [CoverageModelOptionRef],
-        resolve: (parent) => parent.availableModels,
-      }),
-    }),
-  });
-
-function formatRunSignature(config: unknown): string {
-  const runConfig = config as {
-    definitionSnapshot?: {
-      _meta?: { definitionVersion?: unknown };
-      version?: unknown;
-    };
-    temperature?: unknown;
-  } | null;
-  const definitionVersion =
-    parseDefinitionVersion(runConfig?.definitionSnapshot?._meta?.definitionVersion) ??
-    parseDefinitionVersion(runConfig?.definitionSnapshot?.version);
-  const temperature = parseTemperature(runConfig?.temperature);
-  return formatTrialSignature(definitionVersion, temperature);
-}
-
-function runMatchesSignature(runConfig: unknown, signature: string): boolean {
-  if (isVnewSignature(signature)) {
-    return parseTemperature((runConfig as { temperature?: unknown } | null)?.temperature) === parseVnewTemperature(signature);
-  }
-  return formatRunSignature(runConfig) === signature;
-}
+import {
+  DomainValueCoverageResultRef,
+  type DomainValueCoverageCell,
+  type CoverageModelOption,
+  runMatchesSignature,
+} from './domain-coverage-gql-types.js';
 
 const VALUE_PAIR_RESOLVE_CHUNK_SIZE = 20;
 
@@ -233,6 +132,7 @@ builder.queryField('domainValueCoverage', (t) =>
       const pairedBatchIncrementsByGroupId = new Map<string, Map<string, number>>();
       const latestMatchingRunIdByDefinitionId = new Map<string, string>();
       const latestAggregateRunIdByDefinitionId = new Map<string, string>();
+      const incompleteBatchCountByDefinitionId = new Map<string, number>();
       const signatureScopedRunsByDefinitionId = new Map<string, Array<{
         id: string;
         definitionId: string;
@@ -261,6 +161,9 @@ builder.queryField('domainValueCoverage', (t) =>
               where: { deletedAt: null },
               select: { modelId: true },
             },
+            _count: {
+              select: { scenarioSelections: true },
+            },
           },
         });
 
@@ -281,6 +184,21 @@ builder.queryField('domainValueCoverage', (t) =>
             continue;
           }
 
+          // Completeness check: flag if actual transcript count < expected.
+          // Expected = scenarioSelections × models.length × samplesPerScenario.
+          const samplesPerScenario =
+            (run.config as { samplesPerScenario?: unknown } | null)?.samplesPerScenario;
+          const configModels = (run.config as { models?: unknown } | null)?.models;
+          const modelCount = Array.isArray(configModels) ? configModels.length : 0;
+          const expectedCount =
+            run._count.scenarioSelections * modelCount * getCoverageBatchIncrement(samplesPerScenario);
+          if (modelCount > 0 && run.transcripts.length < expectedCount) {
+            incompleteBatchCountByDefinitionId.set(
+              run.definitionId,
+              (incompleteBatchCountByDefinitionId.get(run.definitionId) ?? 0) + 1,
+            );
+          }
+
           // Track non-aggregate runs for per-model trial count computation
           if (effectiveModelIds.length > 0) {
             const nonAggregateRuns = nonAggregateRunsByDefinitionId.get(run.definitionId) ?? [];
@@ -295,8 +213,6 @@ builder.queryField('domainValueCoverage', (t) =>
           if (!latestMatchingRunIdByDefinitionId.has(run.definitionId)) {
             latestMatchingRunIdByDefinitionId.set(run.definitionId, run.id);
           }
-          const samplesPerScenario =
-            (run.config as { samplesPerScenario?: unknown } | null)?.samplesPerScenario;
           const increment = getCoverageBatchIncrement(samplesPerScenario);
           batchCountByDefinitionId.set(
             run.definitionId,
@@ -370,6 +286,7 @@ builder.queryField('domainValueCoverage', (t) =>
               valueB,
               batchCount: 0,
               pairedBatchCount: 0,
+              incompleteBatchCount: 0,
               definitionId: null,
               definitionName: null,
               aggregateRunId: null,
@@ -395,6 +312,12 @@ builder.queryField('domainValueCoverage', (t) =>
                 ?? latestMatchingRunIdByDefinitionId.get(primaryDefId)
                 ?? null);
 
+            // Sum incompleteBatchCount across all definitions for this pair
+            const incompleteBatchCount = defIdsForPair.reduce(
+              (sum, defId) => sum + (incompleteBatchCountByDefinitionId.get(defId) ?? 0),
+              0,
+            );
+
             // Compute per-model trial counts across all definitions for this pair.
             // Deduplicate by group ID first: A-first and B-first companion definitions
             // share the same jobChoiceBatchGroupId, so flatMapping across both would
@@ -413,6 +336,7 @@ builder.queryField('domainValueCoverage', (t) =>
               valueB,
               batchCount,
               pairedBatchCount,
+              incompleteBatchCount,
               definitionId: primaryDefId !== '' ? primaryDefId : null,
               definitionName: primaryPair?.name ?? null,
               aggregateRunId,

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1064,6 +1064,7 @@ type DomainValueCoverageCell {
   batchCount: Int!
   definitionId: String
   definitionName: String
+  incompleteBatchCount: Int!
   maxTrialCount: Int
   minTrialCount: Int
   modelBreakdown: [CoverageModelBreakdown!]

--- a/cloud/apps/web/src/api/operations/domainCoverage.graphql
+++ b/cloud/apps/web/src/api/operations/domainCoverage.graphql
@@ -7,6 +7,7 @@ query DomainValueCoverage($domainId: ID!, $modelIds: [String!], $signature: Stri
       valueB
       batchCount
       pairedBatchCount
+      incompleteBatchCount
       definitionId
       definitionName
       aggregateRunId

--- a/cloud/apps/web/src/api/operations/domainCoverage.ts
+++ b/cloud/apps/web/src/api/operations/domainCoverage.ts
@@ -26,6 +26,7 @@ export type DomainValueCoverageCell = {
   valueB: string;
   batchCount: number;
   pairedBatchCount: number;
+  incompleteBatchCount: number;
   definitionId: string | null;
   definitionName: string | null;
   aggregateRunId: string | null;

--- a/cloud/apps/web/src/components/domains/CoverageCell.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageCell.tsx
@@ -16,6 +16,7 @@ type CoverageCellProps = {
   valueB: string;
   batchCount: number;
   pairedBatchCount: number;
+  incompleteBatchCount?: number | null;
   definitionId: string | null;
   aggregateRunId: string | null;
   minTrialCount?: number | null;
@@ -28,6 +29,7 @@ export function CoverageCell({
   valueB,
   batchCount,
   pairedBatchCount,
+  incompleteBatchCount,
   definitionId,
   aggregateRunId,
   minTrialCount,
@@ -37,6 +39,7 @@ export function CoverageCell({
   const [isOpen, setIsOpen] = useState(false);
   const isDiagonal = valueA === valueB;
   const hasVignette = definitionId !== null;
+  const hasIncompleteBatches = (incompleteBatchCount ?? 0) > 0;
   const hasPerModelData = minTrialCount !== null && minTrialCount !== undefined;
   const displayCount = hasPerModelData ? minTrialCount : (pairedBatchCount > 0 ? pairedBatchCount : batchCount);
   const hasMismatch = hasPerModelData && maxTrialCount !== null && maxTrialCount !== undefined && minTrialCount < maxTrialCount;
@@ -85,7 +88,7 @@ export function CoverageCell({
                 : `${xLabel} versus ${yLabel}: ${displayCount} ${batchLabel}`
           }
           className={cn(
-            'w-full h-full min-h-[48px] p-2 flex flex-col items-center justify-center text-sm font-medium border rounded-none focus:ring-0 focus:ring-offset-0',
+            'relative w-full h-full min-h-[48px] p-2 flex flex-col items-center justify-center text-sm font-medium border rounded-none focus:ring-0 focus:ring-offset-0',
             hasMismatch ? 'border-orange-400 border-2' : 'border-gray-100',
             bgColorClass,
             isDiagonal && 'cursor-not-allowed text-transparent font-normal',
@@ -99,6 +102,12 @@ export function CoverageCell({
             <span className="text-[10px] text-orange-600 font-normal leading-none mt-0.5" aria-label="trial count mismatch across models">
               ⚠
             </span>
+          )}
+          {hasIncompleteBatches && (
+            <span
+              className="absolute top-1 right-1 w-2 h-2 rounded-full bg-amber-400"
+              aria-label={`${incompleteBatchCount ?? 0} incomplete batch${(incompleteBatchCount ?? 0) === 1 ? '' : 'es'}`}
+            />
           )}
         </button>
       </PopoverTrigger>
@@ -134,6 +143,12 @@ export function CoverageCell({
                         </span>
                       </div>
                     ))}
+                  </div>
+                )}
+                {hasIncompleteBatches && (
+                  <div className="mt-2 flex items-center gap-1.5 text-xs text-amber-700">
+                    <span className="inline-block w-2 h-2 rounded-full bg-amber-400 flex-shrink-0" />
+                    {incompleteBatchCount ?? 0} incomplete batch{(incompleteBatchCount ?? 0) === 1 ? '' : 'es'} — not all transcripts generated
                   </div>
                 )}
               </>

--- a/cloud/apps/web/src/components/domains/CoverageMatrix.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageMatrix.tsx
@@ -292,6 +292,7 @@ export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
                             valueB={colVal}
                             batchCount={cell?.batchCount ?? 0}
                             pairedBatchCount={cell?.pairedBatchCount ?? 0}
+                            incompleteBatchCount={cell?.incompleteBatchCount ?? 0}
                             definitionId={cell?.definitionId ?? null}
                             aggregateRunId={cell?.aggregateRunId ?? null}
                             minTrialCount={cell?.minTrialCount ?? null}

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -655,8 +655,16 @@ export type DomainAnalysisModel = {
   values: Array<DomainAnalysisValueScore>;
 };
 
+export type DomainAnalysisRefreshResult = {
+  __typename?: 'DomainAnalysisRefreshResult';
+  message: Scalars['String']['output'];
+  mode: Scalars['String']['output'];
+  success: Scalars['Boolean']['output'];
+};
+
 export type DomainAnalysisResult = {
   __typename?: 'DomainAnalysisResult';
+  cacheStatus: Scalars['String']['output'];
   clusterAnalysis: ClusterAnalysis;
   coveredDefinitions: Scalars['Int']['output'];
   definitionsWithAnalysis: Scalars['Int']['output'];
@@ -881,13 +889,6 @@ export type DomainFindingsEligibility = {
   summary: Scalars['String']['output'];
 };
 
-export type DomainAnalysisRefreshResult = {
-  __typename?: 'DomainAnalysisRefreshResult';
-  message: Scalars['String']['output'];
-  mode: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
-};
-
 export type DomainMutationResult = {
   __typename?: 'DomainMutationResult';
   affectedDefinitions: Scalars['Int']['output'];
@@ -1019,6 +1020,7 @@ export type DomainValueCoverageCell = {
   batchCount: Scalars['Int']['output'];
   definitionId?: Maybe<Scalars['String']['output']>;
   definitionName?: Maybe<Scalars['String']['output']>;
+  incompleteBatchCount: Scalars['Int']['output'];
   maxTrialCount?: Maybe<Scalars['Int']['output']>;
   minTrialCount?: Maybe<Scalars['Int']['output']>;
   modelBreakdown?: Maybe<Array<CoverageModelBreakdown>>;
@@ -1462,6 +1464,7 @@ export type Mutation = {
    *
    */
   recoverRun: RecoverRunPayload;
+  refreshDomainAnalysis: DomainAnalysisRefreshResult;
   /** Manually trigger scenario regeneration for a definition. Queues a new expansion job. */
   regenerateScenarios: RegenerateScenariosResult;
   /** Remove a tag from a definition. No-op if tag was not assigned. */
@@ -1801,6 +1804,12 @@ export type MutationRecomputeAnalysisArgs = {
 
 export type MutationRecoverRunArgs = {
   runId: Scalars['ID']['input'];
+};
+
+
+export type MutationRefreshDomainAnalysisArgs = {
+  domainId: Scalars['ID']['input'];
+  signature?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -3975,7 +3984,7 @@ export type DomainValueCoverageQueryVariables = Exact<{
 }>;
 
 
-export type DomainValueCoverageQuery = { __typename?: 'Query', domainValueCoverage?: { __typename?: 'DomainValueCoverageResult', domainId: string, values: Array<string>, cells: Array<{ __typename?: 'DomainValueCoverageCell', valueA: string, valueB: string, batchCount: number, pairedBatchCount: number, definitionId?: string | null, definitionName?: string | null, aggregateRunId?: string | null, minTrialCount?: number | null, maxTrialCount?: number | null, modelBreakdown?: Array<{ __typename?: 'CoverageModelBreakdown', modelId: string, label: string, trialCount: number }> | null }>, availableModels: Array<{ __typename?: 'CoverageModelOption', modelId: string, label: string }> } | null };
+export type DomainValueCoverageQuery = { __typename?: 'Query', domainValueCoverage?: { __typename?: 'DomainValueCoverageResult', domainId: string, values: Array<string>, cells: Array<{ __typename?: 'DomainValueCoverageCell', valueA: string, valueB: string, batchCount: number, pairedBatchCount: number, incompleteBatchCount: number, definitionId?: string | null, definitionName?: string | null, aggregateRunId?: string | null, minTrialCount?: number | null, maxTrialCount?: number | null, modelBreakdown?: Array<{ __typename?: 'CoverageModelBreakdown', modelId: string, label: string, trialCount: number }> | null }>, availableModels: Array<{ __typename?: 'CoverageModelOption', modelId: string, label: string }> } | null };
 
 export type DomainValueCoverageLegacyQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -5579,6 +5588,7 @@ export const DomainValueCoverageDocument = gql`
       valueB
       batchCount
       pairedBatchCount
+      incompleteBatchCount
       definitionId
       definitionName
       aggregateRunId


### PR DESCRIPTION
## Summary
- Adds `incompleteBatchCount` field to each domain coverage cell — counts non-aggregate runs whose actual transcript count is below expected (scenarioSelections × models × samplesPerScenario)
- API: count-based completeness check in the `domainValueCoverage` resolver using Prisma `_count` aggregate — no expensive per-transcript joins
- Web: amber dot appears on affected matrix cells; popover shows count with "not all transcripts generated" message
- Splits `domain-coverage.ts` (431 lines) into a companion `domain-coverage-gql-types.ts` to keep both under the 400-line CI limit

## Test plan
- [x] Preflight passed: API lint (0 new errors), web lint (0 errors), web tests (1232/1232), web build ✓
- [x] `domain-coverage.test.ts` — all 39 tests pass
- [x] All changed files under 400 lines
- [ ] Manual smoke: open domain coverage matrix and confirm amber dot appears on cells with incomplete batches

## Validation
- `npm run lint --workspace @valuerank/api` — 0 new errors (2 pre-existing)
- `npm run lint --workspace @valuerank/web` — 0 errors
- `npm run test --workspace @valuerank/web` — 1232/1232 pass
- `npm run build --workspace @valuerank/web` — ✓
- `src/graphql/queries/__tests__/domain-coverage.test.ts` — 39/39 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)