### PR TITLE
fix: show — for vignette count on stale pre-v1.2.0 snapshots

### DIFF
--- a/cloud/apps/api/src/graphql/queries/models-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/models-analysis.ts
@@ -49,7 +49,9 @@ function buildEmptyValueResult(valueKey: DomainAnalysisValueKey): ModelsAnalysis
 }
 
 function buildValueResult(valueKey: DomainAnalysisValueKey, domains: DomainContribution[]): ModelsAnalysisValueResultShape {
-  const eligibleDomains = domains.filter((domain) => domain.evidenceWeight > 0);
+  // Null evidenceWeight means the snapshot predates the vignetteCount field (pre-v1.2.0) but the
+  // win rate is still valid — include those domains in the pool. Exclude only genuine zero-evidence entries.
+  const eligibleDomains = domains.filter((domain) => domain.evidenceWeight == null || domain.evidenceWeight > 0);
   return {
     valueKey,
     pooledWinRate: computePooledWinRate(eligibleDomains),
@@ -148,16 +150,19 @@ builder.queryField('modelsAnalysis', (t) =>
                 winRate: precomputedWinRate,
               });
             } else {
-              // Fallback: compute win rate directly from accumulated counts
+              // Fallback: snapshot predates vignetteCount (pre-v1.2.0). Compute win rate from
+              // accumulated counts but do NOT use the raw count total as evidenceWeight — that
+              // number is total scenario outcomes (not vignette count) and would be misleading.
+              // Set evidenceWeight to null so the UI can show "—" until the snapshot rebuilds.
               const counts = model.counts[valueKey] ?? { prioritized: 0, deprioritized: 0, neutral: 0 };
-              const evidenceWeight = counts.prioritized + counts.deprioritized + counts.neutral;
-              if (evidenceWeight <= 0) continue;
+              const rawTotal = counts.prioritized + counts.deprioritized + counts.neutral;
+              if (rawTotal <= 0) continue;
               const winRate = computeDomainWinRate(counts.prioritized, counts.deprioritized, counts.neutral);
               if (winRate == null) continue;
               contributions.push({
                 domainId: domainMatch ?? parsed.domainId,
                 domainName: parsed.domainName,
-                evidenceWeight,
+                evidenceWeight: null,
                 winRate,
               });
             }

--- a/cloud/apps/api/src/graphql/types/models-analysis.ts
+++ b/cloud/apps/api/src/graphql/types/models-analysis.ts
@@ -3,7 +3,8 @@ import { builder } from '../builder.js';
 export type ModelsAnalysisDomainBreakdownShape = {
   domainId: string;
   domainName: string;
-  evidenceWeight: number;
+  /** Vignette count from v1.2.0+ snapshots. Null for older snapshots that predate this field. */
+  evidenceWeight: number | null;
   winRate: number;
 };
 
@@ -42,7 +43,7 @@ builder.objectType(ModelsAnalysisDomainBreakdownRef, {
   fields: (t) => ({
     domainId: t.exposeString('domainId'),
     domainName: t.exposeString('domainName'),
-    evidenceWeight: t.exposeInt('evidenceWeight'),
+    evidenceWeight: t.exposeInt('evidenceWeight', { nullable: true }),
     winRate: t.exposeFloat('winRate'),
   }),
 });

--- a/cloud/apps/web/src/api/operations/modelsAnalysis.ts
+++ b/cloud/apps/web/src/api/operations/modelsAnalysis.ts
@@ -3,7 +3,8 @@ import { gql } from 'urql';
 export type ModelsAnalysisDomainBreakdown = {
   domainId: string;
   domainName: string;
-  evidenceWeight: number;
+  /** Vignette count. Null for snapshots built before v1.2.0 (rebuilds on next domain page load). */
+  evidenceWeight: number | null;
   winRate: number;
 };
 

