### PR TITLE
test(api): mock DB in summarize-transcript tests to cut CI time

### DIFF
--- a/cloud/apps/api/tests/queue/handlers/summarize-transcript.test.ts
+++ b/cloud/apps/api/tests/queue/handlers/summarize-transcript.test.ts
@@ -1,164 +1,240 @@
 /**
  * Unit tests for summarize-transcript handler
  *
- * Tests summary generation and run completion logic.
+ * Tests the handler's contract with its collaborators: which persistence
+ * call it makes for each input (cache hit, cache miss, success, failure),
+ * what it passes to the Python worker, and how it decides to skip/spawn.
+ *
+ * This file does NOT hit the database. End-to-end state (transcript updates,
+ * run completion side effects, cache record shape) is covered separately in
+ * summarize-persistence.test.ts, which owns the persistence layer.
  */
 
 import crypto from 'crypto';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { db } from '@valuerank/db';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SummaryCache } from '@valuerank/db';
 import { config } from '../../../src/config.js';
 
-// Mock pg-boss types
+// These vi.mock() calls are hoisted above all imports by Vitest's transform,
+// so they register before the handler module (and its transitive imports)
+// are evaluated. Keep mock factories self-contained — they run before the
+// surrounding file body, including the `vi` import.
+vi.mock('@valuerank/db', () => ({
+  db: {
+    transcript: {
+      findUnique: vi.fn(),
+    },
+    scenario: {
+      findUnique: vi.fn(),
+    },
+  },
+  Prisma: { DbNull: null },
+}));
+
+vi.mock('../../../src/queue/spawn.js', () => ({
+  spawnPython: vi.fn(),
+}));
+
+vi.mock('../../../src/queue/handlers/summarize-persistence.js', () => ({
+  persistCachedSummary: vi.fn(async () => undefined),
+  persistSuccessfulSummary: vi.fn(async () => undefined),
+  persistSummarizeFailure: vi.fn(async () => false),
+  isCacheRecordMatch: vi.fn(() => false),
+}));
+
+vi.mock('../../../src/services/infra-models.js', () => ({
+  getSummarizerModel: vi.fn(),
+}));
+
+vi.mock('../../../src/services/summarization-parallelism/index.js', () => ({
+  getMaxParallelSummarizations: vi.fn(async () => 4),
+}));
+
+vi.mock('../../../src/services/rate-limiter/index.js', () => ({
+  schedule: vi.fn(
+    async (
+      _provider: string,
+      _label: string,
+      _runId: string,
+      _modelId: string,
+      _transcriptId: string,
+      fn: () => Promise<unknown>,
+    ) => fn(),
+  ),
+  getLimiterStats: vi.fn(() => ({
+    activeJobs: 0,
+    queuedJobs: 0,
+    maxParallel: 1,
+    requestsPerMinute: 60,
+  })),
+}));
+
+vi.mock('../../../src/graphql/queries/domain/shared.js', () => ({
+  resolveTranscriptDecisionModel: vi.fn(() => ({
+    canonical: {
+      direction: 'unknown',
+      strength: 'unknown',
+      favoredValueKey: null,
+    },
+  })),
+}));
+
+// Static imports resolve to the mocked modules above.
+import { db } from '@valuerank/db';
+import { createSummarizeTranscriptHandler } from '../../../src/queue/handlers/summarize-transcript.js';
+import { spawnPython } from '../../../src/queue/spawn.js';
+import {
+  persistCachedSummary,
+  persistSuccessfulSummary,
+  persistSummarizeFailure,
+  isCacheRecordMatch,
+} from '../../../src/queue/handlers/summarize-persistence.js';
+import { getSummarizerModel } from '../../../src/services/infra-models.js';
+import { resolveTranscriptDecisionModel } from '../../../src/graphql/queries/domain/shared.js';
+
+const mockSpawnPython = vi.mocked(spawnPython);
+const mockFindUnique = vi.mocked(db.transcript.findUnique);
+const mockScenarioFindUnique = vi.mocked(db.scenario.findUnique);
+const mockPersistCached = vi.mocked(persistCachedSummary);
+const mockPersistSuccess = vi.mocked(persistSuccessfulSummary);
+const mockPersistFailure = vi.mocked(persistSummarizeFailure);
+const mockIsCacheRecordMatch = vi.mocked(isCacheRecordMatch);
+const mockGetSummarizerModel = vi.mocked(getSummarizerModel);
+const mockResolveTranscriptDecisionModel = vi.mocked(resolveTranscriptDecisionModel);
+
 type MockJob<T> = {
   id: string;
   data: T;
   retrycount?: number;
 };
 
-// Mock the spawn module
-vi.mock('../../../src/queue/spawn.js', () => ({
-  spawnPython: vi.fn(),
-}));
+type TranscriptShape = {
+  id: string;
+  runId: string;
+  scenarioId: string | null;
+  modelId: string;
+  content: unknown;
+  turnCount: number;
+  tokenCount: number;
+  durationMs: number;
+  decisionCode: string | null;
+  decisionCodeSource: string | null;
+  decisionText: string | null;
+  decisionMetadata: unknown;
+  definitionSnapshot: unknown;
+  summarizedAt: Date | null;
+};
 
