### PR TITLE
Remove discretionary pauses from feature workflow skills

### DIFF
--- a/.claude/skills/feature-implement/SKILL.md
+++ b/.claude/skills/feature-implement/SKILL.md
@@ -5,6 +5,18 @@ description: Execute feature tasks phase-by-phase with automatic progress tracki
 
 # Feature Implementation Skill
 
+## ⚠️ Keep Moving Between Phases
+
+Do **not** pause between phases, checklists, or implementation checkpoints unless one of these is true:
+- A runner or checkpoint command returns `mark_blocked`
+- A task fails and halts execution per Step 7
+- The user explicitly asked to stop at a specific point
+- The repo state makes the next action unsafe
+
+Checklist warnings, diff-size notices, and other advisory signals should be **logged and passed through** — not turned into "yes/no" prompts. Keep moving.
+
+---
+
 ## ⚠️ VALUERANK REPO: Use the factory workflow instead
 
 If you are working in the `valuerank` / `chrislawcodes/valuerank` repository, **do not follow this skill**. This is a generic skill that references `.specify/` and constitution files that do not exist in this repo.
@@ -69,28 +81,7 @@ Executes implementation that:
    - `<feature-dir>/plan.md` (REQUIRED)
    - `<feature-dir>/spec-acceptance.md` OR `<feature-dir>/spec.md` (at least one REQUIRED — prefer spec-acceptance.md if it exists; fall back to spec.md and extract acceptance criteria from it)
 
-4. **Diff size estimate** — count unchecked tasks and files in scope, then warn if the expected diff is likely to be large:
-
-   ```
-   # Count unchecked tasks
-   task_count = grep -c '^\s*- \[ \]' tasks.md
-
-   # Count unique files in task descriptions (rough proxy)
-   file_scope = extract unique paths from [P: ...] annotations and task descriptions
-   ```
-
-   **If `task_count >= 20` OR `len(file_scope) >= 15`**:
-   ```
-   ⚠️  Large task set detected: [N] tasks across [M] files.
-   The diff review stage has a hard cap of 150K chars (~80K triggers a rerun warning).
-   Consider splitting into two implementation passes:
-   - Pass 1: Phases 1–2 (Foundation) + Phase 3 (P1 story)
-   - Pass 2: Remaining phases
-   Proceed anyway? (yes/split)
-   ```
-   Wait for user confirmation before continuing. If "split", stop here and ask which phases to include in pass 1.
-
-   **If `task_count < 20` AND `len(file_scope) < 15`**: proceed without warning.
+4. **Diff size note** — count unchecked tasks and files in scope. If `task_count >= 20` OR `len(file_scope) >= 15`, log a one-line notice that the diff may be large and phase-by-phase commits will help keep review budgets manageable. Do **not** pause or ask the user whether to proceed — the diff checkpoint stage enforces size limits at the right time.
 
 **Output**: Confirmed feature directory and prerequisites met
 
@@ -134,7 +125,7 @@ Starting Phase 1: Setup...
 
 **If ANY checklist incomplete**:
 ```
-⚠️ Some checklists are incomplete
+⚠️ Some checklists are incomplete — continuing with implementation
 
 Incomplete Items:
 - implementation.md: 3 items unchecked
@@ -142,14 +133,10 @@ Incomplete Items:
   - [ ] [Item from checklist]
   - [ ] [Item from checklist]
 
-This may indicate the plan is not fully validated.
-
-Do you want to proceed with implementation anyway? (yes/no)
+These items are logged but not blocking. Review them during diff checkpoint.
 ```
 
-**Wait for user response**:
-- "yes" / "proceed" / "continue" → Continue to Step 3
-- "no" / "wait" / "stop" → Halt execution, suggest reviewing checklists
+Emit the warning, then **proceed to Step 3 without waiting for user input**. Halt only if the user has explicitly asked to stop on checklist warnings.
 
 **If no checklists exist**: Skip validation, proceed to Step 3
 

--- a/.claude/skills/feature-plan/SKILL.md
+++ b/.claude/skills/feature-plan/SKILL.md
@@ -5,6 +5,18 @@ description: Generate technical implementation plan from feature specification. 
 
 # Feature Planning Skill
 
