### PR TITLE
fix(models): prevent background scroll when detail drawer is open

### DIFF
--- a/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
+++ b/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
@@ -53,12 +53,19 @@ export function ModelValueDetailDrawer({
       if (event.key === 'Escape') onClose();
     };
 
-    const originalOverflow = document.body.style.overflow;
+    // Lock both body and the layout's <main> scroll container. The app layout uses
+    // overflow-auto on <main> (not body), so only locking body has no effect — scroll
+    // events still reach <main> and scroll the background behind the drawer.
+    const main = document.querySelector<HTMLElement>('main');
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalMainOverflow = main?.style.overflow ?? '';
     document.body.style.overflow = 'hidden';
+    if (main != null) main.style.overflow = 'hidden';
     window.addEventListener('keydown', onKeyDown);
 
     return () => {
-      document.body.style.overflow = originalOverflow;
+      document.body.style.overflow = originalBodyOverflow;
+      if (main != null) main.style.overflow = originalMainOverflow;
       window.removeEventListener('keydown', onKeyDown);
     };
   }, [open, onClose]);


### PR DESCRIPTION
## Summary
- Fixes white space / background scroll bug when the model value detail drawer is open
- Root cause: the app layout scrolls via `overflow-auto` on `<main>`, not on `<body>`. The drawer was only locking `body.overflow`, which had no effect — scroll events still reached `<main>` and scrolled the background content behind the overlay.
- Fix: lock both `body` and `<main>` when the drawer opens, restore both on close.

## Test plan
- [ ] Open the Models page, click a cell to open the drawer
- [ ] With the drawer open, hover over the backdrop or the drawer header (non-scrollable area) and scroll — background should not move
- [ ] Scroll inside the drawer's content area — drawer content should scroll normally
- [ ] Close the drawer — page scroll should resume normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)