### PR TITLE
fix(models): column-header sorting, full value names, collapsible model set

### DIFF
--- a/cloud/apps/api/src/queue/handlers/__tests__/summarize-persistence.test.ts
+++ b/cloud/apps/api/src/queue/handlers/__tests__/summarize-persistence.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeAll, beforeEach } from 'vitest';
 
-// Mock @valuerank/db before importing the module under test
+// Register mock factories — these are hoisted by Vitest and persist across resetModules()
 vi.mock('@valuerank/db', () => ({
   db: {
     transcript: {
@@ -10,18 +10,30 @@ vi.mock('@valuerank/db', () => ({
   Prisma: { DbNull: null },
 }));
 
-// Mock findMissingProbes from coverage-completeness
 vi.mock('../../../services/run/coverage-completeness.js', () => ({
   findMissingProbes: vi.fn(),
 }));
 
-import { db } from '@valuerank/db';
-import { findMissingProbes } from '../../../services/run/coverage-completeness.js';
-import { checkAllSummarized } from '../summarize-persistence.js';
+// In single-fork mode, summarize-transcript.test.ts (integration test) may load
+// summarize-persistence.ts before this file runs, giving it a live ESM binding to
+// the REAL findMissingProbes. vi.resetModules() clears the module cache so our
+// subsequent dynamic imports get a fresh summarize-persistence.ts that binds to
+// the mock instead.
+let checkAllSummarized: (runId: string) => Promise<boolean>;
+let mockCount: ReturnType<typeof vi.fn>;
+let mockFindMissingProbes: ReturnType<typeof vi.fn>;
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const mockCount = vi.mocked(db.transcript.count);
-const mockFindMissingProbes = vi.mocked(findMissingProbes);
+beforeAll(async () => {
+  vi.resetModules();
+  const dbModule = await import('@valuerank/db');
+  const coverageModule = await import('../../../services/run/coverage-completeness.js');
+  const persistenceModule = await import('../summarize-persistence.js');
+
+  checkAllSummarized = persistenceModule.checkAllSummarized;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  mockCount = vi.mocked(dbModule.db.transcript.count);
+  mockFindMissingProbes = vi.mocked(coverageModule.findMissingProbes);
+});
 
 describe('checkAllSummarized', () => {
   beforeEach(() => {

--- a/cloud/apps/api/src/services/export/domain-csv.ts
+++ b/cloud/apps/api/src/services/export/domain-csv.ts
@@ -7,7 +7,6 @@ import {
   getProbePrompt,
   getTargetResponse,
   extractTrialSignature,
-  type TranscriptWithScenario,
 } from './csv.js';
 import {
   formatDecisionDisplay,
@@ -136,8 +135,8 @@ function domainTranscriptToRow(transcript: DomainTranscriptWithScenario): string
   const strengthScore = getDecisionPreferenceScore(decisionDisplay);
   const decisionStrength = strengthScore != null ? String(strengthScore) : '';
 
-  const probePrompt = getProbePrompt(transcript as TranscriptWithScenario);
-  const targetResponse = getTargetResponse(transcript as TranscriptWithScenario);
+  const probePrompt = getProbePrompt(transcript);
+  const targetResponse = getTargetResponse(transcript);
 
   return [
     modelName,

--- a/cloud/apps/web/src/components/models/ModelsMatrix.tsx
+++ b/cloud/apps/web/src/components/models/ModelsMatrix.tsx
@@ -1,92 +1,36 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { type ModelsAnalysisModelResult, type ModelsAnalysisValueResult } from '../../api/operations/modelsAnalysis';
 import { VALUE_LABELS, VALUES, type ValueKey } from '../../data/domainAnalysisData';
 import { ModelsMatrixCell } from './ModelsMatrixCell';
+import { Button } from '../ui/Button';
 
 export type ModelsMatrixSortKey = 'model' | ValueKey;
-export type StabilityVisibility = 'all' | 'stable' | 'low';
-
-export const VALUE_SHORT_LABELS: Record<ValueKey, string> = {
-  Self_Direction_Action: 'Self-Dir',
-  Universalism_Nature: 'Univ',
-  Benevolence_Dependability: 'Bene',
-  Security_Personal: 'Security',
-  Power_Dominance: 'Power',
-  Achievement: 'Achieve',
-  Tradition: 'Tradition',
-  Stimulation: 'Stimulate',
-  Hedonism: 'Hedone',
-  Conformity_Interpersonal: 'Conform',
-};
 
 type ModelsMatrixProps = {
   models: ModelsAnalysisModelResult[];
   selectedModelIds: string[];
-  sortBy: ModelsMatrixSortKey;
-  stabilityVisibility: StabilityVisibility;
   singleDomainActive: boolean;
   selectedCellKey: string | null;
   onCellClick: (modelId: string, valueKey: string) => void;
 };
 
-function getVisibleCell(
-  value: ModelsAnalysisValueResult,
-  stabilityVisibility: StabilityVisibility,
-  singleDomainActive: boolean,
-): { hiddenByFilter: boolean } {
-  if (singleDomainActive || stabilityVisibility === 'all') {
-    return { hiddenByFilter: false };
-  }
-
-  if (value.stabilityScore == null) {
-    return { hiddenByFilter: true };
-  }
-
-  if (stabilityVisibility === 'stable') {
-    return { hiddenByFilter: value.stabilityScore < 75 };
-  }
-
-  return { hiddenByFilter: value.stabilityScore >= 50 };
-}
-
 function getSortableCell(
   model: ModelsAnalysisModelResult,
-  sortBy: ModelsMatrixSortKey,
-  stabilityVisibility: StabilityVisibility,
-  singleDomainActive: boolean,
+  sortKey: ModelsMatrixSortKey,
 ): ModelsAnalysisValueResult | null {
-  if (sortBy === 'model') return null;
-  const value = model.values.find((entry) => entry.valueKey === sortBy) ?? null;
-  if (value == null) return null;
-  const visible = getVisibleCell(value, stabilityVisibility, singleDomainActive);
-  if (visible.hiddenByFilter) return null;
-  if (value.pooledWinRate == null) return null;
+  if (sortKey === 'model') return null;
+  const value = model.values.find((entry) => entry.valueKey === sortKey) ?? null;
+  if (value == null || value.pooledWinRate == null) return null;
   return value;
-}
-
-function compareNullableDescending(left: number | null, right: number | null): number {
-  if (left == null && right == null) return 0;
-  if (left == null) return 1;
-  if (right == null) return -1;
-  if (left === right) return 0;
-  return right - left;
 }
 
 function getEmptyStateMessage(params: {
   selectedModelCount: number;
   visibleCellCount: number;
-  stabilityVisibility: StabilityVisibility;
   singleDomainActive: boolean;
 }): string {
   if (params.selectedModelCount === 0) {
     return 'No models are selected. Re-enable one or more models in the Model set filter.';
-  }
-
-  if (params.visibleCellCount === 0 && params.stabilityVisibility !== 'all') {
-    if (params.stabilityVisibility === 'stable') {
-      return 'No cells meet the Stable only filter. Switch Stability visibility back to All or Low stability only.';
-    }
-    return 'No cells meet the Low stability only filter. Switch Stability visibility back to All or Stable only.';
   }
 
   if (params.visibleCellCount === 0) {
@@ -101,24 +45,28 @@ function getEmptyStateMessage(params: {
 
 function sortModels(
   models: ModelsAnalysisModelResult[],
-  sortBy: ModelsMatrixSortKey,
-  stabilityVisibility: StabilityVisibility,
-  singleDomainActive: boolean,
+  sortKey: ModelsMatrixSortKey,
+  sortDirection: 'asc' | 'desc',
 ): ModelsAnalysisModelResult[] {
   const next = [...models];
   next.sort((left, right) => {
-    if (sortBy === 'model') {
-      return left.label.localeCompare(right.label);
+    if (sortKey === 'model') {
+      const cmp = left.label.localeCompare(right.label);
+      return sortDirection === 'asc' ? cmp : -cmp;
     }
 
-    const leftCell = getSortableCell(left, sortBy, stabilityVisibility, singleDomainActive);
-    const rightCell = getSortableCell(right, sortBy, stabilityVisibility, singleDomainActive);
+    const leftCell = getSortableCell(left, sortKey);
+    const rightCell = getSortableCell(right, sortKey);
 
-    const pooledCompare = compareNullableDescending(leftCell?.pooledWinRate ?? null, rightCell?.pooledWinRate ?? null);
-    if (pooledCompare !== 0) return pooledCompare;
+    const leftRate = leftCell?.pooledWinRate ?? null;
+    const rightRate = rightCell?.pooledWinRate ?? null;
 
-    const stabilityCompare = compareNullableDescending(leftCell?.stabilityScore ?? null, rightCell?.stabilityScore ?? null);
-    if (stabilityCompare !== 0) return stabilityCompare;
+    if (leftRate == null && rightRate == null) return left.label.localeCompare(right.label);
+    if (leftRate == null) return 1;
+    if (rightRate == null) return -1;
+
+    const diff = sortDirection === 'desc' ? rightRate - leftRate : leftRate - rightRate;
+    if (diff !== 0) return diff;
 
     return left.label.localeCompare(right.label);
   });
@@ -128,35 +76,43 @@ function sortModels(
 export function ModelsMatrix({
   models,
   selectedModelIds,
-  sortBy,
-  stabilityVisibility,
   singleDomainActive,
   selectedCellKey,
   onCellClick,
 }: ModelsMatrixProps) {
+  const [sortKey, setSortKey] = useState<ModelsMatrixSortKey>('model');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  const updateSort = (key: ModelsMatrixSortKey) => {
+    if (key === sortKey) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDirection(key === 'model' ? 'asc' : 'desc');
+    }
+  };
+
   const visibleModels = useMemo(() => {
     const selected = new Set(selectedModelIds);
     const filtered = models.filter((model) => selected.has(model.modelId));
-    return sortModels(filtered, sortBy, stabilityVisibility, singleDomainActive);
-  }, [models, selectedModelIds, sortBy, stabilityVisibility, singleDomainActive]);
+    return sortModels(filtered, sortKey, sortDirection);
+  }, [models, selectedModelIds, sortKey, sortDirection]);
 
   const visibleCellCount = useMemo(() => {
     let count = 0;
     for (const model of visibleModels) {
       for (const value of model.values) {
-        const visible = getVisibleCell(value, stabilityVisibility, singleDomainActive);
-        if (!visible.hiddenByFilter && value.pooledWinRate != null) {
+        if (value.pooledWinRate != null) {
           count += 1;
         }
       }
     }
     return count;
-  }, [visibleModels, stabilityVisibility, singleDomainActive]);
+  }, [visibleModels]);
 
   const emptyStateMessage = getEmptyStateMessage({
     selectedModelCount: selectedModelIds.length,
     visibleCellCount,
-    stabilityVisibility,
     singleDomainActive,
   });
 
@@ -178,26 +134,44 @@ export function ModelsMatrix({
 
   const headers = VALUES.map((valueKey) => ({
     valueKey,
-    shortLabel: VALUE_SHORT_LABELS[valueKey],
-    fullLabel: VALUE_LABELS[valueKey],
+    label: VALUE_LABELS[valueKey],
   }));
 
   return (
     <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
       <div className="overflow-x-auto">
-        <table className="min-w-[980px] border-separate border-spacing-0 text-sm">
+        <table className="min-w-[1200px] border-separate border-spacing-0 text-sm">
           <thead>
             <tr>
-              <th className="sticky left-0 top-0 z-20 border-b border-gray-200 bg-white px-3 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
-                Model
+              <th
+                className="sticky left-0 top-0 z-20 border-b border-gray-200 bg-white px-3 py-3 text-left"
+                aria-sort={sortKey === 'model' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+              >
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto min-h-0 !p-0 text-xs font-semibold uppercase tracking-wide text-gray-500 hover:text-gray-900"
+                  onClick={() => updateSort('model')}
+                >
+                  Model {sortKey === 'model' ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
+                </Button>
               </th>
               {headers.map((value) => (
                 <th
                   key={value.valueKey}
-                  className="sticky top-0 z-10 border-b border-gray-200 bg-white px-2 py-3 text-center text-xs font-semibold uppercase tracking-wide text-gray-500"
-                  title={value.fullLabel}
+                  className="sticky top-0 z-10 border-b border-gray-200 bg-white px-2 py-3 text-center"
+                  aria-sort={sortKey === value.valueKey ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
                 >
-                  {value.shortLabel}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-auto min-h-0 !p-0 text-xs font-semibold uppercase tracking-wide text-gray-500 hover:text-gray-900"
+                    onClick={() => updateSort(value.valueKey)}
+                  >
+                    {value.label} {sortKey === value.valueKey ? (sortDirection === 'asc' ? '↑' : '↓') : ''}
+                  </Button>
                 </th>
               ))}
             </tr>
@@ -227,19 +201,17 @@ export function ModelsMatrix({
                       );
                     }
 
-                    const visible = getVisibleCell(cell, stabilityVisibility, singleDomainActive);
                     const selected = selectedCellKey === `${model.modelId}:${value.valueKey}`;
 
                     return (
                       <td key={value.valueKey} className="border-b border-gray-100 px-1 py-1 align-middle">
                         <ModelsMatrixCell
                           modelLabel={model.label}
-                          valueLabel={value.fullLabel}
+                          valueLabel={value.label}
                           pooledWinRate={cell.pooledWinRate}
                           stabilityScore={cell.stabilityScore}
                           eligibleDomainCount={cell.eligibleDomainCount}
                           domains={cell.domains}
-                          hiddenByFilter={visible.hiddenByFilter}
                           singleDomainActive={singleDomainActive}
                           selected={selected}
                           onClick={() => onCellClick(model.modelId, value.valueKey)}
@@ -254,7 +226,7 @@ export function ModelsMatrix({
         </table>
       </div>
       <div className="mt-3 text-xs text-gray-500">
-        Rows sort by model name or by the selected value column. Stable only means stability score is at least 75. Low stability only means the score is below 50.
+        Click a column heading to sort.
       </div>
     </section>
   );

--- a/cloud/apps/web/src/pages/Models.tsx
+++ b/cloud/apps/web/src/pages/Models.tsx
@@ -13,12 +13,7 @@ import {
 } from '../api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { ModelValueDetailDrawer } from '../components/models/ModelValueDetailDrawer';
-import {
-  ModelsMatrix,
-  VALUE_SHORT_LABELS,
-  type ModelsMatrixSortKey,
-  type StabilityVisibility,
-} from '../components/models/ModelsMatrix';
+import { ModelsMatrix } from '../components/models/ModelsMatrix';
 
 export function Models() {
   const { domains, queryLoading: domainsLoading, error: domainsError } = useDomains();
@@ -42,8 +37,6 @@ export function Models() {
     requestPolicy: 'cache-and-network',
   });
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
-  const [sortBy, setSortBy] = useState<ModelsMatrixSortKey>('model');
-  const [stabilityVisibility, setStabilityVisibility] = useState<StabilityVisibility>('all');
   const [selectedCell, setSelectedCell] = useState<{ modelId: string; valueKey: string } | null>(null);
   const initializedModelSelection = useRef(false);
 
@@ -95,14 +88,6 @@ export function Models() {
     label: model.label,
   })), [models]);
 
-  const sortOptions = useMemo(() => [
-    { value: 'model', label: 'Model name' },
-    ...Object.entries(VALUE_SHORT_LABELS).map(([valueKey, label]) => ({
-      value: valueKey as ModelsMatrixSortKey,
-      label,
-    })),
-  ], []);
-
   const domainOptions = useMemo(() => [
     { value: 'all', label: 'All domains' },
     ...domains.map((domain) => ({
@@ -142,7 +127,13 @@ export function Models() {
     setSelectedCell({ modelId, valueKey });
   };
 
-  const stabilityDisabled = singleDomainActive;
+  const modelSetSummary = loading
+    ? 'Loading...'
+    : modelOptions.length === 0
+      ? 'No models available'
+      : selectedModelCount === modelOptions.length
+        ? 'All selected'
+        : `${selectedModelCount} of ${modelOptions.length} selected`;
 
   return (
     <div className="space-y-6">
@@ -157,92 +148,78 @@ export function Models() {
         <ErrorMessage message={`Failed to load models analysis: ${(domainsError ?? error)?.message ?? 'Unknown error'}`} />
       )}
 
-      <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5 space-y-4">
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          <Select
-            label="Domain scope"
-            options={domainOptions}
-            value={selectedDomainId ?? 'all'}
-            onChange={(value) => setSelectedDomainId(value === 'all' ? null : value)}
-            placeholder="All domains"
-          />
-          <Select
-            label="Sort rows by"
-            options={sortOptions}
-            value={sortBy}
-            onChange={(value) => setSortBy(value as ModelsMatrixSortKey)}
-          />
-          <Select
-            label="Stability visibility"
-            options={[
-              { value: 'all', label: 'All' },
-              { value: 'stable', label: 'Stable only' },
-              { value: 'low', label: 'Low stability only' },
-            ]}
-            value={stabilityVisibility}
-            onChange={(value) => setStabilityVisibility(value as StabilityVisibility)}
-            disabled={stabilityDisabled}
-            placeholder="All"
-          />
-          <div className="flex items-end">
-            <div className="text-xs text-gray-500">
-              {singleDomainActive ? 'Stability visibility is disabled while a single domain is selected.' : 'Stability is a cross-domain scan signal.'}
+      <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+        <div className="flex flex-wrap items-start gap-4">
+          <div className="w-48 flex-shrink-0">
+            <Select
+              label="Domain scope"
+              options={domainOptions}
+              value={selectedDomainId ?? 'all'}
+              onChange={(value) => setSelectedDomainId(value === 'all' ? null : value)}
+              placeholder="All domains"
+            />
+          </div>
+          <details className="flex-1 min-w-[220px]">
+            <summary className="cursor-pointer list-none">
+              <p className="text-sm font-medium text-gray-700 mb-1">Model set</p>
+              <div className="inline-flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm hover:border-gray-400 min-h-[44px] sm:min-h-0">
+                <span className={modelOptions.length === 0 && !loading ? 'text-gray-400' : ''}>
+                  {modelSetSummary}
+                </span>
+                <span className="ml-2 text-gray-400">▾</span>
+              </div>
+            </summary>
+            <div className="mt-2 space-y-3 rounded-lg border border-gray-200 bg-white p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-xs text-gray-600">All visible models are selected by default.</p>
+                <div className="flex items-center gap-2">
+                  <Button type="button" variant="secondary" size="sm" onClick={selectAllModels} disabled={loading}>
+                    Select all
+                  </Button>
+                  <Button type="button" variant="secondary" size="sm" onClick={clearModels} disabled={loading}>
+                    Clear
+                  </Button>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {modelOptions.map((model) => {
+                  const isSelected = selectedModelIds.includes(model.value);
+                  return (
+                    <Button
+                      key={model.value}
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => toggleModelId(model.value)}
+                      className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
+                        isSelected
+                          ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
+                          : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
+                      }`}
+                      title={model.label}
+                    >
+                      {model.label}
+                    </Button>
+                  );
+                })}
+                {modelOptions.length === 0 && !loading && (
+                  <span className="text-sm text-gray-500">No active models are available.</span>
+                )}
+              </div>
+              <div className="text-xs text-gray-500">
+                {loading
+                  ? 'Loading models and domains...'
+                  : modelOptions.length === 0
+                    ? 'No active models are available.'
+                    : selectedModelCount === modelOptions.length
+                      ? 'All visible models selected.'
+                      : `${selectedModelCount} of ${modelOptions.length} visible models selected.`}
+                {singleDomainActive && selectedDomain != null && (
+                  <span className="ml-2">Viewing {selectedDomain.name} only.</span>
+                )}
+              </div>
             </div>
-          </div>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div>
-              <h2 className="text-sm font-semibold text-gray-900">Model set</h2>
-              <p className="text-xs text-gray-600">All visible models are selected by default.</p>
-            </div>
-            <div className="flex items-center gap-2">
-              <Button type="button" variant="secondary" size="sm" onClick={selectAllModels} disabled={loading}>
-                Select all
-              </Button>
-              <Button type="button" variant="secondary" size="sm" onClick={clearModels} disabled={loading}>
-                Clear
-              </Button>
-            </div>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {modelOptions.map((model) => {
-              const isSelected = selectedModelIds.includes(model.value);
-              return (
-                <Button
-                  key={model.value}
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => toggleModelId(model.value)}
-                  className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
-                    isSelected
-                      ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
-                      : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
-                  }`}
-                  title={model.label}
-                >
-                  {model.label}
-                </Button>
-              );
-            })}
-            {modelOptions.length === 0 && !loading && (
-              <span className="text-sm text-gray-500">No active models are available.</span>
-            )}
-          </div>
-          <div className="text-xs text-gray-500">
-            {loading
-              ? 'Loading models and domains...'
-              : modelOptions.length === 0
-                ? 'No active models are available.'
-                : selectedModelCount === modelOptions.length
-                  ? 'All visible models selected.'
-                  : `${selectedModelCount} of ${modelOptions.length} visible models selected.`}
-            {singleDomainActive && selectedDomain != null && (
-              <span className="ml-2">Viewing {selectedDomain.name} only, so stability uses one domain at most.</span>
-            )}
-          </div>
+          </details>
         </div>
       </section>
 
@@ -252,8 +229,6 @@ export function Models() {
         <ModelsMatrix
           models={models}
           selectedModelIds={selectedModelIds}
-          sortBy={sortBy}
-          stabilityVisibility={stabilityVisibility}
           singleDomainActive={singleDomainActive}
           selectedCellKey={selectedCell == null ? null : `${selectedCell.modelId}:${selectedCell.valueKey}`}
           onCellClick={handleCellClick}


### PR DESCRIPTION
## Summary

- Removes the "Sort rows by" dropdown and "Stability visibility" dropdown from the filter bar
- Column headers are now clickable to sort (same pattern as Value Priorities page: first click = desc, click again = toggle direction, ↑/↓ indicator shows active column)
- Column labels use full names — Self-Direction, Universalism, Benevolence, etc. — instead of truncated abbreviations
- Model set chip list is now collapsed behind a `<details>` disclosure widget; it shows the current selection count (e.g. "5 of 8 selected") when closed
- Domain scope dropdown and Model set disclosure sit side-by-side in a flex row, reducing vertical real estate

## Validation

- `npm run lint --workspace @valuerank/web` — 0 errors (79 pre-existing warnings)
- `npm run test --workspace @valuerank/web` — 1232/1232 passed
- `npm run build --workspace @valuerank/web` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)