### PR TITLE
test(api): unit tests for getUnresolvableCount live-resolver invariant

### DIFF
--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -9,7 +9,6 @@ import { calculatePercentComplete } from '../../services/run/index.js';
 import { AnalysisResultRef } from './analysis.js';
 import { CostEstimateRef, type CostEstimateShape } from './cost-estimate.js';
 import { getAllMetrics, getTotals } from '../../services/rate-limiter/index.js';
-import { getUnresolvableCount } from '../../services/unresolvable-count.js';
 
 // Re-export for backward compatibility
 export { RunRef, TranscriptRef, ExperimentRef };
@@ -49,27 +48,6 @@ type QueueFailurePayload = {
   error?: unknown;
   value?: unknown;
 };
-
-const UnresolvableByModel = builder
-  .objectRef<{ modelId: string; count: number }>('UnresolvableByModel')
-  .implement({
-    fields: (t) => ({
-      modelId: t.exposeString('modelId'),
-      count: t.exposeInt('count'),
-    }),
-  });
-
-const UnresolvableCount = builder
-  .objectRef<{ total: number; byModel: { modelId: string; count: number }[] }>('UnresolvableCount')
-  .implement({
-    fields: (t) => ({
-      total: t.exposeInt('total'),
-      byModel: t.field({
-        type: [UnresolvableByModel],
-        resolve: (p) => p.byModel,
-      }),
-    }),
-  });
 
 function normalizeTaskError(output: unknown): string | null {
   if (output === null || output === undefined) {
@@ -354,16 +332,6 @@ builder.objectType(RunRef, {
           percentComplete: Math.min(100, Math.round(((dynamicCompleted + dynamicFailed) / progress.total) * 100)),
           byModel: byModel.length > 0 ? byModel : undefined,
         };
-      },
-    }),
-
-    unresolvableTranscriptCount: t.field({
-      type: UnresolvableCount,
-      nullable: true,
-      description: 'Count of summarized transcripts that could not be scored',
-      resolve: async (run) => {
-        const result = await getUnresolvableCount(run.id);
-        return result.total > 0 ? result : null;
       },
     }),
 

--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -9,6 +9,7 @@ import { calculatePercentComplete } from '../../services/run/index.js';
 import { AnalysisResultRef } from './analysis.js';
 import { CostEstimateRef, type CostEstimateShape } from './cost-estimate.js';
 import { getAllMetrics, getTotals } from '../../services/rate-limiter/index.js';
+import { getUnresolvableCount } from '../../services/unresolvable-count.js';
 
 // Re-export for backward compatibility
 export { RunRef, TranscriptRef, ExperimentRef };
@@ -48,6 +49,27 @@ type QueueFailurePayload = {
   error?: unknown;
   value?: unknown;
 };
+
+const UnresolvableByModel = builder
+  .objectRef<{ modelId: string; count: number }>('UnresolvableByModel')
+  .implement({
+    fields: (t) => ({
+      modelId: t.exposeString('modelId'),
+      count: t.exposeInt('count'),
+    }),
+  });
+
+const UnresolvableCount = builder
+  .objectRef<{ total: number; byModel: { modelId: string; count: number }[] }>('UnresolvableCount')
+  .implement({
+    fields: (t) => ({
+      total: t.exposeInt('total'),
+      byModel: t.field({
+        type: [UnresolvableByModel],
+        resolve: (p) => p.byModel,
+      }),
+    }),
+  });
 
 function normalizeTaskError(output: unknown): string | null {
   if (output === null || output === undefined) {
@@ -332,6 +354,16 @@ builder.objectType(RunRef, {
           percentComplete: Math.min(100, Math.round(((dynamicCompleted + dynamicFailed) / progress.total) * 100)),
           byModel: byModel.length > 0 ? byModel : undefined,
         };
+      },
+    }),
+
+    unresolvableTranscriptCount: t.field({
+      type: UnresolvableCount,
+      nullable: true,
+      description: 'Count of summarized transcripts that could not be scored',
+      resolve: async (run) => {
+        const result = await getUnresolvableCount(run.id);
+        return result.total > 0 ? result : null;
       },
     }),
 