+## ⚠️ Keep Moving Between Phases
+
+Do **not** pause between phases of the feature workflow (spec → plan → tasks → implement) unless one of these is true:
+- A runner or checkpoint command returns `mark_blocked`
+- The user explicitly asked to stop at a specific point
+- Constitution check returns **FAIL**
+- The repo state makes the next action unsafe
+
+When the plan is complete, auto-continue into `feature-tasks` without waiting for the user to say "continue." Report a one-sentence status and proceed.
+
+---
+
 ## ⚠️ VALUERANK REPO: Use the factory workflow instead
 
 If you are working in the `valuerank` / `chrislawcodes/valuerank` repository, **do not follow this skill**. This is a generic skill that references `.specify/` and constitution files that do not exist in this repo.
@@ -582,19 +594,17 @@ Generated Files:
 Constitution Check: [PASS/WARN/FAIL/SKIPPED]
 [If checked:] - [Summary of findings]
 
-Next Steps:
-1. Review generated files for technical accuracy
-2. When ready for task breakdown, invoke the feature-tasks skill
-3. Or refine architecture decisions in plan.md if needed
-
-To continue: Simply say "use feature-tasks skill" or "generate the tasks"
+Plan complete — proceeding to task breakdown.
 ```
 
 **Handoff Instructions**:
-- Tell the user the technical plan is complete and ready for review
-- Invite them to proceed with the `feature-tasks` skill when ready
-- DO NOT suggest using `/speckit.tasks` or any other speckit command
-- Make it clear they should invoke the feature-tasks SKILL, not a slash command
+- Report plan completion in one sentence.
+- **Auto-continue into the `feature-tasks` skill immediately** unless one of the following is true:
+  - Constitution check returned **FAIL** (must be resolved before tasks can be written)
+  - The user explicitly asked to stop after planning
+  - The repo state makes proceeding unsafe
+- Do not wait for the user to say "continue" or "use feature-tasks skill."
+- DO NOT suggest using `/speckit.tasks` or any other speckit command.
 
 ---
 

--- a/.claude/skills/feature-spec/SKILL.md
+++ b/.claude/skills/feature-spec/SKILL.md
@@ -5,6 +5,18 @@ description: Create a high-quality feature specification with prioritized user s
 
 # Feature Specification Skill
 
+## ⚠️ Keep Moving Between Phases
+
+Do **not** pause between phases of the feature workflow (spec → plan → tasks → implement) unless one of these is true:
+- A runner or checkpoint command returns `mark_blocked`
+- The user explicitly asked to stop at a specific point
+- Discovery questions have unresolved items that require the user's answer
+- The repo state makes the next action unsafe
+
+When the spec is complete, auto-continue into `feature-plan` without waiting for the user to say "continue." Report a one-sentence status and proceed.
+
+---
+
 ## ⚠️ VALUERANK REPO: Use the factory workflow instead
 
 If you are working in the `valuerank` / `chrislawcodes/valuerank` repository, **do not follow this skill**. This is a generic skill that references `.specify/` and constitution files that do not exist in this repo.
@@ -310,19 +322,17 @@ Summary:
 - Success Criteria: 4
 - Constitution Check: PASS (or SKIPPED if no constitution)
 
-Next Steps:
-1. Review spec.md for accuracy
-2. When ready for technical planning, invoke the feature-plan skill
-3. Or ask clarifying questions if requirements need refinement
-
-To continue: Simply say "use feature-plan skill" or "generate the technical plan"
+Spec complete — proceeding to technical planning.
 ```
 
 **Handoff Instructions**:
-- Tell the user the specification is complete and ready for review
-- Invite them to proceed with the `feature-plan` skill when ready
-- DO NOT suggest using `/speckit.plan` or any other speckit command
-- Make it clear they should invoke the feature-plan SKILL, not a slash command
+- Report spec completion in one sentence.
+- **Auto-continue into the `feature-plan` skill immediately** unless one of the following is true:
+  - Constitution check returned **FAIL**
+  - The user explicitly asked to stop after the spec
+  - Discovery questions left unresolved items that require the user's answer before planning
+- Do not wait for the user to say "continue" or "use feature-plan skill."
+- DO NOT suggest using `/speckit.plan` or any other speckit command.
 
 ---
 

