### PR TITLE
fix(ux): redirect scroll wheel to horizontal on overflow-x tables

### DIFF
--- a/cloud/apps/web/src/App.tsx
+++ b/cloud/apps/web/src/App.tsx
@@ -41,6 +41,7 @@ import { StartRedirect } from './pages/StartRedirect';
 import { StatusRedirect } from './pages/StatusRedirect';
 import { NotFound } from './pages/NotFound';
 import { client } from './api/client';
+import { useHorizontalScrollOnWheel } from './hooks/useHorizontalScrollOnWheel';
 
 // Protected layout wrapper
 function ProtectedLayout({ children, fullWidth = false }: { children: React.ReactNode; fullWidth?: boolean }) {
@@ -53,6 +54,8 @@ function ProtectedLayout({ children, fullWidth = false }: { children: React.Reac
 
 
 function App() {
+  useHorizontalScrollOnWheel();
+
   return (
     <BrowserRouter>
       <Provider value={client}>

--- a/cloud/apps/web/src/hooks/index.ts
+++ b/cloud/apps/web/src/hooks/index.ts
@@ -26,3 +26,6 @@ export { useRunsWithAnalysis } from './useRunsWithAnalysis';
 
 // Viewport hooks
 export { useViewport, useMediaQuery } from './useViewport';
+
+// Scroll UX hooks
+export { useHorizontalScrollOnWheel } from './useHorizontalScrollOnWheel';

--- a/cloud/apps/web/src/hooks/useHorizontalScrollOnWheel.ts
+++ b/cloud/apps/web/src/hooks/useHorizontalScrollOnWheel.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+
+/**
+ * Attaches a global wheel listener that redirects vertical scroll to horizontal
+ * when the nearest scrollable ancestor is a horizontal-only overflow container.
+ *
+ * This fixes the UX issue where hovering over the left-side labels of a wide
+ * table and scrolling moves the page instead of the table.
+ *
+ * Logic:
+ * - Walk up from the event target to find the first element that can actually scroll.
+ * - If that element can only scroll horizontally (not vertically), redirect deltaY
+ *   to scrollLeft so the table moves instead of the page.
+ * - If the first scrollable ancestor is vertical (or both), let the browser handle
+ *   the event normally — we never interfere with intentional page/modal scroll.
+ */
+export function useHorizontalScrollOnWheel(): void {
+  useEffect(() => {
+    const handleWheel = (e: WheelEvent): void => {
+      // Only intercept pure vertical scroll input
+      if (e.deltaX !== 0 || e.deltaY === 0) return;
+
+      let el: HTMLElement | null =
+        e.target instanceof HTMLElement ? e.target : null;
+
+      while (el !== null && el !== document.documentElement) {
+        const style = window.getComputedStyle(el);
+        const ox = style.overflowX;
+        const oy = style.overflowY;
+        const canScrollX =
+          (ox === 'auto' || ox === 'scroll') && el.scrollWidth > el.clientWidth;
+        const canScrollY =
+          (oy === 'auto' || oy === 'scroll') && el.scrollHeight > el.clientHeight;
+
+        if (canScrollX || canScrollY) {
+          if (canScrollX && !canScrollY) {
+            // Horizontal-only container: redirect wheel to horizontal scroll
+            e.preventDefault();
+            el.scrollLeft += e.deltaY;
+          }
+          // If vertical (or both), fall through — browser handles normally
+          return;
+        }
+
+        el = el.parentElement;
+      }
+    };
+
+    document.addEventListener('wheel', handleWheel, { passive: false });
+    return () => document.removeEventListener('wheel', handleWheel);
+  }, []);
+}


### PR DESCRIPTION
## Summary
- Adds `useHorizontalScrollOnWheel` hook called once from `App`
- Attaches a global `wheel` listener that walks up from the event target to find the nearest scrollable ancestor
- If that ancestor is horizontal-only (`overflow-x: auto/scroll`, no vertical overflow), `deltaY` is redirected to `scrollLeft` so the table scrolls instead of the page
- Vertical scroll containers (modals, panels with `overflow-y`) are untouched — the handler returns without calling `preventDefault`
- Fixes the issue where hovering over left-side row labels (outside the scrollable column area) and using the scroll wheel scrolled the browser page instead of the table

## Validation
- `npx turbo lint --filter=@valuerank/web` — passed (0 errors)
- `npx turbo build --filter=@valuerank/web` — passed

## Test plan
- [ ] Hover over left-side row labels on a wide table (e.g. Value Priorities, Coverage Matrix) and scroll — table should scroll horizontally
- [ ] Scrolling on a page with vertical content still scrolls the page normally
- [ ] Scrolling inside a modal or vertical panel is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)