### PR TITLE
fix(screenshot): remove scrollbars from copy-as-image captures

### DIFF
--- a/cloud/apps/web/src/components/ui/CopyVisualButton.tsx
+++ b/cloud/apps/web/src/components/ui/CopyVisualButton.tsx
@@ -66,11 +66,29 @@ export function CopyVisualButton({ targetRef, label }: CopyVisualButtonProps) {
     setIsCopying(true);
     setStatus('idle');
 
+    // Temporarily expand scroll containers so the full content is captured without scrollbars
+    const scrollEls = Array.from(
+      target.querySelectorAll<HTMLElement>('.overflow-x-auto, .overflow-y-auto, .overflow-auto'),
+    );
+    const saved = scrollEls.map((el) => ({
+      el,
+      overflow: el.style.overflow,
+      width: el.style.width,
+    }));
+    scrollEls.forEach((el) => {
+      el.style.overflow = 'visible';
+      el.style.width = `${el.scrollWidth}px`;
+    });
+    const captureWidth = target.scrollWidth;
+    const captureHeight = target.scrollHeight;
+
     try {
       const dataUrl = await toPng(target, {
         cacheBust: true,
         pixelRatio: 2,
         backgroundColor: '#ffffff',
+        width: captureWidth,
+        height: captureHeight,
         filter: (node) => {
           if (!(node instanceof Element)) return true;
           return !node.classList.contains(COPY_CONTROL_CLASS);
@@ -94,6 +112,11 @@ export function CopyVisualButton({ targetRef, label }: CopyVisualButtonProps) {
       setStatus('error');
       window.setTimeout(() => setStatus('idle'), 2200);
     } finally {
+      // Restore scroll container styles
+      saved.forEach(({ el, overflow, width }) => {
+        el.style.overflow = overflow;
+        el.style.width = width;
+      });
       setIsCopying(false);
     }
   };


### PR DESCRIPTION
## Summary
- Screenshot buttons captured scroll containers at their clipped viewport size, including scrollbar artifacts
- `CopyVisualButton` now temporarily expands all `.overflow-x-auto/.overflow-y-auto/.overflow-auto` containers to their full `scrollWidth` and sets `overflow: visible` before calling `html-to-image`
- Full content dimensions are passed to `toPng` so the canvas matches the expanded layout
- Styles are restored in `finally` so the page layout is unaffected
- Fix applies to all 16 components that use `CopyVisualButton`

## Validation
- `npx turbo lint --filter=@valuerank/shared` — passed (0 errors)
- `npx turbo lint --filter=@valuerank/web` — passed (19 warnings, 0 errors, pre-existing)
- `npx turbo build --filter=@valuerank/web` — passed

## Test plan
- [ ] Copy a wide table (e.g. Value Priorities) and confirm no scrollbar in pasted image
- [ ] Confirm page layout is unchanged after copying

🤖 Generated with [Claude Code](https://claude.com/claude-code)