--- a/.claude/skills/feature-tasks/SKILL.md
+++ b/.claude/skills/feature-tasks/SKILL.md
@@ -5,6 +5,18 @@ description: Generate executable task breakdown from feature plan. Creates tasks
 
 # Feature Tasks Skill
 
+## ⚠️ Keep Moving Between Phases
+
+Do **not** pause between phases of the feature workflow (spec → plan → tasks → implement) unless one of these is true:
+- A runner or checkpoint command returns `mark_blocked`
+- The user explicitly asked to stop at a specific point
+- Constitution check returns **FAIL**
+- The repo state makes the next action unsafe
+
+When tasks are complete, auto-continue into `feature-implement` (or `/feature-implement <slug>` in ValueRank) without waiting for the user to say "continue." Report a one-sentence status and proceed.
+
+---
+
 ## ⚠️ VALUERANK REPO: Use the factory workflow instead
 
 If you are working in the `valuerank` / `chrislawcodes/valuerank` repository, **do not follow this skill**. This is a generic skill that references `.specify/` and constitution files that do not exist in this repo.
@@ -493,24 +505,17 @@ Task Statistics:
 
 Constitution Check: [PASS/WARN/SKIPPED]
 
-Next Steps:
-1. Review tasks.md for completeness
-2. Review checklists/ for quality gates
-3. When ready to implement:
-   - In ValueRank, use `/feature-implement <slug>`
-   - In other repos, invoke the feature-implement skill
-
-To continue:
-- In ValueRank: say `/feature-implement <slug>` or "start implementation"
-- In other repos: say "use feature-implement skill" or "start implementation"
+Tasks complete — proceeding to implementation.
 ```
 
 **Handoff Instructions**:
-- Tell the user the task breakdown is complete and ready for review
-- Invite them to proceed with `/feature-implement <slug>` in ValueRank, or the
-  `feature-implement` skill in other repos
-- DO NOT suggest using `/speckit.implement` or any other speckit command
-- Make it clear that ValueRank uses `/feature-implement <slug>`, not this generic next step
+- Report task breakdown completion in one sentence.
+- **Auto-continue into `/feature-implement <slug>` (ValueRank) or the `feature-implement` skill (other repos) immediately** unless one of the following is true:
+  - Constitution check returned **FAIL**
+  - The user explicitly asked to stop after tasks
+  - The repo state makes proceeding unsafe
+- Do not wait for the user to say "continue" or "start implementation."
+- DO NOT suggest using `/speckit.implement` or any other speckit command.
 
 ---
 


### PR DESCRIPTION
## Summary
- Root cause: individual feature skills (`feature-spec`, `feature-plan`, `feature-tasks`, `feature-implement`) explicitly instructed Claude to stop and wait for the user between phases, contradicting the orchestrator's "Keep Moving" rule in `docs/workflow/operations/codex-skills/feature-factory/SKILL.md`.
- Adds a "Keep Moving Between Phases" rule at the top of each skill listing the only conditions that justify stopping (runner `mark_blocked`, constitution FAIL, task failure, explicit user stop, unsafe repo state).
- Rewrites end-of-skill handoffs to auto-continue into the next stage instead of telling the user to invoke the next skill manually.
- Removes the diff-size "Proceed anyway? (yes/split)" prompt in `feature-implement` (the diff checkpoint stage already enforces size limits).
- Changes incomplete-checklist handling in `feature-implement` from a yes/no prompt to a logged warning that lets implementation continue.

## Test plan
- [ ] Docs-only change — verify no code affected
- [ ] Review the four SKILL.md diffs for clarity of the new "Keep Moving" language
- [ ] Next feature run: confirm Claude auto-chains spec -> plan -> tasks -> implement without waiting for "continue"

Generated with [Claude Code](https://claude.com/claude-code)