### PR TITLE
fix(domain-seed): leave national-priorities defaultModelIds empty

### DIFF
--- a/cloud/scripts/seed-national-priorities-choice.ts
+++ b/cloud/scripts/seed-national-priorities-choice.ts
@@ -101,23 +101,14 @@ async function main(): Promise<void> {
     }
   }
 
-  // 6. Populate defaultModelIds from admin-flagged default models if not already set
-  if (domain.defaultModelIds.length === 0) {
-    const defaultModels = await db.llmModel.findMany({
-      where: { isDefault: true, status: 'ACTIVE' },
-      select: { id: true },
-    });
-    if (defaultModels.length > 0) {
-      const modelIds = defaultModels.map((m) => m.id);
-      await db.domain.update({
-        where: { id: domain.id },
-        data: { defaultModelIds: modelIds },
-      });
-      log.info({ modelCount: modelIds.length }, 'Populated defaultModelIds from admin defaults');
-    } else {
-      log.warn('No admin-flagged default models found; defaultModelIds left empty');
-    }
-  }
+  // 6. Leave Domain.defaultModelIds empty — matches job-choice, neighborhood,
+  // software-approach behavior. resolveEffectiveDefaultModelIds() falls back to
+  // LlmModel.isDefault=true at query time, so the domain stays in sync with
+  // whatever models the admin currently has flagged as default. The previous
+  // implementation tried to snapshot LlmModel.id (cuid) into defaultModelIds,
+  // but the coverage query expects LlmModel.modelId (short name like
+  // "gpt-5.1") to match transcripts.modelId — different ID type. Falling back
+  // is both simpler and consistent with other domains.
 
   log.info({ upserted, domainId: domain.id, contextId: context.id }, 'Seed complete');
 }

--- a/docs/workflow/plans/national-priorities-domain.md
+++ b/docs/workflow/plans/national-priorities-domain.md
@@ -42,7 +42,7 @@ We picked advisor over ruler deliberately. Some models are trained to refuse rol
 | `name` | `National Priorities` |
 | `sentencePrefix` | `One program provides citizens with [level]` |
 | `labelPrefix` | `the program that provides citizens with` |
-| `defaultModelIds` | Pulled at seed time from `LlmModel` where `isDefault = true` and `status = ACTIVE` |
+| `defaultModelIds` | Left empty (`[]`). `resolveEffectiveDefaultModelIds()` falls back to `LlmModel.isDefault=true` at query time, keeping the domain in sync with admin-set defaults. Matches `job-choice`, `neighborhood`, `software-approach`. |
 | `defaultPreambleVersionId` | Copied from `job-choice` domain at seed time |
 | `defaultLevelPresetVersionId` | Copied from `job-choice` domain at seed time |
 
@@ -63,9 +63,11 @@ This adds one word of scope divergence from other domains. Justified by the diff
 
 The existing "[verb] the [thing] with" pattern fits options that *have* features. A program *does* things. Paralleling the sentence prefix keeps the language consistent and puts "citizens" in the label as the explicit beneficiary, matching the body structure.
 
-### Why `defaultModelIds` is populated at seed time
+### `defaultModelIds` is left empty by design
 
-Other domains leave `defaultModelIds` empty and rely on the admin UI to configure it. For this domain we instead pull the system-level default set (`LlmModel` rows flagged `isDefault = true`) at seed time, so the domain is usable without an extra UI step. The admin-flagged default set stays the source of truth; the seed just snapshots it.
+Other domains (`job-choice`, `neighborhood`, `software-approach`) leave `Domain.defaultModelIds` as `[]`. Coverage and analysis queries call `resolveEffectiveDefaultModelIds()`, which falls back to `LlmModel` rows flagged `isDefault = true` at query time. This keeps the domain automatically in sync with whatever the admin currently has marked default — no per-domain configuration step needed.
+
+An earlier draft of the seed script tried to *snapshot* the admin defaults into `Domain.defaultModelIds` at seed time, but stored `LlmModel.id` (cuid) when the coverage query actually compares against `LlmModel.modelId` (short name like `gpt-5.1`). That ID-type mismatch made every cell report `minTrialCount: 0` even though transcripts existed. Falling back via the empty-array path is both simpler and consistent with every other domain.
 
 ### Scale labels are level-agnostic (accepted behavior)
 
@@ -128,5 +130,5 @@ Three files, following the `software-approach-choice` pattern:
 | File | Purpose |
 |---|---|
 | `cloud/packages/shared/src/national-priorities-value-statements.ts` | The 10 bodies above, exported as a typed const array |
-| `cloud/scripts/seed-national-priorities-choice.ts` | Creates the Domain + DomainContext + sentencePrefix/labelPrefix + ValueStatements; copies level preset and preamble defaults from `job-choice`; populates `defaultModelIds` from `LlmModel` where `isDefault = true` |
+| `cloud/scripts/seed-national-priorities-choice.ts` | Creates the Domain + DomainContext + sentencePrefix/labelPrefix + ValueStatements; copies level preset and preamble defaults from `job-choice`. Leaves `defaultModelIds` empty; the resolver falls back to `LlmModel.isDefault = true` at query time. |
 | `cloud/scripts/seed-national-priorities-pairs.ts` | Creates all 45 definition pairs (10 values choose 2) with vignettes, in dry-run + `--apply` modes |


### PR DESCRIPTION
## Summary
Fixes a coverage-query bug introduced in #691: my seed script for the National Priorities domain stored \`LlmModel.id\` (cuid) values in \`Domain.defaultModelIds\`, but the coverage query expects \`LlmModel.modelId\` (short name like \`gpt-5.1\`). That ID-type mismatch made every cell on the domain overview report \`minTrialCount: 0\` despite 18,000 transcripts existing.

The fix matches the existing pattern used by \`job-choice\`, \`neighborhood\`, and \`software-approach\`: leave \`Domain.defaultModelIds\` empty. The resolver \`resolveEffectiveDefaultModelIds()\` falls back to \`LlmModel\` where \`isDefault = true\` at query time and returns the correct short modelIds. This also keeps the domain in sync with admin-set defaults automatically.

## Prod state
Already corrected on prod by manually setting \`defaultModelIds = []\` on the existing \`national-priorities\` Domain row. The overview now populates correctly. This PR updates the seed script so future re-runs and any new domains seeded from this template don't reintroduce the bug.

## Test plan
- [x] \`@valuerank/shared\` lint + build pass
- [x] Verified on prod: clearing \`defaultModelIds\` made \`domainValueCoverage\` return non-zero \`minTrialCount\`/\`maxTrialCount\` for all 45 cells
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)