### PR TITLE
fix(value-detail): always pass audit mode; TranscriptRow handles per-row fallback

### DIFF
--- a/cloud/apps/web/src/pages/DomainAnalysisValueDetail.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysisValueDetail.tsx
@@ -16,10 +16,6 @@ import {
   type DomainAnalysisValueDetailQueryVariables,
 } from '../api/operations/domainAnalysis';
 import { VALUE_LABELS, type ValueKey } from '../data/domainAnalysisData';
-import {
-  getTranscriptDecisionDisplayMode,
-  type TranscriptDecisionDisplayMode,
-} from '../utils/transcriptDecisionModel';
 import { ConditionMatrix } from '../components/domains/ConditionMatrix';
 
 const VALUE_DETAIL_COPY = {
@@ -125,9 +121,7 @@ export function DomainAnalysisValueDetail() {
       lastAccessedAt: null,
     }));
 
-    const displayMode: TranscriptDecisionDisplayMode = getTranscriptDecisionDisplayMode(transcripts);
-
-    return { transcripts, displayMode };
+    return { transcripts };
   }, [transcriptData]);
 
   if (domainId === '' || modelId === '' || valueKey === '') {
@@ -158,7 +152,7 @@ export function DomainAnalysisValueDetail() {
   const mathDenominator = detail.deprioritized + 1;
   const ratio = mathNumerator / mathDenominator;
   const selectedConditionKey = selectedCondition === null ? '' : `${selectedCondition.definitionId}:${selectedCondition.scenarioId ?? '__unknown__'}`;
-  const reportDecisionDisplayMode = selectedConditionTranscriptState.displayMode;
+  const reportDecisionDisplayMode = 'audit' as const;
   const decisionColumnLabel = VALUE_DETAIL_COPY.decisionColumnLabel;
 
   const handleConditionClick = (definitionId: string, conditionName: string, scenarioId: string | null) => {

--- a/cloud/apps/web/tests/pages/DomainAnalysisValueDetail.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysisValueDetail.test.tsx
@@ -377,7 +377,7 @@ describe('DomainAnalysisValueDetail', () => {
     });
   });
 
-  it('renders transcripts in legacy mode when decisionModelV2 is missing', async () => {
+  it('renders transcripts and always passes audit mode (TranscriptRow handles per-row fallback)', async () => {
     mockQueries({
       detail: createDetail([
         createVignette('def-1', 'One vignette', [
@@ -412,7 +412,7 @@ describe('DomainAnalysisValueDetail', () => {
       expect(screen.getByTestId('transcript-list')).toBeInTheDocument();
     });
 
-    expect(lastTranscriptListProps?.decisionDisplayMode).toBe('legacy');
+    expect(lastTranscriptListProps?.decisionDisplayMode).toBe('audit');
     expect(screen.queryByText(/Failed to render transcripts/)).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #639 and #640. After those fixes, transcripts with valid `decisionModelV2` were still showing `-` in the Decision Summary column.

**Root cause:** `getTranscriptDecisionDisplayMode` is a batch check — if *any* transcript in the batch has `direction='unknown'`, it returns `'legacy'` for *all* of them. Modern transcripts (new runs) have `decisionCode: null` because they use the text-label approach exclusively, so in legacy mode they showed `-`.

**Fix:** `TranscriptRow` already has per-transcript mode selection:
```ts
const rowDecisionDisplayMode = hasRenderableTranscriptDecisionModelV2(transcript)
  ? (decisionDisplayMode ?? 'audit')
  : 'legacy';
```
The page just needs to pass `'audit'` always. Non-renderable rows fall back to legacy on their own; renderable rows show their canonical summaries (`"Somewhat favors Benevolence Dependability"`, etc.).

## Test plan

- [ ] Open a condition cell that mixes renderable and non-renderable transcripts
- [ ] Renderable transcripts show their canonical summary (e.g. "Somewhat favors X")
- [ ] Non-renderable transcripts (direction='unknown') show their numeric code or `-`
- [ ] No regression on cells where all transcripts are fully renderable

🤖 Generated with [Claude Code](https://claude.com/claude-code)