### PR TITLE
feat(models): show Default — N models selected in model set summary

### DIFF
--- a/cloud/apps/web/src/pages/Models.tsx
+++ b/cloud/apps/web/src/pages/Models.tsx
@@ -104,6 +104,18 @@ export function Models() {
     return selectedModel.values.find((value) => value.valueKey === selectedCell.valueKey) ?? null;
   }, [selectedCell, selectedModel]);
 
+  const defaultSelection = useMemo(() => {
+    const availableIds = models.map((model) => model.modelId);
+    const defaults = availableIds.filter((id) => defaultModelIds.has(id));
+    return defaults.length > 0 ? defaults : availableIds;
+  }, [models, defaultModelIds]);
+
+  const isDefaultSelection = useMemo(() => {
+    if (selectedModelIds.length !== defaultSelection.length) return false;
+    const defaultSet = new Set(defaultSelection);
+    return selectedModelIds.every((id) => defaultSet.has(id));
+  }, [selectedModelIds, defaultSelection]);
+
   const loading = (domainsLoading && domains.length === 0) || (fetching && data == null);
   const selectedModelCount = selectedModelIds.length;
 
@@ -131,9 +143,11 @@ export function Models() {
     ? 'Loading...'
     : modelOptions.length === 0
       ? 'No models available'
-      : selectedModelCount === modelOptions.length
-        ? 'All selected'
-        : `${selectedModelCount} of ${modelOptions.length} selected`;
+      : isDefaultSelection
+        ? `Default — ${selectedModelCount} models selected`
+        : selectedModelCount === modelOptions.length
+          ? 'All selected'
+          : `${selectedModelCount} of ${modelOptions.length} selected`;
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- When the selected models match the configured default set, the Model set disclosure button now reads "Default — 8 models selected" instead of "All selected"
- Computes `defaultSelection` (mirrors initialization logic) and `isDefaultSelection` (set-equality check) as memoized values
- Falls back to existing "All selected" / "N of M selected" strings when the selection diverges from defaults

## Test plan
- [ ] Preflight passed (lint + build)
- [ ] Page loads showing "Default — 8 models selected" in model set summary
- [ ] Toggling a model off changes to "7 of 12 selected"; toggling back shows "Default — 8 models selected" again

🤖 Generated with [Claude Code](https://claude.com/claude-code)