### PR TITLE
feat(models): calculation tooltips on drawer metrics + remove cell domain count

### DIFF
--- a/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
+++ b/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { Link } from 'react-router-dom';
-import { X } from 'lucide-react';
+import { Info, X } from 'lucide-react';
 import { type ModelsAnalysisModelResult, type ModelsAnalysisValueResult } from '../../api/operations/modelsAnalysis';
 import { VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
 import { Button } from '../ui/Button';
-import { computeDots, computeWeightedMad, formatStabilityTooltip } from './stabilityDots';
+import { Tooltip } from '../ui/Tooltip';
+import { computeDots, computeWeightedMad, computeWeightedMean, formatStabilityTooltip } from './stabilityDots';
 
 type ModelValueDetailDrawerProps = {
   open: boolean;
@@ -37,6 +38,10 @@ function renderDots(score: number | null): string {
       }
     })
     .join('');
+}
+
+function InfoIcon() {
+  return <Info className="h-3.5 w-3.5" />;
 }
 
 export function ModelValueDetailDrawer({
@@ -75,12 +80,146 @@ export function ModelValueDetailDrawer({
   const valueKey = value.valueKey as ValueKey;
   const valueLabel = VALUE_LABELS[valueKey] ?? value.valueKey;
   const mad = computeWeightedMad(value.domains);
-  const tooltip = formatStabilityTooltip(value.stabilityScore, value.eligibleDomainCount, mad, singleDomainActive);
+  const stabilityCardText = formatStabilityTooltip(value.stabilityScore, value.eligibleDomainCount, mad, singleDomainActive);
   const dots = renderDots(value.stabilityScore);
   const domains = [...value.domains].sort((left, right) => {
     const diff = right.evidenceWeight - left.evidenceWeight;
     return diff !== 0 ? diff : left.domainName.localeCompare(right.domainName);
   });
+
+  // --- Pooled win rate tooltip data ---
+  const totalWeight = domains.reduce((sum, d) => sum + d.evidenceWeight, 0);
+  const weightedSum = domains.reduce((sum, d) => sum + d.evidenceWeight * d.winRate, 0);
+
+  const pooledWinRateTooltip = (
+    <div className="space-y-2">
+      <p>
+        <strong>What it means:</strong> A weighted average of win rates across each eligible domain.
+        Head-to-head comparisons were run where judges picked which model response better showed this value.
+        Win rate = % of those comparisons this model won.
+        Domains with more comparisons (higher evidence weight) count more in the average.
+      </p>
+      <p>
+        <strong>Formula:</strong> add up (weight × win rate) for every domain, then divide by the total weight.
+      </p>
+      {domains.length > 0 && (
+        <div className="border-t border-gray-200 pt-2">
+          <p className="font-semibold mb-1">Calculation for this cell:</p>
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="border-b border-gray-200 text-gray-500">
+                <th className="text-left pb-1 pr-3 font-medium">Domain</th>
+                <th className="text-right pb-1 px-2 font-medium">Weight</th>
+                <th className="text-right pb-1 px-2 font-medium">Win rate</th>
+                <th className="text-right pb-1 pl-2 font-medium">W × WR</th>
+              </tr>
+            </thead>
+            <tbody>
+              {domains.map((d) => (
+                <tr key={d.domainId} className="border-b border-gray-100">
+                  <td className="py-0.5 pr-3">{d.domainName}</td>
+                  <td className="text-right py-0.5 px-2">{d.evidenceWeight}</td>
+                  <td className="text-right py-0.5 px-2">{formatPercent(d.winRate)}</td>
+                  <td className="text-right py-0.5 pl-2">{(d.evidenceWeight * d.winRate).toFixed(1)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-t border-gray-300 font-semibold">
+                <td className="pt-1 pr-3 text-gray-500 font-normal" colSpan={3}>
+                  {weightedSum.toFixed(1)} ÷ {totalWeight} =
+                </td>
+                <td className="text-right pt-1 pl-2">{formatPercent(value.pooledWinRate)}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+
+  // --- Cross-domain stability tooltip data ---
+  const pooledMean = computeWeightedMean(domains);
+
+  const crossDomainStabilityTooltip = (
+    <div className="space-y-2">
+      <p>
+        <strong>What it means:</strong> How consistently this model wins across different domains.
+        A high score means the model behaves the same way no matter which domain it&apos;s tested in.
+        A low score means the results vary a lot by domain.
+      </p>
+      <p>
+        <strong>How the score is built:</strong>
+      </p>
+      <ol className="list-decimal pl-4 space-y-0.5">
+        <li>Find each domain&apos;s win rate (table below).</li>
+        <li>Measure how far each domain&apos;s win rate is from the pooled mean — the &quot;spread.&quot;</li>
+        <li>Take a weighted average of those distances (bigger domains count more).</li>
+        <li>Convert that average spread into a 0–100 score: less spread = higher score.</li>
+      </ol>
+      {!singleDomainActive && value.eligibleDomainCount >= 2 && pooledMean != null && domains.length > 0 && (
+        <div className="border-t border-gray-200 pt-2">
+          <p className="font-semibold mb-1">
+            Calculation for this cell <span className="font-normal text-gray-500">(pooled mean: {formatPercent(pooledMean)})</span>:
+          </p>
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="border-b border-gray-200 text-gray-500">
+                <th className="text-left pb-1 pr-3 font-medium">Domain</th>
+                <th className="text-right pb-1 px-2 font-medium">Win rate</th>
+                <th className="text-right pb-1 pl-2 font-medium">Distance from mean</th>
+              </tr>
+            </thead>
+            <tbody>
+              {domains.map((d) => (
+                <tr key={d.domainId} className="border-b border-gray-100">
+                  <td className="py-0.5 pr-3">{d.domainName}</td>
+                  <td className="text-right py-0.5 px-2">{formatPercent(d.winRate)}</td>
+                  <td className="text-right py-0.5 pl-2">{Math.abs(d.winRate - pooledMean).toFixed(1)} pts</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-t border-gray-300 font-semibold">
+                <td className="pt-1 pr-3" colSpan={2}>Weighted avg spread</td>
+                <td className="text-right pt-1 pl-2">{mad != null ? `${mad.toFixed(1)} pts` : 'n/a'}</td>
+              </tr>
+              <tr className="font-semibold">
+                <td className="pt-0.5 pr-3" colSpan={2}>Score</td>
+                <td className="text-right pt-0.5 pl-2">
+                  {value.stabilityScore != null ? `${Math.round(value.stabilityScore)}/100` : 'n/a'}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+          <p className="mt-1.5 text-gray-500">Score guide: 75–100 very consistent · 50–74 some variation · 0–49 changes a lot by domain.</p>
+        </div>
+      )}
+      {singleDomainActive && (
+        <p className="text-amber-700 border-t border-gray-200 pt-2">
+          Not available when a single domain is selected — you need at least 2 domains to compare consistency.
+        </p>
+      )}
+      {!singleDomainActive && value.eligibleDomainCount < 2 && (
+        <p className="text-amber-700 border-t border-gray-200 pt-2">
+          Needs at least 2 eligible domains. Currently: {value.eligibleDomainCount}.
+        </p>
+      )}
+    </div>
+  );
+
+  // --- Evidence weight tooltip ---
+  const evidenceWeightTooltip = (
+    <div className="space-y-2">
+      <p>
+        <strong>What it means:</strong> The number of head-to-head comparisons run in this domain for this model and value.
+      </p>
+      <p>
+        Domains with more comparisons get more weight when calculating the pooled win rate —
+        a domain with 50 comparisons has twice the pull of a domain with 25.
+      </p>
+    </div>
+  );
 
   return createPortal(
     <div className="fixed inset-0 z-50">
@@ -105,7 +244,19 @@ export function ModelValueDetailDrawer({
         <div className="flex-1 overflow-y-auto p-5 space-y-5">
           <section className="grid gap-4 md:grid-cols-2">
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
-              <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">Pooled win rate</div>
+              <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <span>Pooled win rate</span>
+                <Tooltip
+                  content={pooledWinRateTooltip}
+                  position="bottom"
+                  variant="light"
+                  className="w-96 px-3 py-3 text-xs leading-relaxed normal-case tracking-normal font-normal"
+                >
+                  <Button type="button" variant="ghost" size="icon" className="cursor-help p-0 min-w-0 min-h-0 h-4 w-4 text-gray-400 hover:text-gray-600 hover:bg-transparent" aria-label="How pooled win rate is calculated">
+                    <InfoIcon />
+                  </Button>
+                </Tooltip>
+              </div>
               <div className="mt-2 text-4xl font-semibold text-gray-900">
                 {formatPercent(value.pooledWinRate)}
               </div>
@@ -114,12 +265,24 @@ export function ModelValueDetailDrawer({
               </p>
             </div>
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
-              <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">Cross-domain stability</div>
-              <div className="mt-2 flex items-center gap-2 font-mono text-lg text-gray-900" title={tooltip}>
+              <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                <span>Cross-domain stability</span>
+                <Tooltip
+                  content={crossDomainStabilityTooltip}
+                  position="bottom"
+                  variant="light"
+                  className="w-96 px-3 py-3 text-xs leading-relaxed normal-case tracking-normal font-normal"
+                >
+                  <Button type="button" variant="ghost" size="icon" className="cursor-help p-0 min-w-0 min-h-0 h-4 w-4 text-gray-400 hover:text-gray-600 hover:bg-transparent" aria-label="How cross-domain stability is calculated">
+                    <InfoIcon />
+                  </Button>
+                </Tooltip>
+              </div>
+              <div className="mt-2 flex items-center gap-2 font-mono text-lg text-gray-900">
                 <span aria-hidden="true">{dots}</span>
                 <span>{value.stabilityScore == null ? 'n/a' : `${Math.round(value.stabilityScore)}/100`}</span>
               </div>
-              <p className="mt-2 text-sm text-gray-600">{tooltip}</p>
+              <p className="mt-2 text-sm text-gray-600">{stabilityCardText}</p>
             </div>
           </section>
 
@@ -141,7 +304,21 @@ export function ModelValueDetailDrawer({
                     <tr className="text-left text-xs uppercase tracking-wide text-gray-500">
                       <th className="border-b border-gray-200 px-4 py-3">Domain</th>
                       <th className="border-b border-gray-200 px-4 py-3">Win rate</th>
-                      <th className="border-b border-gray-200 px-4 py-3">Evidence weight</th>
+                      <th className="border-b border-gray-200 px-4 py-3">
+                        <div className="flex items-center gap-1">
+                          <span>Evidence weight</span>
+                          <Tooltip
+                            content={evidenceWeightTooltip}
+                            position="bottom"
+                            variant="light"
+                            className="w-72 px-3 py-3 text-xs leading-relaxed normal-case tracking-normal font-normal"
+                          >
+                            <Button type="button" variant="ghost" size="icon" className="cursor-help p-0 min-w-0 min-h-0 h-4 w-4 text-gray-400 hover:text-gray-600 hover:bg-transparent" aria-label="What evidence weight means">
+                              <InfoIcon />
+                            </Button>
+                          </Tooltip>
+                        </div>
+                      </th>
                     </tr>
                   </thead>
                   <tbody>

--- a/cloud/apps/web/src/components/models/ModelsMatrixCell.tsx
+++ b/cloud/apps/web/src/components/models/ModelsMatrixCell.tsx
@@ -59,7 +59,6 @@ export function ModelsMatrixCell({
     ? 'Filtered out by the current stability visibility setting.'
     : formatStabilityTooltip(stabilityScore, eligibleDomainCount, mad, singleDomainActive);
   const primaryLabel = hiddenByFilter || pooledWinRate == null ? 'n/a' : formatPercent(pooledWinRate);
-  const domainCountLabel = hiddenByFilter ? '—' : eligibleDomainCount > 0 ? `${eligibleDomainCount}d` : '—';
   const dots = renderDots(stabilityScore, mutedDots);
   const isClickable = !hiddenByFilter;
 
@@ -91,9 +90,8 @@ export function ModelsMatrixCell({
       <span className={`text-sm font-semibold ${hiddenByFilter || pooledWinRate == null ? 'text-gray-400' : 'text-gray-900'}`}>
         {primaryLabel}
       </span>
-      <span className={`mt-1 flex items-center gap-1 font-mono text-[11px] ${mutedDots ? 'text-gray-400' : 'text-gray-700'}`}>
+      <span className={`mt-1 font-mono text-[11px] ${mutedDots ? 'text-gray-400' : 'text-gray-700'}`}>
         <span aria-hidden="true">{dots}</span>
-        <span>{domainCountLabel}</span>
       </span>
       <span className="sr-only">{tooltip}</span>
     </Button>


### PR DESCRIPTION
## Summary
- Adds ⓘ info tooltips to all three metrics in the model value detail drawer
- **Pooled Win Rate**: definition (weighted average of win rates, higher evidence weight = counts more) + live per-domain calculation table showing weight × win rate and the final sum ÷ total
- **Cross-Domain Stability**: definition, 4-step scoring method, per-domain spread table, weighted average spread, and final score
- **Evidence Weight** (column header): explains what the count means and how it affects the pooled average
- Removes the noisy "3d" domain count label from matrix cells — that detail lives in the drawer

## Validation
- `npm run lint --workspace @valuerank/web` → 0 errors
- TypeScript build error in worktree is a pre-existing symlink path issue (unrelated to these changes); CI uses clean install

## Test plan
- [ ] Open any model cell drawer — confirm ⓘ icons appear next to Pooled Win Rate and Cross-Domain Stability card headers
- [ ] Hover each ⓘ — tooltip shows definition + actual numbers from that cell
- [ ] Hover Evidence Weight column header ⓘ — tooltip explains the count
- [ ] Matrix cells no longer show "3d" / "1d" etc. — just the win rate and dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)