--- a/cloud/apps/api/tests/services/unresolvable-count.test.ts
+++ b/cloud/apps/api/tests/services/unresolvable-count.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getUnresolvableCount } from '../../src/services/unresolvable-count.js';
+
+const mockFindMany = vi.hoisted(() => vi.fn());
+
+vi.mock('@valuerank/db', () => ({
+  db: {
+    transcript: {
+      findMany: mockFindMany,
+    },
+  },
+}));
+
+const SNAPSHOT_WITH_PAIR = {
+  dimensions: [{ name: 'Self_Direction_Action' }, { name: 'Stimulation' }],
+};
+
+const STALE_UNKNOWN_CACHE = {
+  summaryCache: {
+    summary: {
+      canonicalDecision: {
+        cacheVersion: 1,
+        decisionState: 'unknown',
+        favoredValueKey: null,
+        strength: 'none',
+      },
+    },
+  },
+};
+
+describe('getUnresolvableCount', () => {
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  it('does not count a transcript where the stale cache says unknown but raw evidence is resolvable', async () => {
+    // This is the core invariant: the function must use the live resolver, not the
+    // stale summaryCache. The cache stored 'unknown' but the parsePath encodes a
+    // clear favor_first outcome — the resolver recovers it.
+    mockFindMany.mockResolvedValue([{
+      modelId: 'claude-sonnet-4-5',
+      decisionCode: null,
+      decisionMetadata: {
+        parsePath: 'exact.favor_first.strong',
+        parseClass: 'exact',
+        parserVersion: 'parser-1',
+        matchedText: 'Self_Direction_Action',
+        matchedLabel: 'Self_Direction_Action',
+        ...STALE_UNKNOWN_CACHE,
+      },
+      definitionSnapshot: SNAPSHOT_WITH_PAIR,
+      scenario: { orientationFlipped: false },
+    }]);
+
+    const result = await getUnresolvableCount('run-1');
+
+    expect(result.total).toBe(0);
+    expect(result.byModel).toEqual([]);
+  });
+
+  it('counts a transcript where the live resolver genuinely cannot resolve', async () => {
+    mockFindMany.mockResolvedValue([{
+      modelId: 'model-a',
+      decisionCode: null,
+      decisionMetadata: null,
+      definitionSnapshot: SNAPSHOT_WITH_PAIR,
+      scenario: { orientationFlipped: false },
+    }]);
+
+    const result = await getUnresolvableCount('run-1');
+
+    expect(result.total).toBe(1);
+    expect(result.byModel).toEqual([{ modelId: 'model-a', count: 1 }]);
+  });
+
+  it('groups unresolvable counts by model', async () => {
+    mockFindMany.mockResolvedValue([
+      { modelId: 'model-a', decisionCode: null, decisionMetadata: null, definitionSnapshot: SNAPSHOT_WITH_PAIR, scenario: null },
+      { modelId: 'model-a', decisionCode: null, decisionMetadata: null, definitionSnapshot: SNAPSHOT_WITH_PAIR, scenario: null },
+      { modelId: 'model-b', decisionCode: null, decisionMetadata: null, definitionSnapshot: SNAPSHOT_WITH_PAIR, scenario: null },
+    ]);
+
+    const result = await getUnresolvableCount('run-1');
+
+    expect(result.total).toBe(3);
+    expect(result.byModel).toContainEqual({ modelId: 'model-a', count: 2 });
+    expect(result.byModel).toContainEqual({ modelId: 'model-b', count: 1 });
+  });
+
+  it('queries only summarized non-manual transcripts', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    await getUnresolvableCount('run-abc');
+
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          runId: 'run-abc',
+          summarizedAt: { not: null },
+          decisionCodeSource: { not: 'manual' },
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for `getUnresolvableCount` that enforce the core invariant: the function must use the live `resolveTranscriptDecisionModel` resolver, not the stale `summaryCache` in `decisionMetadata`
- Tests cover: stale-cache override (resolvable transcript not counted), genuinely unresolvable transcript counted, per-model grouping, and correct DB query filters

## Test plan
- [x] All 4 tests pass locally
- [x] Only adds a test file — no production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)