--- a/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
+++ b/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
@@ -85,7 +85,7 @@ export function ModelValueDetailDrawer({
   const mad = computeSimpleMad(value.domains);
   const stabilityCardText = formatStabilityTooltip(value.stabilityScore, value.eligibleDomainCount, mad, singleDomainActive);
   const domains = [...value.domains].sort((left, right) => {
-    const diff = right.evidenceWeight - left.evidenceWeight;
+    const diff = (right.evidenceWeight ?? 0) - (left.evidenceWeight ?? 0);
     return diff !== 0 ? diff : left.domainName.localeCompare(right.domainName);
   });
 
@@ -115,7 +115,7 @@ export function ModelValueDetailDrawer({
               {domains.map((d) => (
                 <tr key={d.domainId} className="border-b border-gray-100">
                   <td className="py-0.5 pr-3">{d.domainName}</td>
-                  <td className="text-right py-0.5 px-2">{d.evidenceWeight}</td>
+                  <td className="text-right py-0.5 px-2">{d.evidenceWeight ?? '—'}</td>
                   <td className="text-right py-0.5 pl-2">{formatPercent(d.winRate)}</td>
                 </tr>
               ))}
@@ -347,7 +347,7 @@ export function ModelValueDetailDrawer({
                           {formatPercent(domain.winRate)}
                         </td>
                         <td className="border-b border-gray-100 px-4 py-3 font-mono text-gray-900">
-                          {domain.evidenceWeight}
+                          {domain.evidenceWeight ?? '—'}
                         </td>
                       </tr>
                     ))}

--- a/cloud/apps/web/src/components/models/stabilityDots.ts
+++ b/cloud/apps/web/src/components/models/stabilityDots.ts
@@ -1,7 +1,7 @@
 export type DotState = 'full' | 'half' | 'empty' | 'muted';
 
 export type StabilityDomainContribution = {
-  evidenceWeight: number;
+  evidenceWeight: number | null;
   winRate: number;
 };
 

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1321,7 +1321,7 @@ export type ModelsAnalysisDomainBreakdown = {
   __typename?: 'ModelsAnalysisDomainBreakdown';
   domainId: Scalars['String']['output'];
   domainName: Scalars['String']['output'];
-  evidenceWeight: Scalars['Int']['output'];
+  evidenceWeight?: Scalars['Int']['output'] | null;
   winRate: Scalars['Float']['output'];
 };
 
@@ -4329,7 +4329,7 @@ export type ModelsAnalysisQueryVariables = Exact<{
 }>;
 
 
-export type ModelsAnalysisQuery = { __typename?: 'Query', modelsAnalysis: { __typename?: 'ModelsAnalysisResult', models: Array<{ __typename?: 'ModelsAnalysisModelResult', modelId: string, label: string, values: Array<{ __typename?: 'ModelsAnalysisValueResult', valueKey: string, pooledWinRate?: number | null, stabilityScore?: number | null, eligibleDomainCount: number, domains: Array<{ __typename?: 'ModelsAnalysisDomainBreakdown', domainId: string, domainName: string, winRate: number, evidenceWeight: number }> }> }> } };
+export type ModelsAnalysisQuery = { __typename?: 'Query', modelsAnalysis: { __typename?: 'ModelsAnalysisResult', models: Array<{ __typename?: 'ModelsAnalysisModelResult', modelId: string, label: string, values: Array<{ __typename?: 'ModelsAnalysisValueResult', valueKey: string, pooledWinRate?: number | null, stabilityScore?: number | null, eligibleDomainCount: number, domains: Array<{ __typename?: 'ModelsAnalysisDomainBreakdown', domainId: string, domainName: string, winRate: number, evidenceWeight?: number | null }> }> }> } };
 
 export type CreatePairedVignetteMutationVariables = Exact<{
   input: CreatePairedVignetteInput;


### PR DESCRIPTION
## Root cause

The snapshot for Software Approach Choice (and Job Choice) was built before PR #659 deployed. Pre-v1.2.0 snapshots don't have the `vignetteCount` field, so `models-analysis.ts` fell back to using raw accumulated scenario-outcome totals as `evidenceWeight`. With 90 definitions × ~26 scenarios each, that came out to ~2353 — a number the UI then displayed under the "Vignette count" label. The formula itself is correct; the data was stale.

Snapshots auto-rebuild (on next domain analysis page load), so this would have healed itself — but until then the displayed number was ~26× too large and mislabeled.

## Changes

- `evidenceWeight` is now `number | null` in the API type, GraphQL schema, web operation type, and generated types
- Fallback path sets `evidenceWeight: null` instead of the misleading raw count total
- `eligibleDomains` filter updated to treat `null` as eligible (win rate is still valid for old snapshots)
- Sort and display in `ModelValueDetailDrawer` handle `null` → shows "—"

## Immediate action (in parallel)

Visit the Software Approach Choice and Job Choice domain analysis pages to trigger snapshot rebuilds. Once the jobs run (seconds), the models matrix will show the correct vignette counts (~90).

## Test plan
- [x] `npm run build --workspace @valuerank/api` — clean
- [x] `npm run lint --workspace @valuerank/api` — 0 errors
- [x] `npm run build --workspace @valuerank/web` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)