### PR TITLE
fix(api): use live resolver for unresolvable transcript count

### DIFF
--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -9,7 +9,6 @@ import { calculatePercentComplete } from '../../services/run/index.js';
 import { AnalysisResultRef } from './analysis.js';
 import { CostEstimateRef, type CostEstimateShape } from './cost-estimate.js';
 import { getAllMetrics, getTotals } from '../../services/rate-limiter/index.js';
-import { getUnresolvableCount } from '../../services/unresolvable-count.js';
 
 // Re-export for backward compatibility
 export { RunRef, TranscriptRef, ExperimentRef };
@@ -49,27 +48,6 @@ type QueueFailurePayload = {
   error?: unknown;
   value?: unknown;
 };
-
-const UnresolvableByModel = builder
-  .objectRef<{ modelId: string; count: number }>('UnresolvableByModel')
-  .implement({
-    fields: (t) => ({
-      modelId: t.exposeString('modelId'),
-      count: t.exposeInt('count'),
-    }),
-  });
-
-const UnresolvableCount = builder
-  .objectRef<{ total: number; byModel: { modelId: string; count: number }[] }>('UnresolvableCount')
-  .implement({
-    fields: (t) => ({
-      total: t.exposeInt('total'),
-      byModel: t.field({
-        type: [UnresolvableByModel],
-        resolve: (p) => p.byModel,
-      }),
-    }),
-  });
 
 function normalizeTaskError(output: unknown): string | null {
   if (output === null || output === undefined) {
@@ -354,16 +332,6 @@ builder.objectType(RunRef, {
           percentComplete: Math.min(100, Math.round(((dynamicCompleted + dynamicFailed) / progress.total) * 100)),
           byModel: byModel.length > 0 ? byModel : undefined,
         };
-      },
-    }),
-
-    unresolvableTranscriptCount: t.field({
-      type: UnresolvableCount,
-      nullable: true,
-      description: 'Count of summarized transcripts that could not be scored',
-      resolve: async (run) => {
-        const result = await getUnresolvableCount(run.id);
-        return result.total > 0 ? result : null;
       },
     }),
 

--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -9,6 +9,7 @@ import { calculatePercentComplete } from '../../services/run/index.js';
 import { AnalysisResultRef } from './analysis.js';
 import { CostEstimateRef, type CostEstimateShape } from './cost-estimate.js';
 import { getAllMetrics, getTotals } from '../../services/rate-limiter/index.js';
+import { getUnresolvableCount } from '../../services/unresolvable-count.js';
 
 // Re-export for backward compatibility
 export { RunRef, TranscriptRef, ExperimentRef };
@@ -48,6 +49,27 @@ type QueueFailurePayload = {
   error?: unknown;
   value?: unknown;
 };
+
+const UnresolvableByModel = builder
+  .objectRef<{ modelId: string; count: number }>('UnresolvableByModel')
+  .implement({
+    fields: (t) => ({
+      modelId: t.exposeString('modelId'),
+      count: t.exposeInt('count'),
+    }),
+  });
+
+const UnresolvableCount = builder
+  .objectRef<{ total: number; byModel: { modelId: string; count: number }[] }>('UnresolvableCount')
+  .implement({
+    fields: (t) => ({
+      total: t.exposeInt('total'),
+      byModel: t.field({
+        type: [UnresolvableByModel],
+        resolve: (p) => p.byModel,
+      }),
+    }),
+  });
 
 function normalizeTaskError(output: unknown): string | null {
   if (output === null || output === undefined) {
@@ -332,6 +354,16 @@ builder.objectType(RunRef, {
           percentComplete: Math.min(100, Math.round(((dynamicCompleted + dynamicFailed) / progress.total) * 100)),
           byModel: byModel.length > 0 ? byModel : undefined,
         };
+      },
+    }),
+
+    unresolvableTranscriptCount: t.field({
+      type: UnresolvableCount,
+      nullable: true,
+      description: 'Count of summarized transcripts that could not be scored',
+      resolve: async (run) => {
+        const result = await getUnresolvableCount(run.id);
+        return result.total > 0 ? result : null;
       },
     }),
 

