### PR TITLE
refactor(ui): shared formatTranscriptDate utility for all transcript lists

### DIFF
--- a/cloud/apps/web/src/components/runs/TranscriptRow.tsx
+++ b/cloud/apps/web/src/components/runs/TranscriptRow.tsx
@@ -1,6 +1,7 @@
 import { FileText } from 'lucide-react';
 import type { ChangeEvent } from 'react';
 import type { Transcript } from '../../api/operations/runs';
+import { formatTranscriptDate } from '../../lib/format';
 import { formatDisplayLabel } from '../../utils/displayLabels';
 import { getDecisionMetadata } from '../../utils/methodology';
 import {
@@ -26,21 +27,6 @@ type TranscriptRowProps = {
 };
 
 
-function formatDate(dateString: string): string {
-  const date = new Date(dateString);
-  const datePart = date.toLocaleDateString('en-US', {
-    month: '2-digit',
-    day: '2-digit',
-    year: 'numeric',
-    timeZone: 'America/Los_Angeles',
-  });
-  const timePart = date.toLocaleTimeString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-    timeZone: 'America/Los_Angeles',
-  });
-  return `${datePart} ${timePart} Pacific`;
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -348,7 +334,7 @@ export function TranscriptRow({
               </div>
             )}
           </div>
-          <div className="text-xs text-gray-500">{formatDate(transcript.createdAt)}</div>
+          <div className="text-xs text-gray-500">{formatTranscriptDate(transcript.createdAt)}</div>
         </div>
       ) : (
         <div className="flex items-center justify-between gap-4">
@@ -389,7 +375,7 @@ export function TranscriptRow({
               )}
             </span>
             <span className="text-xs" title="Created at">
-              {formatDate(transcript.createdAt)}
+              {formatTranscriptDate(transcript.createdAt)}
             </span>
           </div>
         </div>

--- a/cloud/apps/web/src/components/runs/TranscriptViewer.tsx
+++ b/cloud/apps/web/src/components/runs/TranscriptViewer.tsx
@@ -8,6 +8,7 @@ import { X, User, Bot, Clock, Hash, Calendar } from 'lucide-react';
 import type { ChangeEvent } from 'react';
 import { Button } from '../ui/Button';
 import type { Transcript } from '../../api/operations/runs';
+import { formatTranscriptDate } from '../../lib/format';
 import { getDecisionMetadata } from '../../utils/methodology';
 import {
   formatCanonicalDecisionHeadline,
@@ -86,21 +87,6 @@ function parseTranscriptContent(content: unknown): TranscriptContent {
   };
 }
 
-function formatCreatedAt(dateString: string): string {
-  const date = new Date(dateString);
-  const datePart = date.toLocaleDateString('en-US', {
-    month: '2-digit',
-    day: '2-digit',
-    year: 'numeric',
-    timeZone: 'America/Los_Angeles',
-  });
-  const timePart = date.toLocaleTimeString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-    timeZone: 'America/Los_Angeles',
-  });
-  return `${datePart} ${timePart} Pacific`;
-}
 
 /**
  * Format duration in ms to human readable.
@@ -195,7 +181,7 @@ export function TranscriptViewer({
           </span>
           <span className="flex items-center gap-1">
             <Calendar className="w-4 h-4" />
-            {formatCreatedAt(transcript.createdAt)}
+            {formatTranscriptDate(transcript.createdAt)}
           </span>
           {isAuditMode ? (
             <span className="flex items-center gap-2">

--- a/cloud/apps/web/src/lib/format.ts
+++ b/cloud/apps/web/src/lib/format.ts
@@ -3,6 +3,26 @@
  */
 
 /**
+ * Format a transcript's createdAt timestamp for display in lists and detail views.
+ * Always shows MM/DD/YYYY HH:MM AM/PM Pacific.
+ */
+export function formatTranscriptDate(dateString: string): string {
+  const date = new Date(dateString);
+  const datePart = date.toLocaleDateString('en-US', {
+    month: '2-digit',
+    day: '2-digit',
+    year: 'numeric',
+    timeZone: 'America/Los_Angeles',
+  });
+  const timePart = date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'America/Los_Angeles',
+  });
+  return `${datePart} ${timePart} Pacific`;
+}
+
+/**
  * Format a run's display name.
  * If the run has a custom name, use it.
  * Otherwise, generate an algorithmic name from the definition name and date.


### PR DESCRIPTION
## Summary
- Extracts `formatTranscriptDate` into `lib/format.ts` as a single shared utility
- Removes duplicate local `formatDate`/`formatCreatedAt` functions from `TranscriptRow` and `TranscriptViewer`
- All transcript lists and the transcript detail modal now use the same `MM/DD/YYYY HH:MM AM/PM Pacific` format via one source of truth

## Test plan
- [ ] Preflight passed (lint + tests + build)
- [ ] Transcript list rows and viewer modal show consistent date+time format

🤖 Generated with [Claude Code](https://claude.com/claude-code)