### PR TITLE
fix(screenshot): handle overflow on the capture target element itself

### DIFF
--- a/cloud/apps/web/src/components/ui/CopyVisualButton.tsx
+++ b/cloud/apps/web/src/components/ui/CopyVisualButton.tsx
@@ -66,10 +66,14 @@ export function CopyVisualButton({ targetRef, label }: CopyVisualButtonProps) {
     setIsCopying(true);
     setStatus('idle');
 
-    // Temporarily expand scroll containers so the full content is captured without scrollbars
-    const scrollEls = Array.from(
-      target.querySelectorAll<HTMLElement>('.overflow-x-auto, .overflow-y-auto, .overflow-auto'),
-    );
+    // Temporarily expand scroll containers so the full content is captured without scrollbars.
+    // Include the target itself in case it IS the overflow container (e.g. CoverageMatrix),
+    // not just its descendants.
+    const overflowSelector = '.overflow-x-auto, .overflow-y-auto, .overflow-auto';
+    const scrollEls: HTMLElement[] = [
+      ...(target.matches(overflowSelector) ? [target] : []),
+      ...Array.from(target.querySelectorAll<HTMLElement>(overflowSelector)),
+    ];
     const saved = scrollEls.map((el) => ({
       el,
       overflow: el.style.overflow,


### PR DESCRIPTION
## Summary
- Follow-up to #641. The previous fix used `querySelectorAll` which only searches descendants, so it missed cases where the `ref` is attached directly to the `overflow-x-auto` element (e.g. `CoverageMatrix`)
- Added `target.matches(overflowSelector)` check to include the target element itself in the expansion list, then still also scan its descendants as before

## Root cause
`CoverageMatrix.tsx` attaches its screenshot ref directly to the scroll container div:
```tsx
<div ref={ref} className="overflow-x-auto ...">
```
When `target` is that div, `target.querySelectorAll('.overflow-x-auto')` finds nothing inside it and the overflow is never cleared — so the scrollbar renders in the captured image.

## Validation
- `npx turbo lint --filter=@valuerank/web` — passed (0 errors)
- `npx turbo build --filter=@valuerank/web` — passed

## Test plan
- [ ] Copy the Coverage Matrix screenshot and confirm no scrollbar in pasted image
- [ ] Confirm Value Priorities table (descendant overflow case) still works too

🤖 Generated with [Claude Code](https://claude.com/claude-code)