### PR TITLE
fix: resolve all 10 job-choice-v2 values when definitionSnapshot is absent

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/decision-model-helpers.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model-helpers.ts
@@ -1,0 +1,387 @@
+import { DOMAIN_ANALYSIS_VALUE_KEYS, toPascalCaseKey, type DomainAnalysisValueKey } from '../domain-analysis-values.js';
+import { JOB_CHOICE_VALUE_STATEMENTS, labelFromBody } from '@valuerank/shared';
+import type {
+  DecisionDirection,
+  DecisionStrength,
+  DecisionSource,
+  CanonicalAppliedDecision,
+  CanonicalDecision,
+  DecisionPair,
+  ValueStatementEntry,
+  ParsedDecisionPath,
+  CachedWinnerFirstDecision,
+} from './decision-model-types.js';
+
+export { JOB_CHOICE_VALUE_STATEMENTS };
+
+export function isValueKey(value: string): value is DomainAnalysisValueKey {
+  return (DOMAIN_ANALYSIS_VALUE_KEYS as readonly string[]).includes(value);
+}
+
+export function isDecisionDirection(value: unknown): value is DecisionDirection {
+  return value === 'favor_first' || value === 'favor_second' || value === 'neutral' || value === 'refusal' || value === 'unknown';
+}
+
+export function isDecisionStrength(value: unknown): value is DecisionStrength {
+  return value === 'strong' || value === 'lean' || value === 'neutral' || value === 'unknown';
+}
+
+export function isCanonicalAppliedDecision(value: unknown): value is CanonicalAppliedDecision {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const decision = value as CanonicalAppliedDecision;
+  return (
+    isDecisionDirection(decision.direction) &&
+    isDecisionStrength(decision.strength) &&
+    (decision.favoredValueKey === null || (typeof decision.favoredValueKey === 'string' && isValueKey(decision.favoredValueKey))) &&
+    (decision.opposedValueKey === null || (typeof decision.opposedValueKey === 'string' && isValueKey(decision.opposedValueKey)))
+  );
+}
+
+export function isCachedWinnerFirstDecision(value: unknown): value is CachedWinnerFirstDecision {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const decision = value as CachedWinnerFirstDecision;
+  if (
+    decision.cacheVersion !== 1
+    || (decision.decisionState !== 'resolved' && decision.decisionState !== 'neutral' && decision.decisionState !== 'unknown')
+  ) {
+    return false;
+  }
+
+  if (decision.decisionState === 'resolved') {
+    return (
+      typeof decision.favoredValueKey === 'string'
+      && isValueKey(decision.favoredValueKey)
+      && (decision.strength === 'strong' || decision.strength === 'lean')
+    );
+  }
+
+  if (decision.decisionState === 'neutral') {
+    return decision.favoredValueKey === null && decision.strength === 'neutral';
+  }
+
+  return decision.favoredValueKey === null && decision.strength === 'unknown';
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isValidDecisionPair(pair: DecisionPair | null | undefined): pair is DecisionPair {
+  if (pair === null || pair === undefined) {
+    return false;
+  }
+
+  return (
+    isValueKey(pair.valueA) &&
+    isValueKey(pair.valueB) &&
+    pair.valueA !== pair.valueB
+  );
+}
+
+export function parseDecisionPath(parsePath: string | null | undefined): ParsedDecisionPath | null {
+  if (typeof parsePath !== 'string') {
+    return null;
+  }
+
+  const trimmed = parsePath.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const segments = trimmed.split('.');
+  if (segments.length > 3) {
+    return null;
+  }
+  const [branch, first, second] = segments;
+  const normalizedBranch = branch === 'fallback_resolved' ? 'fallback' : branch;
+
+  if (normalizedBranch !== 'exact' && normalizedBranch !== 'fallback' && normalizedBranch !== 'manual') {
+    return null;
+  }
+
+  if (normalizedBranch === 'manual') {
+    return first === 'override' && second === undefined
+      ? { branch: 'manual', direction: 'unknown', strength: 'unknown' }
+      : null;
+  }
+
+  if (first === 'neutral' && (second === undefined || second === 'neutral')) {
+    return { branch: normalizedBranch, direction: 'neutral', strength: 'neutral' };
+  }
+
+  if (!isDecisionDirection(first) || !isDecisionStrength(second)) {
+    return null;
+  }
+
+  return {
+    branch: normalizedBranch,
+    direction: first,
+    strength: second,
+  };
+}
+
+export function isJobChoiceDecisionPath(parsePath: string | null | undefined): boolean {
+  return typeof parsePath === 'string' && (
+    parsePath.startsWith('numeric_')
+    || parsePath.startsWith('text_label_')
+  );
+}
+
+export function flipDirection(direction: DecisionDirection): DecisionDirection {
+  if (direction === 'favor_first') return 'favor_second';
+  if (direction === 'favor_second') return 'favor_first';
+  return direction;
+}
+
+export function normalizeJobChoiceLabelText(text: string): string {
+  const stripped = text
+    .replace(/[*_`]+/g, ' ')
+    .replace(/^level of support\s*:\s*/i, '')
+    .replace(/^(?:my\s+)?(?:final\s+|overall\s+)?(?:judg(?:e)?ment|answer|response|decision|choice|rating|score)(?:\s+on\s+the\s+scale)?\s*(?:(?:is)\s*[:=]?|[:=])?\s*/i, '')
+    .trim();
+
+  return stripped
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function parseJobChoiceStrengthFromText(text: string): DecisionStrength | null {
+  const normalized = normalizeJobChoiceLabelText(text);
+  if (normalized.startsWith('strongly support')) return 'strong';
+  if (normalized.startsWith('somewhat support')) return 'lean';
+  if (normalized.startsWith('neutral')) return 'neutral';
+  return null;
+}
+
+export function resolveValueKeyFromText(
+  text: string,
+  valueStatements: readonly ValueStatementEntry[] | undefined,
+  labelPrefix: string | null,
+): DomainAnalysisValueKey | null {
+  if (valueStatements == null || valueStatements.length === 0) {
+    return null;
+  }
+
+  const normalized = normalizeJobChoiceLabelText(text);
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  const prefix = labelPrefix ?? '';
+  let resolved: DomainAnalysisValueKey | null = null;
+  for (const entry of valueStatements) {
+    const valueKey = toPascalCaseKey(entry.token) as DomainAnalysisValueKey;
+    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, prefix));
+    if (!label || !normalized.includes(label)) {
+      continue;
+    }
+    if (resolved !== null && resolved !== valueKey) {
+      return null;
+    }
+    resolved = valueKey;
+  }
+
+  return resolved;
+}
+
+export function buildUnknownCanonicalDecision(source: DecisionSource): CanonicalDecision {
+  return {
+    favoredValueKey: null,
+    opposedValueKey: null,
+    direction: 'unknown',
+    strength: 'unknown',
+    normalizationApplied: false,
+    normalizationReason: null,
+    source,
+  };
+}
+
+export function canonicalDecisionScoreFromDirectionStrength(
+  direction: DecisionDirection,
+  strength: DecisionStrength,
+): 1 | 2 | 3 | 4 | 5 | null {
+  if (direction === 'favor_first' && strength === 'strong') return 5;
+  if (direction === 'favor_first' && strength === 'lean') return 4;
+  if (direction === 'neutral' && strength === 'neutral') return 3;
+  if (direction === 'favor_second' && strength === 'lean') return 2;
+  if (direction === 'favor_second' && strength === 'strong') return 1;
+  return null;
+}
+
+export function buildCanonicalDecisionFromPair(
+  pair: DecisionPair,
+  direction: DecisionDirection,
+  strength: DecisionStrength,
+  normalizationApplied: boolean,
+  source: DecisionSource,
+): CanonicalDecision {
+  if (direction === 'neutral') {
+    return {
+      favoredValueKey: null,
+      opposedValueKey: null,
+      direction,
+      strength,
+      normalizationApplied,
+      normalizationReason: normalizationApplied ? 'orientation_flipped' : null,
+      source,
+    };
+  }
+
+  if (direction === 'favor_first') {
+    return {
+      favoredValueKey: pair.valueA,
+      opposedValueKey: pair.valueB,
+      direction,
+      strength,
+      normalizationApplied,
+      normalizationReason: normalizationApplied ? 'orientation_flipped' : null,
+      source,
+    };
+  }
+
+  if (direction === 'favor_second') {
+    return {
+      favoredValueKey: pair.valueB,
+      opposedValueKey: pair.valueA,
+      direction,
+      strength,
+      normalizationApplied,
+      normalizationReason: normalizationApplied ? 'orientation_flipped' : null,
+      source,
+    };
+  }
+
+  return buildUnknownCanonicalDecision(source);
+}
+
+export function validateManualAppliedDecision(
+  pair: DecisionPair,
+  appliedDecision: unknown,
+): { ok: true; canonical: CanonicalDecision } | { ok: false } {
+  if (!isCanonicalAppliedDecision(appliedDecision)) {
+    return { ok: false };
+  }
+
+  const decision = appliedDecision;
+  const validKnownPair =
+    (decision.direction === 'neutral' &&
+      decision.strength === 'neutral' &&
+      decision.favoredValueKey === null &&
+      decision.opposedValueKey === null) ||
+    (decision.direction === 'unknown' &&
+      decision.strength === 'unknown' &&
+      decision.favoredValueKey === null &&
+      decision.opposedValueKey === null) ||
+    (decision.direction === 'favor_first' &&
+      decision.strength !== 'unknown' &&
+      decision.strength !== 'neutral' &&
+      decision.favoredValueKey === pair.valueA &&
+      decision.opposedValueKey === pair.valueB) ||
+    (decision.direction === 'favor_second' &&
+      decision.strength !== 'unknown' &&
+      decision.strength !== 'neutral' &&
+      decision.favoredValueKey === pair.valueB &&
+      decision.opposedValueKey === pair.valueA);
+
+  if (!validKnownPair) {
+    return { ok: false };
+  }
+
+  return {
+    ok: true,
+    canonical: {
+      favoredValueKey: decision.favoredValueKey,
+      opposedValueKey: decision.opposedValueKey,
+      direction: decision.direction,
+      strength: decision.strength,
+      normalizationApplied: false,
+      normalizationReason: null,
+      source: 'manual',
+    },
+  };
+}
+
+export function extractManualOverrideDecision(
+  decisionMetadata: unknown,
+): CanonicalAppliedDecision | null {
+  const record = isRecord(decisionMetadata) ? decisionMetadata : null;
+  const manualOverride = record && isRecord(record.manualOverride) ? record.manualOverride : null;
+  if (!manualOverride || !isCanonicalAppliedDecision(manualOverride.appliedDecision)) {
+    return null;
+  }
+  return manualOverride.appliedDecision;
+}
+
+export function extractCachedWinnerFirstDecision(
+  decisionMetadata: unknown,
+): CachedWinnerFirstDecision | null {
+  const record = isRecord(decisionMetadata) ? decisionMetadata : null;
+  const summaryCache = record && isRecord(record.summaryCache) ? record.summaryCache : null;
+  const summary = summaryCache && isRecord(summaryCache.summary) ? summaryCache.summary : null;
+  const canonicalDecision = summary && isCachedWinnerFirstDecision(summary.canonicalDecision)
+    ? summary.canonicalDecision
+    : null;
+
+  return canonicalDecision;
+}
+
+export function extractValueStatementsFromSnapshot(snapshot: unknown): ValueStatementEntry[] | undefined {
+  if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) return undefined;
+  const components = (snapshot as { components?: unknown }).components;
+  if (components === null || typeof components !== 'object' || Array.isArray(components)) return undefined;
+
+  const vf = (components as { value_first?: unknown }).value_first;
+  const vs = (components as { value_second?: unknown }).value_second;
+  if (!isRecord(vf) || !isRecord(vs)) return undefined;
+
+  const tokenFirst = typeof vf.token === 'string' ? vf.token : null;
+  const bodyFirst = typeof vf.body === 'string' ? vf.body : null;
+  const tokenSecond = typeof vs.token === 'string' ? vs.token : null;
+  const bodySecond = typeof vs.body === 'string' ? vs.body : null;
+
+  if (tokenFirst == null || bodyFirst == null || tokenSecond == null || bodySecond == null) return undefined;
+  return [
+    { token: tokenFirst, body: bodyFirst },
+    { token: tokenSecond, body: bodySecond },
+  ];
+}
+
+const LABEL_PREFIX_REGEX = /^(?:Strongly|Somewhat) support (.+)$/;
+
+export function extractLabelPrefixFromSnapshot(snapshot: unknown): string | undefined {
+  if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) return undefined;
+  const template = (snapshot as { template?: unknown }).template;
+  if (typeof template !== 'string') return undefined;
+
+  const components = (snapshot as { components?: unknown }).components;
+  if (components === null || typeof components !== 'object' || Array.isArray(components)) return undefined;
+  const vf = (components as { value_first?: unknown }).value_first;
+  if (!isRecord(vf) || typeof vf.body !== 'string') return undefined;
+
+  // Extract the short body (before "because") to find it in the scale label
+  const shortBody = (vf.body.split(' because')[0] ?? vf.body).trim();
+  if (shortBody.length === 0) return undefined;
+
+  // Find a scale label line that ends with the short body
+  const lines = template.split('\n');
+  for (const line of lines) {
+    const trimmed = line.replace(/^- /, '').trim();
+    const match = LABEL_PREFIX_REGEX.exec(trimmed);
+    if (match == null) continue;
+    const afterStrength = match[1] ?? '';
+    if (afterStrength.endsWith(shortBody)) {
+      const prefix = afterStrength.slice(0, afterStrength.length - shortBody.length).trimEnd();
+      if (prefix.length > 0) return prefix;
+    }
+  }
+
+  return undefined;
+}

--- a/cloud/apps/api/src/graphql/queries/domain/decision-model-types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model-types.ts
@@ -1,0 +1,115 @@
+import type { DomainAnalysisValueKey, DomainAnalysisValuePair } from '../domain-analysis-values.js';
+
+export type DecisionDirection = 'favor_first' | 'favor_second' | 'neutral' | 'refusal' | 'unknown';
+export type DecisionStrength = 'strong' | 'lean' | 'neutral' | 'unknown';
+export type DecisionSource = 'deterministic' | 'manual' | 'error' | 'unknown';
+
+export type CanonicalAppliedDecision = {
+  favoredValueKey: DomainAnalysisValueKey | null;
+  opposedValueKey: DomainAnalysisValueKey | null;
+  direction: DecisionDirection;
+  strength: DecisionStrength;
+};
+
+export type RawDecisionEvidence = {
+  matchedText: string | null;
+  matchedLabel: string | null;
+  parseClass: 'exact' | 'fallback_resolved' | 'ambiguous' | 'unparseable' | null;
+  parsePath: string | null;
+  parserVersion: string | null;
+  responseExcerpt: string | null;
+  manualOverride: {
+    previousValue: string | null;
+    overriddenAt: string | null;
+    overriddenByUserId: string | null;
+  } | null;
+};
+
+export type CanonicalDecision = {
+  favoredValueKey: DomainAnalysisValueKey | null;
+  opposedValueKey: DomainAnalysisValueKey | null;
+  direction: DecisionDirection;
+  strength: DecisionStrength;
+  normalizationApplied: boolean;
+  normalizationReason: 'orientation_flipped' | null;
+  source: DecisionSource;
+};
+
+export type DecisionReadSurface = 'api' | 'web' | 'worker' | 'export';
+export type DecisionReadMode = 'v1' | 'v2';
+export type DecisionReadRule = {
+  surface: DecisionReadSurface;
+  defaultMode: DecisionReadMode;
+  fallbackLayer: 'server_adapter' | 'none';
+};
+
+export const DECISION_MODEL_READ_RULES: Record<DecisionReadSurface, DecisionReadRule> = {
+  api: {
+    surface: 'api',
+    defaultMode: 'v1',
+    fallbackLayer: 'server_adapter',
+  },
+  web: {
+    surface: 'web',
+    defaultMode: 'v1',
+    fallbackLayer: 'none',
+  },
+  worker: {
+    surface: 'worker',
+    defaultMode: 'v1',
+    fallbackLayer: 'server_adapter',
+  },
+  export: {
+    surface: 'export',
+    defaultMode: 'v1',
+    fallbackLayer: 'server_adapter',
+  },
+} as const;
+
+export type DecisionPair = {
+  valueA: DomainAnalysisValueKey;
+  valueB: DomainAnalysisValueKey;
+};
+
+export type ValueStatementEntry = { token: string; body: string };
+
+export type DecisionModelInput = {
+  pair: DecisionPair | null;
+  orientationFlipped: boolean | null | undefined;
+  raw: RawDecisionEvidence;
+  manualOverridePresent?: boolean;
+  manualOverrideDecision?: CanonicalAppliedDecision | null;
+  cachedDecision?: CachedWinnerFirstDecision | null;
+  valueStatements?: readonly ValueStatementEntry[];
+  labelPrefix?: string | null;
+};
+
+export type DecisionModelResult = {
+  raw: RawDecisionEvidence;
+  canonical: CanonicalDecision;
+};
+
+export type TranscriptDecisionModelInput = {
+  decisionCode: string | null;
+  decisionMetadata: unknown;
+  /** Supply definitionSnapshot OR pairOverride — pairOverride takes precedence if both provided */
+  definitionSnapshot?: unknown;
+  orientationFlipped: boolean | null | undefined;
+  /** Pre-resolved value pair; avoids fetching definitionSnapshot from DB when pair is already known */
+  pairOverride?: DomainAnalysisValuePair | null;
+};
+
+export type TranscriptDecisionModelResult = DecisionModelResult;
+
+export type ParsedDecisionPath = {
+  branch: 'exact' | 'fallback' | 'manual';
+  direction: DecisionDirection;
+  strength: DecisionStrength;
+};
+
+export type CachedWinnerFirstDecision = {
+  cacheVersion: 1;
+  decisionState: 'resolved' | 'neutral' | 'unknown';
+  favoredValueKey: DomainAnalysisValueKey | null;
+  strength: DecisionStrength;
+};

--- a/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
@@ -1,5 +1,5 @@
 import { DOMAIN_ANALYSIS_VALUE_KEYS, extractValuePair, toPascalCaseKey, type DomainAnalysisValueKey, type DomainAnalysisValuePair } from '../domain-analysis-values.js';
-import { labelFromBody } from '@valuerank/shared';
+import { JOB_CHOICE_VALUE_STATEMENTS, labelFromBody } from '@valuerank/shared';
 
 export type DecisionDirection = 'favor_first' | 'favor_second' | 'neutral' | 'refusal' | 'unknown';
 export type DecisionStrength = 'strong' | 'lean' | 'neutral' | 'unknown';
@@ -644,7 +644,13 @@ export function resolveCanonicalDecision(input: DecisionModelInput): CanonicalDe
       );
     }
 
-    const favoredValueKey = resolveValueKeyFromText(candidateText, input.valueStatements, input.labelPrefix ?? null);
+    // When the caller supplies pairOverride without a definitionSnapshot (e.g. domain-analysis
+    // aggregation paths), valueStatements is undefined. For job-choice-v2 transcripts, fall back
+    // to the global JOB_CHOICE_VALUE_STATEMENTS so all 10 values resolve correctly.
+    const effectiveValueStatements = (input.valueStatements != null && input.valueStatements.length > 0)
+      ? input.valueStatements
+      : (input.raw.parserVersion === 'job-choice-v2' ? JOB_CHOICE_VALUE_STATEMENTS : undefined);
+    const favoredValueKey = resolveValueKeyFromText(candidateText, effectiveValueStatements, input.labelPrefix ?? null);
     if (favoredValueKey === null) {
       return buildUnknownCanonicalDecision('unknown');
     }

--- a/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
@@ -1,443 +1,53 @@
-import { DOMAIN_ANALYSIS_VALUE_KEYS, extractValuePair, toPascalCaseKey, type DomainAnalysisValueKey, type DomainAnalysisValuePair } from '../domain-analysis-values.js';
-import { JOB_CHOICE_VALUE_STATEMENTS, labelFromBody } from '@valuerank/shared';
+import { extractValuePair } from '../domain-analysis-values.js';
+import {
+  isValidDecisionPair,
+  isRecord,
+  isValueKey,
+  parseDecisionPath,
+  isJobChoiceDecisionPath,
+  flipDirection,
+  parseJobChoiceStrengthFromText,
+  resolveValueKeyFromText,
+  buildUnknownCanonicalDecision,
+  buildCanonicalDecisionFromPair,
+  canonicalDecisionScoreFromDirectionStrength,
+  validateManualAppliedDecision,
+  extractManualOverrideDecision,
+  extractCachedWinnerFirstDecision,
+  extractValueStatementsFromSnapshot,
+  extractLabelPrefixFromSnapshot,
+  JOB_CHOICE_VALUE_STATEMENTS,
+} from './decision-model-helpers.js';
 
-export type DecisionDirection = 'favor_first' | 'favor_second' | 'neutral' | 'refusal' | 'unknown';
-export type DecisionStrength = 'strong' | 'lean' | 'neutral' | 'unknown';
-export type DecisionSource = 'deterministic' | 'manual' | 'error' | 'unknown';
+// Re-export all types for backward compatibility
+export type {
+  DecisionDirection,
+  DecisionStrength,
+  DecisionSource,
+  CanonicalAppliedDecision,
+  RawDecisionEvidence,
+  CanonicalDecision,
+  DecisionReadSurface,
+  DecisionReadMode,
+  DecisionReadRule,
+  DecisionPair,
+  ValueStatementEntry,
+  DecisionModelInput,
+  DecisionModelResult,
+  TranscriptDecisionModelInput,
+  TranscriptDecisionModelResult,
+} from './decision-model-types.js';
+export { DECISION_MODEL_READ_RULES } from './decision-model-types.js';
 
-export type CanonicalAppliedDecision = {
-  favoredValueKey: DomainAnalysisValueKey | null;
-  opposedValueKey: DomainAnalysisValueKey | null;
-  direction: DecisionDirection;
-  strength: DecisionStrength;
-};
-
-export type RawDecisionEvidence = {
-  matchedText: string | null;
-  matchedLabel: string | null;
-  parseClass: 'exact' | 'fallback_resolved' | 'ambiguous' | 'unparseable' | null;
-  parsePath: string | null;
-  parserVersion: string | null;
-  responseExcerpt: string | null;
-  manualOverride: {
-    previousValue: string | null;
-    overriddenAt: string | null;
-    overriddenByUserId: string | null;
-  } | null;
-};
-
-export type CanonicalDecision = {
-  favoredValueKey: DomainAnalysisValueKey | null;
-  opposedValueKey: DomainAnalysisValueKey | null;
-  direction: DecisionDirection;
-  strength: DecisionStrength;
-  normalizationApplied: boolean;
-  normalizationReason: 'orientation_flipped' | null;
-  source: DecisionSource;
-};
-
-export type DecisionReadSurface = 'api' | 'web' | 'worker' | 'export';
-export type DecisionReadMode = 'v1' | 'v2';
-export type DecisionReadRule = {
-  surface: DecisionReadSurface;
-  defaultMode: DecisionReadMode;
-  fallbackLayer: 'server_adapter' | 'none';
-};
-
-export const DECISION_MODEL_READ_RULES: Record<DecisionReadSurface, DecisionReadRule> = {
-  api: {
-    surface: 'api',
-    defaultMode: 'v1',
-    fallbackLayer: 'server_adapter',
-  },
-  web: {
-    surface: 'web',
-    defaultMode: 'v1',
-    fallbackLayer: 'none',
-  },
-  worker: {
-    surface: 'worker',
-    defaultMode: 'v1',
-    fallbackLayer: 'server_adapter',
-  },
-  export: {
-    surface: 'export',
-    defaultMode: 'v1',
-    fallbackLayer: 'server_adapter',
-  },
-} as const;
-
-export type DecisionPair = {
-  valueA: DomainAnalysisValueKey;
-  valueB: DomainAnalysisValueKey;
-};
-
-export type ValueStatementEntry = { token: string; body: string };
-
-export type DecisionModelInput = {
-  pair: DecisionPair | null;
-  orientationFlipped: boolean | null | undefined;
-  raw: RawDecisionEvidence;
-  manualOverridePresent?: boolean;
-  manualOverrideDecision?: CanonicalAppliedDecision | null;
-  cachedDecision?: CachedWinnerFirstDecision | null;
-  valueStatements?: readonly ValueStatementEntry[];
-  labelPrefix?: string | null;
-};
-
-export type DecisionModelResult = {
-  raw: RawDecisionEvidence;
-  canonical: CanonicalDecision;
-};
-
-export type TranscriptDecisionModelInput = {
-  decisionCode: string | null;
-  decisionMetadata: unknown;
-  /** Supply definitionSnapshot OR pairOverride — pairOverride takes precedence if both provided */
-  definitionSnapshot?: unknown;
-  orientationFlipped: boolean | null | undefined;
-  /** Pre-resolved value pair; avoids fetching definitionSnapshot from DB when pair is already known */
-  pairOverride?: DomainAnalysisValuePair | null;
-};
-
-export type TranscriptDecisionModelResult = DecisionModelResult;
-
-type ParsedDecisionPath = {
-  branch: 'exact' | 'fallback' | 'manual';
-  direction: DecisionDirection;
-  strength: DecisionStrength;
-};
-
-type CachedWinnerFirstDecision = {
-  cacheVersion: 1;
-  decisionState: 'resolved' | 'neutral' | 'unknown';
-  favoredValueKey: DomainAnalysisValueKey | null;
-  strength: DecisionStrength;
-};
-
-function isValueKey(value: string): value is DomainAnalysisValueKey {
-  return (DOMAIN_ANALYSIS_VALUE_KEYS as readonly string[]).includes(value);
-}
-
-function isDecisionDirection(value: unknown): value is DecisionDirection {
-  return value === 'favor_first' || value === 'favor_second' || value === 'neutral' || value === 'refusal' || value === 'unknown';
-}
-
-function isDecisionStrength(value: unknown): value is DecisionStrength {
-  return value === 'strong' || value === 'lean' || value === 'neutral' || value === 'unknown';
-}
-
-function isCanonicalAppliedDecision(value: unknown): value is CanonicalAppliedDecision {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    return false;
-  }
-
-  const decision = value as CanonicalAppliedDecision;
-  return (
-    isDecisionDirection(decision.direction) &&
-    isDecisionStrength(decision.strength) &&
-    (decision.favoredValueKey === null || (typeof decision.favoredValueKey === 'string' && isValueKey(decision.favoredValueKey))) &&
-    (decision.opposedValueKey === null || (typeof decision.opposedValueKey === 'string' && isValueKey(decision.opposedValueKey)))
-  );
-}
-
-function isCachedWinnerFirstDecision(value: unknown): value is CachedWinnerFirstDecision {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    return false;
-  }
-
-  const decision = value as CachedWinnerFirstDecision;
-  if (
-    decision.cacheVersion !== 1
-    || (decision.decisionState !== 'resolved' && decision.decisionState !== 'neutral' && decision.decisionState !== 'unknown')
-  ) {
-    return false;
-  }
-
-  if (decision.decisionState === 'resolved') {
-    return (
-      typeof decision.favoredValueKey === 'string'
-      && isValueKey(decision.favoredValueKey)
-      && (decision.strength === 'strong' || decision.strength === 'lean')
-    );
-  }
-
-  if (decision.decisionState === 'neutral') {
-    return decision.favoredValueKey === null && decision.strength === 'neutral';
-  }
-
-  return decision.favoredValueKey === null && decision.strength === 'unknown';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function isValidDecisionPair(pair: DecisionPair | null | undefined): pair is DecisionPair {
-  if (pair === null || pair === undefined) {
-    return false;
-  }
-
-  return (
-    isValueKey(pair.valueA) &&
-    isValueKey(pair.valueB) &&
-    pair.valueA !== pair.valueB
-  );
-}
-
-function parseDecisionPath(parsePath: string | null | undefined): ParsedDecisionPath | null {
-  if (typeof parsePath !== 'string') {
-    return null;
-  }
-
-  const trimmed = parsePath.trim();
-  if (trimmed.length === 0) {
-    return null;
-  }
-
-  const segments = trimmed.split('.');
-  if (segments.length > 3) {
-    return null;
-  }
-  const [branch, first, second] = segments;
-  const normalizedBranch = branch === 'fallback_resolved' ? 'fallback' : branch;
-
-  if (normalizedBranch !== 'exact' && normalizedBranch !== 'fallback' && normalizedBranch !== 'manual') {
-    return null;
-  }
-
-  if (normalizedBranch === 'manual') {
-    return first === 'override' && second === undefined
-      ? { branch: 'manual', direction: 'unknown', strength: 'unknown' }
-      : null;
-  }
-
-  if (first === 'neutral' && (second === undefined || second === 'neutral')) {
-    return { branch: normalizedBranch, direction: 'neutral', strength: 'neutral' };
-  }
-
-  if (!isDecisionDirection(first) || !isDecisionStrength(second)) {
-    return null;
-  }
-
-  return {
-    branch: normalizedBranch,
-    direction: first,
-    strength: second,
-  };
-}
-
-function isJobChoiceDecisionPath(parsePath: string | null | undefined): boolean {
-  return typeof parsePath === 'string' && (
-    parsePath.startsWith('numeric_')
-    || parsePath.startsWith('text_label_')
-  );
-}
-
-function flipDirection(direction: DecisionDirection): DecisionDirection {
-  if (direction === 'favor_first') return 'favor_second';
-  if (direction === 'favor_second') return 'favor_first';
-  return direction;
-}
-
-function normalizeJobChoiceLabelText(text: string): string {
-  const stripped = text
-    .replace(/[*_`]+/g, ' ')
-    .replace(/^level of support\s*:\s*/i, '')
-    .replace(/^(?:my\s+)?(?:final\s+|overall\s+)?(?:judg(?:e)?ment|answer|response|decision|choice|rating|score)(?:\s+on\s+the\s+scale)?\s*(?:(?:is)\s*[:=]?|[:=])?\s*/i, '')
-    .trim();
-
-  return stripped
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-function parseJobChoiceStrengthFromText(text: string): DecisionStrength | null {
-  const normalized = normalizeJobChoiceLabelText(text);
-  if (normalized.startsWith('strongly support')) return 'strong';
-  if (normalized.startsWith('somewhat support')) return 'lean';
-  if (normalized.startsWith('neutral')) return 'neutral';
-  return null;
-}
-
-function resolveValueKeyFromText(
-  text: string,
-  valueStatements: readonly ValueStatementEntry[] | undefined,
-  labelPrefix: string | null,
-): DomainAnalysisValueKey | null {
-  if (valueStatements == null || valueStatements.length === 0) {
-    return null;
-  }
-
-  const normalized = normalizeJobChoiceLabelText(text);
-  if (normalized.length === 0) {
-    return null;
-  }
-
-  const prefix = labelPrefix ?? '';
-  let resolved: DomainAnalysisValueKey | null = null;
-  for (const entry of valueStatements) {
-    const valueKey = toPascalCaseKey(entry.token) as DomainAnalysisValueKey;
-    const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, prefix));
-    if (!label || !normalized.includes(label)) {
-      continue;
-    }
-    if (resolved !== null && resolved !== valueKey) {
-      return null;
-    }
-    resolved = valueKey;
-  }
-
-  return resolved;
-}
-
-function buildUnknownCanonicalDecision(source: DecisionSource): CanonicalDecision {
-  return {
-    favoredValueKey: null,
-    opposedValueKey: null,
-    direction: 'unknown',
-    strength: 'unknown',
-    normalizationApplied: false,
-    normalizationReason: null,
-    source,
-  };
-}
-
-function canonicalDecisionScoreFromDirectionStrength(
-  direction: DecisionDirection,
-  strength: DecisionStrength,
-): 1 | 2 | 3 | 4 | 5 | null {
-  if (direction === 'favor_first' && strength === 'strong') return 5;
-  if (direction === 'favor_first' && strength === 'lean') return 4;
-  if (direction === 'neutral' && strength === 'neutral') return 3;
-  if (direction === 'favor_second' && strength === 'lean') return 2;
-  if (direction === 'favor_second' && strength === 'strong') return 1;
-  return null;
-}
-function buildCanonicalDecisionFromPair(
-  pair: DecisionPair,
-  direction: DecisionDirection,
-  strength: DecisionStrength,
-  normalizationApplied: boolean,
-  source: DecisionSource,
-): CanonicalDecision {
-  if (direction === 'neutral') {
-    return {
-      favoredValueKey: null,
-      opposedValueKey: null,
-      direction,
-      strength,
-      normalizationApplied,
-      normalizationReason: normalizationApplied ? 'orientation_flipped' : null,
-      source,
-    };
-  }
-
-  if (direction === 'favor_first') {
-    return {
-      favoredValueKey: pair.valueA,
-      opposedValueKey: pair.valueB,
-      direction,
-      strength,
-      normalizationApplied,
-      normalizationReason: normalizationApplied ? 'orientation_flipped' : null,
-      source,
-    };
-  }
-
-  if (direction === 'favor_second') {
-    return {
-      favoredValueKey: pair.valueB,
-      opposedValueKey: pair.valueA,
-      direction,
-      strength,
-      normalizationApplied,
-      normalizationReason: normalizationApplied ? 'orientation_flipped' : null,
-      source,
-    };
-  }
-
-  return buildUnknownCanonicalDecision(source);
-}
-
-export function canonicalDecisionToLegacyScore(
-  decision: Pick<CanonicalDecision, 'direction' | 'strength'>,
-): 1 | 2 | 3 | 4 | 5 | null {
-  return canonicalDecisionScoreFromDirectionStrength(decision.direction, decision.strength);
-}
-
-function validateManualAppliedDecision(
-  pair: DecisionPair,
-  appliedDecision: unknown,
-): { ok: true; canonical: CanonicalDecision } | { ok: false } {
-  if (!isCanonicalAppliedDecision(appliedDecision)) {
-    return { ok: false };
-  }
-
-  const decision = appliedDecision;
-  const validKnownPair =
-    (decision.direction === 'neutral' &&
-      decision.strength === 'neutral' &&
-      decision.favoredValueKey === null &&
-      decision.opposedValueKey === null) ||
-    (decision.direction === 'unknown' &&
-      decision.strength === 'unknown' &&
-      decision.favoredValueKey === null &&
-      decision.opposedValueKey === null) ||
-    (decision.direction === 'favor_first' &&
-      decision.strength !== 'unknown' &&
-      decision.strength !== 'neutral' &&
-      decision.favoredValueKey === pair.valueA &&
-      decision.opposedValueKey === pair.valueB) ||
-    (decision.direction === 'favor_second' &&
-      decision.strength !== 'unknown' &&
-      decision.strength !== 'neutral' &&
-      decision.favoredValueKey === pair.valueB &&
-      decision.opposedValueKey === pair.valueA);
-
-  if (!validKnownPair) {
-    return { ok: false };
-  }
-
-  return {
-    ok: true,
-    canonical: {
-      favoredValueKey: decision.favoredValueKey,
-      opposedValueKey: decision.opposedValueKey,
-      direction: decision.direction,
-      strength: decision.strength,
-      normalizationApplied: false,
-      normalizationReason: null,
-      source: 'manual',
-    },
-  };
-}
-
-function extractManualOverrideDecision(
-  decisionMetadata: unknown,
-): CanonicalAppliedDecision | null {
-  const record = isRecord(decisionMetadata) ? decisionMetadata : null;
-  const manualOverride = record && isRecord(record.manualOverride) ? record.manualOverride : null;
-  if (!manualOverride || !isCanonicalAppliedDecision(manualOverride.appliedDecision)) {
-    return null;
-  }
-  return manualOverride.appliedDecision;
-}
-
-function extractCachedWinnerFirstDecision(
-  decisionMetadata: unknown,
-): CachedWinnerFirstDecision | null {
-  const record = isRecord(decisionMetadata) ? decisionMetadata : null;
-  const summaryCache = record && isRecord(record.summaryCache) ? record.summaryCache : null;
-  const summary = summaryCache && isRecord(summaryCache.summary) ? summaryCache.summary : null;
-  const canonicalDecision = summary && isCachedWinnerFirstDecision(summary.canonicalDecision)
-    ? summary.canonicalDecision
-    : null;
-
-  return canonicalDecision;
-}
+import type {
+  RawDecisionEvidence,
+  CanonicalDecision,
+  DecisionDirection,
+  DecisionModelInput,
+  DecisionModelResult,
+  TranscriptDecisionModelInput,
+  TranscriptDecisionModelResult,
+} from './decision-model-types.js';
 
 export function buildRawDecisionEvidence(
   decisionMetadata: unknown,
@@ -483,57 +93,10 @@ export function buildRawDecisionEvidence(
   };
 }
 
