### PR TITLE
fix(domain-csv): rename Value 1/2 to First/Second Value and fix prompt-order bug

### DIFF
--- a/cloud/apps/api/src/services/export/domain-csv.ts
+++ b/cloud/apps/api/src/services/export/domain-csv.ts
@@ -20,8 +20,8 @@ export const DOMAIN_CSV_HEADERS = [
   'AI Model Name',
   'Vignette Name',
   'Trial Signature',
-  'Value 1',
-  'Value 2',
+  'First Value',
+  'Second Value',
   'Value Chosen',
   'Decision Strength',
   'Transcript ID',
@@ -55,23 +55,25 @@ type DefinitionSnapshotComponents = {
 
 function getPromptOrderTokens(
   definitionSnapshot: unknown,
-  orientationFlipped: boolean,
 ): { firstToken: string | null; secondToken: string | null } {
   if (definitionSnapshot == null || typeof definitionSnapshot !== 'object' || Array.isArray(definitionSnapshot)) {
     return { firstToken: null, secondToken: null };
   }
 
   const snapshot = definitionSnapshot as { components?: DefinitionSnapshotComponents };
-  const canonicalFirst = snapshot.components?.value_first?.token ?? null;
-  const canonicalSecond = snapshot.components?.value_second?.token ?? null;
+  const firstToken = snapshot.components?.value_first?.token ?? null;
+  const secondToken = snapshot.components?.value_second?.token ?? null;
 
-  if (canonicalFirst == null || canonicalSecond == null) {
+  if (firstToken == null || secondToken == null) {
     return { firstToken: null, secondToken: null };
   }
 
-  return orientationFlipped
-    ? { firstToken: canonicalSecond, secondToken: canonicalFirst }
-    : { firstToken: canonicalFirst, secondToken: canonicalSecond };
+  // value_first in the definition snapshot is always the value that appeared
+  // first in the prompt shown to the model. orientationFlipped is an analysis
+  // normalization flag (used to compare A-first vs B-first definitions on the
+  // same scale) — it does NOT mean the prompt order is reversed relative to
+  // value_first/value_second.
+  return { firstToken, secondToken };
 }
 
 function getDimensionValues(scenarioContent: unknown): Record<string, string> {
@@ -116,10 +118,8 @@ function domainTranscriptToRow(transcript: DomainTranscriptWithScenario): string
     transcript.run?.config,
   );
 
-  const orientationFlipped = transcript.scenario?.orientationFlipped ?? false;
   const { firstToken, secondToken } = getPromptOrderTokens(
     transcript.definitionSnapshot,
-    orientationFlipped,
   );
 
   const dimensionValues = getDimensionValues(transcript.scenario?.content);

--- a/cloud/apps/api/tests/routes/export.test.ts
+++ b/cloud/apps/api/tests/routes/export.test.ts
@@ -673,8 +673,8 @@ describe('Domain Transcript CSV Export Endpoint', () => {
     expect(response.text.charCodeAt(0)).toBe(0xfeff);
     const headerLine = response.text.split('\n')[0]?.replace('\uFEFF', '');
     expect(headerLine).toContain('AI Model Name');
-    expect(headerLine).toContain('Value 1');
-    expect(headerLine).toContain('Value 2');
+    expect(headerLine).toContain('First Value');
+    expect(headerLine).toContain('Second Value');
     expect(headerLine).toContain('Value Chosen');
     expect(headerLine).toContain('Decision Strength');
   });


### PR DESCRIPTION
## Summary
- Rename CSV export columns from 'Value 1'/'Value 2' to 'First Value'/'Second Value'
- Fix a bug where both columns always showed values in alphabetical order regardless of which was actually presented first in the prompt
- Root cause: `getPromptOrderTokens` was incorrectly applying `orientationFlipped` as a prompt-order reversal. In paired definitions, `value_first` in the definition snapshot already stores the value shown first in the prompt (A-first defs have the A-value as `value_first`, B-first defs have the B-value as `value_first`). Applying the flip on top caused a double-negation — both definition types returned the same token as "first", which always happened to be alphabetically first.

## Test plan
- [ ] Preflight passed (lint + build)
- [ ] Header assertions updated in `export.test.ts`
- [ ] Manual: export a domain CSV and confirm First Value varies between rows (reflects actual prompt presentation order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)