### PR TITLE
docs(models): add MAD definition to stability tooltip

### DIFF
--- a/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
+++ b/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
@@ -163,11 +163,16 @@ export function ModelValueDetailDrawer({
       <ol className="list-decimal pl-4 space-y-0.5">
         <li>Find each domain&apos;s win rate (table below).</li>
         <li>Measure how far each domain&apos;s win rate is from the pooled mean — the &quot;spread.&quot;</li>
-        <li>Take a weighted average of those distances (bigger domains count more). This is the <strong>weighted spread</strong>.</li>
         <li>
-          Convert to a score: <strong>score = 100 × (1 − spread ÷ 50)</strong>.
-          A spread of 0 → score 100 (all domains identical).
-          A spread of 50 → score 0 (maximum disagreement possible).
+          Take a weighted average of those distances, where domains with more comparisons count more.
+          This is called the <strong>weighted MAD</strong> (Mean Absolute Deviation) — it&apos;s just
+          the average distance between each domain&apos;s win rate and the overall mean,
+          with bigger domains pulling the average more than smaller ones.
+        </li>
+        <li>
+          Convert to a score: <strong>score = 100 × (1 − MAD ÷ 50)</strong>.
+          A MAD of 0 → score 100 (all domains identical).
+          A MAD of 50 → score 0 (maximum disagreement possible).
         </li>
       </ol>
       {!singleDomainActive && value.eligibleDomainCount >= 2 && pooledMean != null && domains.length > 0 && (
@@ -194,12 +199,12 @@ export function ModelValueDetailDrawer({
             </tbody>
             <tfoot>
               <tr className="border-t border-gray-300 font-semibold">
-                <td className="pt-1 pr-3" colSpan={2}>Weighted avg spread</td>
+                <td className="pt-1 pr-3" colSpan={2}>Weighted MAD</td>
                 <td className="text-right pt-1 pl-2">{mad != null ? `${Math.round(mad)} pts` : 'n/a'}</td>
               </tr>
               <tr className="font-semibold">
                 <td className="pt-0.5 pr-3 font-normal text-gray-500" colSpan={2}>
-                  {mad != null ? `100 × (1 − ${Math.round(mad)} ÷ 50) =` : 'Score'}
+                  {mad != null ? `100 × (1 − MAD ${Math.round(mad)} ÷ 50) =` : 'Score'}
                 </td>
                 <td className="text-right pt-0.5 pl-2">
                   {value.stabilityScore != null ? `${Math.round(value.stabilityScore)}/100` : 'n/a'}


### PR DESCRIPTION
## Summary
- Step 3 of the stability calculation now explains what "weighted MAD (Mean Absolute Deviation)" means in plain language: the average distance between each domain's win rate and the pooled mean, with bigger domains pulling the average more than smaller ones
- Updated the table label from "Weighted avg spread" to "Weighted MAD" for consistency
- Updated the formula row to say `100 × (1 − MAD X ÷ 50)` so the term is visible right where the number appears

## Test plan
- [ ] Hover the stability ⓘ icon — step 3 now defines MAD before using the term
- [ ] The table footer row says "Weighted MAD" and the score row shows "100 × (1 − MAD N ÷ 50)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)