-function extractValueStatementsFromSnapshot(snapshot: unknown): ValueStatementEntry[] | undefined {
-  if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) return undefined;
-  const components = (snapshot as { components?: unknown }).components;
-  if (components === null || typeof components !== 'object' || Array.isArray(components)) return undefined;
-
-  const vf = (components as { value_first?: unknown }).value_first;
-  const vs = (components as { value_second?: unknown }).value_second;
-  if (!isRecord(vf) || !isRecord(vs)) return undefined;
-
-  const tokenFirst = typeof vf.token === 'string' ? vf.token : null;
-  const bodyFirst = typeof vf.body === 'string' ? vf.body : null;
-  const tokenSecond = typeof vs.token === 'string' ? vs.token : null;
-  const bodySecond = typeof vs.body === 'string' ? vs.body : null;
-
-  if (tokenFirst == null || bodyFirst == null || tokenSecond == null || bodySecond == null) return undefined;
-  return [
-    { token: tokenFirst, body: bodyFirst },
-    { token: tokenSecond, body: bodySecond },
-  ];
-}
-
-const LABEL_PREFIX_REGEX = /^(?:Strongly|Somewhat) support (.+)$/;
-
-function extractLabelPrefixFromSnapshot(snapshot: unknown): string | undefined {
-  if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) return undefined;
-  const template = (snapshot as { template?: unknown }).template;
-  if (typeof template !== 'string') return undefined;
-
-  const components = (snapshot as { components?: unknown }).components;
-  if (components === null || typeof components !== 'object' || Array.isArray(components)) return undefined;
-  const vf = (components as { value_first?: unknown }).value_first;
-  if (!isRecord(vf) || typeof vf.body !== 'string') return undefined;
-
-  // Extract the short body (before "because") to find it in the scale label
-  const shortBody = (vf.body.split(' because')[0] ?? vf.body).trim();
-  if (shortBody.length === 0) return undefined;
-
-  // Find a scale label line that ends with the short body
-  const lines = template.split('\n');
-  for (const line of lines) {
-    const trimmed = line.replace(/^- /, '').trim();
-    const match = LABEL_PREFIX_REGEX.exec(trimmed);
-    if (match == null) continue;
-    const afterStrength = match[1] ?? '';
-    if (afterStrength.endsWith(shortBody)) {
-      const prefix = afterStrength.slice(0, afterStrength.length - shortBody.length).trimEnd();
-      if (prefix.length > 0) return prefix;
-    }
-  }
-
-  return undefined;
+export function canonicalDecisionToLegacyScore(
+  decision: Pick<CanonicalDecision, 'direction' | 'strength'>,
+): 1 | 2 | 3 | 4 | 5 | null {
+  return canonicalDecisionScoreFromDirectionStrength(decision.direction, decision.strength);
 }
 
 export function resolveTranscriptDecisionModel(
@@ -703,6 +266,7 @@ export function resolveCanonicalDecision(input: DecisionModelInput): CanonicalDe
     'deterministic',
   );
 }