-// Import handler after mocking
-import { createSummarizeTranscriptHandler } from '../../../src/queue/handlers/summarize-transcript.js';
-import { spawnPython } from '../../../src/queue/spawn.js';
-
-const mockSpawnPython = vi.mocked(spawnPython);
-
-describe('summarize-transcript handler', () => {
-  const createdIds = {
-    definitions: [] as string[],
-    runs: [] as string[],
-    scenarios: [] as string[],
-    transcripts: [] as string[],
+function makeTranscript(overrides: Partial<TranscriptShape> = {}): TranscriptShape {
+  return {
+    id: 'transcript-1',
+    runId: 'run-1',
+    scenarioId: null,
+    modelId: 'test-model',
+    content: {
+      turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }],
+    },
+    turnCount: 1,
+    tokenCount: 50,
+    durationMs: 1000,
+    decisionCode: null,
+    decisionCodeSource: null,
+    decisionText: null,
+    decisionMetadata: null,
+    definitionSnapshot: null,
+    summarizedAt: null,
+    ...overrides,
   };
+}
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+function computeResponseSha256(content: { turns: Array<{ targetResponse?: string }> }): string {
+  const responseText = content.turns
+    .map((turn) => turn.targetResponse ?? '')
+    .filter((response) => response.length > 0)
+    .join('\n')
+    .trim();
+  return crypto.createHash('sha256').update(responseText, 'utf8').digest('hex');
+}
 
-  afterEach(async () => {
-    // Clean up in order: transcripts -> runs -> definitions
-    if (createdIds.transcripts.length > 0) {
-      await db.transcript.deleteMany({
-        where: { id: { in: createdIds.transcripts } },
-      });
-      createdIds.transcripts = [];
-    }
-    if (createdIds.runs.length > 0) {
-      await db.run.deleteMany({
-        where: { id: { in: createdIds.runs } },
-      });
-      createdIds.runs = [];
-    }
-    if (createdIds.scenarios.length > 0) {
-      await db.scenario.deleteMany({
-        where: { id: { in: createdIds.scenarios } },
-      });
-      createdIds.scenarios = [];
-    }
-    if (createdIds.definitions.length > 0) {
-      await db.definition.deleteMany({
-        where: { id: { in: createdIds.definitions } },
-      });
-      createdIds.definitions = [];
-    }
-  });
-
-  function computeResponseSha256(content: { turns: Array<{ targetResponse?: string }> }): string {
-    const responseText = content.turns
-      .map((turn) => turn.targetResponse ?? '')
-      .filter((response) => response.length > 0)
-      .join('\n')
-      .trim();
-
-    return crypto.createHash('sha256').update(responseText, 'utf8').digest('hex');
-  }
-
-  function buildSuccessfulWorkerSummary(
-    content: { turns: Array<{ targetResponse?: string }> },
-    options?: {
+function buildSuccessfulWorkerSummary(
+  content: { turns: Array<{ targetResponse?: string }> },
+  options?: {
     decisionCode?: string;
     decisionSource?: string;
     decisionText?: string | null;
     decisionMetadata?: Record<string, unknown>;
-      parserVersion?: string;
-    }
-  ) {
-    const responseSha256 = computeResponseSha256(content);
-    return {
-      decisionCode: options?.decisionCode ?? '4',
-      decisionSource: options?.decisionSource ?? 'deterministic',
-      decisionText: options?.decisionText ?? 'AI prioritized safety over efficiency',
-      decisionMetadata: options?.decisionMetadata ?? {
+    parserVersion?: string;
+  },
+) {
+  const responseSha256 = computeResponseSha256(content);
+  return {
+    decisionCode: options?.decisionCode ?? '4',
+    decisionSource: options?.decisionSource ?? 'deterministic',
+    decisionText: options?.decisionText ?? 'AI prioritized safety over efficiency',
+    decisionMetadata: options?.decisionMetadata ?? {
+      matchedText: 'Achievement',
+      matchedLabel: 'Achievement',
+      parseClass: 'exact',
+      parsePath: 'numeric_deterministic',
+      parserVersion: options?.parserVersion ?? config.SUMMARIZE_PARSER_VERSION,
+      responseSha256,
+      responseExcerpt: 'Achievement',
+    },
+  };
+}
+
+function makeValidSummaryCache(content: { turns: Array<{ targetResponse?: string }> }): SummaryCache {
+  return {
+    responseSha256: computeResponseSha256(content),
+    parserVersion: config.SUMMARIZE_PARSER_VERSION,
+    modelId: 'anthropic:test-summary-model',
+    summary: {
+      decisionCode: '4',
+      decisionCodeSource: 'deterministic',
+      decisionText: 'Cached decision',
+      decisionMetadata: {
         matchedText: 'Achievement',
         matchedLabel: 'Achievement',
         parseClass: 'exact',
         parsePath: 'numeric_deterministic',
-        parserVersion: options?.parserVersion ?? config.SUMMARIZE_PARSER_VERSION,
-        responseSha256,
+        parserVersion: config.SUMMARIZE_PARSER_VERSION,
         responseExcerpt: 'Achievement',
       },
-    };
-  }
-
-  async function createTestData(options?: {
-    content?: { turns: Array<{ probePrompt?: string; targetResponse?: string }> };
-    decisionMetadata?: unknown;
-    decisionCode?: string | null;
-    decisionCodeSource?: string | null;
-    decisionText?: string | null;
-    summarizedAt?: Date | null;
-  }) {
-    const content =
-      options?.content ??
-      {
-        turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }],
-      };
-
-    const definition = await db.definition.create({
-      data: {
-        name: 'Test Definition',
-        content: { schema_version: 1, preamble: 'Test' },
+      canonicalDecision: {
+        cacheVersion: 1,
+        decisionState: 'resolved',
+        favoredValueKey: 'Achievement',
+        strength: 'strong',
       },
-    });
-    createdIds.definitions.push(definition.id);
+    },
+  } as SummaryCache;
+}
 
-    const run = await db.run.create({
-      data: {
-        definitionId: definition.id,
-        status: 'SUMMARIZING',
-        config: { models: ['test-model'] },
-        progress: { total: 1, completed: 1, failed: 0 },
+describe('summarize-transcript handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSummarizerModel.mockResolvedValue({
+      modelId: 'test-summary-model',
+      providerId: 'provider-id',
+      providerName: 'anthropic',
+      displayName: 'Test Summary Model',
+      apiConfig: null,
+    });
+    mockIsCacheRecordMatch.mockReturnValue(false);
+    mockPersistFailure.mockResolvedValue(false);
+    mockResolveTranscriptDecisionModel.mockReturnValue({
+      canonical: {
+        direction: 'unknown',
+        strength: 'unknown',
+        favoredValueKey: null,
       },
-    });
-    createdIds.runs.push(run.id);
-
-    const transcript = await db.transcript.create({
-      data: {
-        runId: run.id,
-        modelId: 'test-model',
-        content,
-        turnCount: 1,
-        tokenCount: 50,
-        durationMs: 1000,
-        decisionCode: options?.decisionCode ?? null,
-        decisionCodeSource: options?.decisionCodeSource ?? null,
-        decisionText: options?.decisionText ?? null,
-        decisionMetadata: options?.decisionMetadata ?? undefined,
-        summarizedAt: options?.summarizedAt ?? null,
-      },
-    });
-    createdIds.transcripts.push(transcript.id);
-
-    return { definition, run, transcript, content };
-  }
+    } as ReturnType<typeof resolveTranscriptDecisionModel>);
+  });
 
   describe('successful summarization', () => {
-    it('updates transcript with summary metadata and text', async () => {
-      const { run, transcript } = await createTestData();
+    it('passes worker summary to persistSuccessfulSummary', async () => {
+      const transcript = makeTranscript();
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
@@ -166,6 +242,7 @@ describe('summarize-transcript handler', () => {
           success: true,
           summary: {
             decisionCode: '1',
+            decisionSource: 'deterministic',
             decisionText: 'AI prioritized safety over efficiency',
             decisionMetadata: {
               matchedText: 'Achievement',
@@ -177,102 +254,51 @@ describe('summarize-transcript handler', () => {
             },
           },
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
       const job: MockJob<{ runId: string; transcriptId: string }> = {
         id: 'test-job-id',
-        data: { runId: run.id, transcriptId: transcript.id },
+        data: { runId: transcript.runId, transcriptId: transcript.id },
       };
 
       await handler([job] as Parameters<typeof handler>[0]);
 
-      const updated = await db.transcript.findUnique({
-        where: { id: transcript.id },
-      });
-
-      expect(updated?.decisionText).toBe('AI prioritized safety over efficiency');
-      expect(updated?.summarizedAt).not.toBeNull();
-      expect(updated?.decisionMetadata).toMatchObject({
-        rawDecisionEvidence: {
-          matchedText: 'Achievement',
-          matchedLabel: 'Achievement',
-          parseClass: 'exact',
-          parsePath: 'exact.favor_first.strong',
-          parserVersion: 'parser-1',
-          responseExcerpt: 'Achievement',
-          manualOverride: null,
-        },
+      expect(mockPersistSuccess).toHaveBeenCalledTimes(1);
+      const call = mockPersistSuccess.mock.calls[0];
+      if (!call) throw new Error('expected persistSuccessfulSummary call');
+      const summaryArg = call[6];
+      expect(summaryArg.decisionText).toBe('AI prioritized safety over efficiency');
+      expect(summaryArg.decisionMetadata).toMatchObject({
+        matchedText: 'Achievement',
+        parsePath: 'exact.favor_first.strong',
       });
     });
 
-    it('stores a winner-first cache for a B-first transcript', async () => {
-      const definition = await db.definition.create({
-        data: {
-          name: `Transcript Cache Definition ${Date.now()}`,
-          content: {
-            schema_version: 1,
-            dimensions: [
-              { name: 'Achievement' },
-              { name: 'Benevolence_Dependability' },
-            ],
-          },
+    it('builds a resolved winner-first cache for a paired scenario', async () => {
+      const transcript = makeTranscript({
+        scenarioId: 'scenario-1',
+        definitionSnapshot: {
+          dimensions: [{ name: 'Achievement' }, { name: 'Benevolence_Dependability' }],
+          methodology: { presentation_order: 'B_first' },
         },
       });
-      createdIds.definitions.push(definition.id);
-
-      const run = await db.run.create({
-        data: {
-          definitionId: definition.id,
-          status: 'SUMMARIZING',
-          config: { models: ['test-model'] },
-          progress: { total: 1, completed: 0, failed: 0 },
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
+      mockScenarioFindUnique.mockResolvedValueOnce({ orientationFlipped: true } as never);
+      mockResolveTranscriptDecisionModel.mockReturnValueOnce({
+        canonical: {
+          direction: 'favor_first',
+          strength: 'strong',
+          favoredValueKey: 'Benevolence_Dependability',
         },
-      });
-      createdIds.runs.push(run.id);
-
-      const scenario = await db.scenario.create({
-        data: {
-          definitionId: definition.id,
-          name: 'Transcript Cache Scenario',
-          orientationFlipped: true,
-          content: { dimensions: { stakes: 'high' } },
-        },
-      });
-      createdIds.scenarios.push(scenario.id);
-
-      const transcript = await db.transcript.create({
-        data: {
-          runId: run.id,
-          scenarioId: scenario.id,
-          modelId: 'test-model',
-          content: {
-            turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }],
-          },
-          definitionSnapshot: {
-            dimensions: [
-              { name: 'Achievement' },
-              { name: 'Benevolence_Dependability' },
-            ],
-            methodology: {
-              presentation_order: 'B_first',
-            },
-          },
-          turnCount: 1,
-          tokenCount: 50,
-          durationMs: 1000,
-        },
-      });
-      createdIds.transcripts.push(transcript.id);
+      } as ReturnType<typeof resolveTranscriptDecisionModel>);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
         data: {
           success: true,
           summary: buildSuccessfulWorkerSummary(
-            {
-              turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }],
-            },
+            { turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }] },
             {
               decisionCode: '1',
               decisionText: 'AI strongly preferred the first option',
@@ -287,38 +313,45 @@ describe('summarize-transcript handler', () => {
             },
           ),
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
       const job: MockJob<{ runId: string; transcriptId: string }> = {
         id: 'test-job-id',
-        data: { runId: run.id, transcriptId: transcript.id },
+        data: { runId: transcript.runId, transcriptId: transcript.id },
       };
 
       await handler([job] as Parameters<typeof handler>[0]);
 
-      const updated = await db.transcript.findUnique({
-        where: { id: transcript.id },
+      expect(mockScenarioFindUnique).toHaveBeenCalledWith({
+        where: { id: 'scenario-1' },
+        select: { orientationFlipped: true },
       });
+      expect(mockResolveTranscriptDecisionModel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orientationFlipped: true,
+        }),
+      );
 
-      expect(updated?.decisionMetadata).toMatchObject({
-        summaryCache: {
-          summary: {
-            canonicalDecision: {
-              cacheVersion: 1,
-              decisionState: 'resolved',
-              favoredValueKey: 'Benevolence_Dependability',
-              strength: 'strong',
-            },
-          },
-        },
+      expect(mockPersistSuccess).toHaveBeenCalledTimes(1);
+      const call = mockPersistSuccess.mock.calls[0];
+      if (!call) throw new Error('expected persistSuccessfulSummary call');
+      expect(call[5]).toEqual({
+        cacheVersion: 1,
+        decisionState: 'resolved',
+        favoredValueKey: 'Benevolence_Dependability',
+        strength: 'strong',
       });
     });
 
     it('batches multiple transcripts into one Python spawn', async () => {
-      const first = await createTestData();
-      const second = await createTestData();
+      const first = makeTranscript({ id: 'transcript-1', runId: 'run-a' });
+      const second = makeTranscript({ id: 'transcript-2', runId: 'run-b' });
       const summaryModelId = 'anthropic:test-summary-model';
+
+      mockFindUnique
+        .mockResolvedValueOnce(first as never)
+        .mockResolvedValueOnce(second as never);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
@@ -326,34 +359,36 @@ describe('summarize-transcript handler', () => {
           success: true,
           summaries: [
             {
-              transcriptId: first.transcript.id,
+              transcriptId: first.id,
               batchIndex: 0,
               success: true,
-              summary: buildSuccessfulWorkerSummary(first.content, {
-                decisionCode: '1',
-              }),
+              summary: buildSuccessfulWorkerSummary(
+                first.content as { turns: Array<{ targetResponse?: string }> },
+                { decisionCode: '1' },
+              ),
             },
             {
-              transcriptId: second.transcript.id,
+              transcriptId: second.id,
               batchIndex: 1,
               success: true,
-              summary: buildSuccessfulWorkerSummary(second.content, {
-                decisionCode: '2',
-              }),
+              summary: buildSuccessfulWorkerSummary(
+                second.content as { turns: Array<{ targetResponse?: string }> },
+                { decisionCode: '2' },
+              ),
             },
           ],
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
-      const jobs: Array<MockJob<{ runId: string; transcriptId: string }>> = [
+      const jobs: Array<MockJob<{ runId: string; transcriptId: string; summaryModelId: string }>> = [
         {
           id: 'test-job-id-1',
-          data: { runId: first.run.id, transcriptId: first.transcript.id, summaryModelId },
+          data: { runId: first.runId, transcriptId: first.id, summaryModelId },
         },
         {
           id: 'test-job-id-2',
-          data: { runId: second.run.id, transcriptId: second.transcript.id, summaryModelId },
+          data: { runId: second.runId, transcriptId: second.id, summaryModelId },
         },
       ];
 
@@ -365,25 +400,25 @@ describe('summarize-transcript handler', () => {
         expect.objectContaining({
           transcripts: [
             expect.objectContaining({
-              transcriptId: first.transcript.id,
+              transcriptId: first.id,
               modelId: summaryModelId,
             }),
             expect.objectContaining({
-              transcriptId: second.transcript.id,
+              transcriptId: second.id,
               modelId: summaryModelId,
             }),
           ],
         }),
-        expect.objectContaining({
-          cwd: expect.any(String),
-        }),
+        expect.objectContaining({ cwd: expect.any(String) }),
       );
+      expect(mockPersistSuccess).toHaveBeenCalledTimes(2);
     });
 
-    it('preserves non-object decision metadata without corrupting JSON shape', async () => {
-      const { run, transcript } = await createTestData();
+    it('preserves non-object decision metadata as-is on the handler contract', async () => {
+      const transcript = makeTranscript();
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
 
-      const legacyMetadata = ['legacy', 'metadata'] as unknown as never;
+      const legacyMetadata = ['legacy', 'metadata'] as unknown;
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
@@ -391,29 +426,33 @@ describe('summarize-transcript handler', () => {
           success: true,
           summary: {
             decisionCode: '1',
+            decisionSource: 'deterministic',
             decisionText: 'AI prioritized safety over efficiency',
             decisionMetadata: legacyMetadata,
           },
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
       const job: MockJob<{ runId: string; transcriptId: string }> = {
         id: 'test-job-id',
-        data: { runId: run.id, transcriptId: transcript.id },
+        data: { runId: transcript.runId, transcriptId: transcript.id },
       };
 
       await handler([job] as Parameters<typeof handler>[0]);
 
-      const updated = await db.transcript.findUnique({
-        where: { id: transcript.id },
-      });
-
-      expect(updated?.decisionMetadata).toEqual(legacyMetadata);
+      expect(mockPersistSuccess).toHaveBeenCalledTimes(1);
+      const call = mockPersistSuccess.mock.calls[0];
+      if (!call) throw new Error('expected persistSuccessfulSummary call');
+      expect(call[6].decisionMetadata).toEqual(legacyMetadata);
     });
 
-    it('completes run when all transcripts are summarized', async () => {
-      const { run, transcript } = await createTestData();
+    it('delegates run completion to persistSuccessfulSummary (which owns maybeCompleteRun)', async () => {
+      // Run completion / status transition is tested in summarize-persistence.test.ts.
+      // At the handler layer the contract is simply: call persistSuccessfulSummary
+      // for every successful worker result so the persistence layer can decide.
+      const transcript = makeTranscript();
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
@@ -421,59 +460,48 @@ describe('summarize-transcript handler', () => {
           success: true,
           summary: {
             decisionCode: '2',
+            decisionSource: 'deterministic',
             decisionText: 'AI chose balanced approach',
           },
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
       const job: MockJob<{ runId: string; transcriptId: string }> = {
         id: 'test-job-id',
-        data: { runId: run.id, transcriptId: transcript.id },
+        data: { runId: transcript.runId, transcriptId: transcript.id },
       };
 
       await handler([job] as Parameters<typeof handler>[0]);
 
-      const updatedRun = await db.run.findUnique({
-        where: { id: run.id },
-      });
-
-      expect(updatedRun?.status).toBe('COMPLETED');
-      expect(updatedRun?.completedAt).not.toBeNull();
+      expect(mockPersistSuccess).toHaveBeenCalledTimes(1);
+      expect(mockPersistFailure).not.toHaveBeenCalled();
     });
 
-    it('skips already summarized transcripts', async () => {
-      const { run, transcript } = await createTestData();
-
-      // Mark as already summarized
-      await db.transcript.update({
-        where: { id: transcript.id },
-        data: {
-          decisionCode: '3',
-          decisionText: 'Already done',
-          summarizedAt: new Date(),
-        },
+    it('skips already-summarized transcripts with no cache field', async () => {
+      const transcript = makeTranscript({
+        decisionCode: '3',
+        decisionText: 'Already done',
+        summarizedAt: new Date(),
       });
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
 
       const handler = createSummarizeTranscriptHandler();
       const job: MockJob<{ runId: string; transcriptId: string }> = {
         id: 'test-job-id',
-        data: { runId: run.id, transcriptId: transcript.id },
+        data: { runId: transcript.runId, transcriptId: transcript.id },
       };
 
       await handler([job] as Parameters<typeof handler>[0]);
 
-      // spawn should not be called
       expect(mockSpawnPython).not.toHaveBeenCalled();
+      expect(mockPersistSuccess).not.toHaveBeenCalled();
+      expect(mockPersistCached).not.toHaveBeenCalled();
     });
   });
 
   describe('cache behavior', () => {
     const summaryModelId = 'anthropic:test-summary-model';
-
-    function cloneJson<T>(value: T): T {
-      return JSON.parse(JSON.stringify(value));
-    }
 
     function makeJob(runId: string, transcriptId: string, forceSummarize = false) {
       return {
@@ -487,264 +515,249 @@ describe('summarize-transcript handler', () => {
       };
     }
 
-    async function runWorkerWithSummary(
-      runId: string,
-      transcriptId: string,
-      content: { turns: Array<{ targetResponse?: string }> },
-      summary?: ReturnType<typeof buildSuccessfulWorkerSummary>
-    ) {
-      const handler = createSummarizeTranscriptHandler();
-      mockSpawnPython.mockResolvedValueOnce({
-        success: true,
-        data: {
-          success: true,
-          summary: summary ?? buildSuccessfulWorkerSummary(content),
-        },
-      });
-      await handler([makeJob(runId, transcriptId)] as Parameters<typeof handler>[0]);
-    }
-
-    async function seedCacheFromFreshRun() {
-      const first = await createTestData();
-      const firstSummary = buildSuccessfulWorkerSummary(first.content);
-
-      await runWorkerWithSummary(first.run.id, first.transcript.id, first.content, firstSummary);
-
-      const freshTranscript = await db.transcript.findUnique({
-        where: { id: first.transcript.id },
-      });
-
-      if (!freshTranscript?.decisionMetadata) {
-        throw new Error('Fresh transcript missing decision metadata');
-      }
-
-      mockSpawnPython.mockClear();
-
-      return {
-        first,
-        freshTranscript,
-      };
-    }
-
     it('reuses the cached summary for an unchanged transcript', async () => {
-      const { first, freshTranscript } = await seedCacheFromFreshRun();
+      const content = { turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }] };
+      const summaryCache = makeValidSummaryCache(content);
+      const transcript = makeTranscript({
+        content,
+        decisionMetadata: { summaryCache },
+      });
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
+      mockIsCacheRecordMatch.mockReturnValueOnce(true);
 
-      mockSpawnPython.mockClear();
       const handler = createSummarizeTranscriptHandler();
-      await handler([makeJob(first.run.id, first.transcript.id)] as Parameters<typeof handler>[0]);
+      await handler([makeJob(transcript.runId, transcript.id)] as Parameters<typeof handler>[0]);
 
       expect(mockSpawnPython).not.toHaveBeenCalled();
-
-      const cachedTranscript = await db.transcript.findUnique({
-        where: { id: first.transcript.id },
-      });
-
-      expect(cachedTranscript?.decisionText).toBe(freshTranscript.decisionText);
-      expect(cachedTranscript?.decisionMetadata).toEqual(freshTranscript.decisionMetadata);
-      expect(cachedTranscript?.summarizedAt).not.toBeNull();
+      expect(mockPersistCached).toHaveBeenCalledTimes(1);
+      const call = mockPersistCached.mock.calls[0];
+      if (!call) throw new Error('expected persistCachedSummary call');
+      expect(call[2]).toEqual(summaryCache);
+      expect(call[5]).toBe(summaryModelId);
     });
 
     it('re-runs summarization when transcript content changes', async () => {
-      const { first, freshTranscript } = await seedCacheFromFreshRun();
-      const changedContent = {
-        turns: [{ probePrompt: 'Test prompt', targetResponse: 'Different response' }],
-      };
-
-      await db.transcript.update({
-        where: { id: first.transcript.id },
-        data: { content: changedContent, decisionMetadata: cloneJson(freshTranscript.decisionMetadata) },
+      const oldContent = { turns: [{ probePrompt: 'Test prompt', targetResponse: 'Old response' }] };
+      const summaryCache = makeValidSummaryCache({
+        turns: [{ probePrompt: 'Test prompt', targetResponse: 'Stale cached response' }],
       });
+      const transcript = makeTranscript({
+        content: oldContent,
+        decisionMetadata: { summaryCache },
+        summarizedAt: new Date(),
+      });
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
+      mockIsCacheRecordMatch.mockReturnValueOnce(false);
 
-      const handler = createSummarizeTranscriptHandler();
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
         data: {
           success: true,
-          summary: buildSuccessfulWorkerSummary(changedContent, {
+          summary: buildSuccessfulWorkerSummary(oldContent, {
             decisionCode: '2',
             decisionText: 'AI chose balanced approach',
           }),
         },
-      });
+      } as never);
 
-      await handler([makeJob(first.run.id, first.transcript.id)] as Parameters<typeof handler>[0]);
+      const handler = createSummarizeTranscriptHandler();
+      await handler([makeJob(transcript.runId, transcript.id)] as Parameters<typeof handler>[0]);
 
       expect(mockSpawnPython).toHaveBeenCalledTimes(1);
-
-      const updated = await db.transcript.findUnique({
-        where: { id: first.transcript.id },
-      });
-
-      expect(updated?.decisionText).toBe('AI chose balanced approach');
-      expect(updated?.summarizedAt).not.toBeNull();
+      expect(mockPersistSuccess).toHaveBeenCalledTimes(1);
     });
 
     it('re-runs summarization when parser version changes', async () => {
-      const { first, freshTranscript } = await seedCacheFromFreshRun();
-      const changedMetadata = cloneJson(freshTranscript.decisionMetadata) as any;
-      changedMetadata.summaryCache.parserVersion = 'parser-legacy';
-      await db.transcript.update({
-        where: { id: freshTranscript.id },
-        data: {
-          decisionMetadata: changedMetadata,
-          summarizedAt: new Date(),
-        },
+      const content = { turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }] };
+      const summaryCache = makeValidSummaryCache(content);
+      const transcript = makeTranscript({
+        content,
+        decisionMetadata: { summaryCache },
+        summarizedAt: new Date(),
       });
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
+      // parser-version divergence is reported by isCacheRecordMatch
+      mockIsCacheRecordMatch.mockReturnValueOnce(false);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
         data: {
           success: true,
-          summary: buildSuccessfulWorkerSummary(first.content, {
+          summary: buildSuccessfulWorkerSummary(content, {
             decisionCode: '3',
             decisionText: 'AI chose a middle path',
           }),
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
-      await handler([makeJob(freshTranscript.runId, freshTranscript.id)] as Parameters<typeof handler>[0]);
+      await handler([makeJob(transcript.runId, transcript.id)] as Parameters<typeof handler>[0]);
 
       expect(mockSpawnPython).toHaveBeenCalledTimes(1);
     });
 
     it('re-runs summarization when model changes', async () => {
-      const { first, freshTranscript } = await seedCacheFromFreshRun();
-      const changedMetadata = cloneJson(freshTranscript.decisionMetadata) as any;
-      changedMetadata.summaryCache.modelId = 'anthropic:other-model';
-      await db.transcript.update({
-        where: { id: freshTranscript.id },
-        data: {
-          decisionMetadata: changedMetadata,
-          summarizedAt: new Date(),
-        },
+      const content = { turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }] };
+      const summaryCache = makeValidSummaryCache(content);
+      const transcript = makeTranscript({
+        content,
+        decisionMetadata: { summaryCache },
+        summarizedAt: new Date(),
       });
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
+      mockIsCacheRecordMatch.mockReturnValueOnce(false);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
         data: {
           success: true,
-          summary: buildSuccessfulWorkerSummary(first.content, {
+          summary: buildSuccessfulWorkerSummary(content, {
             decisionCode: '1',
             decisionText: 'AI chose the opposite side',
           }),
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
-      await handler([makeJob(freshTranscript.runId, freshTranscript.id)] as Parameters<typeof handler>[0]);
+      await handler([makeJob(transcript.runId, transcript.id)] as Parameters<typeof handler>[0]);
 
       expect(mockSpawnPython).toHaveBeenCalledTimes(1);
     });
 
     it('re-runs summarization when the cached winner-first version is stale', async () => {
-      const { first, freshTranscript } = await seedCacheFromFreshRun();
-      const changedMetadata = cloneJson(freshTranscript.decisionMetadata) as any;
-      changedMetadata.summaryCache.summary.canonicalDecision.cacheVersion = 0;
-      await db.transcript.update({
-        where: { id: freshTranscript.id },
-        data: {
-          decisionMetadata: changedMetadata,
-          summarizedAt: new Date(),
-        },
+      // cacheVersion: 0 is rejected by isWinnerFirstSummaryCache, so the real
+      // isSummaryCache type guard (not mocked) treats summaryCache as invalid.
+      // The summaryCache FIELD still exists, so the handler falls through to
+      // spawning rather than skipping.
+      const content = { turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }] };
+      const summaryCache = makeValidSummaryCache(content) as SummaryCache & {
+        summary: { canonicalDecision: { cacheVersion: number } };
+      };
+      summaryCache.summary.canonicalDecision.cacheVersion = 0;
+
+      const transcript = makeTranscript({
+        content,
+        decisionMetadata: { summaryCache },
+        summarizedAt: new Date(),
       });
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
         data: {
           success: true,
-          summary: buildSuccessfulWorkerSummary(first.content, {
+          summary: buildSuccessfulWorkerSummary(content, {
             decisionCode: '1',
             decisionText: 'AI chose the opposite side',
           }),
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
-      await handler([makeJob(freshTranscript.runId, freshTranscript.id)] as Parameters<typeof handler>[0]);
+      await handler([makeJob(transcript.runId, transcript.id)] as Parameters<typeof handler>[0]);
 
       expect(mockSpawnPython).toHaveBeenCalledTimes(1);
+      // isCacheRecordMatch should never be consulted — isSummaryCache rejects the payload first.
+      expect(mockIsCacheRecordMatch).not.toHaveBeenCalled();
     });
 
     it('bypasses the cache when forceSummarize is set', async () => {
-      const { first } = await seedCacheFromFreshRun();
+      const content = { turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }] };
+      const summaryCache = makeValidSummaryCache(content);
+      const transcript = makeTranscript({
+        content,
+        decisionMetadata: { summaryCache },
+        summarizedAt: new Date(),
+      });
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
+      // Even though the cache would match, forceSummarize skips the check.
+      mockIsCacheRecordMatch.mockReturnValue(true);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
         data: {
           success: true,
-          summary: buildSuccessfulWorkerSummary(first.content, {
+          summary: buildSuccessfulWorkerSummary(content, {
             decisionCode: '5',
             decisionText: 'AI strongly preferred the first option',
           }),
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
-      await handler([makeJob(first.run.id, first.transcript.id, true)] as Parameters<typeof handler>[0]);
+      await handler([makeJob(transcript.runId, transcript.id, true)] as Parameters<typeof handler>[0]);
 
       expect(mockSpawnPython).toHaveBeenCalledTimes(1);
+      expect(mockPersistCached).not.toHaveBeenCalled();
     });
 
     it.each([
       'missing summary payload',
       'error summary payload',
     ])('falls back to the worker when the cache is malformed (%s)', async (caseName) => {
-      const { first, freshTranscript } = await seedCacheFromFreshRun();
-      const malformedMetadata = cloneJson(freshTranscript.decisionMetadata) as any;
+      const content = { turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }] };
+      const summaryCache = makeValidSummaryCache(content);
+      const malformed = JSON.parse(JSON.stringify(summaryCache)) as Record<string, unknown> & {
+        summary: { decisionCode: string };
+      };
+
       if (caseName === 'missing summary payload') {
-        malformedMetadata.summaryCache = {
-          responseSha256: malformedMetadata.summaryCache.responseSha256,
-          parserVersion: malformedMetadata.summaryCache.parserVersion,
-          modelId: malformedMetadata.summaryCache.modelId,
-        };
+        // Drop the `summary` field entirely — isSummaryCache requires it.
+        delete (malformed as { summary?: unknown }).summary;
       } else {
-        malformedMetadata.summaryCache.summary.decisionCode = 'error';
+        // decisionCode === 'error' is explicitly rejected by isSummaryCacheSummary.
+        malformed.summary.decisionCode = 'error';
       }
 
-      await db.transcript.update({
-        where: { id: freshTranscript.id },
-        data: { decisionMetadata: malformedMetadata, summarizedAt: new Date() },
+      const transcript = makeTranscript({
+        content,
+        decisionMetadata: { summaryCache: malformed },
+        summarizedAt: new Date(),
       });
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
         data: {
           success: true,
-          summary: buildSuccessfulWorkerSummary(first.content, {
+          summary: buildSuccessfulWorkerSummary(content, {
             decisionCode: '4',
             decisionText: 'AI prioritized safety over efficiency',
           }),
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
-      await handler([makeJob(freshTranscript.runId, freshTranscript.id)] as Parameters<typeof handler>[0]);
+      await handler([makeJob(transcript.runId, transcript.id)] as Parameters<typeof handler>[0]);
 
       expect(mockSpawnPython).toHaveBeenCalledTimes(1);
     });
 
     it('falls back to the worker when the cache is missing', async () => {
-      const missing = await createTestData();
+      const content = { turns: [{ probePrompt: 'Test prompt', targetResponse: 'Test response' }] };
+      const transcript = makeTranscript({ content });
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
         data: {
           success: true,
-          summary: buildSuccessfulWorkerSummary(missing.content),
+          summary: buildSuccessfulWorkerSummary(content),
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
-      await handler([makeJob(missing.run.id, missing.transcript.id)] as Parameters<typeof handler>[0]);
+      await handler([makeJob(transcript.runId, transcript.id)] as Parameters<typeof handler>[0]);
 
       expect(mockSpawnPython).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('error handling', () => {
-    it('stores error in transcript for non-retryable errors', async () => {
-      const { run, transcript } = await createTestData();
+    it('forwards non-retryable worker errors to persistSummarizeFailure', async () => {
+      const transcript = makeTranscript();
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
+      mockPersistFailure.mockResolvedValueOnce(false);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
@@ -756,27 +769,32 @@ describe('summarize-transcript handler', () => {
             retryable: false,
           },
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
       const job: MockJob<{ runId: string; transcriptId: string }> = {
         id: 'test-job-id',
-        data: { runId: run.id, transcriptId: transcript.id },
+        data: { runId: transcript.runId, transcriptId: transcript.id },
       };
 
       await handler([job] as Parameters<typeof handler>[0]);
 
-      const updated = await db.transcript.findUnique({
-        where: { id: transcript.id },
+      expect(mockPersistFailure).toHaveBeenCalledTimes(1);
+      const call = mockPersistFailure.mock.calls[0];
+      if (!call) throw new Error('expected persistSummarizeFailure call');
+      expect(call[2]).toMatchObject({
+        code: 'INVALID_MODEL',
+        message: 'Invalid model',
+        retryable: false,
       });
-
-      expect(updated?.decisionText).toContain('Invalid model');
-      expect(updated?.decisionMetadata).toBeNull();
-      expect(updated?.summarizedAt).not.toBeNull();
+      expect(mockPersistSuccess).not.toHaveBeenCalled();
     });
 
-    it('throws for retryable errors', async () => {
-      const { run, transcript } = await createTestData();
+    it('rethrows when persistSummarizeFailure signals a retry for a retryable error', async () => {
+      const transcript = makeTranscript();
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
+      // The real persistence returns true (retry) for retryable errors under the retry limit.
+      mockPersistFailure.mockResolvedValueOnce(true);
 
       mockSpawnPython.mockResolvedValueOnce({
         success: true,
@@ -788,55 +806,60 @@ describe('summarize-transcript handler', () => {
             retryable: true,
           },
         },
-      });
+      } as never);
 
       const handler = createSummarizeTranscriptHandler();
       const job: MockJob<{ runId: string; transcriptId: string }> = {
         id: 'test-job-id',
-        data: { runId: run.id, transcriptId: transcript.id },
+        data: { runId: transcript.runId, transcriptId: transcript.id },
       };
 
       await expect(handler([job] as Parameters<typeof handler>[0])).rejects.toThrow(
-        'RATE_LIMIT: Rate limited'
+        'RATE_LIMIT: Rate limited',
       );
     });
 
     it('handles missing transcript gracefully', async () => {
-      const { run } = await createTestData();
+      mockFindUnique.mockResolvedValueOnce(null);
 
       const handler = createSummarizeTranscriptHandler();
       const job: MockJob<{ runId: string; transcriptId: string }> = {
         id: 'test-job-id',
-        data: { runId: run.id, transcriptId: 'non-existent-id' },
+        data: { runId: 'run-1', transcriptId: 'non-existent-id' },
       };
 
-      // Should not throw - just complete the job
       await handler([job] as Parameters<typeof handler>[0]);
 
       expect(mockSpawnPython).not.toHaveBeenCalled();
+      expect(mockPersistSuccess).not.toHaveBeenCalled();
+      expect(mockPersistFailure).not.toHaveBeenCalled();
     });
 
-    it('stores error after max retries', async () => {
-      const { run, transcript } = await createTestData();
+    it('forwards spawn rejections to persistSummarizeFailure without rethrow when retry is exhausted', async () => {
+      const transcript = makeTranscript();
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
+      // persistSummarizeFailure returns false once max retries are reached.
+      mockPersistFailure.mockResolvedValueOnce(false);
 
       mockSpawnPython.mockRejectedValueOnce(new Error('Network error'));
 
       const handler = createSummarizeTranscriptHandler();
       const job: MockJob<{ runId: string; transcriptId: string }> = {
         id: 'test-job-id',
-        data: { runId: run.id, transcriptId: transcript.id },
-        retrycount: 3, // At retry limit
+        data: { runId: transcript.runId, transcriptId: transcript.id },
+        retrycount: 3,
       };
 
-      // Should not throw - stores error and completes
       await handler([job] as Parameters<typeof handler>[0]);
 
-      const updated = await db.transcript.findUnique({
-        where: { id: transcript.id },
+      expect(mockPersistFailure).toHaveBeenCalledTimes(1);
+      const call = mockPersistFailure.mock.calls[0];
+      if (!call) throw new Error('expected persistSummarizeFailure call');
+      expect(call[2]).toMatchObject({
+        code: 'PYTHON_WORKER_FAILED',
+        message: 'Network error',
+        retryable: true,
       });
-
-      expect(updated?.decisionText).toContain('Network error');
-      expect(updated?.decisionMetadata).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Rewrites `cloud/apps/api/tests/queue/handlers/summarize-transcript.test.ts` to mock `@valuerank/db` and `./summarize-persistence.js` instead of creating real database records.
- File runtime drops from ~35s to ~10ms (263ms with Vitest startup). This was 43% of the API test CI stage — a larger CI win than PR #671.
- Semantic shift: tests now assert the handler's contract with its collaborators (which persistence call it makes, what it passes to the Python worker) rather than end-to-end DB state. End-to-end persistence behavior remains covered by `summarize-persistence.test.ts`.

## Test plan
- [x] `npm run test --workspace @valuerank/api -- tests/queue/handlers/summarize-transcript.test.ts` — 19/19 passing in 263ms
- [x] `npm run lint --workspace @valuerank/api` — clean (only pre-existing unrelated warnings)
- [ ] CI preflight (lint + build + web tests) to run in GitHub Actions

## Notes
- No \`@ts-ignore\`, no \`eslint-disable\`, no \`any\` suppressions.
- Handler source unchanged — only the test file is rewritten.
- Follow-up to PR #671 which shipped two trivial CI wins (removed \`needs: lint-build\`, reduced web shards 5→3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)