### PR TITLE
fix(value-detail): fetch and map decisionCode for legacy-mode display

### DIFF
--- a/cloud/apps/web/src/api/operations/domainAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.graphql
@@ -176,6 +176,7 @@ query DomainAnalysisConditionTranscripts(
     runId
     scenarioId
     modelId
+    decisionCode
     decisionModelV2
     turnCount
     tokenCount

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -3961,7 +3961,7 @@ export type DomainAnalysisConditionTranscriptsQueryVariables = Exact<{
 }>;
 
 
-export type DomainAnalysisConditionTranscriptsQuery = { __typename?: 'Query', domainAnalysisConditionTranscripts: Array<{ __typename?: 'DomainAnalysisConditionTranscript', id: string, runId: string, scenarioId?: string | null, modelId: string, decisionModelV2?: unknown | null, turnCount: number, tokenCount: number, durationMs: number, createdAt: string, content: unknown }> };
+export type DomainAnalysisConditionTranscriptsQuery = { __typename?: 'Query', domainAnalysisConditionTranscripts: Array<{ __typename?: 'DomainAnalysisConditionTranscript', id: string, runId: string, scenarioId?: string | null, modelId: string, decisionCode?: string | null, decisionModelV2?: unknown | null, turnCount: number, tokenCount: number, durationMs: number, createdAt: string, content: unknown }> };
 
 export type DomainAvailableSignaturesQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -5526,6 +5526,7 @@ export const DomainAnalysisConditionTranscriptsDocument = gql`
     runId
     scenarioId
     modelId
+    decisionCode
     decisionModelV2
     turnCount
     tokenCount

--- a/cloud/apps/web/src/pages/DomainAnalysisValueDetail.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysisValueDetail.tsx
@@ -115,6 +115,7 @@ export function DomainAnalysisValueDetail() {
       modelId: transcript.modelId,
       modelVersion: null,
       content: transcript.content,
+      decisionCode: transcript.decisionCode ?? null,
       decisionModelV2: transcript.decisionModelV2 ?? null,
       turnCount: transcript.turnCount,
       tokenCount: transcript.tokenCount,


### PR DESCRIPTION
## Summary

- Follow-up to #639: after the fix to show transcripts for unknown/unparseable conditions, the Decision Summary column shows `-` because `decisionCode` was never fetched
- The condition transcripts query did not select `decisionCode`, so `TranscriptRow` had nothing to show in legacy mode (transcripts without `decisionModelV2`)
- Add `decisionCode` to the GraphQL query, update the generated document + type, and map it through the normalization step

## Test plan

- [ ] Open a value detail cell that previously showed the error (e.g. negligible / negligible on the URL in the issue)
- [ ] Transcripts render and the Decision Summary column shows `1`–`5` (not `-`)
- [ ] Cells with full `decisionModelV2` still show audit-mode summaries (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)