+
 export function resolveDecisionModel(input: DecisionModelInput): DecisionModelResult {
   const canonical = resolveCanonicalDecision(input);
   return {
@@ -710,3 +274,4 @@ export function resolveDecisionModel(input: DecisionModelInput): DecisionModelRe
     canonical,
   };
 }
+

--- a/cloud/apps/api/src/queue/handlers/__tests__/summarize-persistence.test.ts
+++ b/cloud/apps/api/src/queue/handlers/__tests__/summarize-persistence.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it, vi, beforeAll, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, beforeAll } from 'vitest';
+import type { db as DbType } from '@valuerank/db';
+import type { findMissingProbes as FindMissingProbesType } from '../../../services/run/coverage-completeness.js';
+import type { checkAllSummarized as CheckAllSummarizedType } from '../summarize-persistence.js';
 
-// Register mock factories — these are hoisted by Vitest and persist across resetModules()
+// These vi.mock() calls are hoisted above all imports by Vitest's transform.
 vi.mock('@valuerank/db', () => ({
   db: {
     transcript: {
@@ -14,25 +17,34 @@ vi.mock('../../../services/run/coverage-completeness.js', () => ({
   findMissingProbes: vi.fn(),
 }));
 
-// In single-fork mode, summarize-transcript.test.ts (integration test) may load
-// summarize-persistence.ts before this file runs, giving it a live ESM binding to
-// the REAL findMissingProbes. vi.resetModules() clears the module cache so our
-// subsequent dynamic imports get a fresh summarize-persistence.ts that binds to
-// the mock instead.
-let checkAllSummarized: (runId: string) => Promise<boolean>;
-let mockCount: ReturnType<typeof vi.fn>;
-let mockFindMissingProbes: ReturnType<typeof vi.fn>;
+/**
+ * Why dynamic imports + vi.resetModules()?
+ *
+ * This suite runs in a singleFork process alongside integration tests (e.g.
+ * summarize-transcript.test.ts) that load summarize-persistence.ts with real
+ * @valuerank/db bindings before this file runs. Without a module cache reset,
+ * Vitest may return that cached instance, so vi.mock('@valuerank/db') misses
+ * the already-bound db reference inside the module under test.
+ *
+ * vi.resetModules() clears the module cache (but NOT the mock factory registry),
+ * so the subsequent dynamic imports load fresh instances that bind to our mocks.
+ */
+
+let checkAllSummarized: typeof CheckAllSummarizedType;
+let mockCount: ReturnType<typeof vi.mocked<typeof DbType.transcript.count>>;
+let mockFindMissingProbes: ReturnType<typeof vi.mocked<typeof FindMissingProbesType>>;
 
 beforeAll(async () => {
   vi.resetModules();
-  const dbModule = await import('@valuerank/db');
-  const coverageModule = await import('../../../services/run/coverage-completeness.js');
-  const persistenceModule = await import('../summarize-persistence.js');
 
-  checkAllSummarized = persistenceModule.checkAllSummarized;
+  const dbModule = await import('@valuerank/db');
+  const ccModule = await import('../../../services/run/coverage-completeness.js');
+  const spModule = await import('../summarize-persistence.js');
+
   // eslint-disable-next-line @typescript-eslint/unbound-method
   mockCount = vi.mocked(dbModule.db.transcript.count);
-  mockFindMissingProbes = vi.mocked(coverageModule.findMissingProbes);
+  mockFindMissingProbes = vi.mocked(ccModule.findMissingProbes);
+  checkAllSummarized = spModule.checkAllSummarized;
 });
 
 describe('checkAllSummarized', () => {

--- a/cloud/apps/api/tests/graphql/queries/decision-model-job-choice-pairoverride.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/decision-model-job-choice-pairoverride.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveTranscriptDecisionModel,
+  type DecisionPair,
+} from '../../../src/graphql/queries/domain/decision-model.js';
+
+/**
+ * Regression tests for job-choice-v2 canonicalization via pairOverride without definitionSnapshot.
+ *
+ * Domain-analysis aggregation callers (value-detail, domain-analysis-aggregation) invoke
+ * resolveTranscriptDecisionModel with pairOverride only — no definitionSnapshot — leaving
+ * valueStatements undefined. Without a fallback, resolveValueKeyFromText returns null and
+ * all job-choice-v2 transcripts are marked "Unknown".
+ *
+ * The fix falls back to JOB_CHOICE_VALUE_STATEMENTS for parserVersion === 'job-choice-v2',
+ * ensuring all 10 Job Choice values resolve correctly.
+ */
+
+const allJobChoiceEntries: Array<{
+  token: string;
+  matchedLabel: string;
+  pair: DecisionPair;
+  expectedFavored: string;
+}> = [
+  {
+    token: 'self_direction_action',
+    matchedLabel: 'Somewhat support taking the job with freedom in how they work',
+    pair: { valueA: 'Achievement', valueB: 'Self_Direction_Action' },
+    expectedFavored: 'Self_Direction_Action',
+  },
+  {
+    token: 'power_dominance',
+    matchedLabel: 'Strongly support taking the job with authority over others',
+    pair: { valueA: 'Power_Dominance', valueB: 'Universalism_Nature' },
+    expectedFavored: 'Power_Dominance',
+  },
+  {
+    token: 'security_personal',
+    matchedLabel: 'Somewhat support taking the job with personal security in everyday life',
+    pair: { valueA: 'Achievement', valueB: 'Security_Personal' },
+    expectedFavored: 'Security_Personal',
+  },
+  {
+    token: 'conformity_interpersonal',
+    matchedLabel: 'Strongly support taking the job with harmony in their close relationships',
+    pair: { valueA: 'Achievement', valueB: 'Conformity_Interpersonal' },
+    expectedFavored: 'Conformity_Interpersonal',
+  },
+  {
+    token: 'tradition',
+    matchedLabel: 'Somewhat support taking the job with connection to their heritage',
+    pair: { valueA: 'Achievement', valueB: 'Tradition' },
+    expectedFavored: 'Tradition',
+  },
+  {
+    token: 'stimulation',
+    matchedLabel: 'Strongly support taking the job with variety and excitement in their daily work',
+    pair: { valueA: 'Achievement', valueB: 'Stimulation' },
+    expectedFavored: 'Stimulation',
+  },
+  {
+    token: 'benevolence_dependability',
+    matchedLabel: 'Somewhat support taking the job with trust from other people',
+    pair: { valueA: 'Achievement', valueB: 'Benevolence_Dependability' },
+    expectedFavored: 'Benevolence_Dependability',
+  },
+  {
+    token: 'universalism_nature',
+    matchedLabel: 'Somewhat support taking the job with connection to the natural world',
+    pair: { valueA: 'Power_Dominance', valueB: 'Universalism_Nature' },
+    expectedFavored: 'Universalism_Nature',
+  },
+  {
+    token: 'achievement',
+    matchedLabel: 'Strongly support taking the job with recognition of their expertise',
+    pair: { valueA: 'Achievement', valueB: 'Benevolence_Dependability' },
+    expectedFavored: 'Achievement',
+  },
+  {
+    token: 'hedonism',
+    matchedLabel: 'Somewhat support taking the job with enjoyment in their daily experience',
+    pair: { valueA: 'Achievement', valueB: 'Hedonism' },
+    expectedFavored: 'Hedonism',
+  },
+];
+
+describe('job-choice-v2 resolves via pairOverride (no definitionSnapshot)', () => {
+  it.each(allJobChoiceEntries)(
+    'resolves $token via pairOverride without definitionSnapshot',
+    ({ matchedLabel, pair, expectedFavored }) => {
+      const result = resolveTranscriptDecisionModel({
+        decisionCode: null,
+        decisionMetadata: {
+          parseClass: 'exact',
+          parsePath: 'text_label_leading',
+          parserVersion: 'job-choice-v2',
+          matchedLabel,
+          responseExcerpt: matchedLabel,
+        },
+        pairOverride: pair,
+        orientationFlipped: false,
+      });
+
+      expect(result.canonical.favoredValueKey).toBe(expectedFavored);
+      expect(result.canonical.direction).not.toBe('unknown');
+      expect(result.canonical.source).toBe('deterministic');
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- **Root cause**: Domain-analysis aggregation callers pass `pairOverride` to `resolveTranscriptDecisionModel` without a `definitionSnapshot`, leaving `valueStatements` undefined. `resolveValueKeyFromText` returns null immediately, making all `job-choice-v2` transcripts show "Unknown" in Decision Summary.
- **Fix**: In `resolveCanonicalDecision`, when `valueStatements` is null/empty and `parserVersion === 'job-choice-v2'`, fall back to the global `JOB_CHOICE_VALUE_STATEMENTS`. Covers all 10 Job Choice values — substring matching on the normalized body text is unambiguous.
- **Tests**: Parametrized `it.each` block with one test per value (all 10) covering the `pairOverride`-only path. All pass.

## Test plan
- [x] Preflight: lint (0 errors), build (clean), 38/38 decision-model tests pass
- [x] All 10 job-choice values verified via parametrized tests
- [ ] Manual smoke test: value-detail page no longer shows Unknown for job-choice-v2 transcripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)