### PR TITLE
fix(analysis): expose count fields as Float to preserve fractional values

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/types.ts
@@ -167,10 +167,10 @@ builder.objectType(DomainAnalysisValueScoreRef, {
   fields: (t) => ({
     valueKey: t.exposeString('valueKey'),
     score: t.exposeFloat('score'),
-    prioritized: t.exposeInt('prioritized'),
-    deprioritized: t.exposeInt('deprioritized'),
-    neutral: t.exposeInt('neutral'),
-    totalComparisons: t.exposeInt('totalComparisons'),
+    prioritized: t.exposeFloat('prioritized'),
+    deprioritized: t.exposeFloat('deprioritized'),
+    neutral: t.exposeFloat('neutral'),
+    totalComparisons: t.exposeFloat('totalComparisons'),
   }),
 });
 

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -80,14 +80,15 @@ function buildDomainAnalysisResultFromSnapshot(params: {
         ? (btScores?.get(valueKey) ?? 0)
         : computeSmoothedLogOddsScore(wins, losses);
       // Counts may be fractional after run-count normalisation (equal-weight per vignette).
-      // Round to the nearest integer so GraphQL Int serialisation succeeds.
+      // Fractional values (e.g. 10.5) signal that a vignette was run multiple times with
+      // mixed results — preserve the decimal so the UI can surface that inconsistency.
       return {
         valueKey,
         score,
-        prioritized: Math.round(counts.prioritized),
-        deprioritized: Math.round(counts.deprioritized),
-        neutral: Math.round(counts.neutral),
-        totalComparisons: Math.round(wins + losses),
+        prioritized: counts.prioritized,
+        deprioritized: counts.deprioritized,
+        neutral: counts.neutral,
+        totalComparisons: wins + losses,
       };
     });
 

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -777,11 +777,11 @@ type DomainAnalysisValueDetailResult {
 }
 
 type DomainAnalysisValueScore {
-  deprioritized: Int!
-  neutral: Int!
-  prioritized: Int!
+  deprioritized: Float!
+  neutral: Float!
+  prioritized: Float!
   score: Float!
-  totalComparisons: Int!
+  totalComparisons: Float!
   valueKey: String!
 }
 

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -710,11 +710,11 @@ export type DomainAnalysisValueDetailResult = {
 
 export type DomainAnalysisValueScore = {
   __typename?: 'DomainAnalysisValueScore';
-  deprioritized: Scalars['Int']['output'];
-  neutral: Scalars['Int']['output'];
-  prioritized: Scalars['Int']['output'];
+  deprioritized: Scalars['Float']['output'];
+  neutral: Scalars['Float']['output'];
+  prioritized: Scalars['Float']['output'];
   score: Scalars['Float']['output'];
-  totalComparisons: Scalars['Int']['output'];
+  totalComparisons: Scalars['Float']['output'];
   valueKey: Scalars['String']['output'];
 };
 


### PR DESCRIPTION
## Summary
- Follow-up to #665 — that PR stopped the crash by rounding fractional counts to `Int`; this PR takes the correct approach instead
- Fractional counts (e.g. `10.5`) are meaningful signal: they mean a vignette was run multiple times with different batch sizes, producing inconsistent results. Rounding hides that from the user
- Change `prioritized`, `deprioritized`, `neutral`, `totalComparisons` from `Int` → `Float` in the GraphQL schema so fractions pass through
- Regenerate `schema.graphql` and `generated/graphql.ts` — both `Int` and `Float` map to TypeScript `number`, so no consumer code needed updating
- Win rate % is derived from these fields in the UI and can still be formatted as an integer there — that's a display concern, not a schema concern

## Test plan
- [x] Preflight: API build passes, codegen clean
- [ ] Deploy to prod and confirm domain analysis loads with decimal counts where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)