### PR TITLE
fix(ui): show date and Pacific time on transcript list rows

### DIFF
--- a/cloud/apps/web/src/components/runs/TranscriptRow.tsx
+++ b/cloud/apps/web/src/components/runs/TranscriptRow.tsx
@@ -28,11 +28,18 @@ type TranscriptRowProps = {
 
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
-  return date.toLocaleTimeString('en-US', {
+  const datePart = date.toLocaleDateString('en-US', {
+    month: '2-digit',
+    day: '2-digit',
+    year: 'numeric',
+    timeZone: 'America/Los_Angeles',
+  });
+  const timePart = date.toLocaleTimeString('en-US', {
     hour: '2-digit',
     minute: '2-digit',
-    second: '2-digit',
+    timeZone: 'America/Los_Angeles',
   });
+  return `${datePart} ${timePart} Pacific`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/cloud/apps/web/tests/components/runs/TranscriptList.test.tsx
+++ b/cloud/apps/web/tests/components/runs/TranscriptList.test.tsx
@@ -299,7 +299,7 @@ describe('TranscriptList', () => {
 
     await user.click(screen.getByText('gpt-4'));
 
-    expect(screen.getByText(/\d{2}:\d{2}:\d{2} [AP]M/)).toBeInTheDocument();
+    expect(screen.getByText(/\d{2}\/\d{2}\/\d{4} \d{2}:\d{2} [AP]M Pacific/)).toBeInTheDocument();
   });
 
   it('shows table headers in flat list even without dimensions', () => {


### PR DESCRIPTION
## Summary
- Transcript timestamps now show date + time instead of time only
- Format: `MM/DD/YYYY HH:MM AM/PM Pacific` (e.g. `04/16/2026 02:34 PM Pacific`)
- Times are displayed in America/Los_Angeles timezone

## Test plan
- [ ] Preflight passed (lint + tests + build)
- [ ] Manual smoke test done

🤖 Generated with [Claude Code](https://claude.com/claude-code)