### PR TITLE
Neighborhood Choice domain + Create Vignettes button

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/ensure-domain-vignette-pair.ts
+++ b/cloud/apps/api/src/graphql/mutations/ensure-domain-vignette-pair.ts
@@ -1,0 +1,299 @@
+import { randomUUID } from 'node:crypto';
+import { db } from '@valuerank/db';
+import { NotFoundError, ValidationError } from '@valuerank/shared';
+import { builder } from '../builder.js';
+import {
+  buildPairedVignetteContent,
+  buildPairedDefinitionName,
+  createPairedScenarios,
+} from './paired-vignette-helpers.js';
+import { getComponentTokens } from '../../utils/auto-pair.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+const VignettePairStatusEnum = builder.enumType('VignettePairStatus', {
+  values: {
+    CREATED: { value: 'CREATED' },
+    UPDATED: { value: 'UPDATED' },
+    SKIPPED: { value: 'SKIPPED' },
+    SKIPPED_HAS_RUNS: { value: 'SKIPPED_HAS_RUNS' },
+  },
+});
+
+type VignettePairStatusValue = 'CREATED' | 'UPDATED' | 'SKIPPED' | 'SKIPPED_HAS_RUNS';
+
+const EnsureDomainVignettePairResultRef = builder.objectRef<{
+  status: VignettePairStatusValue;
+  definitionAId: string | null;
+  definitionBId: string | null;
+}>('EnsureDomainVignettePairResult');
+
+builder.objectType(EnsureDomainVignettePairResultRef, {
+  fields: (t) => ({
+    status: t.field({ type: VignettePairStatusEnum, resolve: (r) => r.status }),
+    definitionAId: t.string({ nullable: true, resolve: (r) => r.definitionAId }),
+    definitionBId: t.string({ nullable: true, resolve: (r) => r.definitionBId }),
+  }),
+});
+
+const EnsureDomainVignettePairInput = builder.inputType('EnsureDomainVignettePairInput', {
+  fields: (t) => ({
+    domainId: t.id({ required: true }),
+    valueFirstId: t.id({ required: true }),
+    valueSecondId: t.id({ required: true }),
+  }),
+});
+
+function buildVignettePairResult(
+  status: VignettePairStatusValue,
+  definitionAId: string | null,
+  definitionBId: string | null,
+) {
+  return { status, definitionAId, definitionBId };
+}
+
+// ---------------------------------------------------------------------------
+// Mutation
+// ---------------------------------------------------------------------------
+
+builder.mutationField('ensureDomainVignettePair', (t) =>
+  t.field({
+    type: EnsureDomainVignettePairResultRef,
+    args: { input: t.arg({ type: EnsureDomainVignettePairInput, required: true }) },
+    resolve: async (_root, { input }, ctx) => {
+      const domainId = String(input.domainId);
+      const valueFirstId = String(input.valueFirstId);
+      const valueSecondId = String(input.valueSecondId);
+
+      if (valueFirstId === valueSecondId) {
+        throw new ValidationError('valueFirstId and valueSecondId must be different');
+      }
+
+      // 1. Load domain config
+      const domain = await db.domain.findUnique({
+        where: { id: domainId },
+        select: {
+          id: true,
+          normalizedName: true,
+          sentencePrefix: true,
+          labelPrefix: true,
+          defaultContextId: true,
+          defaultLevelPresetVersionId: true,
+          defaultPreambleVersionId: true,
+        },
+      });
+      if (domain == null) throw new NotFoundError('Domain', domainId);
+      if (domain.defaultContextId == null) {
+        throw new ValidationError(
+          'Domain has no default context. Set a default context before creating vignettes.',
+        );
+      }
+
+      // 2. Load context, value statements, level preset in parallel
+      const [context, valueFirst, valueSecond, levelPresetVersion] = await Promise.all([
+        db.domainContext.findUnique({ where: { id: domain.defaultContextId } }),
+        db.valueStatement.findUnique({ where: { id: valueFirstId } }),
+        db.valueStatement.findUnique({ where: { id: valueSecondId } }),
+        domain.defaultLevelPresetVersionId != null
+          ? db.levelPresetVersion.findUnique({
+              where: { id: domain.defaultLevelPresetVersionId },
+              select: { l1: true, l2: true, l3: true, l4: true, l5: true },
+            })
+          : Promise.resolve(null),
+      ]);
+
+      if (context == null) throw new NotFoundError('DomainContext', domain.defaultContextId);
+      if (valueFirst == null) throw new NotFoundError('ValueStatement', valueFirstId);
+      if (valueFirst.domainId !== domainId) {
+        throw new ValidationError(`ValueStatement ${valueFirstId} does not belong to domain ${domainId}`);
+      }
+      if (valueSecond == null) throw new NotFoundError('ValueStatement', valueSecondId);
+      if (valueSecond.domainId !== domainId) {
+        throw new ValidationError(`ValueStatement ${valueSecondId} does not belong to domain ${domainId}`);
+      }
+
+      ctx.log.info({ domainId, valueFirstId, valueSecondId }, 'ensureDomainVignettePair');
+
+      const templateConfig = {
+        sentencePrefix: domain.sentencePrefix ?? undefined,
+        labelPrefix: domain.labelPrefix ?? undefined,
+      };
+
+      // Use DB bodies directly - NOT the hardcoded job-choice lookup
+      const vf = { token: valueFirst.token, body: valueFirst.body };
+      const vs = { token: valueSecond.token, body: valueSecond.body };
+
+      // 3. Find existing pair definitions for this domain
+      const allDefs = await db.definition.findMany({
+        where: { domainId, deletedAt: null },
+        select: { id: true, content: true, preambleVersionId: true, levelPresetVersionId: true },
+      });
+
+      let defA: (typeof allDefs)[0] | undefined;
+      let defB: (typeof allDefs)[0] | undefined;
+      for (const def of allDefs) {
+        const tokens = getComponentTokens(def.content);
+        if (tokens == null) continue;
+        if (tokens.value_first.token === vf.token && tokens.value_second.token === vs.token) defA = def;
+        if (tokens.value_first.token === vs.token && tokens.value_second.token === vf.token) defB = def;
+      }
+
+      // 4. Assemble expected pair content
+      const pairKey = randomUUID();
+      const { contentAFirst, contentBFirst, componentsAFirst, componentsBFirst } =
+        buildPairedVignetteContent(
+          pairKey,
+          context.text,
+          context.id,
+          vf,
+          vs,
+          levelPresetVersion,
+          domain.normalizedName,
+          templateConfig,
+        );
+
+      const preambleVersionId = domain.defaultPreambleVersionId ?? null;
+      const levelPresetVersionId = domain.defaultLevelPresetVersionId ?? null;
+
+      // 5a. Neither exists -> create both
+      if (defA == null && defB == null) {
+        const [newDefA, newDefB] = await db.$transaction(async (tx) => {
+          const a = await tx.definition.create({
+            data: {
+              name: buildPairedDefinitionName('', vf.token, vs.token),
+              content: contentAFirst,
+              domainId,
+              domainContextId: context.id,
+              preambleVersionId,
+              levelPresetVersionId,
+              createdByUserId: null,
+            },
+          });
+          const b = await tx.definition.create({
+            data: {
+              name: buildPairedDefinitionName('', vs.token, vf.token),
+              content: contentBFirst,
+              domainId,
+              domainContextId: context.id,
+              preambleVersionId,
+              levelPresetVersionId,
+              createdByUserId: null,
+            },
+          });
+          await createPairedScenarios(tx, {
+            definitionAId: a.id,
+            definitionBId: b.id,
+            contextText: context.text,
+            componentsAFirst,
+            componentsBFirst,
+            valueFirstToken: vf.token,
+            valueSecondToken: vs.token,
+            levelPresetVersion,
+            templateConfig,
+          });
+          return [a, b] as const;
+        });
+        ctx.log.info({ defAId: newDefA.id, defBId: newDefB.id }, 'Created vignette pair');
+        return buildVignettePairResult('CREATED', newDefA.id, newDefB.id);
+      }
+
+      // 5b. Orphan: only one exists -> create the missing companion
+      if (defA == null || defB == null) {
+        const existingDef = (defA ?? defB)!;
+        const missingIsA = defA == null;
+        const newDef = await db.$transaction(async (tx) => {
+          const created = await tx.definition.create({
+            data: {
+              name: missingIsA
+                ? buildPairedDefinitionName('', vf.token, vs.token)
+                : buildPairedDefinitionName('', vs.token, vf.token),
+              content: missingIsA ? contentAFirst : contentBFirst,
+              domainId,
+              domainContextId: context.id,
+              preambleVersionId: existingDef.preambleVersionId ?? preambleVersionId,
+              levelPresetVersionId: existingDef.levelPresetVersionId ?? levelPresetVersionId,
+              createdByUserId: null,
+            },
+          });
+          // Create scenarios for new definition only; leave existing definition's scenarios intact
+          const newDefId = created.id;
+          const existingDefId = existingDef.id;
+          await createPairedScenarios(tx, {
+            definitionAId: missingIsA ? newDefId : existingDefId,
+            definitionBId: missingIsA ? existingDefId : newDefId,
+            contextText: context.text,
+            componentsAFirst,
+            componentsBFirst,
+            valueFirstToken: vf.token,
+            valueSecondToken: vs.token,
+            levelPresetVersion,
+            templateConfig,
+          });
+          return created;
+        });
+        ctx.log.info({ existingId: existingDef.id, newId: newDef.id }, 'Created orphan vignette companion');
+        return buildVignettePairResult(
+          'CREATED',
+          missingIsA ? newDef.id : (defA?.id ?? null),
+          missingIsA ? (defB?.id ?? null) : newDef.id,
+        );
+      }
+
+      // 5c. Both exist -> staleness check (compare assembled template with stored template)
+      const storedContent = defA.content as Record<string, unknown>;
+      const storedTemplate =
+        typeof storedContent?.['template'] === 'string' ? storedContent['template'] : null;
+      const expectedTemplate = (contentAFirst as Record<string, unknown>)['template'] as string;
+
+      if (storedTemplate === expectedTemplate) {
+        return buildVignettePairResult('SKIPPED', defA.id, defB.id);
+      }
+
+      // Stale -> check for run data before updating
+      const [defAScenarios, defBScenarios] = await Promise.all([
+        db.scenario.findMany({ where: { definitionId: defA.id }, select: { id: true } }),
+        db.scenario.findMany({ where: { definitionId: defB.id }, select: { id: true } }),
+      ]);
+      const allScenarioIds = [...defAScenarios.map((s) => s.id), ...defBScenarios.map((s) => s.id)];
+      const transcriptCount =
+        allScenarioIds.length > 0
+          ? await db.transcript.count({ where: { scenarioId: { in: allScenarioIds } } })
+          : 0;
+
+      if (transcriptCount > 0) {
+        return buildVignettePairResult('SKIPPED_HAS_RUNS', defA.id, defB.id);
+      }
+
+      // Safe to update: delete scenarios and recreate, update content
+      await db.$transaction(async (tx) => {
+        const definitionAId = defA.id;
+        const definitionBId = defB.id;
+
+        await tx.scenario.deleteMany({ where: { definitionId: { in: [definitionAId, definitionBId] } } });
+        await tx.definition.update({
+          where: { id: definitionAId },
+          data: { content: contentAFirst },
+        });
+        await tx.definition.update({
+          where: { id: definitionBId },
+          data: { content: contentBFirst },
+        });
+        await createPairedScenarios(tx, {
+          definitionAId,
+          definitionBId,
+          contextText: context.text,
+          componentsAFirst,
+          componentsBFirst,
+          valueFirstToken: vf.token,
+          valueSecondToken: vs.token,
+          levelPresetVersion,
+          templateConfig,
+        });
+      });
+      ctx.log.info({ defAId: defA.id, defBId: defB.id }, 'Updated stale vignette pair');
+      return buildVignettePairResult('UPDATED', defA.id, defB.id);
+    },
+  }),
+);

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -358,6 +358,12 @@ type CostEstimate {
   total: Float!
 }
 
