### PR TITLE
ci: speed up web tests and drop turbo --force

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-        run: npx turbo build --filter=@valuerank/shared --force
+        run: npx turbo build --filter=@valuerank/shared
 
       - name: Run web tests (shard ${{ matrix.shard }}/${{ matrix.total }})
         working-directory: cloud/apps/web

--- a/cloud/apps/web/tests/components/layout/MobileNav.test.tsx
+++ b/cloud/apps/web/tests/components/layout/MobileNav.test.tsx
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { MobileNav } from '../../../src/components/layout/MobileNav';
 
+const user = userEvent.setup({ delay: null });
+
 async function renderMobileNav(initialRoute: string) {
   const result = render(
     <MemoryRouter initialEntries={[initialRoute]}>
@@ -11,7 +13,7 @@ async function renderMobileNav(initialRoute: string) {
     </MemoryRouter>
   );
 
-  await userEvent.click(screen.getByRole('button', { name: /open navigation menu/i }));
+  await user.click(screen.getByRole('button', { name: /open navigation menu/i }));
   return result;
 }
 

--- a/cloud/apps/web/tests/components/layout/NavTabs.test.tsx
+++ b/cloud/apps/web/tests/components/layout/NavTabs.test.tsx
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { NavTabs } from '../../../src/components/layout/NavTabs';
 
+const user = userEvent.setup({ delay: null });
+
 function renderNavTabs(initialRoute = '/') {
   return render(
     <MemoryRouter initialEntries={[initialRoute]}>
@@ -13,7 +15,7 @@ function renderNavTabs(initialRoute = '/') {
 }
 
 async function openMenu(label: string) {
-  await userEvent.click(screen.getByRole('button', { name: `Toggle ${label} menu` }));
+  await user.click(screen.getByRole('button', { name: `Toggle ${label} menu` }));
 }
 
 describe('NavTabs Component', () => {


### PR DESCRIPTION
## Summary

Two targeted fixes to cut CI wall-clock on the critical path (slowest web shard, currently ~76s):

1. **Remove `--force` from web turbo build** — the flag was a workaround that disabled Turbo's remote cache on every run (~10s/shard cost).
2. **Switch `MobileNav` + `NavTabs` tests to `userEvent.setup({ delay: null })`** — these two files dominated web shard 3 (20.67s + 15.57s on CI). Local timings dropped MobileNav from 7.58s → 4.64s and NavTabs → 2.94s.

Expected wall-clock savings: ~15–20s on slowest web shard.

## Test plan

- [x] `npm run lint --workspace @valuerank/web` passes (0 errors)
- [x] `npx vitest run tests/components/layout` — all 21 tests pass locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)