### PR TITLE
fix(feature-factory): multi-slice implement + deliver state preservation

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_deliver.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_deliver.py
@@ -94,7 +94,8 @@ def command_deliver(args: argparse.Namespace) -> int:
         )
 
     pr = current_pr_payload()
-    if pr and pr.get("state") != "OPEN":
+    pr_closed = bool(pr) and pr.get("state") != "OPEN"
+    if pr_closed:
         pr = None
 
     if args.create_pr and not pr:
@@ -235,6 +236,14 @@ def command_deliver(args: argparse.Namespace) -> int:
             print(f"branch: {branch}")
             print(f"head: {head_sha}")
             print("pr: not created (dry-run)")
+            return 0
+        if pr_closed:
+            # PR is already merged or closed — preserve the recorded delivery state
+            # rather than overwriting pr_url with "" and resetting the workflow.
+            state_snapshot = load_workflow_state(args.slug).get(DELIVERY_KEY, {})
+            print(f"branch: {branch}")
+            print(f"head: {head_sha}")
+            print(f"pr: {state_snapshot.get('pr_url', '')} (already closed/merged, state preserved)")
             return 0
         update_workflow_state(
             args.slug,

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_next_action.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_next_action.py
@@ -64,6 +64,10 @@ def recommended_next_action(
         return "repair_diff_checkpoint"
     if not reconciliation_ok:
         return "reconcile_reviews"
+    # If any tasks remain unchecked there are more slices to implement before delivering.
+    tasks_path = workflow_dir(slug) / "tasks.md"
+    if tasks_path.exists() and "- [ ]" in tasks_path.read_text(encoding="utf-8"):
+        return "dispatch_next_slice_to_codex"
     # Import here to avoid circular — refresh_delivery_snapshot is in factory_deliver
     from factory_deliver import refresh_delivery_snapshot  # noqa: E402
     delivery = refresh_delivery_snapshot(state.get(DELIVERY_KEY, {}))

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_parallel.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_parallel.py
@@ -68,10 +68,25 @@ def parse_parallel_task_groups(slug: str) -> list[dict]:
     if not tasks_path.exists():
         return []
 
+    # Determine which slice to read based on checkpoint progress.
+    # Slice N starts after the N-th [CHECKPOINT] marker.  Slice 0 starts at the top.
+    progress = _stages.checkpoint_progress_state(slug)
+    target_slice = progress.get("index", 0)
+
     unchecked_tasks: list[dict[str, object]] = []
+    markers_seen = 0
+    collecting = target_slice == 0  # slice 0 starts immediately
+
     for line in tasks_path.read_text(encoding="utf-8").splitlines():
         if _stages._CHECKPOINT_MARKER_RE.match(line):
-            break
+            if collecting:
+                break  # end of current slice
+            markers_seen += 1
+            if markers_seen == target_slice:
+                collecting = True
+            continue
+        if not collecting:
+            continue
         if not re.match(r"^\s*-\s+\[\s\]\s+", line):
             continue
 
@@ -82,7 +97,7 @@ def parse_parallel_task_groups(slug: str) -> list[dict]:
             }
         )
 
-    if not unchecked_tasks:
+    if not collecting or not unchecked_tasks:
         return []
 
     annotated_indexes = [index for index, item in enumerate(unchecked_tasks) if item["files"]]

--- a/docs/workflow/operations/codex-skills/feature-factory/tests/test_run_factory_repair.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/tests/test_run_factory_repair.py
@@ -563,17 +563,22 @@ class RepairDecisionTests(unittest.TestCase):
             for stage in ("spec", "plan", "tasks", "diff")
         }
         stages["closeout"] = stage_state()
-        with patch.object(NEXT_ACTION_MODULE, "diff_review_budget_state", return_value={"head_mismatch": False}):
-            action = MODULE.recommended_next_action(
-                "feature-workflow-repair",
-                {
-                    "blocked": {"active": False},
-                    "delivery": {"pr_url": "https://example.com", "head_mismatch": True},
-                    "parallel_analysis": {"reviewed": True, "found": False, "note": "", "updated_at": 0},
-                },
-                stages,
-                True,
-            )
+        with tempfile.TemporaryDirectory() as tmp:
+            # All tasks checked off — no remaining slices to implement.
+            workflow_root = Path(tmp)
+            (workflow_root / "tasks.md").write_text("- [x] Task 1\n- [x] Task 2\n", encoding="utf-8")
+            with patch.object(NEXT_ACTION_MODULE, "workflow_dir", return_value=workflow_root), \
+                    patch.object(NEXT_ACTION_MODULE, "diff_review_budget_state", return_value={"head_mismatch": False}):
+                action = MODULE.recommended_next_action(
+                    "feature-workflow-repair",
+                    {
+                        "blocked": {"active": False},
+                        "delivery": {"pr_url": "https://example.com", "head_mismatch": True},
+                        "parallel_analysis": {"reviewed": True, "found": False, "note": "", "updated_at": 0},
+                    },
+                    stages,
+                    True,
+                )
         self.assertEqual(action, "deliver")
 
     def test_command_deliver_blocks_when_reviewed_diff_head_moves(self) -> None:


### PR DESCRIPTION
## Summary
- **Finding 1**: `recommended_next_action` now checks for any remaining `- [ ]` tasks after a healthy diff checkpoint. Previously it fell straight through to `deliver`, skipping slices 2+.
- **Finding 2**: `parse_parallel_task_groups` uses `checkpoint_progress_state.index` to scan past the right number of `[CHECKPOINT]` markers before collecting tasks. Previously it always broke at the first marker, making later slices unreachable.
- **Finding 4**: `command_deliver` detects when the PR is already merged/closed and preserves the existing delivery state instead of overwriting `pr_url` with `""`, which previously caused the next-action loop to re-enter deliver indefinitely.

## Test plan
- [ ] 122/122 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)