+type CoverageModelBreakdown {
+  label: String!
+  modelId: String!
+  trialCount: Int!
+}
+
 type CoverageModelOption {
   label: String!
   modelId: String!
@@ -723,7 +729,14 @@ type DomainAnalysisModel {
   values: [DomainAnalysisValueScore!]!
 }
 
+type DomainAnalysisRefreshResult {
+  message: String!
+  mode: String!
+  success: Boolean!
+}
+
 type DomainAnalysisResult {
+  cacheStatus: String!
   clusterAnalysis: ClusterAnalysis!
   coveredDefinitions: Int!
   definitionsWithAnalysis: Int!
@@ -968,10 +981,8 @@ type DomainSettings {
   sentencePrefix: String
   contextId: String
   domainId: ID!
-  labelPrefix: String
   levelPresetVersionId: String
   preambleVersionId: String
-  sentencePrefix: String
   valueStatements: [ValueStatementWithVersions!]!
 }
 
@@ -1055,6 +1066,11 @@ type DomainValueCoverageCell {
   batchCount: Int!
   definitionId: String
   definitionName: String
+  incompleteBatchCount: Int!
+  maxTrialCount: Int
+  minTrialCount: Int
+  modelBreakdown: [CoverageModelBreakdown!]
+  pairedBatchCount: Int!
   valueA: String!
   valueB: String!
 }
@@ -1175,12 +1191,6 @@ type ExportResult {
 
   """MIME type for the content"""
   mimeType: String!
-}
-
-type FinalTrialPlan {
-  definitionId: String!
-  models: [ModelPlan!]!
-  totalJobs: Int!
 }
 
 input ForkDefinitionInput {
@@ -1589,6 +1599,7 @@ type Mutation {
     """Tag to remove"""
     tagId: String!
   ): Definition!
+  refreshDomainAnalysis(domainId: ID!, signature: String): DomainAnalysisRefreshResult!
   renameDomain(id: ID!, name: String!): Domain!
 
   "\n      Restart summarization for a run.\n\n      Only works when run is in a terminal state (COMPLETED/FAILED/CANCELLED).\n      By default, only re-queues transcripts without summaries or with errors.\n      With force=true, re-queues all transcripts.\n\n      Requires authentication.\n    "
@@ -2062,6 +2073,31 @@ type ProviderHealthStatus {
   remainingBudgetUsd: Float
 }
 
+type ModelsAnalysisDomainBreakdown {
+  domainId: String!
+  domainName: String!
+  evidenceWeight: Int!
+  winRate: Float!
+}
+
+type ModelsAnalysisModelResult {
+  label: String!
+  modelId: String!
+  values: [ModelsAnalysisValueResult!]!
+}
+
+type ModelsAnalysisResult {
+  models: [ModelsAnalysisModelResult!]!
+}
+
+type ModelsAnalysisValueResult {
+  domains: [ModelsAnalysisDomainBreakdown!]!
+  eligibleDomainCount: Int!
+  pooledWinRate: Float
+  stabilityScore: Float
+  valueKey: String!
+}
+
 type Query {
   """
   Get the average token statistics across all models. Used as fallback when model-specific stats are unavailable.
@@ -2165,6 +2201,7 @@ type Query {
     """Number of results to skip (default: 0)"""
     offset: Int
   ): [AvailableModel!]!
+  modelsAnalysis(domainId: ID): ModelsAnalysisResult!
   debugAssumptionsMismatches(modelId: String!, scenarioId: String!): DebugMismatchResult!
 
   """Fetch a single definition by ID. Returns null if not found."""
@@ -2318,7 +2355,6 @@ type Query {
     samplesPerScenario: Int = 1
   ): CostEstimate!
   estimateDomainEvaluationCost(definitionIds: [ID!], domainId: ID!, modelIds: [String!], samplePercentage: Int, samplesPerScenario: Int, scopeCategory: String, temperature: Float): DomainEvaluationCostEstimate!
-  finalTrialPlan(definitionId: String!, models: [String!]!): FinalTrialPlan!
 
   """
   Get the configured infrastructure model for a specific purpose (e.g., "scenario_expansion")
@@ -2929,11 +2965,6 @@ input StartRunInput {
 
   """Optional experiment to associate this run with"""
   experimentId: ID
-
-  """
-  If true, runs an adaptive sampling strategy to reach 10 samples per condition
-  """
-  finalTrial: Boolean
 
   """Launch mode hint: STANDARD, PAIRED_BATCH, or AD_HOC_BATCH"""
   launchMode: String

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -358,12 +358,6 @@ type CostEstimate {
   total: Float!
 }
 
-type CoverageModelBreakdown {
-  label: String!
-  modelId: String!
-  trialCount: Int!
-}
-
 type CoverageModelOption {
   label: String!
   modelId: String!
@@ -729,14 +723,7 @@ type DomainAnalysisModel {
   values: [DomainAnalysisValueScore!]!
 }
 
-type DomainAnalysisRefreshResult {
-  message: String!
-  mode: String!
-  success: Boolean!
-}
-
 type DomainAnalysisResult {
-  cacheStatus: String!
   clusterAnalysis: ClusterAnalysis!
   coveredDefinitions: Int!
   definitionsWithAnalysis: Int!
@@ -981,8 +968,10 @@ type DomainSettings {
   sentencePrefix: String
   contextId: String
   domainId: ID!
+  labelPrefix: String
   levelPresetVersionId: String
   preambleVersionId: String
+  sentencePrefix: String
   valueStatements: [ValueStatementWithVersions!]!
 }
 
@@ -1066,11 +1055,6 @@ type DomainValueCoverageCell {
   batchCount: Int!
   definitionId: String
   definitionName: String
-  incompleteBatchCount: Int!
-  maxTrialCount: Int
-  minTrialCount: Int
-  modelBreakdown: [CoverageModelBreakdown!]
-  pairedBatchCount: Int!
   valueA: String!
   valueB: String!
 }
@@ -1191,6 +1175,12 @@ type ExportResult {
 
   """MIME type for the content"""
   mimeType: String!
+}
+
+type FinalTrialPlan {
+  definitionId: String!
+  models: [ModelPlan!]!
+  totalJobs: Int!
 }
 
 input ForkDefinitionInput {
@@ -1599,7 +1589,6 @@ type Mutation {
     """Tag to remove"""
     tagId: String!
   ): Definition!
-  refreshDomainAnalysis(domainId: ID!, signature: String): DomainAnalysisRefreshResult!
   renameDomain(id: ID!, name: String!): Domain!
 
   "\n      Restart summarization for a run.\n\n      Only works when run is in a terminal state (COMPLETED/FAILED/CANCELLED).\n      By default, only re-queues transcripts without summaries or with errors.\n      With force=true, re-queues all transcripts.\n\n      Requires authentication.\n    "
@@ -2073,31 +2062,6 @@ type ProviderHealthStatus {
   remainingBudgetUsd: Float
 }
 
-type ModelsAnalysisDomainBreakdown {
-  domainId: String!
-  domainName: String!
-  evidenceWeight: Int!
-  winRate: Float!
-}
-
-type ModelsAnalysisModelResult {
-  label: String!
-  modelId: String!
-  values: [ModelsAnalysisValueResult!]!
-}
-
-type ModelsAnalysisResult {
-  models: [ModelsAnalysisModelResult!]!
-}
-
-type ModelsAnalysisValueResult {
-  domains: [ModelsAnalysisDomainBreakdown!]!
-  eligibleDomainCount: Int!
-  pooledWinRate: Float
-  stabilityScore: Float
-  valueKey: String!
-}
-
 type Query {
   """
   Get the average token statistics across all models. Used as fallback when model-specific stats are unavailable.
@@ -2201,7 +2165,6 @@ type Query {
     """Number of results to skip (default: 0)"""
     offset: Int
   ): [AvailableModel!]!
-  modelsAnalysis(domainId: ID): ModelsAnalysisResult!
   debugAssumptionsMismatches(modelId: String!, scenarioId: String!): DebugMismatchResult!
 
   """Fetch a single definition by ID. Returns null if not found."""
@@ -2355,6 +2318,7 @@ type Query {
     samplesPerScenario: Int = 1
   ): CostEstimate!
   estimateDomainEvaluationCost(definitionIds: [ID!], domainId: ID!, modelIds: [String!], samplePercentage: Int, samplesPerScenario: Int, scopeCategory: String, temperature: Float): DomainEvaluationCostEstimate!
+  finalTrialPlan(definitionId: String!, models: [String!]!): FinalTrialPlan!
 
   """
   Get the configured infrastructure model for a specific purpose (e.g., "scenario_expansion")
@@ -2965,6 +2929,11 @@ input StartRunInput {
 
   """Optional experiment to associate this run with"""
   experimentId: ID
+
+  """
+  If true, runs an adaptive sampling strategy to reach 10 samples per condition
+  """
+  finalTrial: Boolean
 
   """Launch mode hint: STANDARD, PAIRED_BATCH, or AD_HOC_BATCH"""
   launchMode: String

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1426,6 +1426,25 @@ type ModelTokenStats {
   sampleCount: Int!
 }
 
+enum VignettePairStatus {
+  CREATED
+  UPDATED
+  SKIPPED
+  SKIPPED_HAS_RUNS
+}
+
+type EnsureDomainVignettePairResult {
+  status: VignettePairStatus!
+  definitionAId: ID
+  definitionBId: ID
+}
+
+input EnsureDomainVignettePairInput {
+  domainId: ID!
+  valueFirstId: ID!
+  valueSecondId: ID!
+}
+
 type Mutation {
   """Add a tag to a definition. No-op if tag is already assigned."""
   addTagToDefinition(
@@ -1476,6 +1495,7 @@ type Mutation {
   createDefinition(input: CreateDefinitionInput!): Definition!
   createDomain(name: String!): Domain!
   createDomainContext(input: CreateDomainContextInput!): DomainContext!
+  ensureDomainVignettePair(input: EnsureDomainVignettePairInput!): EnsureDomainVignettePairResult!
   createJobChoicePair(input: CreatePairedVignetteInput!): CreatePairedVignetteResult! @deprecated(reason: "Renamed to createPairedVignette")
   createPairedVignette(input: CreatePairedVignetteInput!): CreatePairedVignetteResult!
   createLevelPreset(l1: String!, l2: String!, l3: String!, l4: String!, l5: String!, name: String!): LevelPreset!

--- a/cloud/apps/web/src/api/operations/domains.graphql
+++ b/cloud/apps/web/src/api/operations/domains.graphql
@@ -352,3 +352,11 @@ mutation SetDomainSettings(
     defaultContextId
   }
 }
+
+mutation EnsureDomainVignettePair($input: EnsureDomainVignettePairInput!) {
+  ensureDomainVignettePair(input: $input) {
+    status
+    definitionAId
+    definitionBId
+  }
+}

--- a/cloud/apps/web/src/api/operations/preambles.ts
+++ b/cloud/apps/web/src/api/operations/preambles.ts
@@ -1,0 +1,22 @@
+export const PREAMBLES_QUERY = `
+  query PreamblesForDomainSettings {
+    preambles {
+      id
+      name
+      latestVersion {
+        id
+        version
+      }
+    }
+  }
+`;
+
+export type Preamble = {
+  id: string;
+  name: string;
+  latestVersion: { id: string; version: string } | null;
+};
+
+export type PreamblesQueryData = {
+  preambles: Preamble[];
+};

--- a/cloud/apps/web/src/components/domains/ConfigHistorySection.tsx
+++ b/cloud/apps/web/src/components/domains/ConfigHistorySection.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { Button } from '../ui/Button';
+import type { DomainConfigSnapshotSummary } from '../../api/operations/domains';
+
+function formatSnapshotDate(isoString: string): string {
+  try {
+    const d = new Date(isoString);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  } catch {
+    return isoString;
+  }
+}
+
+type Props = {
+  snapshots: DomainConfigSnapshotSummary[];
+};
+
+export function ConfigHistorySection({ snapshots }: Props) {
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  return (
+    <div className="border-t border-gray-200 pt-4">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="flex items-center gap-1 !px-0 text-sm font-medium text-gray-600 hover:text-teal-700"
+        onClick={() => setHistoryOpen((v) => !v)}
+      >
+        {historyOpen ? (
+          <ChevronDown className="w-4 h-4" />
+        ) : (
+          <ChevronRight className="w-4 h-4" />
+        )}
+        Config history ({snapshots.length})
+      </Button>
+
+      {historyOpen && (
+        <div className="mt-3">
+          {snapshots.length === 0 ? (
+            <p className="text-sm text-gray-500">No history yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {snapshots.map((snap) => (
+                <div
+                  key={snap.id}
+                  className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs space-y-0.5"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-gray-700">
+                      {formatSnapshotDate(snap.createdAt)}
+                    </span>
+                    <span className="text-gray-400">
+                      {snap.valueStatementCount} value stmt{snap.valueStatementCount === 1 ? '' : 's'}
+                    </span>
+                  </div>
+                  <div className="text-gray-500 space-y-0.5">
+                    {snap.preambleLabel != null && (
+                      <div>Preamble: {snap.preambleLabel}</div>
+                    )}
+                    {snap.levelPresetLabel != null && (
+                      <div>Level preset: {snap.levelPresetLabel}</div>
+                    )}
+                    {snap.contextLabel != null && (
+                      <div>Context: {snap.contextLabel}</div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/cloud/apps/web/src/components/domains/CreateVignettesSection.tsx
+++ b/cloud/apps/web/src/components/domains/CreateVignettesSection.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react';
+import { Button } from '../ui/Button';
+import {
+  useEnsureDomainVignettePairMutation,
+  type VignettePairStatus,
+} from '../../generated/graphql';
+
+type ValueStatement = { id: string; token: string };
+
+type Props = {
+  domainId: string;
+  valueStatements: ValueStatement[];
+  hasPendingChanges: boolean;
+};
+
+type ProgressState = {
+  phase: 'idle' | 'running' | 'done' | 'error';
+  current: number;
+  total: number;
+  created: number;
+  updated: number;
+  skipped: number;
+  skippedHasRuns: number;
+  errors: number;
+  fatalError: string | null;
+};
+
+const INITIAL_PROGRESS: ProgressState = {
+  phase: 'idle',
+  current: 0,
+  total: 0,
+  created: 0,
+  updated: 0,
+  skipped: 0,
+  skippedHasRuns: 0,
+  errors: 0,
+  fatalError: null,
+};
+
+export function CreateVignettesSection({
+  domainId,
+  valueStatements,
+  hasPendingChanges,
+}: Props) {
+  const [progress, setProgress] = useState<ProgressState>(INITIAL_PROGRESS);
+  const [, executeMutation] = useEnsureDomainVignettePairMutation();
+
+  const pairs: [ValueStatement, ValueStatement][] = [];
+  for (let i = 0; i < valueStatements.length; i++) {
+    for (let j = i + 1; j < valueStatements.length; j++) {
+      pairs.push([valueStatements[i]!, valueStatements[j]!]);
+    }
+  }
+  const total = pairs.length;
+
+  const handleCreate = async () => {
+    if (hasPendingChanges || progress.phase === 'running') return;
+
+    setProgress({
+      phase: 'running',
+      current: 0,
+      total,
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      skippedHasRuns: 0,
+      errors: 0,
+      fatalError: null,
+    });
+
+    let created = 0;
+    let updated = 0;
+    let skipped = 0;
+    let skippedHasRuns = 0;
+    let errors = 0;
+    let isFirstCall = true;
+
+    for (let i = 0; i < pairs.length; i++) {
+      const pair = pairs[i]!;
+      const result = await executeMutation({
+        input: {
+          domainId,
+          valueFirstId: pair[0].id,
+          valueSecondId: pair[1].id,
+        },
+      });
+
+      if (result.error != null) {
+        if (isFirstCall) {
+          setProgress((prev) => ({
+            ...prev,
+            phase: 'error',
+            fatalError: result.error?.message ?? 'Failed to create vignettes',
+          }));
+          return;
+        }
+        errors += 1;
+      } else {
+        const status: VignettePairStatus | undefined =
+          result.data?.ensureDomainVignettePair?.status;
+
+        if (status === 'CREATED') created += 1;
+        else if (status === 'UPDATED') updated += 1;
+        else if (status === 'SKIPPED_HAS_RUNS') skippedHasRuns += 1;
+        else skipped += 1;
+      }
+
+      isFirstCall = false;
+      const current = i + 1;
+      setProgress((prev) => ({
+        ...prev,
+        current,
+        created,
+        updated,
+        skipped,
+        skippedHasRuns,
+        errors,
+      }));
+    }
+
+    setProgress((prev) => ({ ...prev, phase: 'done' }));
+  };
+
+  const isDisabled = hasPendingChanges || progress.phase === 'running' || total < 2;
+
+  return (
+    <div className="border-t border-gray-200 pt-4 mt-4">
+      <h4 className="text-sm font-medium text-gray-700 mb-2">Vignettes</h4>
+
+      {hasPendingChanges && (
+        <p className="text-xs text-amber-600 mb-2">
+          Save your changes before creating vignettes.
+        </p>
+      )}
+
+      {total < 2 && (
+        <p className="text-xs text-gray-500 mb-2">
+          Add at least 2 value statements to create vignette pairs.
+        </p>
+      )}
+
+      {progress.phase === 'running' && (
+        <p className="text-xs text-gray-600 mb-2">
+          Processing pair {progress.current} of {total}…
+        </p>
+      )}
+
+      {progress.phase === 'done' && (
+        <p className="text-xs text-gray-600 mb-2">
+          Done — Created {progress.created}, Updated {progress.updated}, Skipped{' '}
+          {progress.skipped + progress.skippedHasRuns}
+          {progress.skippedHasRuns > 0 && ` (${progress.skippedHasRuns} skipped — has run data)`}
+          {progress.errors > 0 && `, ${progress.errors} failed`}
+        </p>
+      )}
+
+      {progress.phase === 'error' && progress.fatalError != null && (
+        <p className="text-xs text-red-600 mb-2">Error: {progress.fatalError}</p>
+      )}
+
+      <Button
+        onClick={() => void handleCreate()}
+        disabled={isDisabled}
+        variant="secondary"
+        size="sm"
+      >
+        {progress.phase === 'running' ? 'Creating…' : 'Create Vignettes'}
+      </Button>
+    </div>
+  );
+}

--- a/cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx
+++ b/cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { Button } from '../ui/Button';
 import { ErrorMessage } from '../ui/ErrorMessage';
 import { useDomainSettings } from '../../hooks/useDomainSettings';
+import { CreateVignettesSection } from './CreateVignettesSection';
 import {
   LEVEL_PRESETS_QUERY,
   type LevelPresetsQueryData,
@@ -145,6 +146,14 @@ export function DomainSettingsPanel({ domainId, onSaved }: Props) {
   const sortedStatements = [...(settings?.valueStatements ?? [])].sort((a, b) =>
     a.token.localeCompare(b.token)
   );
+
+  const hasPendingChanges =
+    Object.keys(drafts).length > 0 ||
+    localPreambleVersionId !== (settings?.preambleVersionId ?? null) ||
+    localLevelPresetVersionId !== (settings?.levelPresetVersionId ?? null) ||
+    localContextId !== (settings?.contextId ?? null) ||
+    localSentencePrefix !== (settings?.sentencePrefix ?? '') ||
+    localLabelPrefix !== (settings?.labelPrefix ?? '');
 
   return (
     <div className="space-y-6 mt-6">
@@ -444,6 +453,14 @@ export function DomainSettingsPanel({ domainId, onSaved }: Props) {
           </div>
         )}
       </div>
+
+      {settings != null && (
+        <CreateVignettesSection
+          domainId={domainId}
+          valueStatements={settings.valueStatements}
+          hasPendingChanges={hasPendingChanges}
+        />
+      )}
     </div>
   );
 }

--- a/cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx
+++ b/cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useQuery } from 'urql';
-import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Button } from '../ui/Button';
 import { ErrorMessage } from '../ui/ErrorMessage';
 import { useDomainSettings } from '../../hooks/useDomainSettings';
+import { ConfigHistorySection } from './ConfigHistorySection';
 import { CreateVignettesSection } from './CreateVignettesSection';
 import {
   LEVEL_PRESETS_QUERY,
@@ -12,52 +13,20 @@ import {
 } from '../../api/operations/level-presets';
 import {
   DOMAIN_CONTEXTS_QUERY,
-  type DomainContext,
+  type DomainContextsQueryResult,
 } from '../../api/operations/domain-contexts';
 import type { SetDomainSettingsMutationVariables } from '../../api/operations/domains';
 import { labelFromBody, DEFAULT_SENTENCE_PREFIX } from '@valuerank/shared';
-
-const PREAMBLES_QUERY = `
-  query PreamblesForDomainSettings {
-    preambles {
-      id
-      name
-      latestVersion {
-        id
-        version
-      }
-    }
-  }
-`;
-
-type Preamble = {
-  id: string;
-  name: string;
-  latestVersion: { id: string; version: string } | null;
-};
-
-type PreamblesQueryData = {
-  preambles: Preamble[];
-};
-
-type DomainContextsQueryData = {
-  domainContexts: DomainContext[];
-};
+import {
+  PREAMBLES_QUERY,
+  type Preamble,
+  type PreamblesQueryData,
+} from '../../api/operations/preambles';
 
 type Props = {
   domainId: string;
   onSaved?: () => void;
 };
-
-function formatSnapshotDate(isoString: string): string {
-  try {
-    const d = new Date(isoString);
-    const pad = (n: number) => String(n).padStart(2, '0');
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
-  } catch {
-    return isoString;
-  }
-}
 
 export function DomainSettingsPanel({ domainId, onSaved }: Props) {
   const { settings, snapshots, loading, saving, error, setDomainSettings } =
@@ -71,7 +40,6 @@ export function DomainSettingsPanel({ domainId, onSaved }: Props) {
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [editingToken, setEditingToken] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [historyOpen, setHistoryOpen] = useState(false);
 
   // Sync local state when settings load
   useEffect(() => {
@@ -93,7 +61,7 @@ export function DomainSettingsPanel({ domainId, onSaved }: Props) {
     query: LEVEL_PRESETS_QUERY,
   });
 
-  const [{ data: contextsData }] = useQuery<DomainContextsQueryData>({
+  const [{ data: contextsData }] = useQuery<DomainContextsQueryResult>({
     query: DOMAIN_CONTEXTS_QUERY,
     variables: { domainId },
   });
@@ -400,59 +368,7 @@ export function DomainSettingsPanel({ domainId, onSaved }: Props) {
       </div>
 
       {/* Config history */}
-      <div className="border-t border-gray-200 pt-4">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="flex items-center gap-1 !px-0 text-sm font-medium text-gray-600 hover:text-teal-700"
-          onClick={() => setHistoryOpen((v) => !v)}
-        >
-          {historyOpen ? (
-            <ChevronDown className="w-4 h-4" />
-          ) : (
-            <ChevronRight className="w-4 h-4" />
-          )}
-          Config history ({snapshots.length})
-        </Button>
-
-        {historyOpen && (
-          <div className="mt-3">
-            {snapshots.length === 0 ? (
-              <p className="text-sm text-gray-500">No history yet.</p>
-            ) : (
-              <div className="space-y-2">
-                {snapshots.map((snap) => (
-                  <div
-                    key={snap.id}
-                    className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs space-y-0.5"
-                  >
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-gray-700">
-                        {formatSnapshotDate(snap.createdAt)}
-                      </span>
-                      <span className="text-gray-400">
-                        {snap.valueStatementCount} value stmt{snap.valueStatementCount === 1 ? '' : 's'}
-                      </span>
-                    </div>
-                    <div className="text-gray-500 space-y-0.5">
-                      {snap.preambleLabel != null && (
-                        <div>Preamble: {snap.preambleLabel}</div>
-                      )}
-                      {snap.levelPresetLabel != null && (
-                        <div>Level preset: {snap.levelPresetLabel}</div>
-                      )}
-                      {snap.contextLabel != null && (
-                        <div>Context: {snap.contextLabel}</div>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      <ConfigHistorySection snapshots={snapshots} />
 
       {settings != null && (
         <CreateVignettesSection

--- a/cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx
+++ b/cloud/apps/web/src/components/domains/DomainSettingsPanel.tsx
@@ -19,7 +19,6 @@ import type { SetDomainSettingsMutationVariables } from '../../api/operations/do
 import { labelFromBody, DEFAULT_SENTENCE_PREFIX } from '@valuerank/shared';
 import {
   PREAMBLES_QUERY,
-  type Preamble,
   type PreamblesQueryData,
 } from '../../api/operations/preambles';
 

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -15,8 +15,8 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
-  DateTime: { input: any; output: any; }
-  JSON: { input: any; output: any; }
+  DateTime: { input: string; output: string; }
+  JSON: { input: unknown; output: unknown; }
 };
 
 /** Actual cost summary for a completed run */
@@ -114,10 +114,9 @@ export type AnalysisResult = {
 };
 
 /** Status of an analysis result */
-export enum AnalysisStatus {
-  Current = 'CURRENT',
-  Superseded = 'SUPERSEDED'
-}
+export type AnalysisStatus =
+  | 'CURRENT'
+  | 'SUPERSEDED';
 
 /** Warning about statistical assumptions or data quality */
 export type AnalysisWarning = {
@@ -155,12 +154,11 @@ export type AssumptionsTempZeroResult = {
 };
 
 /** Type of action that was audited */
-export enum AuditAction {
-  Action = 'ACTION',
-  Create = 'CREATE',
-  Delete = 'DELETE',
-  Update = 'UPDATE'
-}
+export type AuditAction =
+  | 'ACTION'
+  | 'CREATE'
+  | 'DELETE'
+  | 'UPDATE';
 
 /** An audit log entry recording a mutation */
 export type AuditLog = {
@@ -1041,6 +1039,19 @@ export type DomainValueCoverageResult = {
   values: Array<Scalars['String']['output']>;
 };
 
+export type EnsureDomainVignettePairInput = {
+  domainId: Scalars['ID']['input'];
+  valueFirstId: Scalars['ID']['input'];
+  valueSecondId: Scalars['ID']['input'];
+};
+
+export type EnsureDomainVignettePairResult = {
+  __typename?: 'EnsureDomainVignettePairResult';
+  definitionAId?: Maybe<Scalars['ID']['output']>;
+  definitionBId?: Maybe<Scalars['ID']['output']>;
+  status: VignettePairStatus;
+};
+
 /** Real-time execution metrics for monitoring parallel processing */
 export type ExecutionMetrics = {
   __typename?: 'ExecutionMetrics';
@@ -1057,18 +1068,17 @@ export type ExecutionMetrics = {
 };
 
 /** Status of a scenario expansion job */
-export enum ExpansionJobStatus {
+export type ExpansionJobStatus =
   /** Job is currently running */
-  Active = 'ACTIVE',
+  | 'ACTIVE'
   /** Job completed successfully */
-  Completed = 'COMPLETED',
+  | 'COMPLETED'
   /** Job failed */
-  Failed = 'FAILED',
+  | 'FAILED'
   /** No expansion job exists */
-  None = 'NONE',
+  | 'NONE'
   /** Job is queued and waiting to run */
-  Pending = 'PENDING'
-}
+  | 'PENDING';
 
 /** Real-time progress during scenario expansion */
 export type ExpansionProgress = {
@@ -1239,10 +1249,9 @@ export type LlmModel = {
 };
 
 /** Lifecycle status of an LLM model */
-export enum LlmModelStatus {
-  Active = 'ACTIVE',
-  Deprecated = 'DEPRECATED'
-}
+export type LlmModelStatus =
+  | 'ACTIVE'
+  | 'DEPRECATED';
 
 /** An LLM API provider with rate limiting and parallelism settings */
 export type LlmProvider = {
@@ -1440,6 +1449,7 @@ export type Mutation = {
   deprecateLlmModel: DeprecateModelResult;
   /** Duplicate a survey into a new survey family at version 1. */
   duplicateSurvey: Experiment;
+  ensureDomainVignettePair: EnsureDomainVignettePairResult;
   /** Export a definition as markdown in devtool-compatible format */
   exportDefinitionAsMd: ExportResult;
   /** Export scenarios as CLI-compatible YAML for use with probe.py */
@@ -1794,6 +1804,11 @@ export type MutationDeprecateLlmModelArgs = {
 export type MutationDuplicateSurveyArgs = {
   id: Scalars['ID']['input'];
   name?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type MutationEnsureDomainVignettePairArgs = {
+  input: EnsureDomainVignettePairInput;
 };
 
 
@@ -3276,11 +3291,10 @@ export type RunConditionGridCell = {
 };
 
 /** Priority level for run execution (affects job queue ordering) */
-export enum RunPriority {
-  High = 'HIGH',
-  Low = 'LOW',
-  Normal = 'NORMAL'
-}
+export type RunPriority =
+  | 'HIGH'
+  | 'LOW'
+  | 'NORMAL';
 
 /** Progress information for a run */
 export type RunProgress = {
@@ -3298,13 +3312,12 @@ export type RunProgress = {
 };
 
 /** Status of a run execution */
-export enum RunStatus {
-  Cancelled = 'CANCELLED',
-  Completed = 'COMPLETED',
-  Failed = 'FAILED',
-  Pending = 'PENDING',
-  Running = 'RUNNING'
-}
+export type RunStatus =
+  | 'CANCELLED'
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'PENDING'
+  | 'RUNNING';
 
 /** A generated scenario from a definition */
 export type Scenario = {
@@ -3424,12 +3437,11 @@ export type TaskResult = {
 };
 
 /** Status of an individual task/job */
-export enum TaskStatus {
-  Completed = 'COMPLETED',
-  Failed = 'FAILED',
-  Pending = 'PENDING',
-  Running = 'RUNNING'
-}
+export type TaskStatus =
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'PENDING'
+  | 'RUNNING';
 
 export type TempZeroDecision = {
   __typename?: 'TempZeroDecision';
@@ -3742,6 +3754,12 @@ export type ValueStatementWithVersions = {
   token: Scalars['String']['output'];
 };
 
+export type VignettePairStatus =
+  | 'CREATED'
+  | 'SKIPPED'
+  | 'SKIPPED_HAS_RUNS'
+  | 'UPDATED';
+
 /** Health status for Python workers */
 export type WorkerHealth = {
   __typename?: 'WorkerHealth';
@@ -3761,33 +3779,33 @@ export type WorkerHealth = {
   warnings: Array<Scalars['String']['output']>;
 };
 
-export type AnalysisResultFieldsFragment = { __typename?: 'AnalysisResult', id: string, runId: string, analysisType: string, status: string, codeVersion: string, inputHash: string, createdAt: any, computedAt?: any | null, durationMs?: number | null, perModel: any, modelAgreement: any, dimensionAnalysis?: any | null, visualizationData?: any | null, varianceAnalysis?: any | null, methodsUsed: any, preferenceSummary?: { __typename?: 'PreferenceSummary', perModel: any } | null, reliabilitySummary?: { __typename?: 'ReliabilitySummary', perModel: any } | null, aggregateMetadata?: { __typename?: 'AggregateMetadata', aggregateEligibility: string, aggregateIneligibilityReason?: string | null, sourceRunCount: number, sourceRunIds: Array<string>, conditionCoverage: any, perModelRepeatCoverage: any, perModelDrift: any } | null, mostContestedScenarios: Array<{ __typename?: 'ContestedScenario', scenarioId: string, scenarioName: string, variance: number, modelScores: any }>, warnings: Array<{ __typename?: 'AnalysisWarning', code: string, message: string, recommendation: string }> };
+export type AnalysisResultFieldsFragment = { __typename?: 'AnalysisResult', id: string, runId: string, analysisType: string, status: string, codeVersion: string, inputHash: string, createdAt: string, computedAt?: string | null, durationMs?: number | null, perModel: unknown, modelAgreement: unknown, dimensionAnalysis?: unknown | null, visualizationData?: unknown | null, varianceAnalysis?: unknown | null, methodsUsed: unknown, preferenceSummary?: { __typename?: 'PreferenceSummary', perModel: unknown } | null, reliabilitySummary?: { __typename?: 'ReliabilitySummary', perModel: unknown } | null, aggregateMetadata?: { __typename?: 'AggregateMetadata', aggregateEligibility: string, aggregateIneligibilityReason?: string | null, sourceRunCount: number, sourceRunIds: Array<string>, conditionCoverage: unknown, perModelRepeatCoverage: unknown, perModelDrift: unknown } | null, mostContestedScenarios: Array<{ __typename?: 'ContestedScenario', scenarioId: string, scenarioName: string, variance: number, modelScores: unknown }>, warnings: Array<{ __typename?: 'AnalysisWarning', code: string, message: string, recommendation: string }> };
 
 export type AnalysisQueryVariables = Exact<{
   runId: Scalars['ID']['input'];
 }>;
 
 
-export type AnalysisQuery = { __typename?: 'Query', analysis?: { __typename?: 'AnalysisResult', id: string, runId: string, analysisType: string, status: string, codeVersion: string, inputHash: string, createdAt: any, computedAt?: any | null, durationMs?: number | null, perModel: any, modelAgreement: any, dimensionAnalysis?: any | null, visualizationData?: any | null, varianceAnalysis?: any | null, methodsUsed: any, preferenceSummary?: { __typename?: 'PreferenceSummary', perModel: any } | null, reliabilitySummary?: { __typename?: 'ReliabilitySummary', perModel: any } | null, aggregateMetadata?: { __typename?: 'AggregateMetadata', aggregateEligibility: string, aggregateIneligibilityReason?: string | null, sourceRunCount: number, sourceRunIds: Array<string>, conditionCoverage: any, perModelRepeatCoverage: any, perModelDrift: any } | null, mostContestedScenarios: Array<{ __typename?: 'ContestedScenario', scenarioId: string, scenarioName: string, variance: number, modelScores: any }>, warnings: Array<{ __typename?: 'AnalysisWarning', code: string, message: string, recommendation: string }> } | null };
+export type AnalysisQuery = { __typename?: 'Query', analysis?: { __typename?: 'AnalysisResult', id: string, runId: string, analysisType: string, status: string, codeVersion: string, inputHash: string, createdAt: string, computedAt?: string | null, durationMs?: number | null, perModel: unknown, modelAgreement: unknown, dimensionAnalysis?: unknown | null, visualizationData?: unknown | null, varianceAnalysis?: unknown | null, methodsUsed: unknown, preferenceSummary?: { __typename?: 'PreferenceSummary', perModel: unknown } | null, reliabilitySummary?: { __typename?: 'ReliabilitySummary', perModel: unknown } | null, aggregateMetadata?: { __typename?: 'AggregateMetadata', aggregateEligibility: string, aggregateIneligibilityReason?: string | null, sourceRunCount: number, sourceRunIds: Array<string>, conditionCoverage: unknown, perModelRepeatCoverage: unknown, perModelDrift: unknown } | null, mostContestedScenarios: Array<{ __typename?: 'ContestedScenario', scenarioId: string, scenarioName: string, variance: number, modelScores: unknown }>, warnings: Array<{ __typename?: 'AnalysisWarning', code: string, message: string, recommendation: string }> } | null };
 
 export type RecomputeAnalysisMutationVariables = Exact<{
   runId: Scalars['ID']['input'];
 }>;
 
 
-export type RecomputeAnalysisMutation = { __typename?: 'Mutation', recomputeAnalysis?: { __typename?: 'AnalysisResult', id: string, runId: string, analysisType: string, status: string, codeVersion: string, inputHash: string, createdAt: any, computedAt?: any | null, durationMs?: number | null, perModel: any, modelAgreement: any, dimensionAnalysis?: any | null, visualizationData?: any | null, varianceAnalysis?: any | null, methodsUsed: any, preferenceSummary?: { __typename?: 'PreferenceSummary', perModel: any } | null, reliabilitySummary?: { __typename?: 'ReliabilitySummary', perModel: any } | null, aggregateMetadata?: { __typename?: 'AggregateMetadata', aggregateEligibility: string, aggregateIneligibilityReason?: string | null, sourceRunCount: number, sourceRunIds: Array<string>, conditionCoverage: any, perModelRepeatCoverage: any, perModelDrift: any } | null, mostContestedScenarios: Array<{ __typename?: 'ContestedScenario', scenarioId: string, scenarioName: string, variance: number, modelScores: any }>, warnings: Array<{ __typename?: 'AnalysisWarning', code: string, message: string, recommendation: string }> } | null };
+export type RecomputeAnalysisMutation = { __typename?: 'Mutation', recomputeAnalysis?: { __typename?: 'AnalysisResult', id: string, runId: string, analysisType: string, status: string, codeVersion: string, inputHash: string, createdAt: string, computedAt?: string | null, durationMs?: number | null, perModel: unknown, modelAgreement: unknown, dimensionAnalysis?: unknown | null, visualizationData?: unknown | null, varianceAnalysis?: unknown | null, methodsUsed: unknown, preferenceSummary?: { __typename?: 'PreferenceSummary', perModel: unknown } | null, reliabilitySummary?: { __typename?: 'ReliabilitySummary', perModel: unknown } | null, aggregateMetadata?: { __typename?: 'AggregateMetadata', aggregateEligibility: string, aggregateIneligibilityReason?: string | null, sourceRunCount: number, sourceRunIds: Array<string>, conditionCoverage: unknown, perModelRepeatCoverage: unknown, perModelDrift: unknown } | null, mostContestedScenarios: Array<{ __typename?: 'ContestedScenario', scenarioId: string, scenarioName: string, variance: number, modelScores: unknown }>, warnings: Array<{ __typename?: 'AnalysisWarning', code: string, message: string, recommendation: string }> } | null };
 
 export type ApiKeysQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ApiKeysQuery = { __typename?: 'Query', apiKeys: Array<{ __typename?: 'ApiKey', id: string, name: string, keyPrefix: string, lastUsedAt?: any | null, expiresAt?: any | null, createdAt: any }> };
+export type ApiKeysQuery = { __typename?: 'Query', apiKeys: Array<{ __typename?: 'ApiKey', id: string, name: string, keyPrefix: string, lastUsedAt?: string | null, expiresAt?: string | null, createdAt: string }> };
 
 export type CreateApiKeyMutationVariables = Exact<{
   input: CreateApiKeyInput;
 }>;
 
 
-export type CreateApiKeyMutation = { __typename?: 'Mutation', createApiKey: { __typename?: 'CreateApiKeyResult', key: string, apiKey: { __typename?: 'ApiKey', id: string, name: string, keyPrefix: string, lastUsedAt?: any | null, expiresAt?: any | null, createdAt: any } } };
+export type CreateApiKeyMutation = { __typename?: 'Mutation', createApiKey: { __typename?: 'CreateApiKeyResult', key: string, apiKey: { __typename?: 'ApiKey', id: string, name: string, keyPrefix: string, lastUsedAt?: string | null, expiresAt?: string | null, createdAt: string } } };
 
 export type RevokeApiKeyMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -3799,18 +3817,18 @@ export type RevokeApiKeyMutation = { __typename?: 'Mutation', revokeApiKey: bool
 export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id: string, email: string, name?: string | null, lastLoginAt?: any | null, createdAt: any } | null };
+export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id: string, email: string, name?: string | null, lastLoginAt?: string | null, createdAt: string } | null };
 
-export type ComparisonRunListFieldsFragment = { __typename?: 'Run', id: string, name?: string | null, definitionId: string, status: string, config: any, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, transcriptCount: number, analysisStatus?: string | null, definition?: { __typename?: 'Definition', id: string, name: string, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null };
+export type ComparisonRunListFieldsFragment = { __typename?: 'Run', id: string, name?: string | null, definitionId: string, status: string, config: unknown, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, transcriptCount: number, analysisStatus?: string | null, definition?: { __typename?: 'Definition', id: string, name: string, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null };
 
-export type ComparisonRunFullFieldsFragment = { __typename?: 'Run', id: string, name?: string | null, definitionId: string, status: string, config: any, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, transcriptCount: number, analysisStatus?: string | null, definition?: { __typename?: 'Definition', id: string, name: string, parentId?: string | null, resolvedContent: any, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null };
+export type ComparisonRunFullFieldsFragment = { __typename?: 'Run', id: string, name?: string | null, definitionId: string, status: string, config: unknown, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, transcriptCount: number, analysisStatus?: string | null, definition?: { __typename?: 'Definition', id: string, name: string, parentId?: string | null, resolvedContent: unknown, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null };
 
 export type RunsWithAnalysisQueryVariables = Exact<{
   ids: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
 }>;
 
 
-export type RunsWithAnalysisQuery = { __typename?: 'Query', runsWithAnalysis: Array<{ __typename?: 'Run', id: string, name?: string | null, definitionId: string, status: string, config: any, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, transcriptCount: number, analysisStatus?: string | null, analysis?: { __typename?: 'AnalysisResult', id: string, runId: string, analysisType: string, status: string, codeVersion: string, inputHash: string, createdAt: any, computedAt?: any | null, durationMs?: number | null, perModel: any, modelAgreement: any, dimensionAnalysis?: any | null, visualizationData?: any | null, varianceAnalysis?: any | null, methodsUsed: any, preferenceSummary?: { __typename?: 'PreferenceSummary', perModel: any } | null, reliabilitySummary?: { __typename?: 'ReliabilitySummary', perModel: any } | null, aggregateMetadata?: { __typename?: 'AggregateMetadata', aggregateEligibility: string, aggregateIneligibilityReason?: string | null, sourceRunCount: number, sourceRunIds: Array<string>, conditionCoverage: any, perModelRepeatCoverage: any, perModelDrift: any } | null, mostContestedScenarios: Array<{ __typename?: 'ContestedScenario', scenarioId: string, scenarioName: string, variance: number, modelScores: any }>, warnings: Array<{ __typename?: 'AnalysisWarning', code: string, message: string, recommendation: string }> } | null, definition?: { __typename?: 'Definition', id: string, name: string, parentId?: string | null, resolvedContent: any, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null }> };
+export type RunsWithAnalysisQuery = { __typename?: 'Query', runsWithAnalysis: Array<{ __typename?: 'Run', id: string, name?: string | null, definitionId: string, status: string, config: unknown, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, transcriptCount: number, analysisStatus?: string | null, analysis?: { __typename?: 'AnalysisResult', id: string, runId: string, analysisType: string, status: string, codeVersion: string, inputHash: string, createdAt: string, computedAt?: string | null, durationMs?: number | null, perModel: unknown, modelAgreement: unknown, dimensionAnalysis?: unknown | null, visualizationData?: unknown | null, varianceAnalysis?: unknown | null, methodsUsed: unknown, preferenceSummary?: { __typename?: 'PreferenceSummary', perModel: unknown } | null, reliabilitySummary?: { __typename?: 'ReliabilitySummary', perModel: unknown } | null, aggregateMetadata?: { __typename?: 'AggregateMetadata', aggregateEligibility: string, aggregateIneligibilityReason?: string | null, sourceRunCount: number, sourceRunIds: Array<string>, conditionCoverage: unknown, perModelRepeatCoverage: unknown, perModelDrift: unknown } | null, mostContestedScenarios: Array<{ __typename?: 'ContestedScenario', scenarioId: string, scenarioName: string, variance: number, modelScores: unknown }>, warnings: Array<{ __typename?: 'AnalysisWarning', code: string, message: string, recommendation: string }> } | null, definition?: { __typename?: 'Definition', id: string, name: string, parentId?: string | null, resolvedContent: unknown, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null }> };
 
 export type ComparisonRunsListQueryVariables = Exact<{
   definitionId?: InputMaybe<Scalars['String']['input']>;
@@ -3820,7 +3838,7 @@ export type ComparisonRunsListQueryVariables = Exact<{
 }>;
 
 
-export type ComparisonRunsListQuery = { __typename?: 'Query', runs: Array<{ __typename?: 'Run', id: string, name?: string | null, definitionId: string, status: string, config: any, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, transcriptCount: number, analysisStatus?: string | null, definition?: { __typename?: 'Definition', id: string, name: string, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null }> };
+export type ComparisonRunsListQuery = { __typename?: 'Query', runs: Array<{ __typename?: 'Run', id: string, name?: string | null, definitionId: string, status: string, config: unknown, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, transcriptCount: number, analysisStatus?: string | null, definition?: { __typename?: 'Definition', id: string, name: string, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null }> };
 
 export type EstimateCostQueryVariables = Exact<{
   definitionId: Scalars['ID']['input'];
@@ -3844,14 +3862,14 @@ export type DefinitionsQueryVariables = Exact<{
 }>;
 
 
-export type DefinitionsQuery = { __typename?: 'Query', definitions: Array<{ __typename?: 'Definition', id: string, name: string, domainId?: string | null, parentId?: string | null, content: any, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, version: number, runCount: number, trialCount: number, domain?: { __typename?: 'Domain', id: string, name: string } | null, trialConfig: { __typename?: 'TrialConfigSummary', definitionVersion?: number | null, temperature?: number | null, signature?: string | null, isConsistent: boolean, message?: string | null, signatureBreakdown: Array<{ __typename?: 'TrialSignatureBreakdown', signature: string, definitionVersion?: number | null, temperature?: number | null, trialCount: number }> }, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, allTags: Array<{ __typename?: 'Tag', id: string, name: string }> }> };
+export type DefinitionsQuery = { __typename?: 'Query', definitions: Array<{ __typename?: 'Definition', id: string, name: string, domainId?: string | null, parentId?: string | null, content: unknown, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, version: number, runCount: number, trialCount: number, domain?: { __typename?: 'Domain', id: string, name: string } | null, trialConfig: { __typename?: 'TrialConfigSummary', definitionVersion?: number | null, temperature?: number | null, signature?: string | null, isConsistent: boolean, message?: string | null, signatureBreakdown: Array<{ __typename?: 'TrialSignatureBreakdown', signature: string, definitionVersion?: number | null, temperature?: number | null, trialCount: number }> }, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, allTags: Array<{ __typename?: 'Tag', id: string, name: string }> }> };
 
 export type DefinitionQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type DefinitionQuery = { __typename?: 'Query', definition?: { __typename?: 'Definition', id: string, name: string, domainId?: string | null, domainContextId?: string | null, parentId?: string | null, content: any, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, version: number, runCount: number, trialCount: number, scenarioCount: number, preambleVersionId?: string | null, levelPresetVersionId?: string | null, isForked: boolean, resolvedContent: any, localContent: any, domain?: { __typename?: 'Domain', id: string, name: string } | null, trialConfig: { __typename?: 'TrialConfigSummary', definitionVersion?: number | null, temperature?: number | null, signature?: string | null, isConsistent: boolean, message?: string | null, signatureBreakdown: Array<{ __typename?: 'TrialSignatureBreakdown', signature: string, definitionVersion?: number | null, temperature?: number | null, trialCount: number }> }, preambleVersion?: { __typename?: 'PreambleVersion', id: string, version: string, content: string, preamble?: { __typename?: 'Preamble', name: string } | null } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string, createdAt: any }>, parent?: { __typename?: 'Definition', id: string, name: string } | null, children: Array<{ __typename?: 'Definition', id: string, name: string, createdAt: any }>, overrides: { __typename?: 'DefinitionOverrides', template: boolean, dimensions: boolean, matchingRules: boolean }, inheritedTags: Array<{ __typename?: 'Tag', id: string, name: string, createdAt: any }>, allTags: Array<{ __typename?: 'Tag', id: string, name: string, createdAt: any }>, expansionStatus: { __typename?: 'ExpansionStatus', status: ExpansionJobStatus, jobId?: string | null, triggeredBy?: string | null, createdAt?: any | null, completedAt?: any | null, error?: string | null, scenarioCount: number, progress?: { __typename?: 'ExpansionProgress', phase: string, expectedScenarios: number, generatedScenarios: number, inputTokens: number, outputTokens: number, message: string, updatedAt: string } | null } } | null };
+export type DefinitionQuery = { __typename?: 'Query', definition?: { __typename?: 'Definition', id: string, name: string, domainId?: string | null, domainContextId?: string | null, parentId?: string | null, content: unknown, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, version: number, runCount: number, trialCount: number, scenarioCount: number, preambleVersionId?: string | null, levelPresetVersionId?: string | null, isForked: boolean, resolvedContent: unknown, localContent: unknown, domain?: { __typename?: 'Domain', id: string, name: string } | null, trialConfig: { __typename?: 'TrialConfigSummary', definitionVersion?: number | null, temperature?: number | null, signature?: string | null, isConsistent: boolean, message?: string | null, signatureBreakdown: Array<{ __typename?: 'TrialSignatureBreakdown', signature: string, definitionVersion?: number | null, temperature?: number | null, trialCount: number }> }, preambleVersion?: { __typename?: 'PreambleVersion', id: string, version: string, content: string, preamble?: { __typename?: 'Preamble', name: string } | null } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string, createdAt: string }>, parent?: { __typename?: 'Definition', id: string, name: string } | null, children: Array<{ __typename?: 'Definition', id: string, name: string, createdAt: string }>, overrides: { __typename?: 'DefinitionOverrides', template: boolean, dimensions: boolean, matchingRules: boolean }, inheritedTags: Array<{ __typename?: 'Tag', id: string, name: string, createdAt: string }>, allTags: Array<{ __typename?: 'Tag', id: string, name: string, createdAt: string }>, expansionStatus: { __typename?: 'ExpansionStatus', status: ExpansionJobStatus, jobId?: string | null, triggeredBy?: string | null, createdAt?: string | null, completedAt?: string | null, error?: string | null, scenarioCount: number, progress?: { __typename?: 'ExpansionProgress', phase: string, expectedScenarios: number, generatedScenarios: number, inputTokens: number, outputTokens: number, message: string, updatedAt: string } | null } } | null };
 
 export type DefinitionAncestorsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -3859,7 +3877,7 @@ export type DefinitionAncestorsQueryVariables = Exact<{
 }>;
 
 
-export type DefinitionAncestorsQuery = { __typename?: 'Query', definitionAncestors: Array<{ __typename?: 'Definition', id: string, name: string, parentId?: string | null, createdAt: any }> };
+export type DefinitionAncestorsQuery = { __typename?: 'Query', definitionAncestors: Array<{ __typename?: 'Definition', id: string, name: string, parentId?: string | null, createdAt: string }> };
 
 export type DefinitionDescendantsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -3867,7 +3885,7 @@ export type DefinitionDescendantsQueryVariables = Exact<{
 }>;
 
 
-export type DefinitionDescendantsQuery = { __typename?: 'Query', definitionDescendants: Array<{ __typename?: 'Definition', id: string, name: string, parentId?: string | null, createdAt: any }> };
+export type DefinitionDescendantsQuery = { __typename?: 'Query', definitionDescendants: Array<{ __typename?: 'Definition', id: string, name: string, parentId?: string | null, createdAt: string }> };
 
 export type DefinitionCountQueryVariables = Exact<{
   rootOnly?: InputMaybe<Scalars['Boolean']['input']>;
@@ -3886,7 +3904,7 @@ export type CreateDefinitionMutationVariables = Exact<{
 }>;
 
 
-export type CreateDefinitionMutation = { __typename?: 'Mutation', createDefinition: { __typename?: 'Definition', id: string, name: string, parentId?: string | null, content: any, createdAt: any, updatedAt: any } };
+export type CreateDefinitionMutation = { __typename?: 'Mutation', createDefinition: { __typename?: 'Definition', id: string, name: string, parentId?: string | null, content: unknown, createdAt: string, updatedAt: string } };
 
 export type UpdateDefinitionMutationVariables = Exact<{
   id: Scalars['String']['input'];
@@ -3894,21 +3912,21 @@ export type UpdateDefinitionMutationVariables = Exact<{
 }>;
 
 
-export type UpdateDefinitionMutation = { __typename?: 'Mutation', updateDefinition: { __typename?: 'Definition', id: string, name: string, content: any, updatedAt: any } };
+export type UpdateDefinitionMutation = { __typename?: 'Mutation', updateDefinition: { __typename?: 'Definition', id: string, name: string, content: unknown, updatedAt: string } };
 
 export type ForkDefinitionMutationVariables = Exact<{
   input: ForkDefinitionInput;
 }>;
 
 
-export type ForkDefinitionMutation = { __typename?: 'Mutation', forkDefinition: { __typename?: 'Definition', id: string, name: string, parentId?: string | null, content: any, createdAt: any, isForked: boolean, resolvedContent: any, localContent: any, overrides: { __typename?: 'DefinitionOverrides', template: boolean, dimensions: boolean, matchingRules: boolean } } };
+export type ForkDefinitionMutation = { __typename?: 'Mutation', forkDefinition: { __typename?: 'Definition', id: string, name: string, parentId?: string | null, content: unknown, createdAt: string, isForked: boolean, resolvedContent: unknown, localContent: unknown, overrides: { __typename?: 'DefinitionOverrides', template: boolean, dimensions: boolean, matchingRules: boolean } } };
 
 export type UnforkDefinitionMutationVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
 
-export type UnforkDefinitionMutation = { __typename?: 'Mutation', unforkDefinition: { __typename?: 'Definition', id: string, name: string, parentId?: string | null, content: any, updatedAt: any, version: number, isForked: boolean, resolvedContent: any, localContent: any, overrides: { __typename?: 'DefinitionOverrides', template: boolean, dimensions: boolean, matchingRules: boolean } } };
+export type UnforkDefinitionMutation = { __typename?: 'Mutation', unforkDefinition: { __typename?: 'Definition', id: string, name: string, parentId?: string | null, content: unknown, updatedAt: string, version: number, isForked: boolean, resolvedContent: unknown, localContent: unknown, overrides: { __typename?: 'DefinitionOverrides', template: boolean, dimensions: boolean, matchingRules: boolean } } };
 
 export type DeleteDefinitionMutationVariables = Exact<{
   id: Scalars['String']['input'];
@@ -3936,14 +3954,14 @@ export type DomainContextsQueryVariables = Exact<{
 }>;
 
 
-export type DomainContextsQuery = { __typename?: 'Query', domainContexts: Array<{ __typename?: 'DomainContext', id: string, domainId: string, text: string, version: number, updatedAt: any, domain?: { __typename?: 'Domain', id: string, name: string } | null }> };
+export type DomainContextsQuery = { __typename?: 'Query', domainContexts: Array<{ __typename?: 'DomainContext', id: string, domainId: string, text: string, version: number, updatedAt: string, domain?: { __typename?: 'Domain', id: string, name: string } | null }> };
 
 export type CreateDomainContextMutationVariables = Exact<{
   input: CreateDomainContextInput;
 }>;
 
 
-export type CreateDomainContextMutation = { __typename?: 'Mutation', createDomainContext: { __typename?: 'DomainContext', id: string, domainId: string, text: string, version: number, updatedAt: any } };
+export type CreateDomainContextMutation = { __typename?: 'Mutation', createDomainContext: { __typename?: 'DomainContext', id: string, domainId: string, text: string, version: number, updatedAt: string } };
 
 export type UpdateDomainContextMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -3951,7 +3969,7 @@ export type UpdateDomainContextMutationVariables = Exact<{
 }>;
 
 
-export type UpdateDomainContextMutation = { __typename?: 'Mutation', updateDomainContext: { __typename?: 'DomainContext', id: string, domainId: string, text: string, version: number, updatedAt: any } };
+export type UpdateDomainContextMutation = { __typename?: 'Mutation', updateDomainContext: { __typename?: 'DomainContext', id: string, domainId: string, text: string, version: number, updatedAt: string } };
 
 export type DeleteDomainContextMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -3967,7 +3985,7 @@ export type DomainAnalysisQueryVariables = Exact<{
 }>;
 
 
-export type DomainAnalysisQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, definitionsWithAnalysis: number, cacheStatus: string, generatedAt: any, missingDefinitions: Array<{ __typename?: 'DomainAnalysisMissingDefinition', definitionId: string, definitionName: string, reasonCode: string, reasonLabel: string, missingAllModels: boolean, missingModelIds: Array<string>, missingModelLabels: Array<string> }>, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number }>, rankingShape: { __typename?: 'RankingShape', topStructure: string, bottomStructure: string, topGap: number, bottomGap: number, spread: number, steepness: number, dominanceZScore?: number | null } }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }>, rankingShapeBenchmarks: { __typename?: 'RankingShapeBenchmarks', domainMeanTopGap: number, domainStdTopGap?: number | null, medianSpread: number }, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: any, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: any, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } } };
+export type DomainAnalysisQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, definitionsWithAnalysis: number, cacheStatus: string, generatedAt: string, missingDefinitions: Array<{ __typename?: 'DomainAnalysisMissingDefinition', definitionId: string, definitionName: string, reasonCode: string, reasonLabel: string, missingAllModels: boolean, missingModelIds: Array<string>, missingModelLabels: Array<string> }>, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number }>, rankingShape: { __typename?: 'RankingShape', topStructure: string, bottomStructure: string, topGap: number, bottomGap: number, spread: number, steepness: number, dominanceZScore?: number | null } }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }>, rankingShapeBenchmarks: { __typename?: 'RankingShapeBenchmarks', domainMeanTopGap: number, domainStdTopGap?: number | null, medianSpread: number }, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } } };
 
 export type RefreshDomainAnalysisMutationVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -3982,7 +4000,7 @@ export type DomainAnalysisLegacyQueryVariables = Exact<{
 }>;
 
 
-export type DomainAnalysisLegacyQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, definitionsWithAnalysis: number, generatedAt: any, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number }> }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }> } };
+export type DomainAnalysisLegacyQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, definitionsWithAnalysis: number, generatedAt: string, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number }> }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }> } };
 
 export type DomainAnalysisValueDetailQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -3993,7 +4011,7 @@ export type DomainAnalysisValueDetailQueryVariables = Exact<{
 }>;
 
 
-export type DomainAnalysisValueDetailQuery = { __typename?: 'Query', domainAnalysisValueDetail: { __typename?: 'DomainAnalysisValueDetailResult', domainId: string, domainName: string, modelId: string, modelLabel: string, valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalTrials: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, generatedAt: any, vignettes: Array<{ __typename?: 'DomainAnalysisVignetteDetail', definitionId: string, definitionName: string, definitionVersion: number, aggregateRunId?: string | null, otherValueKey: string, prioritized: number, deprioritized: number, neutral: number, totalTrials: number, selectedValueWinRate?: number | null, conditions: Array<{ __typename?: 'DomainAnalysisConditionDetail', scenarioId?: string | null, conditionName: string, dimensions?: any | null, prioritized: number, deprioritized: number, neutral: number, totalTrials: number, selectedValueWinRate?: number | null, strongly: number, somewhat: number, opponentSomewhat: number, opponentStrongly: number, unknownCount: number }> }> } };
+export type DomainAnalysisValueDetailQuery = { __typename?: 'Query', domainAnalysisValueDetail: { __typename?: 'DomainAnalysisValueDetailResult', domainId: string, domainName: string, modelId: string, modelLabel: string, valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalTrials: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, generatedAt: string, vignettes: Array<{ __typename?: 'DomainAnalysisVignetteDetail', definitionId: string, definitionName: string, definitionVersion: number, aggregateRunId?: string | null, otherValueKey: string, prioritized: number, deprioritized: number, neutral: number, totalTrials: number, selectedValueWinRate?: number | null, conditions: Array<{ __typename?: 'DomainAnalysisConditionDetail', scenarioId?: string | null, conditionName: string, dimensions?: unknown | null, prioritized: number, deprioritized: number, neutral: number, totalTrials: number, selectedValueWinRate?: number | null, strongly: number, somewhat: number, opponentSomewhat: number, opponentStrongly: number, unknownCount: number }> }> } };
 
 export type DomainAnalysisConditionTranscriptsQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -4006,7 +4024,7 @@ export type DomainAnalysisConditionTranscriptsQueryVariables = Exact<{
 }>;
 
 
-export type DomainAnalysisConditionTranscriptsQuery = { __typename?: 'Query', domainAnalysisConditionTranscripts: Array<{ __typename?: 'DomainAnalysisConditionTranscript', id: string, runId: string, scenarioId?: string | null, modelId: string, decisionCode?: string | null, decisionModelV2?: any | null, turnCount: number, tokenCount: number, durationMs: number, createdAt: any, content: any }> };
+export type DomainAnalysisConditionTranscriptsQuery = { __typename?: 'Query', domainAnalysisConditionTranscripts: Array<{ __typename?: 'DomainAnalysisConditionTranscript', id: string, runId: string, scenarioId?: string | null, modelId: string, decisionCode?: string | null, decisionModelV2?: unknown | null, turnCount: number, tokenCount: number, durationMs: number, createdAt: string, content: unknown }> };
 
 export type DomainAvailableSignaturesQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -4020,7 +4038,7 @@ export type DomainFindingsEligibilityQueryVariables = Exact<{
 }>;
 
 
-export type DomainFindingsEligibilityQuery = { __typename?: 'Query', domainFindingsEligibility: { __typename?: 'DomainFindingsEligibility', domainId: string, eligible: boolean, status: string, summary: string, reasons: Array<string>, recommendedActions: Array<string>, consideredScopeCategories: Array<string>, completedEligibleEvaluationCount: number, latestEligibleEvaluationId?: string | null, latestEligibleScopeCategory?: string | null, latestEligibleCompletedAt?: any | null } };
+export type DomainFindingsEligibilityQuery = { __typename?: 'Query', domainFindingsEligibility: { __typename?: 'DomainFindingsEligibility', domainId: string, eligible: boolean, status: string, summary: string, reasons: Array<string>, recommendedActions: Array<string>, consideredScopeCategories: Array<string>, completedEligibleEvaluationCount: number, latestEligibleEvaluationId?: string | null, latestEligibleScopeCategory?: string | null, latestEligibleCompletedAt?: string | null } };
 
 export type DomainValueCoverageQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -4046,14 +4064,14 @@ export type DomainsQueryVariables = Exact<{
 }>;
 
 
-export type DomainsQuery = { __typename?: 'Query', domains: Array<{ __typename?: 'Domain', id: string, name: string, createdAt: any, updatedAt: any, definitionCount: number, defaultLevelPresetVersionId?: string | null, defaultPreambleVersionId?: string | null, defaultContextId?: string | null }> };
+export type DomainsQuery = { __typename?: 'Query', domains: Array<{ __typename?: 'Domain', id: string, name: string, createdAt: string, updatedAt: string, definitionCount: number, defaultLevelPresetVersionId?: string | null, defaultPreambleVersionId?: string | null, defaultContextId?: string | null }> };
 
 export type CreateDomainMutationVariables = Exact<{
   name: Scalars['String']['input'];
 }>;
 
 
-export type CreateDomainMutation = { __typename?: 'Mutation', createDomain: { __typename?: 'Domain', id: string, name: string, createdAt: any, updatedAt: any, definitionCount: number } };
+export type CreateDomainMutation = { __typename?: 'Mutation', createDomain: { __typename?: 'Domain', id: string, name: string, createdAt: string, updatedAt: string, definitionCount: number } };
 
 export type RenameDomainMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -4061,7 +4079,7 @@ export type RenameDomainMutationVariables = Exact<{
 }>;
 
 
-export type RenameDomainMutation = { __typename?: 'Mutation', renameDomain: { __typename?: 'Domain', id: string, name: string, createdAt: any, updatedAt: any, definitionCount: number } };
+export type RenameDomainMutation = { __typename?: 'Mutation', renameDomain: { __typename?: 'Domain', id: string, name: string, createdAt: string, updatedAt: string, definitionCount: number } };
 
 export type DeleteDomainMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -4125,14 +4143,14 @@ export type DomainEvaluationsQueryVariables = Exact<{
 }>;
 
 
-export type DomainEvaluationsQuery = { __typename?: 'Query', domainEvaluations: Array<{ __typename?: 'DomainEvaluation', id: string, domainId: string, domainNameAtLaunch: string, scopeCategory: string, status: string, createdAt: any, startedAt?: any | null, completedAt?: any | null, startedRuns: number, failedDefinitions: number, skippedForBudget: number, projectedCostUsd: number, models: Array<string>, temperature?: number | null, maxBudgetUsd?: number | null, memberCount: number }> };
+export type DomainEvaluationsQuery = { __typename?: 'Query', domainEvaluations: Array<{ __typename?: 'DomainEvaluation', id: string, domainId: string, domainNameAtLaunch: string, scopeCategory: string, status: string, createdAt: string, startedAt?: string | null, completedAt?: string | null, startedRuns: number, failedDefinitions: number, skippedForBudget: number, projectedCostUsd: number, models: Array<string>, temperature?: number | null, maxBudgetUsd?: number | null, memberCount: number }> };
 
 export type DomainEvaluationQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type DomainEvaluationQuery = { __typename?: 'Query', domainEvaluation?: { __typename?: 'DomainEvaluation', id: string, domainId: string, domainNameAtLaunch: string, scopeCategory: string, status: string, createdAt: any, startedAt?: any | null, completedAt?: any | null, startedRuns: number, failedDefinitions: number, skippedForBudget: number, projectedCostUsd: number, models: Array<string>, temperature?: number | null, maxBudgetUsd?: number | null, memberCount: number, members: Array<{ __typename?: 'DomainEvaluationMember', runId: string, definitionIdAtLaunch: string, definitionNameAtLaunch: string, domainIdAtLaunch: string, createdAt: any, runStatus: string, runCategory: string, runStartedAt?: any | null, runCompletedAt?: any | null }> } | null };
+export type DomainEvaluationQuery = { __typename?: 'Query', domainEvaluation?: { __typename?: 'DomainEvaluation', id: string, domainId: string, domainNameAtLaunch: string, scopeCategory: string, status: string, createdAt: string, startedAt?: string | null, completedAt?: string | null, startedRuns: number, failedDefinitions: number, skippedForBudget: number, projectedCostUsd: number, models: Array<string>, temperature?: number | null, maxBudgetUsd?: number | null, memberCount: number, members: Array<{ __typename?: 'DomainEvaluationMember', runId: string, definitionIdAtLaunch: string, definitionNameAtLaunch: string, domainIdAtLaunch: string, createdAt: string, runStatus: string, runCategory: string, runStartedAt?: string | null, runCompletedAt?: string | null }> } | null };
 
 export type DomainEvaluationStatusQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -4169,7 +4187,7 @@ export type DomainTrialRunsStatusQueryVariables = Exact<{
 }>;
 
 
-export type DomainTrialRunsStatusQuery = { __typename?: 'Query', domainTrialRunsStatus: Array<{ __typename?: 'DomainTrialRunStatus', runId: string, definitionId: string, status: string, updatedAt: any, stalledModels: Array<string>, analysisStatus?: string | null, modelStatuses: Array<{ __typename?: 'DomainTrialModelStatus', modelId: string, generationCompleted: number, generationFailed: number, generationTotal: number, summarizationCompleted: number, summarizationFailed: number, summarizationTotal: number, latestErrorMessage?: string | null }> }> };
+export type DomainTrialRunsStatusQuery = { __typename?: 'Query', domainTrialRunsStatus: Array<{ __typename?: 'DomainTrialRunStatus', runId: string, definitionId: string, status: string, updatedAt: string, stalledModels: Array<string>, analysisStatus?: string | null, modelStatuses: Array<{ __typename?: 'DomainTrialModelStatus', modelId: string, generationCompleted: number, generationFailed: number, generationTotal: number, summarizationCompleted: number, summarizationFailed: number, summarizationTotal: number, latestErrorMessage?: string | null }> }> };
 
 export type DomainSettingsQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -4184,7 +4202,7 @@ export type DomainConfigSnapshotsQueryVariables = Exact<{
 }>;
 
 
-export type DomainConfigSnapshotsQuery = { __typename?: 'Query', domainConfigSnapshots: Array<{ __typename?: 'DomainConfigSnapshotSummary', id: string, createdAt: any, preambleLabel?: string | null, levelPresetLabel?: string | null, contextLabel?: string | null, valueStatementCount: number }> };
+export type DomainConfigSnapshotsQuery = { __typename?: 'Query', domainConfigSnapshots: Array<{ __typename?: 'DomainConfigSnapshotSummary', id: string, createdAt: string, preambleLabel?: string | null, levelPresetLabel?: string | null, contextLabel?: string | null, valueStatementCount: number }> };
 
 export type SetDomainSettingsMutationVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -4199,17 +4217,24 @@ export type SetDomainSettingsMutationVariables = Exact<{
 
 export type SetDomainSettingsMutation = { __typename?: 'Mutation', setDomainSettings: { __typename?: 'Domain', id: string, name: string, defaultPreambleVersionId?: string | null, defaultLevelPresetVersionId?: string | null, defaultContextId?: string | null } };
 
+export type EnsureDomainVignettePairMutationVariables = Exact<{
+  input: EnsureDomainVignettePairInput;
+}>;
+
+
+export type EnsureDomainVignettePairMutation = { __typename?: 'Mutation', ensureDomainVignettePair: { __typename?: 'EnsureDomainVignettePairResult', status: VignettePairStatus, definitionAId?: string | null, definitionBId?: string | null } };
+
 export type SystemHealthQueryVariables = Exact<{
   refresh?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 
-export type SystemHealthQuery = { __typename?: 'Query', systemHealth: { __typename?: 'SystemHealth', providers: { __typename?: 'ProviderHealth', checkedAt: any, providers: Array<{ __typename?: 'ProviderHealthStatus', id: string, name: string, configured: boolean, connected: boolean, error?: string | null, remainingBudgetUsd?: number | null, lastChecked?: any | null }> }, queue: { __typename?: 'QueueHealth', isHealthy: boolean, isRunning: boolean, isPaused: boolean, activeJobs: number, pendingJobs: number, completedLast24h: number, failedLast24h: number, successRate?: number | null, error?: string | null, checkedAt: any, jobTypes?: Array<{ __typename?: 'JobTypeStatus', type: string, pending: number, active: number, completed: number, failed: number }> | null }, worker: { __typename?: 'WorkerHealth', isHealthy: boolean, pythonVersion?: string | null, packages: any, apiKeys: any, warnings: Array<string>, error?: string | null, checkedAt: any } } };
+export type SystemHealthQuery = { __typename?: 'Query', systemHealth: { __typename?: 'SystemHealth', providers: { __typename?: 'ProviderHealth', checkedAt: string, providers: Array<{ __typename?: 'ProviderHealthStatus', id: string, name: string, configured: boolean, connected: boolean, error?: string | null, remainingBudgetUsd?: number | null, lastChecked?: string | null }> }, queue: { __typename?: 'QueueHealth', isHealthy: boolean, isRunning: boolean, isPaused: boolean, activeJobs: number, pendingJobs: number, completedLast24h: number, failedLast24h: number, successRate?: number | null, error?: string | null, checkedAt: string, jobTypes?: Array<{ __typename?: 'JobTypeStatus', type: string, pending: number, active: number, completed: number, failed: number }> | null }, worker: { __typename?: 'WorkerHealth', isHealthy: boolean, pythonVersion?: string | null, packages: unknown, apiKeys: unknown, warnings: Array<string>, error?: string | null, checkedAt: string } } };
 
 export type GetLevelPresetsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetLevelPresetsQuery = { __typename?: 'Query', levelPresets: Array<{ __typename?: 'LevelPreset', id: string, name: string, updatedAt: any, latestVersion?: { __typename?: 'LevelPresetVersion', id: string, version: string, l1: string, l2: string, l3: string, l4: string, l5: string, createdAt: any } | null }> };
+export type GetLevelPresetsQuery = { __typename?: 'Query', levelPresets: Array<{ __typename?: 'LevelPreset', id: string, name: string, updatedAt: string, latestVersion?: { __typename?: 'LevelPresetVersion', id: string, version: string, l1: string, l2: string, l3: string, l4: string, l5: string, createdAt: string } | null }> };
 
 export type CreateLevelPresetMutationVariables = Exact<{
   name: Scalars['String']['input'];
@@ -4233,7 +4258,7 @@ export type UpdateLevelPresetMutationVariables = Exact<{
 }>;
 
 
-export type UpdateLevelPresetMutation = { __typename?: 'Mutation', updateLevelPreset: { __typename?: 'LevelPreset', id: string, name: string, updatedAt: any, latestVersion?: { __typename?: 'LevelPresetVersion', id: string, version: string, l1: string, l2: string, l3: string, l4: string, l5: string } | null } };
+export type UpdateLevelPresetMutation = { __typename?: 'Mutation', updateLevelPreset: { __typename?: 'LevelPreset', id: string, name: string, updatedAt: string, latestVersion?: { __typename?: 'LevelPresetVersion', id: string, version: string, l1: string, l2: string, l3: string, l4: string, l5: string } | null } };
 
 export type DeleteLevelPresetMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -4242,14 +4267,14 @@ export type DeleteLevelPresetMutationVariables = Exact<{
 
 export type DeleteLevelPresetMutation = { __typename?: 'Mutation', deleteLevelPreset: { __typename?: 'DeleteLevelPresetResult', id: string } };
 
-export type LlmModelFieldsFragment = { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any };
+export type LlmModelFieldsFragment = { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string };
 
-export type LlmProviderFieldsFragment = { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: any, updatedAt: any };
+export type LlmProviderFieldsFragment = { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: string, updatedAt: string };
 
 export type LlmProvidersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type LlmProvidersQuery = { __typename?: 'Query', llmProviders: Array<{ __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: any, updatedAt: any, models: Array<{ __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any }> }> };
+export type LlmProvidersQuery = { __typename?: 'Query', llmProviders: Array<{ __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: string, updatedAt: string, models: Array<{ __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string }> }> };
 
 export type LlmModelsQueryVariables = Exact<{
   providerId?: InputMaybe<Scalars['String']['input']>;
@@ -4257,21 +4282,21 @@ export type LlmModelsQueryVariables = Exact<{
 }>;
 
 
-export type LlmModelsQuery = { __typename?: 'Query', llmModels: Array<{ __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any, provider: { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: any, updatedAt: any } }> };
+export type LlmModelsQuery = { __typename?: 'Query', llmModels: Array<{ __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string, provider: { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: string, updatedAt: string } }> };
 
 export type InfraModelQueryVariables = Exact<{
   purpose: Scalars['String']['input'];
 }>;
 
 
-export type InfraModelQuery = { __typename?: 'Query', infraModel?: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any, provider: { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: any, updatedAt: any } } | null };
+export type InfraModelQuery = { __typename?: 'Query', infraModel?: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string, provider: { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: string, updatedAt: string } } | null };
 
 export type CreateLlmModelMutationVariables = Exact<{
   input: CreateLlmModelInput;
 }>;
 
 
-export type CreateLlmModelMutation = { __typename?: 'Mutation', createLlmModel: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any } };
+export type CreateLlmModelMutation = { __typename?: 'Mutation', createLlmModel: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string } };
 
 export type UpdateLlmModelMutationVariables = Exact<{
   id: Scalars['String']['input'];
@@ -4279,35 +4304,35 @@ export type UpdateLlmModelMutationVariables = Exact<{
 }>;
 
 
-export type UpdateLlmModelMutation = { __typename?: 'Mutation', updateLlmModel: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any } };
+export type UpdateLlmModelMutation = { __typename?: 'Mutation', updateLlmModel: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string } };
 
 export type DeprecateLlmModelMutationVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
 
-export type DeprecateLlmModelMutation = { __typename?: 'Mutation', deprecateLlmModel: { __typename?: 'DeprecateModelResult', model: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any }, newDefault?: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any } | null } };
+export type DeprecateLlmModelMutation = { __typename?: 'Mutation', deprecateLlmModel: { __typename?: 'DeprecateModelResult', model: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string }, newDefault?: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string } | null } };
 
 export type ReactivateLlmModelMutationVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
 
-export type ReactivateLlmModelMutation = { __typename?: 'Mutation', reactivateLlmModel: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any } };
+export type ReactivateLlmModelMutation = { __typename?: 'Mutation', reactivateLlmModel: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string } };
 
 export type SetDefaultLlmModelMutationVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
 
-export type SetDefaultLlmModelMutation = { __typename?: 'Mutation', setDefaultLlmModel: { __typename?: 'SetDefaultModelResult', model: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any }, previousDefault?: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any } | null } };
+export type SetDefaultLlmModelMutation = { __typename?: 'Mutation', setDefaultLlmModel: { __typename?: 'SetDefaultModelResult', model: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string }, previousDefault?: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string } | null } };
 
 export type UnsetDefaultLlmModelMutationVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
 
-export type UnsetDefaultLlmModelMutation = { __typename?: 'Mutation', unsetDefaultLlmModel: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: any | null, createdAt: any, updatedAt: any } };
+export type UnsetDefaultLlmModelMutation = { __typename?: 'Mutation', unsetDefaultLlmModel: { __typename?: 'LlmModel', id: string, providerId: string, modelId: string, displayName: string, costInputPerMillion: number, costOutputPerMillion: number, status: string, isDefault: boolean, isAvailable: boolean, apiConfig?: unknown | null, createdAt: string, updatedAt: string } };
 
 export type UpdateLlmProviderMutationVariables = Exact<{
   id: Scalars['String']['input'];
@@ -4315,14 +4340,14 @@ export type UpdateLlmProviderMutationVariables = Exact<{
 }>;
 
 
-export type UpdateLlmProviderMutation = { __typename?: 'Mutation', updateLlmProvider: { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: any, updatedAt: any } };
+export type UpdateLlmProviderMutation = { __typename?: 'Mutation', updateLlmProvider: { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: string, updatedAt: string } };
 
 export type UpdateSystemSettingMutationVariables = Exact<{
   input: UpdateSystemSettingInput;
 }>;
 
 
-export type UpdateSystemSettingMutation = { __typename?: 'Mutation', updateSystemSetting: { __typename?: 'SystemSetting', id: string, key: string, value: any, updatedAt: any } };
+export type UpdateSystemSettingMutation = { __typename?: 'Mutation', updateSystemSetting: { __typename?: 'SystemSetting', id: string, key: string, value: unknown, updatedAt: string } };
 
 export type SetProviderBalanceMutationVariables = Exact<{
   providerId: Scalars['String']['input'];
@@ -4330,7 +4355,7 @@ export type SetProviderBalanceMutationVariables = Exact<{
 }>;
 
 
-export type SetProviderBalanceMutation = { __typename?: 'Mutation', setProviderBalance: { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: any, updatedAt: any } };
+export type SetProviderBalanceMutation = { __typename?: 'Mutation', setProviderBalance: { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: string, updatedAt: string } };
 
 export type AvailableModelsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -4358,9 +4383,9 @@ export type UpdatePairedVignetteMutationVariables = Exact<{
 
 export type UpdatePairedVignetteMutation = { __typename?: 'Mutation', updatePairedVignette: { __typename?: 'CreatePairedVignetteResult', definitionA: { __typename?: 'Definition', id: string, name: string }, definitionB: { __typename?: 'Definition', id: string, name: string } } };
 
-export type RunFieldsFragment = { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null };
+export type RunFieldsFragment = { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null };
 
-export type RunWithTranscriptsFieldsFragment = { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, failedProbes: Array<{ __typename?: 'ProbeResult', modelId: string, errorCode?: string | null, errorMessage?: string | null }>, transcripts: Array<{ __typename?: 'Transcript', id: string, runId: string, scenarioId?: string | null, modelId: string, modelVersion?: string | null, content: any, decisionMetadata?: any | null, turnCount: number, tokenCount: number, durationMs: number, estimatedCost?: number | null, createdAt: any, lastAccessedAt?: any | null, dimensionValues?: any | null, decisionModelV2?: any | null }>, analysis?: { __typename?: 'AnalysisResult', actualCost?: { __typename?: 'ActualCost', total: number, perModel: Array<{ __typename?: 'ActualModelCost', modelId: string, inputTokens: number, outputTokens: number, cost: number, probeCount: number }> } | null } | null, recentTasks: Array<{ __typename?: 'TaskResult', scenarioId: string, modelId: string, status: string, error?: string | null, completedAt?: any | null }>, executionMetrics?: { __typename?: 'ExecutionMetrics', totalActive: number, totalQueued: number, estimatedSecondsRemaining?: number | null, totalRetries: number, providers: Array<{ __typename?: 'ProviderExecutionMetrics', provider: string, activeJobs: number, queuedJobs: number, maxParallel: number, requestsPerMinute: number, activeModelIds: Array<string>, recentCompletions: Array<{ __typename?: 'CompletionEvent', modelId: string, scenarioId: string, success: boolean, completedAt: any, durationMs: number }> }> } | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null };
+export type RunWithTranscriptsFieldsFragment = { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, failedProbes: Array<{ __typename?: 'ProbeResult', modelId: string, errorCode?: string | null, errorMessage?: string | null }>, transcripts: Array<{ __typename?: 'Transcript', id: string, runId: string, scenarioId?: string | null, modelId: string, modelVersion?: string | null, content: unknown, decisionMetadata?: unknown | null, turnCount: number, tokenCount: number, durationMs: number, estimatedCost?: number | null, createdAt: string, lastAccessedAt?: string | null, dimensionValues?: unknown | null, decisionModelV2?: unknown | null }>, analysis?: { __typename?: 'AnalysisResult', actualCost?: { __typename?: 'ActualCost', total: number, perModel: Array<{ __typename?: 'ActualModelCost', modelId: string, inputTokens: number, outputTokens: number, cost: number, probeCount: number }> } | null } | null, recentTasks: Array<{ __typename?: 'TaskResult', scenarioId: string, modelId: string, status: string, error?: string | null, completedAt?: string | null }>, executionMetrics?: { __typename?: 'ExecutionMetrics', totalActive: number, totalQueued: number, estimatedSecondsRemaining?: number | null, totalRetries: number, providers: Array<{ __typename?: 'ProviderExecutionMetrics', provider: string, activeJobs: number, queuedJobs: number, maxParallel: number, requestsPerMinute: number, activeModelIds: Array<string>, recentCompletions: Array<{ __typename?: 'CompletionEvent', modelId: string, scenarioId: string, success: boolean, completedAt: string, durationMs: number }> }> } | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null };
 
 export type RunsQueryVariables = Exact<{
   definitionId?: InputMaybe<Scalars['String']['input']>;
@@ -4375,7 +4400,7 @@ export type RunsQueryVariables = Exact<{
 }>;
 
 
-export type RunsQuery = { __typename?: 'Query', runs: Array<{ __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null }> };
+export type RunsQuery = { __typename?: 'Query', runs: Array<{ __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null }> };
 
 export type RunCountQueryVariables = Exact<{
   definitionId?: InputMaybe<Scalars['String']['input']>;
@@ -4408,35 +4433,35 @@ export type RunQueryVariables = Exact<{
 }>;
 
 
-export type RunQuery = { __typename?: 'Query', run?: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, failedProbes: Array<{ __typename?: 'ProbeResult', modelId: string, errorCode?: string | null, errorMessage?: string | null }>, transcripts: Array<{ __typename?: 'Transcript', id: string, runId: string, scenarioId?: string | null, modelId: string, modelVersion?: string | null, content: any, decisionMetadata?: any | null, turnCount: number, tokenCount: number, durationMs: number, estimatedCost?: number | null, createdAt: any, lastAccessedAt?: any | null, dimensionValues?: any | null, decisionModelV2?: any | null }>, analysis?: { __typename?: 'AnalysisResult', actualCost?: { __typename?: 'ActualCost', total: number, perModel: Array<{ __typename?: 'ActualModelCost', modelId: string, inputTokens: number, outputTokens: number, cost: number, probeCount: number }> } | null } | null, recentTasks: Array<{ __typename?: 'TaskResult', scenarioId: string, modelId: string, status: string, error?: string | null, completedAt?: any | null }>, executionMetrics?: { __typename?: 'ExecutionMetrics', totalActive: number, totalQueued: number, estimatedSecondsRemaining?: number | null, totalRetries: number, providers: Array<{ __typename?: 'ProviderExecutionMetrics', provider: string, activeJobs: number, queuedJobs: number, maxParallel: number, requestsPerMinute: number, activeModelIds: Array<string>, recentCompletions: Array<{ __typename?: 'CompletionEvent', modelId: string, scenarioId: string, success: boolean, completedAt: any, durationMs: number }> }> } | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } | null };
+export type RunQuery = { __typename?: 'Query', run?: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, failedProbes: Array<{ __typename?: 'ProbeResult', modelId: string, errorCode?: string | null, errorMessage?: string | null }>, transcripts: Array<{ __typename?: 'Transcript', id: string, runId: string, scenarioId?: string | null, modelId: string, modelVersion?: string | null, content: unknown, decisionMetadata?: unknown | null, turnCount: number, tokenCount: number, durationMs: number, estimatedCost?: number | null, createdAt: string, lastAccessedAt?: string | null, dimensionValues?: unknown | null, decisionModelV2?: unknown | null }>, analysis?: { __typename?: 'AnalysisResult', actualCost?: { __typename?: 'ActualCost', total: number, perModel: Array<{ __typename?: 'ActualModelCost', modelId: string, inputTokens: number, outputTokens: number, cost: number, probeCount: number }> } | null } | null, recentTasks: Array<{ __typename?: 'TaskResult', scenarioId: string, modelId: string, status: string, error?: string | null, completedAt?: string | null }>, executionMetrics?: { __typename?: 'ExecutionMetrics', totalActive: number, totalQueued: number, estimatedSecondsRemaining?: number | null, totalRetries: number, providers: Array<{ __typename?: 'ProviderExecutionMetrics', provider: string, activeJobs: number, queuedJobs: number, maxParallel: number, requestsPerMinute: number, activeModelIds: Array<string>, recentCompletions: Array<{ __typename?: 'CompletionEvent', modelId: string, scenarioId: string, success: boolean, completedAt: string, durationMs: number }> }> } | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } | null };
 
 export type StartRunMutationVariables = Exact<{
   input: StartRunInput;
 }>;
 
 
-export type StartRunMutation = { __typename?: 'Mutation', startRun: { __typename?: 'StartRunPayload', jobCount: number, pairedRunIds?: Array<string> | null, run: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } } };
+export type StartRunMutation = { __typename?: 'Mutation', startRun: { __typename?: 'StartRunPayload', jobCount: number, pairedRunIds?: Array<string> | null, run: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } } };
 
 export type PauseRunMutationVariables = Exact<{
   runId: Scalars['ID']['input'];
 }>;
 
 
-export type PauseRunMutation = { __typename?: 'Mutation', pauseRun: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } };
+export type PauseRunMutation = { __typename?: 'Mutation', pauseRun: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } };
 
 export type ResumeRunMutationVariables = Exact<{
   runId: Scalars['ID']['input'];
 }>;
 
 
-export type ResumeRunMutation = { __typename?: 'Mutation', resumeRun: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } };
+export type ResumeRunMutation = { __typename?: 'Mutation', resumeRun: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } };
 
 export type CancelRunMutationVariables = Exact<{
   runId: Scalars['ID']['input'];
 }>;
 
 
-export type CancelRunMutation = { __typename?: 'Mutation', cancelRun: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } };
+export type CancelRunMutation = { __typename?: 'Mutation', cancelRun: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } };
 
 export type DeleteRunMutationVariables = Exact<{
   runId: Scalars['ID']['input'];
@@ -4451,14 +4476,14 @@ export type UpdateRunMutationVariables = Exact<{
 }>;
 
 
-export type UpdateRunMutation = { __typename?: 'Mutation', updateRun: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } };
+export type UpdateRunMutation = { __typename?: 'Mutation', updateRun: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } };
 
 export type CancelSummarizationMutationVariables = Exact<{
   runId: Scalars['ID']['input'];
 }>;
 
 
-export type CancelSummarizationMutation = { __typename?: 'Mutation', cancelSummarization: { __typename?: 'CancelSummarizationPayload', cancelledCount: number, run: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } } };
+export type CancelSummarizationMutation = { __typename?: 'Mutation', cancelSummarization: { __typename?: 'CancelSummarizationPayload', cancelledCount: number, run: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } } };
 
 export type RestartSummarizationMutationVariables = Exact<{
   runId: Scalars['ID']['input'];
@@ -4466,7 +4491,7 @@ export type RestartSummarizationMutationVariables = Exact<{
 }>;
 
 
-export type RestartSummarizationMutation = { __typename?: 'Mutation', restartSummarization: { __typename?: 'RestartSummarizationPayload', queuedCount: number, run: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: any, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: any | null, startedAt?: any | null, completedAt?: any | null, createdAt: any, updatedAt: any, lastAccessedAt?: any | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: any | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: any, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } } };
+export type RestartSummarizationMutation = { __typename?: 'Mutation', restartSummarization: { __typename?: 'RestartSummarizationPayload', queuedCount: number, run: { __typename?: 'Run', id: string, name?: string | null, definitionId: string, definitionVersion?: number | null, experimentId?: string | null, status: string, runCategory: string, config: unknown, stalledModels: Array<string>, companionRunId?: string | null, batchCount: number, pairedBatchGroupId?: string | null, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, updatedAt: string, lastAccessedAt?: string | null, transcriptCount: number, analysisStatus?: string | null, definitionSnapshot?: unknown | null, runProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number, byModel?: Array<{ __typename?: 'ByModelProgress', modelId: string, completed: number, failed: number }> | null } | null, summarizeProgress?: { __typename?: 'RunProgress', total: number, completed: number, failed: number, percentComplete: number } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }>, definition?: { __typename?: 'Definition', id: string, name: string, version: number, content: unknown, domain?: { __typename?: 'Domain', name: string } | null, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null } } };
 
 export type UpdateTranscriptDecisionMutationVariables = Exact<{
   transcriptId: Scalars['ID']['input'];
@@ -4474,7 +4499,7 @@ export type UpdateTranscriptDecisionMutationVariables = Exact<{
 }>;
 
 
-export type UpdateTranscriptDecisionMutation = { __typename?: 'Mutation', updateTranscriptDecision: { __typename?: 'Transcript', id: string, runId: string, scenarioId?: string | null, modelId: string, modelVersion?: string | null, content: any, decisionMetadata?: any | null, turnCount: number, tokenCount: number, durationMs: number, estimatedCost?: number | null, createdAt: any, lastAccessedAt?: any | null } };
+export type UpdateTranscriptDecisionMutation = { __typename?: 'Mutation', updateTranscriptDecision: { __typename?: 'Transcript', id: string, runId: string, scenarioId?: string | null, modelId: string, modelVersion?: string | null, content: unknown, decisionMetadata?: unknown | null, turnCount: number, tokenCount: number, durationMs: number, estimatedCost?: number | null, createdAt: string, lastAccessedAt?: string | null } };
 
 export type ScenariosQueryVariables = Exact<{
   definitionId: Scalars['ID']['input'];
@@ -4483,7 +4508,7 @@ export type ScenariosQueryVariables = Exact<{
 }>;
 
 
-export type ScenariosQuery = { __typename?: 'Query', scenarios: Array<{ __typename?: 'Scenario', id: string, definitionId: string, name: string, content: any, createdAt: any }> };
+export type ScenariosQuery = { __typename?: 'Query', scenarios: Array<{ __typename?: 'Scenario', id: string, definitionId: string, name: string, content: unknown, createdAt: string }> };
 
 export type ScenarioCountQueryVariables = Exact<{
   definitionId: Scalars['ID']['input'];
@@ -4504,14 +4529,14 @@ export type SurveysQueryVariables = Exact<{
 }>;
 
 
-export type SurveysQuery = { __typename?: 'Query', surveys: Array<{ __typename?: 'Experiment', id: string, name: string, hypothesis?: string | null, analysisPlan?: any | null, createdAt: any, updatedAt: any, runCount: number }> };
+export type SurveysQuery = { __typename?: 'Query', surveys: Array<{ __typename?: 'Experiment', id: string, name: string, hypothesis?: string | null, analysisPlan?: unknown | null, createdAt: string, updatedAt: string, runCount: number }> };
 
 export type CreateSurveyMutationVariables = Exact<{
   input: CreateSurveyInput;
 }>;
 
 
-export type CreateSurveyMutation = { __typename?: 'Mutation', createSurvey: { __typename?: 'Experiment', id: string, name: string, hypothesis?: string | null, analysisPlan?: any | null, createdAt: any, updatedAt: any, runCount: number } };
+export type CreateSurveyMutation = { __typename?: 'Mutation', createSurvey: { __typename?: 'Experiment', id: string, name: string, hypothesis?: string | null, analysisPlan?: unknown | null, createdAt: string, updatedAt: string, runCount: number } };
 
 export type UpdateSurveyMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -4519,7 +4544,7 @@ export type UpdateSurveyMutationVariables = Exact<{
 }>;
 
 
-export type UpdateSurveyMutation = { __typename?: 'Mutation', updateSurvey: { __typename?: 'Experiment', id: string, name: string, hypothesis?: string | null, analysisPlan?: any | null, createdAt: any, updatedAt: any, runCount: number } };
+export type UpdateSurveyMutation = { __typename?: 'Mutation', updateSurvey: { __typename?: 'Experiment', id: string, name: string, hypothesis?: string | null, analysisPlan?: unknown | null, createdAt: string, updatedAt: string, runCount: number } };
 
 export type DeleteSurveyMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -4534,7 +4559,7 @@ export type DuplicateSurveyMutationVariables = Exact<{
 }>;
 
 
-export type DuplicateSurveyMutation = { __typename?: 'Mutation', duplicateSurvey: { __typename?: 'Experiment', id: string, name: string, hypothesis?: string | null, analysisPlan?: any | null, createdAt: any, updatedAt: any, runCount: number } };
+export type DuplicateSurveyMutation = { __typename?: 'Mutation', duplicateSurvey: { __typename?: 'Experiment', id: string, name: string, hypothesis?: string | null, analysisPlan?: unknown | null, createdAt: string, updatedAt: string, runCount: number } };
 
 export type TagsQueryVariables = Exact<{
   search?: InputMaybe<Scalars['String']['input']>;
@@ -4542,14 +4567,14 @@ export type TagsQueryVariables = Exact<{
 }>;
 
 
-export type TagsQuery = { __typename?: 'Query', tags: Array<{ __typename?: 'Tag', id: string, name: string, createdAt: any, definitionCount: number }> };
+export type TagsQuery = { __typename?: 'Query', tags: Array<{ __typename?: 'Tag', id: string, name: string, createdAt: string, definitionCount: number }> };
 
 export type CreateTagMutationVariables = Exact<{
   name: Scalars['String']['input'];
 }>;
 
 
-export type CreateTagMutation = { __typename?: 'Mutation', createTag: { __typename?: 'Tag', id: string, name: string, createdAt: any } };
+export type CreateTagMutation = { __typename?: 'Mutation', createTag: { __typename?: 'Tag', id: string, name: string, createdAt: string } };
 
 export type DeleteTagMutationVariables = Exact<{
   id: Scalars['String']['input'];
@@ -4582,24 +4607,19 @@ export type CreateAndAssignTagMutationVariables = Exact<{
 
 export type CreateAndAssignTagMutation = { __typename?: 'Mutation', createAndAssignTag: { __typename?: 'Definition', id: string, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } };
 
-export type TempZeroVerificationReportQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type TempZeroVerificationReportQuery = { __typename?: 'Query', tempZeroVerificationReport?: { __typename?: 'TempZeroVerificationReport', generatedAt: any, transcriptCount: number, batchTimestamp?: any | null, models: Array<{ __typename?: 'TempZeroModelVerification', modelId: string, transcriptCount: number, adapterModes: Array<string>, promptHashStabilityPct?: number | null, fingerprintDriftPct?: number | null, decisionMatchRatePct?: number | null }> } | null };
-
 export type ValueStatementsQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
 }>;
 
 
-export type ValueStatementsQuery = { __typename?: 'Query', valueStatements: Array<{ __typename?: 'ValueStatement', id: string, domainId: string, token: string, body: string, updatedAt: any }> };
+export type ValueStatementsQuery = { __typename?: 'Query', valueStatements: Array<{ __typename?: 'ValueStatement', id: string, domainId: string, token: string, body: string, updatedAt: string }> };
 
 export type CreateValueStatementMutationVariables = Exact<{
   input: CreateValueStatementInput;
 }>;
 
 
-export type CreateValueStatementMutation = { __typename?: 'Mutation', createValueStatement: { __typename?: 'ValueStatement', id: string, domainId: string, token: string, body: string, updatedAt: any } };
+export type CreateValueStatementMutation = { __typename?: 'Mutation', createValueStatement: { __typename?: 'ValueStatement', id: string, domainId: string, token: string, body: string, updatedAt: string } };
 
 export type UpdateValueStatementMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -4607,7 +4627,7 @@ export type UpdateValueStatementMutationVariables = Exact<{
 }>;
 
 
-export type UpdateValueStatementMutation = { __typename?: 'Mutation', updateValueStatement: { __typename?: 'ValueStatement', id: string, domainId: string, token: string, body: string, updatedAt: any } };
+export type UpdateValueStatementMutation = { __typename?: 'Mutation', updateValueStatement: { __typename?: 'ValueStatement', id: string, domainId: string, token: string, body: string, updatedAt: string } };
 
 export type DeleteValueStatementMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -6117,6 +6137,19 @@ export const SetDomainSettingsDocument = gql`
 export function useSetDomainSettingsMutation() {
   return Urql.useMutation<SetDomainSettingsMutation, SetDomainSettingsMutationVariables>(SetDomainSettingsDocument);
 };
+export const EnsureDomainVignettePairDocument = gql`
+    mutation EnsureDomainVignettePair($input: EnsureDomainVignettePairInput!) {
+  ensureDomainVignettePair(input: $input) {
+    status
+    definitionAId
+    definitionBId
+  }
+}
+    `;
+
+export function useEnsureDomainVignettePairMutation() {
+  return Urql.useMutation<EnsureDomainVignettePairMutation, EnsureDomainVignettePairMutationVariables>(EnsureDomainVignettePairDocument);
+};
 export const SystemHealthDocument = gql`
     query SystemHealth($refresh: Boolean) {
   systemHealth(refresh: $refresh) {
@@ -6887,27 +6920,6 @@ export const CreateAndAssignTagDocument = gql`
 
 export function useCreateAndAssignTagMutation() {
   return Urql.useMutation<CreateAndAssignTagMutation, CreateAndAssignTagMutationVariables>(CreateAndAssignTagDocument);
-};
-export const TempZeroVerificationReportDocument = gql`
-    query TempZeroVerificationReport {
-  tempZeroVerificationReport {
-    generatedAt
-    transcriptCount
-    batchTimestamp
-    models {
-      modelId
-      transcriptCount
-      adapterModes
-      promptHashStabilityPct
-      fingerprintDriftPct
-      decisionMatchRatePct
-    }
-  }
-}
-    `;
-
-export function useTempZeroVerificationReportQuery(options?: Omit<Urql.UseQueryArgs<TempZeroVerificationReportQueryVariables>, 'query'>) {
-  return Urql.useQuery<TempZeroVerificationReportQuery, TempZeroVerificationReportQueryVariables>({ query: TempZeroVerificationReportDocument, ...options });
 };
 export const ValueStatementsDocument = gql`
     query ValueStatements($domainId: ID!) {


### PR DESCRIPTION
## Summary

- Adds the Neighborhood Choice domain to ValueRank with 10 value statements, correct sentence prefix, label prefix, and context text
- Fixes domain management page: sentencePrefix and labelPrefix now display real values (GraphQL query was missing those fields)
- Adds a **Create Vignettes** button at the bottom of the domain management page — idempotent, domain-agnostic, with live pair-by-pair progress

## Create Vignettes button

- New `ensureDomainVignettePair` GraphQL mutation reuses existing `paired-vignette-helpers.ts` infrastructure
- Creates missing pairs, updates stale pairs (assembled template changed), skips up-to-date pairs, safely skips pairs with run data
- Client-side loop: one mutation call per pair, shows "Processing pair X of N…" in real time
- Button disabled while domain panel has unsaved edits
- Domain-agnostic — works for neighborhood, job choice, software approach, etc.

## Validation

From `cloud/` in the worktree:
- `npm run lint --workspace @valuerank/shared` ✅ 0 errors
- `npm run lint --workspace @valuerank/api` ✅ 0 errors
- `npm run build --workspace @valuerank/api` ✅
- `npm run lint --workspace @valuerank/web` ✅ 0 errors
- `npm run build --workspace @valuerank/web` ✅
- `npm run test --workspace @valuerank/web` ✅ 1232 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)