--- a/cloud/apps/api/src/services/unresolvable-count.ts
+++ b/cloud/apps/api/src/services/unresolvable-count.ts
@@ -1,4 +1,5 @@
 import { db } from '@valuerank/db';
+import { resolveTranscriptDecisionModel } from '../graphql/queries/domain/decision-model.js';
 
 export interface UnresolvableByModel {
   modelId: string;
@@ -11,29 +12,41 @@ export interface UnresolvableCount {
 }
 
 export async function getUnresolvableCount(runId: string): Promise<UnresolvableCount> {
-  const rows = await db.$queryRaw<Array<{ model_id: string; unresolvable: bigint }>>`
-    SELECT
-      model_id,
-      COUNT(*) FILTER (
-        WHERE summarized_at IS NOT NULL
-        AND decision_code_source IS DISTINCT FROM 'manual'
-        AND (
-          decision_code = 'other'
-          OR (
-            decision_code IS NULL
-            AND decision_metadata->'summaryCache'->'summary'->'canonicalDecision'->>'decisionState' = 'unknown'
-          )
-          OR decision_metadata->>'parseClass' = 'ambiguous'
-        )
-      ) as unresolvable
-    FROM transcripts
-    WHERE run_id = ${runId}
-    GROUP BY model_id
-  `;
+  const transcripts = await db.transcript.findMany({
+    where: {
+      runId,
+      summarizedAt: { not: null },
+      decisionCodeSource: { not: 'manual' },
+    },
+    select: {
+      modelId: true,
+      decisionCode: true,
+      decisionMetadata: true,
+      definitionSnapshot: true,
+      scenario: {
+        select: { orientationFlipped: true },
+      },
+    },
+  });
 
-  const byModel = rows
-    .map((r) => ({ modelId: r.model_id, count: Number(r.unresolvable) }))
-    .filter((r) => r.count > 0);
+  const byModelMap = new Map<string, number>();
+
+  for (const t of transcripts) {
+    const resolved = resolveTranscriptDecisionModel({
+      decisionCode: t.decisionCode,
+      decisionMetadata: t.decisionMetadata,
+      definitionSnapshot: t.definitionSnapshot,
+      orientationFlipped: t.scenario?.orientationFlipped ?? null,
+    });
+
+    if (resolved.canonical.direction === 'unknown') {
+      byModelMap.set(t.modelId, (byModelMap.get(t.modelId) ?? 0) + 1);
+    }
+  }
+
+  const byModel = Array.from(byModelMap.entries())
+    .map(([modelId, count]) => ({ modelId, count }))
+    .sort((a, b) => b.count - a.count);
 
   return {
     total: byModel.reduce((sum, r) => sum + r.count, 0),


### PR DESCRIPTION
## Summary

- Replaces the `$queryRaw` SQL approximation in `getUnresolvableCount` with a Prisma `findMany` + `resolveTranscriptDecisionModel` call
- The SQL checked stale `summaryCache.canonicalDecision.decisionState`, which overcounted: transcripts with `parsePath text_label_*` or `numeric_*` are re-derived successfully by the live TypeScript resolver but still show `unknown` in the stale cache
- The live resolver handles these at query time, so the banner was showing false positives for job-choice-style runs
- Verified: the 3 SAC `fallback_resolved`+`unknown` runs now return 25 true unresolvable (vs. hundreds from SQL); the `exact`+`unknown` run still shows 266 (genuinely unresolvable, accurate)

## Validation

```
npx tsc --noEmit (cloud/apps/api)  → pass (0 errors)
npx turbo lint --filter=@valuerank/api → pass (0 errors, pre-existing warnings only)
npx vitest run (full suite, worktree) → 2071 pass, 2 fail (pre-existing order-dependent flakiness in queue/handlers/index.test.ts, unrelated — pass in isolation)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)