### PR TITLE
fix(ui): show created date+time in TranscriptViewer

### DIFF
--- a/cloud/apps/web/src/components/runs/TranscriptViewer.tsx
+++ b/cloud/apps/web/src/components/runs/TranscriptViewer.tsx
@@ -4,7 +4,7 @@
  * Displays the full content of a transcript in a modal or expanded view.
  */
 
-import { X, User, Bot, Clock, Hash } from 'lucide-react';
+import { X, User, Bot, Clock, Hash, Calendar } from 'lucide-react';
 import type { ChangeEvent } from 'react';
 import { Button } from '../ui/Button';
 import type { Transcript } from '../../api/operations/runs';
@@ -84,6 +84,22 @@ function parseTranscriptContent(content: unknown): TranscriptContent {
     preamble: typeof data.preamble === 'string' ? data.preamble : undefined,
     metadata: data.metadata as Record<string, unknown> | undefined,
   };
+}
+
+function formatCreatedAt(dateString: string): string {
+  const date = new Date(dateString);
+  const datePart = date.toLocaleDateString('en-US', {
+    month: '2-digit',
+    day: '2-digit',
+    year: 'numeric',
+    timeZone: 'America/Los_Angeles',
+  });
+  const timePart = date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'America/Los_Angeles',
+  });
+  return `${datePart} ${timePart} Pacific`;
 }
 
 /**
@@ -176,6 +192,10 @@ export function TranscriptViewer({
           <span className="flex items-center gap-1">
             <Clock className="w-4 h-4" />
             {formatDuration(transcript.durationMs)}
+          </span>
+          <span className="flex items-center gap-1">
+            <Calendar className="w-4 h-4" />
+            {formatCreatedAt(transcript.createdAt)}
           </span>
           {isAuditMode ? (
             <span className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- TranscriptViewer modal now shows the created date+time in the metadata bar
- Format: `MM/DD/YYYY HH:MM AM/PM Pacific` (same as transcript list rows)
- Adds Calendar icon alongside the existing Clock (duration) icon

## Test plan
- [ ] Preflight passed (lint + tests + build)
- [ ] Click a transcript on value-detail page → modal shows created date

🤖 Generated with [Claude Code](https://claude.com/claude-code)