### PR TITLE
fix(analysis): tip condition cell at |netScore|=0.05 to directional

### DIFF
--- a/cloud/apps/web/src/utils/canonicalConditionSummary.ts
+++ b/cloud/apps/web/src/utils/canonicalConditionSummary.ts
@@ -160,10 +160,12 @@ function summarizeCanonicalConditionTally(counts: CanonicalConditionTally): Cano
     - (2 * counts.opponentStrongly + counts.opponentSomewhat)
   ) / totalTrials;
 
+  // Threshold is inclusive (>= 0.05) so it aligns with the one-decimal label:
+  // |netScore| >= 0.05 rounds to "0.1" and should render directional, not neutral.
   let direction: CanonicalConditionSummary['direction'] = 'neutral';
-  if (netScore > 0.05) {
+  if (netScore >= 0.05) {
     direction = 'self';
-  } else if (netScore < -0.05) {
+  } else if (netScore <= -0.05) {
     direction = 'opponent';
   }
 

--- a/cloud/apps/web/tests/utils/canonicalConditionSummary.test.ts
+++ b/cloud/apps/web/tests/utils/canonicalConditionSummary.test.ts
@@ -262,7 +262,7 @@ describe('summarizeCanonicalConditionCounts', () => {
 
   it.each([
     {
-      name: 'positive boundary stays neutral at 0.05',
+      name: 'positive boundary tips to self at 0.05 so color matches the "0.1" label',
       counts: {
         strongly: 0,
         somewhat: 1,
@@ -271,7 +271,7 @@ describe('summarizeCanonicalConditionCounts', () => {
         opponentStrongly: 0,
       },
       expectedNetScore: 0.05,
-      expectedDirection: 'neutral' as const,
+      expectedDirection: 'self' as const,
     },
     {
       name: 'positive values above the boundary are self',
@@ -286,7 +286,7 @@ describe('summarizeCanonicalConditionCounts', () => {
       expectedDirection: 'self' as const,
     },
     {
-      name: 'negative boundary stays neutral at -0.05',
+      name: 'negative boundary tips to opponent at -0.05 so color matches the "0.1" label',
       counts: {
         strongly: 0,
         somewhat: 0,
@@ -295,7 +295,7 @@ describe('summarizeCanonicalConditionCounts', () => {
         opponentStrongly: 0,
       },
       expectedNetScore: -0.05,
-      expectedDirection: 'neutral' as const,
+      expectedDirection: 'opponent' as const,
     },
     {
       name: 'negative values below the boundary are opponent',

--- a/docs/workflow/feature-runs/unified-net-weighted-condition-score/closeout.md
+++ b/docs/workflow/feature-runs/unified-net-weighted-condition-score/closeout.md
@@ -1,0 +1,80 @@
+# Closeout — Unified Net-Weighted Condition Score
+
+**Status:** Shipped
+**PR:** [#680](https://github.com/chrislawcodes/valuerank/pull/680) (squash-merged)
+**Merge commit:** `f3708b6c`
+**Merged:** 2026-04-17T01:32:38Z
+**Branch:** `feature/unified-condition-score` (deleted)
+
+---
+
+## Summary
+
+Unified the three condition-level analysis views (Condition Decisions Table, Pivot Analysis Table, Condition Matrix) onto a single net-weighted score:
+
+```
+netScore = ((2·strongly + somewhat) − (2·opponentStrongly + opponentSomewhat)) / totalTrials
+```
+
+All three views now consume the same `getConditionCellDisplay(summary)` bundle helper, which returns `{ netScore, direction, hasData, label, backgroundColor, textColorClass }`. `direction` is tri-state (`'self' | 'opponent' | 'neutral'`) with a ±0.05 tolerance. The legend classifier in PivotAnalysisTable keys off `summary.direction` instead of recomputing signal thresholds.
+
+---
+
+## Slices Delivered
+
+| Slice | Scope | Commit |
+|-------|-------|--------|
+| 1 | `canonicalConditionSummary.ts` — net-weighted formula, helper bundle, 17 unit tests | `7bf030f2` |
+| 2 | `ConditionMatrix` migration to bundle helper | `6626dc38` |
+| 3 | `ConditionDecisionsTable` + `PivotAnalysisTable` migration; legend rewrite; help copy update | `1531a6a0` |
+| Cleanup | Inline color helpers into bundle, purge old exports (ship-gate G3) | `4c9b6dc0` |
+| Refactor | Split oversized tables to satisfy 400-line file-size gate | `3c5ff924` (squashed) |
+
+---
+
+## Ship Gates (all green)
+
+- G1 — no `winnerScore` references outside archived docs
+- G2 — no `selectedValueWinRate` outside archived docs
+- G3 — no `getCanonicalConditionBackground` / `getCanonicalConditionTextColor` exports
+- G4 — no inline `2 *` net-weighted math outside `canonicalConditionSummary.ts`
+- G5 — no `.toFixed(` outside the bundle helper
+- G6 — `Math.abs(netScore)` scoped to bundle helper
+- G7 — no bundle-helper callers in files outside `ConditionDecisionsTable`, `PivotAnalysisTable`, `ConditionMatrix`
+- G8 — old preference helpers removed
+
+File-size check: all 5 changed files under 400 lines after refactor extraction.
+
+---
+
+## Validation
+
+- `npm run lint --workspace @valuerank/web` — 0 errors (81 pre-existing warnings)
+- `npm run build --workspace @valuerank/web` — pass
+- `npm run test --workspace @valuerank/web` — 1246/1246 pass across 125 test files
+- CI on PR #680 post-rebase — all green (Lint & Build, API & DB Tests, Web Tests 1/3, 2/3, 3/3)
+
+---
+
+## Review Rounds
+
+- **Spec:** 7 rounds (accepted per advance policy)
+- **Plan:** 5 rounds (accepted per firm policy after diminishing returns)
+- **Tasks:** 2 rounds
+- **Slice 1 diff:** 2 Codex + 1 Gemini — accepted
+- **Slice 2 diff:** 2 Codex + 1 Gemini — accepted (artifacts preserved at `reviews/slice2-diff/`)
+- **Slice 3 diff:** 2 Codex + 1 Gemini — accepted; Gemini "unseen abstraction" flagged FALSE POSITIVE (Slice 1 landed with 17 tests); Codex 0.05-boundary label→"0.1" with direction=neutral acknowledged as edge case
+
+---
+
+## New Files
+
+- `cloud/apps/web/src/components/analysis/modelHeaderLabels.ts` (225 lines)
+- `cloud/apps/web/src/components/analysis/ConditionDecisionsTableHead.tsx` (90 lines)
+- `cloud/apps/web/src/components/analysis/PivotAnalysisLegend.tsx` (32 lines)
+
+---
+
+## Follow-ups
+
+None blocking. The 0.05-boundary display edge case (`netScore = 0.05` → rounds to label `"0.1"` while `direction = 'neutral'`) was documented and accepted.


### PR DESCRIPTION
## Summary

Follow-up to #680. At exactly `netScore = 0.05`, the condition cell was rendering as gray (neutral) with a label of `0.1` — visually inconsistent with the neighboring cell at `0.06` which showed the same label but tinted blue.

Root cause: `(0.05).toFixed(1)` returns `"0.1"` in JavaScript (IEEE 754 stores 0.05 as `0.05000000000000000277…`), but the direction classifier used strict `>` and `<`, so the boundary value fell into the neutral branch.

Fix: change direction classification from `> 0.05 / < -0.05` to `>= 0.05 / <= -0.05`, so the tie zone is `(−0.05, 0.05)` exclusive and boundary values tip to directional. This aligns color with the one-decimal label.

Also includes `closeout.md` for the parent feature (#680) which was written locally after the squash merge.

## Behavior change

| netScore | Before | After |
|---|---|---|
| 0.04 | neutral (gray, "0.0") | neutral (gray, "0.0") — unchanged |
| 0.05 | neutral (gray, "0.1") — mismatch | self (blue, "0.1") — aligned |
| 0.06 | self (blue, "0.1") | self (blue, "0.1") — unchanged |

Mirrored for the opponent (orange) side.

## Test plan

- [x] Preflight passed: lint (0 errors), build, test (1247/1247)
- [x] 17 unit tests in canonicalConditionSummary.test.ts pass — including the two boundary cases flipped from 'neutral' to 'self' / 'opponent'
- [ ] Manual smoke: find a cell with exactly 1 somewhat vote out of 20 trials and verify it renders blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)