### PR TITLE
fix(ui): raise Select dropdown z-index so it clears sticky table headers

### DIFF
--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -9,7 +9,6 @@ import { calculatePercentComplete } from '../../services/run/index.js';
 import { AnalysisResultRef } from './analysis.js';
 import { CostEstimateRef, type CostEstimateShape } from './cost-estimate.js';
 import { getAllMetrics, getTotals } from '../../services/rate-limiter/index.js';
-import { getUnresolvableCount } from '../../services/unresolvable-count.js';
 
 // Re-export for backward compatibility
 export { RunRef, TranscriptRef, ExperimentRef };
@@ -49,27 +48,6 @@ type QueueFailurePayload = {
   error?: unknown;
   value?: unknown;
 };
-
-const UnresolvableByModel = builder
-  .objectRef<{ modelId: string; count: number }>('UnresolvableByModel')
-  .implement({
-    fields: (t) => ({
-      modelId: t.exposeString('modelId'),
-      count: t.exposeInt('count'),
-    }),
-  });
-
-const UnresolvableCount = builder
-  .objectRef<{ total: number; byModel: { modelId: string; count: number }[] }>('UnresolvableCount')
-  .implement({
-    fields: (t) => ({
-      total: t.exposeInt('total'),
-      byModel: t.field({
-        type: [UnresolvableByModel],
-        resolve: (p) => p.byModel,
-      }),
-    }),
-  });
 
 function normalizeTaskError(output: unknown): string | null {
   if (output === null || output === undefined) {
@@ -354,16 +332,6 @@ builder.objectType(RunRef, {
           percentComplete: Math.min(100, Math.round(((dynamicCompleted + dynamicFailed) / progress.total) * 100)),
           byModel: byModel.length > 0 ? byModel : undefined,
         };
-      },
-    }),
-
-    unresolvableTranscriptCount: t.field({
-      type: UnresolvableCount,
-      nullable: true,
-      description: 'Count of summarized transcripts that could not be scored',
-      resolve: async (run) => {
-        const result = await getUnresolvableCount(run.id);
-        return result.total > 0 ? result : null;
       },
     }),
 

--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -9,6 +9,7 @@ import { calculatePercentComplete } from '../../services/run/index.js';
 import { AnalysisResultRef } from './analysis.js';
 import { CostEstimateRef, type CostEstimateShape } from './cost-estimate.js';
 import { getAllMetrics, getTotals } from '../../services/rate-limiter/index.js';
+import { getUnresolvableCount } from '../../services/unresolvable-count.js';
 
 // Re-export for backward compatibility
 export { RunRef, TranscriptRef, ExperimentRef };
@@ -48,6 +49,27 @@ type QueueFailurePayload = {
   error?: unknown;
   value?: unknown;
 };
+
+const UnresolvableByModel = builder
+  .objectRef<{ modelId: string; count: number }>('UnresolvableByModel')
+  .implement({
+    fields: (t) => ({
+      modelId: t.exposeString('modelId'),
+      count: t.exposeInt('count'),
+    }),
+  });
+
+const UnresolvableCount = builder
+  .objectRef<{ total: number; byModel: { modelId: string; count: number }[] }>('UnresolvableCount')
+  .implement({
+    fields: (t) => ({
+      total: t.exposeInt('total'),
+      byModel: t.field({
+        type: [UnresolvableByModel],
+        resolve: (p) => p.byModel,
+      }),
+    }),
+  });
 
 function normalizeTaskError(output: unknown): string | null {
   if (output === null || output === undefined) {
@@ -332,6 +354,16 @@ builder.objectType(RunRef, {
           percentComplete: Math.min(100, Math.round(((dynamicCompleted + dynamicFailed) / progress.total) * 100)),
           byModel: byModel.length > 0 ? byModel : undefined,
         };
+      },
+    }),
+
+    unresolvableTranscriptCount: t.field({
+      type: UnresolvableCount,
+      nullable: true,
+      description: 'Count of summarized transcripts that could not be scored',
+      resolve: async (run) => {
+        const result = await getUnresolvableCount(run.id);
+        return result.total > 0 ? result : null;
       },
     }),
 

--- a/cloud/apps/web/src/components/ui/Select.tsx
+++ b/cloud/apps/web/src/components/ui/Select.tsx
@@ -220,7 +220,7 @@ export function Select<T extends string = string>({
           id={listboxId}
           role="listbox"
           aria-label={label}
-          className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto py-1"
+          className="absolute z-50 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto py-1"
         >
           {options.map((option, index) => {
             const isSelected = option.value === value;


### PR DESCRIPTION
## Summary
- The domain dropdown on the Models page was hidden behind the table headers
- Root cause: dropdown used `z-10`, sticky table headers used `z-10`/`z-20` — headers painted on top
- Fix: bump dropdown to `z-50` so it always appears above sticky elements

## Validation
- `npm run lint --workspace @valuerank/web` — pass
- `npm run build --workspace @valuerank/web` — pass

## Test plan
- [ ] Open Models page, click Domain scope dropdown — list appears above the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)