### PR TITLE
fix(run): move ensureDomainConfigSnapshot outside db.$transaction

### DIFF
--- a/cloud/apps/api/src/services/analysis/aggregate/aggregate-run-workflow.ts
+++ b/cloud/apps/api/src/services/analysis/aggregate/aggregate-run-workflow.ts
@@ -177,6 +177,7 @@ export async function persistAggregateRun(
       data: {
         config: finalConfig as unknown as Prisma.InputJsonValue,
         status: 'COMPLETED',
+        completedAt: new Date(),
       },
     });
 

--- a/cloud/apps/api/src/services/run/start.ts
+++ b/cloud/apps/api/src/services/run/start.ts
@@ -286,22 +286,22 @@ export async function startRun(input: StartRunInput): Promise<StartRunResult> {
       skipDuplicates: true, // Safety for overlaps if any
     });
 
-    // Capture domain config snapshot at run creation time
-    if (definition.domain?.id) {
-      try {
-        const snapshotId = await ensureDomainConfigSnapshot(definition.domain.id, tx);
-        await tx.run.update({
-          where: { id: newRun.id },
-          data: { domainConfigSnapshotId: snapshotId },
-        });
-      } catch (err) {
-        // Non-fatal: log warning but don't fail run creation
-        log.warn({ err, domainId: definition.domain.id }, 'Failed to capture domain config snapshot');
-      }
-    }
-
     return newRun;
   });
+
+  // Capture domain config snapshot outside the transaction to avoid concurrent
+  // upsert contention aborting the transaction while $transaction still returns the run.
+  if (definition.domain?.id) {
+    try {
+      const snapshotId = await ensureDomainConfigSnapshot(definition.domain.id);
+      await db.run.update({
+        where: { id: run.id },
+        data: { domainConfigSnapshotId: snapshotId },
+      });
+    } catch (err) {
+      log.warn({ err, runId: run.id, domainId: definition.domain.id }, 'Failed to capture domain config snapshot');
+    }
+  }
 
   log.info({ runId: run.id, totalJobs }, 'Run created, queuing jobs');
 


### PR DESCRIPTION
## Summary

Two bugs fixed in the domain paired batch flow:

**Fix 1: Transaction rollback on launch (the original error)**
- `ensureDomainConfigSnapshot()` was called inside `db.$transaction()` using the `tx` client
- Under concurrent load (25 parallel runs), this caused lock contention on the upsert → PostgreSQL aborted the transaction
- Prisma's `$transaction` swallowed the aborted state and returned the run ID anyway (phantom run)
- The subsequent `domainEvaluationRun.createMany()` got phantom IDs → FK violation → GraphQL "Unexpected error occurred"
- **Fix:** Move `ensureDomainConfigSnapshot()` outside the transaction, using the default `db` client

**Fix 2: Aggregate runs missing `completedAt`**
- `persistAggregateRun()` set `status: 'COMPLETED'` without writing `completedAt`
- The analysis status resolver checks `completedAt` to determine if analysis was triggered — null leaves runs permanently orphaned with no analysis visible
- **Fix:** Add `completedAt: new Date()` to the update in `persistAggregateRun()`

## Validation

- `npm run lint --workspace @valuerank/api` — 0 errors, 41 pre-existing warnings (unchanged)
- `npm run build --workspace @valuerank/api` — pre-existing errors in `domain-analysis-cache.ts` on `main` (unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)