### PR TITLE
fix: honor audit mode; rename favors→supports in decision headline

### DIFF
--- a/cloud/apps/web/src/components/runs/TranscriptRow.tsx
+++ b/cloud/apps/web/src/components/runs/TranscriptRow.tsx
@@ -199,9 +199,9 @@ export function TranscriptRow({
   const showGrid = !compact && Boolean(gridTemplateColumns);
   const rawDecision = transcript.decisionModelV2?.legacy?.canonicalScore ?? transcript.decisionCode ?? extractDecision(transcript.content);
   const decisionScaleLabels = decisionMetadata?.scaleLabels ?? [];
-  const rowDecisionDisplayMode = hasRenderableTranscriptDecisionModelV2(transcript)
-    ? (decisionDisplayMode ?? 'audit')
-    : 'legacy';
+  const rowDecisionDisplayMode = decisionDisplayMode ?? (
+    hasRenderableTranscriptDecisionModelV2(transcript) ? 'audit' : 'legacy'
+  );
   const legacyDecisionDisplay = getLegacyDecisionDisplay(transcript, String(rawDecision), normalizeDecision, dimensions);
   const canonicalDecision = transcript.decisionModelV2?.canonical ?? null;
   const canonicalDecisionDisplay = formatCanonicalDecisionHeadline(transcript);

--- a/cloud/apps/web/src/utils/transcriptDecisionModel.ts
+++ b/cloud/apps/web/src/utils/transcriptDecisionModel.ts
@@ -170,7 +170,7 @@ export function formatCanonicalDecisionHeadline(transcript: Transcript): string 
     return 'Unknown';
   }
 
-  const strengthLabel = canonical.strength === 'strong' ? 'Strongly favors' : 'Somewhat favors';
+  const strengthLabel = canonical.strength === 'strong' ? 'Strongly supports' : 'Somewhat supports';
   return `${strengthLabel} ${formatDisplayLabel(canonical.favoredValueKey)}`;
 }
 

