### PR TITLE
fix(models): move Models first in nav; default to isDefault models

### DIFF
--- a/cloud/apps/web/src/components/layout/MobileNav.tsx
+++ b/cloud/apps/web/src/components/layout/MobileNav.tsx
@@ -14,6 +14,7 @@ type NavItem = {
 
 const navItems: NavItem[] = [
   { name: 'Home', path: '/', icon: Home },
+  { name: 'Models', path: '/models', icon: Cpu },
   {
     name: 'Domains',
     path: '/domains',
@@ -23,7 +24,6 @@ const navItems: NavItem[] = [
       { name: 'Manage Domains', path: '/domains/manage', icon: FolderTree },
     ],
   },
-  { name: 'Models', path: '/models', icon: Cpu },
   {
     name: 'Vignettes',
     path: '/definitions',

--- a/cloud/apps/web/src/components/layout/NavTabs.tsx
+++ b/cloud/apps/web/src/components/layout/NavTabs.tsx
@@ -218,7 +218,6 @@ export function NavTabs() {
     <nav className="hidden sm:block bg-[#1A1A1A] border-t border-gray-800">
       <div className="max-w-7xl mx-auto px-4">
         <div className="flex gap-1">
-          {renderMenu(domainMenuRef, 'Domains', '/domains', FolderTree, domainMenuItems, isDomainsActive, isDomainsMenuOpen, setIsDomainsMenuOpen)}
           <NavLink
             to="/models"
             className={`flex items-center gap-2 px-3 py-3 min-h-[44px] text-sm font-medium transition-colors border-b-2 ${
@@ -230,6 +229,7 @@ export function NavTabs() {
             <Cpu className="w-4 h-4" />
             <span className="hidden sm:inline">Models</span>
           </NavLink>
+          {renderMenu(domainMenuRef, 'Domains', '/domains', FolderTree, domainMenuItems, isDomainsActive, isDomainsMenuOpen, setIsDomainsMenuOpen)}
           {renderMenu(vignettesMenuRef, 'Vignettes', '/definitions', Library, vignettesMenuItems, isVignettesActive, isVignettesMenuOpen, setIsVignettesMenuOpen)}
           {renderMenu(archiveMenuRef, 'Archive', '/archive', Archive, archiveMenuItems, isArchiveActive, isArchiveMenuOpen, setIsArchiveMenuOpen)}
           {renderMenu(settingsMenuRef, 'Settings', '/settings/account', Settings, settingsMenuItems, isSettingsActive, isSettingsMenuOpen, setIsSettingsMenuOpen)}

--- a/cloud/apps/web/src/pages/Models.tsx
+++ b/cloud/apps/web/src/pages/Models.tsx
@@ -11,6 +11,7 @@ import {
   type ModelsAnalysisQueryVariables,
   type ModelsAnalysisValueResult,
 } from '../api/operations/modelsAnalysis';
+import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { ModelValueDetailDrawer } from '../components/models/ModelValueDetailDrawer';
 import {
   ModelsMatrix,
@@ -35,6 +36,11 @@ export function Models() {
     variables: queryVariables,
     requestPolicy: 'cache-and-network',
   });
+  const [{ data: llmModelsData }] = useQuery<LlmModelsQueryResult>({
+    query: LLM_MODELS_QUERY,
+    variables: { status: 'ACTIVE' },
+    requestPolicy: 'cache-and-network',
+  });
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
   const [sortBy, setSortBy] = useState<ModelsMatrixSortKey>('model');
   const [stabilityVisibility, setStabilityVisibility] = useState<StabilityVisibility>('all');
@@ -42,6 +48,10 @@ export function Models() {
   const initializedModelSelection = useRef(false);
 
   const models = useMemo(() => data?.modelsAnalysis.models ?? [], [data]);
+  const defaultModelIds = useMemo(
+    () => new Set((llmModelsData?.llmModels ?? []).filter((m) => m.isDefault).map((m) => m.modelId)),
+    [llmModelsData],
+  );
   const selectedDomain = selectedDomainId != null ? domains.find((domain) => domain.id === selectedDomainId) ?? null : null;
   const singleDomainActive = selectedDomainId != null;
 
@@ -54,9 +64,13 @@ export function Models() {
   useEffect(() => {
     if (initializedModelSelection.current) return;
     if (models.length === 0) return;
-    setSelectedModelIds(models.map((model) => model.modelId));
+    if (llmModelsData == null) return;
+    const availableIds = models.map((model) => model.modelId);
+    const defaultSelection = availableIds.filter((id) => defaultModelIds.has(id));
+    // Fall back to all models if no defaults are configured or none match the current result set
+    setSelectedModelIds(defaultSelection.length > 0 ? defaultSelection : availableIds);
     initializedModelSelection.current = true;
-  }, [models]);
+  }, [models, llmModelsData, defaultModelIds]);
 
   useEffect(() => {
     if (!initializedModelSelection.current) return;


### PR DESCRIPTION
## Summary
- Models tab moved to far left position in desktop and mobile nav
- Models page now defaults to selecting only models with `isDefault=true` from Settings → LLM Models
- Falls back to selecting all models if no defaults are configured

## Test plan
- [ ] Visit /models — only default models should be pre-selected in the filter chips
- [ ] Settings → LLM Models — verify which models have isDefault=true; confirm those are the ones pre-selected
- [ ] Nav bar — Models should be the leftmost tab on desktop
- [ ] Mobile nav — Models should appear right after Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)