### PR TITLE
fix(models): integer percents, CSS dots (cross-platform), explicit stability formula

### DIFF
--- a/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
+++ b/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
@@ -18,30 +18,40 @@ type ModelValueDetailDrawerProps = {
 
 function formatPercent(value: number | null): string {
   if (value == null || Number.isNaN(value)) return 'n/a';
-  const rounded = value.toFixed(1);
-  return rounded.endsWith('.0') ? `${rounded.slice(0, -2)}%` : `${rounded}%`;
-}
-
-function renderDots(score: number | null): string {
-  return computeDots(score)
-    .map((state) => {
-      switch (state) {
-        case 'full':
-          return '●';
-        case 'half':
-          return '◐';
-        case 'empty':
-        case 'muted':
-          return '○';
-        default:
-          return '○';
-      }
-    })
-    .join('');
+  return `${Math.round(value)}%`;
 }
 
 function InfoIcon() {
   return <Info className="h-3.5 w-3.5" />;
+}
+
+function Dots({ score }: { score: number | null }) {
+  const states = computeDots(score);
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-hidden="true">
+      {states.map((state, i) => {
+        if (state === 'full') {
+          return <span key={i} className="inline-block w-3 h-3 rounded-full flex-shrink-0 bg-current" />;
+        }
+        if (state === 'half') {
+          return (
+            <span
+              key={i}
+              className="inline-block w-3 h-3 rounded-full flex-shrink-0"
+              style={{
+                background: 'linear-gradient(to right, currentColor 50%, transparent 50%)',
+                boxShadow: '0 0 0 1px currentColor',
+              }}
+            />
+          );
+        }
+        if (state === 'muted') {
+          return <span key={i} className="inline-block w-3 h-3 rounded-full flex-shrink-0 border border-current opacity-30" />;
+        }
+        return <span key={i} className="inline-block w-3 h-3 rounded-full flex-shrink-0 border border-current" />;
+      })}
+    </span>
+  );
 }
 
 export function ModelValueDetailDrawer({
@@ -81,7 +91,6 @@ export function ModelValueDetailDrawer({
   const valueLabel = VALUE_LABELS[valueKey] ?? value.valueKey;
   const mad = computeWeightedMad(value.domains);
   const stabilityCardText = formatStabilityTooltip(value.stabilityScore, value.eligibleDomainCount, mad, singleDomainActive);
-  const dots = renderDots(value.stabilityScore);
   const domains = [...value.domains].sort((left, right) => {
     const diff = right.evidenceWeight - left.evidenceWeight;
     return diff !== 0 ? diff : left.domainName.localeCompare(right.domainName);
@@ -120,14 +129,14 @@ export function ModelValueDetailDrawer({
                   <td className="py-0.5 pr-3">{d.domainName}</td>
                   <td className="text-right py-0.5 px-2">{d.evidenceWeight}</td>
                   <td className="text-right py-0.5 px-2">{formatPercent(d.winRate)}</td>
-                  <td className="text-right py-0.5 pl-2">{(d.evidenceWeight * d.winRate).toFixed(1)}</td>
+                  <td className="text-right py-0.5 pl-2">{Math.round(d.evidenceWeight * d.winRate)}</td>
                 </tr>
               ))}
             </tbody>
             <tfoot>
               <tr className="border-t border-gray-300 font-semibold">
                 <td className="pt-1 pr-3 text-gray-500 font-normal" colSpan={3}>
-                  {weightedSum.toFixed(1)} ÷ {totalWeight} =
+                  {Math.round(weightedSum)} ÷ {totalWeight} =
                 </td>
                 <td className="text-right pt-1 pl-2">{formatPercent(value.pooledWinRate)}</td>
               </tr>
@@ -154,8 +163,12 @@ export function ModelValueDetailDrawer({
       <ol className="list-decimal pl-4 space-y-0.5">
         <li>Find each domain&apos;s win rate (table below).</li>
         <li>Measure how far each domain&apos;s win rate is from the pooled mean — the &quot;spread.&quot;</li>
-        <li>Take a weighted average of those distances (bigger domains count more).</li>
-        <li>Convert that average spread into a 0–100 score: less spread = higher score.</li>
+        <li>Take a weighted average of those distances (bigger domains count more). This is the <strong>weighted spread</strong>.</li>
+        <li>
+          Convert to a score: <strong>score = 100 × (1 − spread ÷ 50)</strong>.
+          A spread of 0 → score 100 (all domains identical).
+          A spread of 50 → score 0 (maximum disagreement possible).
+        </li>
       </ol>
       {!singleDomainActive && value.eligibleDomainCount >= 2 && pooledMean != null && domains.length > 0 && (
         <div className="border-t border-gray-200 pt-2">
@@ -175,17 +188,19 @@ export function ModelValueDetailDrawer({
                 <tr key={d.domainId} className="border-b border-gray-100">
                   <td className="py-0.5 pr-3">{d.domainName}</td>
                   <td className="text-right py-0.5 px-2">{formatPercent(d.winRate)}</td>
-                  <td className="text-right py-0.5 pl-2">{Math.abs(d.winRate - pooledMean).toFixed(1)} pts</td>
+                  <td className="text-right py-0.5 pl-2">{Math.round(Math.abs(d.winRate - pooledMean))} pts</td>
                 </tr>
               ))}
             </tbody>
             <tfoot>
               <tr className="border-t border-gray-300 font-semibold">
                 <td className="pt-1 pr-3" colSpan={2}>Weighted avg spread</td>
-                <td className="text-right pt-1 pl-2">{mad != null ? `${mad.toFixed(1)} pts` : 'n/a'}</td>
+                <td className="text-right pt-1 pl-2">{mad != null ? `${Math.round(mad)} pts` : 'n/a'}</td>
               </tr>
               <tr className="font-semibold">
-                <td className="pt-0.5 pr-3" colSpan={2}>Score</td>
+                <td className="pt-0.5 pr-3 font-normal text-gray-500" colSpan={2}>
+                  {mad != null ? `100 × (1 − ${Math.round(mad)} ÷ 50) =` : 'Score'}
+                </td>
                 <td className="text-right pt-0.5 pl-2">
                   {value.stabilityScore != null ? `${Math.round(value.stabilityScore)}/100` : 'n/a'}
                 </td>
@@ -278,9 +293,9 @@ export function ModelValueDetailDrawer({
                   </Button>
                 </Tooltip>
               </div>
-              <div className="mt-2 flex items-center gap-2 font-mono text-lg text-gray-900">
-                <span aria-hidden="true">{dots}</span>
-                <span>{value.stabilityScore == null ? 'n/a' : `${Math.round(value.stabilityScore)}/100`}</span>
+              <div className="mt-2 flex items-center gap-2 text-lg text-gray-900">
+                <Dots score={value.stabilityScore} />
+                <span className="font-mono">{value.stabilityScore == null ? 'n/a' : `${Math.round(value.stabilityScore)}/100`}</span>
               </div>
               <p className="mt-2 text-sm text-gray-600">{stabilityCardText}</p>
             </div>

--- a/cloud/apps/web/src/components/models/ModelsMatrixCell.tsx
+++ b/cloud/apps/web/src/components/models/ModelsMatrixCell.tsx
@@ -17,28 +17,38 @@ type ModelsMatrixCellProps = {
 };
 
 function formatPercent(value: number): string {
-  const rounded = value.toFixed(1);
-  return rounded.endsWith('.0') ? `${rounded.slice(0, -2)}%` : `${rounded}%`;
+  return `${Math.round(value)}%`;
 }
 
-function renderDots(score: number | null, muted: boolean): string {
+type DotsProps = { score: number | null; muted: boolean; className?: string };
+
+function Dots({ score, muted, className }: DotsProps) {
   const states = computeDots(muted ? null : score);
-  return states
-    .map((state) => {
-      switch (state) {
-        case 'full':
-          return '●';
-        case 'half':
-          return '◐';
-        case 'empty':
-          return '○';
-        case 'muted':
-          return '○';
-        default:
-          return '○';
-      }
-    })
-    .join('');
+  return (
+    <span className={`inline-flex items-center gap-0.5 ${className ?? ''}`} aria-hidden="true">
+      {states.map((state, i) => {
+        if (state === 'full') {
+          return <span key={i} className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 bg-current" />;
+        }
+        if (state === 'half') {
+          return (
+            <span
+              key={i}
+              className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+              style={{
+                background: 'linear-gradient(to right, currentColor 50%, transparent 50%)',
+                boxShadow: '0 0 0 1px currentColor',
+              }}
+            />
+          );
+        }
+        if (state === 'muted') {
+          return <span key={i} className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 border border-current opacity-30" />;
+        }
+        return <span key={i} className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 border border-current" />;
+      })}
+    </span>
+  );
 }
 
 export function ModelsMatrixCell({
@@ -59,7 +69,6 @@ export function ModelsMatrixCell({
     ? 'Filtered out by the current stability visibility setting.'
     : formatStabilityTooltip(stabilityScore, eligibleDomainCount, mad, singleDomainActive);
   const primaryLabel = hiddenByFilter || pooledWinRate == null ? 'n/a' : formatPercent(pooledWinRate);
-  const dots = renderDots(stabilityScore, mutedDots);
   const isClickable = !hiddenByFilter;
 
   const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
@@ -90,9 +99,7 @@ export function ModelsMatrixCell({
       <span className={`text-sm font-semibold ${hiddenByFilter || pooledWinRate == null ? 'text-gray-400' : 'text-gray-900'}`}>
         {primaryLabel}
       </span>
-      <span className={`mt-1 font-mono text-[11px] ${mutedDots ? 'text-gray-400' : 'text-gray-700'}`}>
-        <span aria-hidden="true">{dots}</span>
-      </span>
+      <Dots score={stabilityScore} muted={mutedDots} className={`mt-1 ${mutedDots ? 'text-gray-400' : 'text-gray-700'}`} />
       <span className="sr-only">{tooltip}</span>
     </Button>
   );


### PR DESCRIPTION
## Summary
- **Integer percentages**: all win rates now show as whole numbers (53% not 53.3%) everywhere — matrix cells, drawer header, domain table, and tooltip calculations
- **CSS dots (cross-platform fix)**: replaces Unicode ●◐○ characters with pixel-exact CSS inline-block circles — Unicode characters render at different sizes depending on the font stack, which was visible on Windows Chrome; CSS circles are always identical in size
- **Explicit stability formula in tooltip**: step 4 now shows the actual server-side formula `score = 100 × (1 − spread ÷ 50)`, and the live calculation row shows the real numbers substituted in (e.g. `100 × (1 − 8 ÷ 50) = 84/100`)

## Validation
- `npm run lint --workspace @valuerank/web` → 0 errors

## Test plan
- [ ] Matrix cells show whole-number percentages (no decimals)
- [ ] Dots in cells are all the same size — verify on Windows Chrome
- [ ] Stability tooltip shows the formula `score = 100 × (1 − spread ÷ 50)` in step 4
- [ ] Live calculation row in tooltip shows real numbers (e.g. `100 × (1 − 8 ÷ 50) = 84/100`)
- [ ] Half-filled dot (◐ equivalent) renders correctly as left-half filled circle

🤖 Generated with [Claude Code](https://claude.com/claude-code)