### PR TITLE
fix: stabilize summarize-persistence test against module cache contamination

### DIFF
--- a/cloud/apps/api/src/queue/handlers/__tests__/summarize-persistence.test.ts
+++ b/cloud/apps/api/src/queue/handlers/__tests__/summarize-persistence.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach, beforeAll } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { db as DbType } from '@valuerank/db';
 import type { findMissingProbes as FindMissingProbesType } from '../../../services/run/coverage-completeness.js';
 import type { checkAllSummarized as CheckAllSummarizedType } from '../summarize-persistence.js';
@@ -18,23 +18,29 @@ vi.mock('../../../services/run/coverage-completeness.js', () => ({
 }));
 
 /**
- * Why dynamic imports + vi.resetModules()?
+ * Why dynamic imports + vi.resetModules() in beforeEach?
  *
  * This suite runs in a singleFork process alongside integration tests (e.g.
  * summarize-transcript.test.ts) that load summarize-persistence.ts with real
- * @valuerank/db bindings before this file runs. Without a module cache reset,
- * Vitest may return that cached instance, so vi.mock('@valuerank/db') misses
- * the already-bound db reference inside the module under test.
+ * @valuerank/db bindings. Without a module cache reset, Vitest may return that
+ * cached instance, so vi.mock('@valuerank/db') misses the already-bound db
+ * reference inside the module under test.
  *
  * vi.resetModules() clears the module cache (but NOT the mock factory registry),
  * so the subsequent dynamic imports load fresh instances that bind to our mocks.
+ *
+ * We reset in beforeEach (not beforeAll) because the singleFork worker can
+ * repopulate the module cache between tests when other suites run concurrently.
+ * Moving the reset to beforeEach ensures every test starts with a clean,
+ * properly-mocked module — eliminating the intermittent failures seen when
+ * beforeAll-based resets were skipped on the wrong test execution order.
  */
 
 let checkAllSummarized: typeof CheckAllSummarizedType;
 let mockCount: ReturnType<typeof vi.mocked<typeof DbType.transcript.count>>;
 let mockFindMissingProbes: ReturnType<typeof vi.mocked<typeof FindMissingProbesType>>;
 
-beforeAll(async () => {
+beforeEach(async () => {
   vi.resetModules();
 
   const dbModule = await import('@valuerank/db');
@@ -48,10 +54,6 @@ beforeAll(async () => {
 });
 
 describe('checkAllSummarized', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('returns false when there are unsummarized transcripts', async () => {
     mockCount.mockResolvedValueOnce(2);
     // findMissingProbes should not be called since we short-circuit


### PR DESCRIPTION
## Summary
- Moves `vi.resetModules()` + dynamic imports from `beforeAll` to `beforeEach` in `summarize-persistence.test.ts`
- Removes the now-redundant inner `beforeEach(() => vi.clearAllMocks())` since fresh imports give clean `vi.fn()` instances each time
- Updates the inline comment to explain the `beforeEach` rationale

## Root cause
In `singleFork` Vitest mode this suite shares a worker process with integration tests (e.g. `summarize-transcript.test.ts`). Those files load `summarize-persistence.ts` with real `@valuerank/db` bindings. With `vi.resetModules()` only in `beforeAll`, the module cache could be repopulated with real bindings between individual tests, causing the mock for `findMissingProbes` to miss — `missing` came back `undefined` and `missing.length` threw. The failure was intermittent because it depended on test-file execution order within the worker.

## Test plan
- [x] `npm run test --workspace @valuerank/api "summarize-persistence"` → 5/5 pass
- [x] `npm run lint --workspace @valuerank/api` → 0 errors
- [x] `npm run build --workspace @valuerank/api` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)