### PR TITLE
fix(cors): expose Content-Disposition so download filename works in browser

### DIFF
--- a/cloud/apps/api/src/server.ts
+++ b/cloud/apps/api/src/server.ts
@@ -32,7 +32,7 @@ export function createServer() {
 
   // Middleware
   app.use(compression());
-  app.use(cors());
+  app.use(cors({ exposedHeaders: ['Content-Disposition'] }));
   app.use(express.json());
   app.use(express.urlencoded({ extended: true })); // For OAuth form submissions
 


### PR DESCRIPTION
## Summary
- Add `exposedHeaders: ['Content-Disposition']` to the CORS config
- Without this, browsers block JS from reading `Content-Disposition` on cross-origin fetch responses, so the web client was falling back to the hardcoded `domain-<id>-transcripts.csv` filename instead of the server-generated name

## Root cause
`cors()` with no options only exposes the CORS "safe-list" headers (Content-Type, Cache-Control, etc.). `Content-Disposition` is not on that list, so `response.headers.get('Content-Disposition')` returned `null` in the browser, triggering the fallback.

## Test plan
- [ ] Download a domain CSV and confirm the filename is `<Domain Name> - MM-DD-YYYY-HH:MM - transcript.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)