--- a/cloud/apps/web/tests/components/runs/RunResults.test.tsx
+++ b/cloud/apps/web/tests/components/runs/RunResults.test.tsx
@@ -216,7 +216,7 @@ describe('RunResults', () => {
     await user.click(screen.getByText('gpt-4'));
 
     expect(screen.getByText('Decision summary')).toBeInTheDocument();
-    expect(screen.getByText(/Strongly favors Benevolence Dependability/)).toBeInTheDocument();
+    expect(screen.getByText(/Strongly supports Benevolence Dependability/)).toBeInTheDocument();
   });
 
   it('opens transcript viewer when transcript is clicked', async () => {

--- a/cloud/apps/web/tests/components/runs/TranscriptList.test.tsx
+++ b/cloud/apps/web/tests/components/runs/TranscriptList.test.tsx
@@ -216,7 +216,7 @@ describe('TranscriptList', () => {
       />
     );
 
-    expect(screen.getByText(/Strongly favors Benevolence Dependability/)).toBeInTheDocument();
+    expect(screen.getByText(/Strongly supports Benevolence Dependability/)).toBeInTheDocument();
     expect(screen.queryByText('Fallback')).not.toBeInTheDocument();
   });
 

--- a/cloud/apps/web/tests/components/runs/TranscriptViewer.test.tsx
+++ b/cloud/apps/web/tests/components/runs/TranscriptViewer.test.tsx
@@ -64,7 +64,7 @@ describe('TranscriptViewer', () => {
     );
 
     expect(screen.getByText('Decision summary:')).toBeInTheDocument();
-    expect(screen.getByText(/Strongly favors Benevolence Dependability/)).toBeInTheDocument();
+    expect(screen.getByText(/Strongly supports Benevolence Dependability/)).toBeInTheDocument();
     expect(screen.getByText('Raw Evidence')).toBeInTheDocument();
     expect(screen.getByText('exact')).toBeInTheDocument();
     expect(screen.queryByText('42 tokens')).not.toBeInTheDocument();

--- a/cloud/apps/web/tests/pages/AnalysisTranscripts.test.tsx
+++ b/cloud/apps/web/tests/pages/AnalysisTranscripts.test.tsx
@@ -372,7 +372,7 @@ describe('AnalysisTranscripts', () => {
     expect(headerMeta).toHaveTextContent('Repeat Pattern: Stable');
     expect(headerMeta).toHaveTextContent('Model: model1');
     expect(headerMeta).toHaveTextContent('Conditions: 1');
-    expect(headerMeta).toHaveTextContent('Decision summary: Strongly favors Benevolence Dependability');
+    expect(headerMeta).toHaveTextContent('Decision summary: Strongly supports Benevolence Dependability');
     expect(screen.queryByText('Decision: 1')).not.toBeInTheDocument();
     expect(screen.getByTestId('transcript-list')).toHaveTextContent('Transcript count: 2');
   });
@@ -886,7 +886,7 @@ describe('AnalysisTranscripts', () => {
 
     renderPage('/analysis/run-4/transcripts?modelId=model1&repeatPattern=stable&rowDim=Freedom&colDim=Harmony&conditionIds=High%7C%7CLow');
 
-    expect(screen.getByText('Strongly favors Benevolence Dependability')).toBeInTheDocument();
+    expect(screen.getByText('Strongly supports Benevolence Dependability')).toBeInTheDocument();
     expect(screen.getByText(/requires canonical decisionModelV2 data for every visible transcript/i)).toBeInTheDocument();
     expect(screen.queryByTestId('transcript-list')).not.toBeInTheDocument();
     expect(screen.queryByTestId('transcript-viewer')).not.toBeInTheDocument();

--- a/cloud/apps/web/tests/pages/SurveyResults.test.tsx
+++ b/cloud/apps/web/tests/pages/SurveyResults.test.tsx
@@ -350,17 +350,17 @@ describe('SurveyResults', () => {
     expect(screen.getByText('Question x AI Matrix')).toBeInTheDocument();
     expect(screen.getByText('Empty cell')).toBeInTheDocument();
     expect(screen.getByText('Unknown')).toBeInTheDocument();
-    expect(screen.getByText(/Strongly favors Benevolence Dependability/)).toBeInTheDocument();
+    expect(screen.getByText(/Strongly supports Benevolence Dependability/)).toBeInTheDocument();
     expect(screen.queryByText('4.00')).not.toBeInTheDocument();
     expect(screen.queryByText('5')).not.toBeInTheDocument();
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
 
     const majorityButton = screen.getByRole('button', { name: /View transcript for Majority cell \/ model1/i });
-    expect(majorityButton).toHaveTextContent('Strongly favors Benevolence Dependability');
+    expect(majorityButton).toHaveTextContent('Strongly supports Benevolence Dependability');
     expect(majorityButton).toHaveTextContent('(n=3)');
     expect(majorityButton).toHaveAttribute(
       'title',
-      'View transcript: Strongly favors Benevolence Dependability. Strongly favors Benevolence Dependability (2), Somewhat favors Achievement (1)',
+      'View transcript: Strongly supports Benevolence Dependability. Strongly supports Benevolence Dependability (2), Somewhat supports Achievement (1)',
     );
     fireEvent.click(majorityButton);
     expect(screen.getByTestId('transcript-viewer')).toHaveTextContent('tx-majority-1');
@@ -370,7 +370,7 @@ describe('SurveyResults', () => {
     expect(mixedButton).toHaveTextContent('(n=2)');
     expect(mixedButton).toHaveAttribute(
       'title',
-      'View transcript: Mixed. Strongly favors Benevolence Dependability (1), Somewhat favors Achievement (1)',
+      'View transcript: Mixed. Strongly supports Benevolence Dependability (1), Somewhat supports Achievement (1)',
     );
   });
 
@@ -389,12 +389,12 @@ describe('SurveyResults', () => {
         [
           's-majority::model1',
           {
-            headline: 'Strongly favors Benevolence Dependability',
+            headline: 'Strongly supports Benevolence Dependability',
             totalCount: 1,
             renderableCount: 1,
             unknownCount: 0,
             buckets: [
-              { kind: 'strong', label: 'Strongly favors Benevolence Dependability', count: 1 },
+              { kind: 'strong', label: 'Strongly supports Benevolence Dependability', count: 1 },
             ],
           },
         ],
@@ -414,7 +414,7 @@ describe('SurveyResults', () => {
     } satisfies SurveyMatrixData);
 
     expect(csv).toContain('model1 decision summary');
-    expect(csv).toContain('Strongly favors Benevolence Dependability');
+    expect(csv).toContain('Strongly supports Benevolence Dependability');
     expect(csv).toContain('Unknown');
     expect(csv).not.toContain('decision code');
     expect(csv).not.toContain('4.00');

--- a/cloud/apps/web/tests/utils/reportDecisionDisplay.test.ts
+++ b/cloud/apps/web/tests/utils/reportDecisionDisplay.test.ts
@@ -124,12 +124,12 @@ describe('reportDecisionDisplay', () => {
       }),
     ]);
 
-    expect(summary.headline).toBe('Strongly favors Benevolence Dependability');
+    expect(summary.headline).toBe('Strongly supports Benevolence Dependability');
     expect(summary.renderableCount).toBe(3);
     expect(summary.unknownCount).toBe(0);
     expect(summary.buckets.map((bucket) => `${bucket.kind}:${bucket.label}:${bucket.count}`)).toEqual([
-      'strong:Strongly favors Benevolence Dependability:2',
-      'lean:Somewhat favors Achievement:1',
+      'strong:Strongly supports Benevolence Dependability:2',
+      'lean:Somewhat supports Achievement:1',
     ]);
   });
 
@@ -164,8 +164,8 @@ describe('reportDecisionDisplay', () => {
 
     expect(summary.headline).toBe('Mixed');
     expect(summary.buckets.map((bucket) => bucket.label)).toEqual([
-      'Strongly favors Benevolence Dependability',
-      'Somewhat favors Achievement',
+      'Strongly supports Benevolence Dependability',
+      'Somewhat supports Achievement',
     ]);
   });
 
@@ -176,11 +176,11 @@ describe('reportDecisionDisplay', () => {
       createTranscript({ id: 'unknown-1', decisionModelV2: null }),
     ]);
 
-    expect(summary.headline).toBe('Strongly favors Benevolence Dependability');
+    expect(summary.headline).toBe('Strongly supports Benevolence Dependability');
     expect(summary.renderableCount).toBe(2);
     expect(summary.unknownCount).toBe(1);
     expect(summary.buckets.map((bucket) => bucket.label)).toEqual([
-      'Strongly favors Benevolence Dependability',
+      'Strongly supports Benevolence Dependability',
       'Unknown',
     ]);
   });

--- a/cloud/apps/web/tests/utils/transcriptDecisionModel.test.ts
+++ b/cloud/apps/web/tests/utils/transcriptDecisionModel.test.ts
@@ -229,7 +229,7 @@ describe('transcriptDecisionModel', () => {
     const transcript = createTranscript({ decisionModelV2: createRenderableV2Transcript() });
 
     expect(getTranscriptDecisionAuditBadge(transcript)).toBeNull();
-    expect(formatCanonicalDecisionHeadline(transcript)).toBe('Strongly favors Benevolence Dependability');
+    expect(formatCanonicalDecisionHeadline(transcript)).toBe('Strongly supports Benevolence Dependability');
   });
 
   it('uses canonical audit sort order instead of legacy canonical scores', () => {


### PR DESCRIPTION
## Summary

- **No more raw numbers in audit mode.** `TranscriptRow` was overriding `decisionDisplayMode='audit'` to `'legacy'` on a per-row basis when a transcript lacked renderable canonical data. Old transcripts would show raw numbers like `4` on the value-detail page even though audit mode was explicitly requested. Now the caller's choice is respected — per-row auto-detection only runs when no mode is passed.
- **"supports" not "favors".** The canonical decision headline (`formatCanonicalDecisionHeadline`) now returns `"Strongly supports X"` / `"Somewhat supports X"` to match the vignette language used throughout the rest of the app. Tests updated to match.

## Pages fixed

- `/domains/analysis/value-detail` — transcripts with `direction: 'unknown'` now show `"Unknown"` instead of `"4"`, and modern transcripts show `"Strongly supports Achievement"` instead of `"Strongly favors Achievement"`.
- Other run result pages (`RunResults`, `AnalysisTranscripts`) that explicitly pass `'legacy'` mode are unchanged.

## Validation

```
npx turbo lint --filter=@valuerank/web   ✅ 0 errors
npx turbo test --filter=@valuerank/web   ✅ 1507/1509 pass
```

2 pre-existing `DomainAnalysis.test.tsx` failures (freshness badge + signatures query) are unrelated to this change and fail identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)