### PR TITLE
fix(tests): use vi.hoisted to stabilize summarize-persistence mock pattern

### DIFF
--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -9,7 +9,6 @@ import { calculatePercentComplete } from '../../services/run/index.js';
 import { AnalysisResultRef } from './analysis.js';
 import { CostEstimateRef, type CostEstimateShape } from './cost-estimate.js';
 import { getAllMetrics, getTotals } from '../../services/rate-limiter/index.js';
-import { getUnresolvableCount } from '../../services/unresolvable-count.js';
 
 // Re-export for backward compatibility
 export { RunRef, TranscriptRef, ExperimentRef };
@@ -49,27 +48,6 @@ type QueueFailurePayload = {
   error?: unknown;
   value?: unknown;
 };
-
-const UnresolvableByModel = builder
-  .objectRef<{ modelId: string; count: number }>('UnresolvableByModel')
-  .implement({
-    fields: (t) => ({
-      modelId: t.exposeString('modelId'),
-      count: t.exposeInt('count'),
-    }),
-  });
-
-const UnresolvableCount = builder
-  .objectRef<{ total: number; byModel: { modelId: string; count: number }[] }>('UnresolvableCount')
-  .implement({
-    fields: (t) => ({
-      total: t.exposeInt('total'),
-      byModel: t.field({
-        type: [UnresolvableByModel],
-        resolve: (p) => p.byModel,
-      }),
-    }),
-  });
 
 function normalizeTaskError(output: unknown): string | null {
   if (output === null || output === undefined) {
@@ -354,16 +332,6 @@ builder.objectType(RunRef, {
           percentComplete: Math.min(100, Math.round(((dynamicCompleted + dynamicFailed) / progress.total) * 100)),
           byModel: byModel.length > 0 ? byModel : undefined,
         };
-      },
-    }),
-
-    unresolvableTranscriptCount: t.field({
-      type: UnresolvableCount,
-      nullable: true,
-      description: 'Count of summarized transcripts that could not be scored',
-      resolve: async (run) => {
-        const result = await getUnresolvableCount(run.id);
-        return result.total > 0 ? result : null;
       },
     }),
 

--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -9,6 +9,7 @@ import { calculatePercentComplete } from '../../services/run/index.js';
 import { AnalysisResultRef } from './analysis.js';
 import { CostEstimateRef, type CostEstimateShape } from './cost-estimate.js';
 import { getAllMetrics, getTotals } from '../../services/rate-limiter/index.js';
+import { getUnresolvableCount } from '../../services/unresolvable-count.js';
 
 // Re-export for backward compatibility
 export { RunRef, TranscriptRef, ExperimentRef };
@@ -48,6 +49,27 @@ type QueueFailurePayload = {
   error?: unknown;
   value?: unknown;
 };
+
+const UnresolvableByModel = builder
+  .objectRef<{ modelId: string; count: number }>('UnresolvableByModel')
+  .implement({
+    fields: (t) => ({
+      modelId: t.exposeString('modelId'),
+      count: t.exposeInt('count'),
+    }),
+  });
+
+const UnresolvableCount = builder
+  .objectRef<{ total: number; byModel: { modelId: string; count: number }[] }>('UnresolvableCount')
+  .implement({
+    fields: (t) => ({
+      total: t.exposeInt('total'),
+      byModel: t.field({
+        type: [UnresolvableByModel],
+        resolve: (p) => p.byModel,
+      }),
+    }),
+  });
 
 function normalizeTaskError(output: unknown): string | null {
   if (output === null || output === undefined) {
@@ -332,6 +354,16 @@ builder.objectType(RunRef, {
           percentComplete: Math.min(100, Math.round(((dynamicCompleted + dynamicFailed) / progress.total) * 100)),
           byModel: byModel.length > 0 ? byModel : undefined,
         };
+      },
+    }),
+
+    unresolvableTranscriptCount: t.field({
+      type: UnresolvableCount,
+      nullable: true,
+      description: 'Count of summarized transcripts that could not be scored',
+      resolve: async (run) => {
+        const result = await getUnresolvableCount(run.id);
+        return result.total > 0 ? result : null;
       },
     }),
 

--- a/cloud/apps/api/tests/queue/handlers/summarize-persistence.test.ts
+++ b/cloud/apps/api/tests/queue/handlers/summarize-persistence.test.ts
@@ -1,34 +1,22 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import type { db as DbType } from '@valuerank/db';
-import type { findMissingProbes as FindMissingProbesType } from '../../../src/services/run/coverage-completeness.js';
 
-// These vi.mock() calls are hoisted above all imports by Vitest's transform.
+const mockCount = vi.hoisted(() => vi.fn());
+const mockFindMissingProbes = vi.hoisted(() => vi.fn());
+
 vi.mock('@valuerank/db', () => ({
   db: {
     transcript: {
-      count: vi.fn(),
+      count: mockCount,
     },
   },
   Prisma: { DbNull: null },
 }));
 
 vi.mock('../../../src/services/run/coverage-completeness.js', () => ({
-  findMissingProbes: vi.fn(),
+  findMissingProbes: mockFindMissingProbes,
 }));
 
-// Static imports execute after the hoisted vi.mock() factories are registered,
-// so these resolve to the mocked modules.
-import { db } from '@valuerank/db';
-import * as coverageCompleteness from '../../../src/services/run/coverage-completeness.js';
 import { checkAllSummarized } from '../../../src/queue/handlers/summarize-persistence.js';
-
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const mockCount: ReturnType<typeof vi.mocked<typeof DbType.transcript.count>> = vi.mocked(
-  db.transcript.count
-);
-const mockFindMissingProbes: ReturnType<
-  typeof vi.mocked<typeof FindMissingProbesType>
-> = vi.mocked(coverageCompleteness.findMissingProbes);
 
 describe('checkAllSummarized', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Fixes intermittent CI failures in `summarize-persistence.test.ts` where all 5 `checkAllSummarized` tests would fail with `TypeError: Cannot read properties of undefined (reading 'length')`
- Root cause: `vi.fn()` created inline in the `vi.mock()` factory and the `vi.mocked()` reference at module scope captured different instances when Vitest's hoist transform misfired under CI load. `mockCount` would configure the wrong function, `db.transcript.count` returned `undefined` instead of `2`, and the early-return never fired
- Fix: use `vi.hoisted()` for both mock fns so the same instance is referenced in the factory and in test assertions — identical to the pattern already used in `unresolvable-count.test.ts`

## Test plan
- [x] All 5 tests pass locally
- [x] Only touches the test file — no production code changes
- [x] Preflight passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)