### PR TITLE
fix(analysis): round fractional counts before GraphQL Int serialisation

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -79,13 +79,15 @@ function buildDomainAnalysisResultFromSnapshot(params: {
       const score = params.scoreMethod === 'FULL_BT'
         ? (btScores?.get(valueKey) ?? 0)
         : computeSmoothedLogOddsScore(wins, losses);
+      // Counts may be fractional after run-count normalisation (equal-weight per vignette).
+      // Round to the nearest integer so GraphQL Int serialisation succeeds.
       return {
         valueKey,
         score,
-        prioritized: counts.prioritized,
-        deprioritized: counts.deprioritized,
-        neutral: counts.neutral,
-        totalComparisons: wins + losses,
+        prioritized: Math.round(counts.prioritized),
+        deprioritized: Math.round(counts.deprioritized),
+        neutral: Math.round(counts.neutral),
+        totalComparisons: Math.round(wins + losses),
       };
     });
 


### PR DESCRIPTION
## Summary
- Run-count normalisation (#659) produces fractional values like `10.5` for `prioritized`/`deprioritized`/`neutral` counts when two runs of the same vignette have different batch sizes
- GraphQL's `Int` scalar rejects non-integers (`Number.isInteger(10.5) === false`), throwing during serialisation — masked as "Unexpected error occurred" in production
- Fix: `Math.round()` the four integer fields before building the response; float values are still used for score computation before rounding

## Test plan
- [x] Preflight passed (lint + build)
- [ ] Deploy to prod and confirm domain analysis loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)