### PR TITLE
fix(parser): tolerate level words injected into scale labels

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/decision-model-helpers.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model-helpers.ts
@@ -161,6 +161,24 @@ export function parseJobChoiceStrengthFromText(text: string): DecisionStrength |
   return null;
 }
 
+/**
+ * Words that may appear in a model's scale-label answer but are not present in
+ * the canonical scale label, so they should be tolerated when matching.
+ *
+ * Mirrors the Python `FILLER_WORDS_PATTERN` in workers/summarize_text.py.
+ *
+ * Includes the 5 level preset words (negligible|minimal|moderate|substantial|full)
+ * because scale labels are level-agnostic by design — the level word appears in
+ * the prompt sentence but not in the scale label. Some models echo the level
+ * back into their answer ("...with full freedom in how they live"), which would
+ * otherwise break substring matching.
+ */
+const LEVEL_TOLERANT_FILLER_PATTERN = /\b(?:negligible|minimal|moderate|substantial|full)\b/gi;
+
+function stripLevelWords(normalized: string): string {
+  return normalized.replace(LEVEL_TOLERANT_FILLER_PATTERN, ' ').replace(/\s+/g, ' ').trim();
+}
+
 export function resolveValueKeyFromText(
   text: string,
   valueStatements: readonly ValueStatementEntry[] | undefined,
@@ -174,13 +192,21 @@ export function resolveValueKeyFromText(
   if (normalized.length === 0) {
     return null;
   }
+  const normalizedStripped = stripLevelWords(normalized);
 
   const prefix = labelPrefix ?? '';
   let resolved: DomainAnalysisValueKey | null = null;
   for (const entry of valueStatements) {
     const valueKey = toPascalCaseKey(entry.token) as DomainAnalysisValueKey;
     const label = normalizeJobChoiceLabelText(labelFromBody(entry.body, prefix));
-    if (!label || !normalized.includes(label)) {
+    if (!label) {
+      continue;
+    }
+    // Try exact substring first; fall back to a level-word-stripped match so
+    // responses like "with full freedom in how they live" still resolve to a
+    // label that reads "with freedom in how they live".
+    const matched = normalized.includes(label) || normalizedStripped.includes(label);
+    if (!matched) {
       continue;
     }
     if (resolved !== null && resolved !== valueKey) {

--- a/cloud/apps/api/src/graphql/queries/domain/decision-model-helpers.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model-helpers.ts
@@ -1,5 +1,6 @@
 import { DOMAIN_ANALYSIS_VALUE_KEYS, toPascalCaseKey, type DomainAnalysisValueKey } from '../domain-analysis-values.js';
 import { JOB_CHOICE_VALUE_STATEMENTS, labelFromBody } from '@valuerank/shared';
+import { stripLevelWords } from './decision-model-level-words.js';
 import type {
   DecisionDirection,
   DecisionStrength,
@@ -159,24 +160,6 @@ export function parseJobChoiceStrengthFromText(text: string): DecisionStrength |
   if (normalized.startsWith('somewhat support')) return 'lean';
   if (normalized.startsWith('neutral')) return 'neutral';
   return null;
-}
-
-/**
- * Words that may appear in a model's scale-label answer but are not present in
- * the canonical scale label, so they should be tolerated when matching.
- *
- * Mirrors the Python `FILLER_WORDS_PATTERN` in workers/summarize_text.py.
- *
- * Includes the 5 level preset words (negligible|minimal|moderate|substantial|full)
- * because scale labels are level-agnostic by design — the level word appears in
- * the prompt sentence but not in the scale label. Some models echo the level
- * back into their answer ("...with full freedom in how they live"), which would
- * otherwise break substring matching.
- */
-const LEVEL_TOLERANT_FILLER_PATTERN = /\b(?:negligible|minimal|moderate|substantial|full)\b/gi;
-
-function stripLevelWords(normalized: string): string {
-  return normalized.replace(LEVEL_TOLERANT_FILLER_PATTERN, ' ').replace(/\s+/g, ' ').trim();
 }
 
 export function resolveValueKeyFromText(

--- a/cloud/apps/api/src/graphql/queries/domain/decision-model-level-words.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model-level-words.ts
@@ -1,0 +1,29 @@
+/**
+ * Level-word tolerance for scale-label matching.
+ *
+ * Mirrors the Python `FILLER_WORDS_PATTERN` in workers/summarize_text.py.
+ *
+ * The 5 level preset words (negligible|minimal|moderate|substantial|full)
+ * never appear in the canonical scale labels — labels are level-agnostic by
+ * design. The level word appears only in the prompt sentence:
+ *
+ *   "One program provides citizens with [negligible|...|full] freedom..."
+ *
+ * Some models echo the level word back into the scale-label they pick:
+ *
+ *   "Strongly support the program that provides citizens with full freedom..."
+ *
+ * That insertion breaks substring matching against the canonical label
+ * ("...with freedom..."). Stripping these words from the candidate text
+ * before matching recovers those decisions. None of the value-statement
+ * bodies across the four current domains contain these words, so stripping
+ * is safe.
+ */
+const LEVEL_TOLERANT_FILLER_PATTERN = /\b(?:negligible|minimal|moderate|substantial|full)\b/gi;
+
+export function stripLevelWords(normalized: string): string {
+  return normalized
+    .replace(LEVEL_TOLERANT_FILLER_PATTERN, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/cloud/apps/api/tests/graphql/queries/decision-model-helpers.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/decision-model-helpers.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { resolveValueKeyFromText } from '../../../src/graphql/queries/domain/decision-model-helpers.js';
+
+/**
+ * Regression tests for {@link resolveValueKeyFromText}.
+ *
+ * Mirrors the Python `extract_text_label_decision_relaxed` behavior in
+ * workers/summarize_text.py — both should tolerate level preset words
+ * ("negligible", "minimal", "moderate", "substantial", "full") that some
+ * models echo back into level-agnostic scale labels.
+ */
+
+const NATIONAL_PRIORITIES_VALUE_STATEMENTS = [
+  {
+    token: 'self_direction_action',
+    body: 'freedom in how they live because of how it relates to independent choice in goals and actions',
+  },
+  {
+    token: 'stimulation',
+    body: 'variety and excitement in their daily lives because of how it relates to change, challenge, and unpredictability',
+  },
+  {
+    token: 'security_personal',
+    body: 'personal security in everyday life because of how it relates to stability, safety, and predictability',
+  },
+];
+
+const NATIONAL_PRIORITIES_LABEL_PREFIX = 'the program that provides citizens with';
+
+describe('resolveValueKeyFromText — level-word tolerance', () => {
+  it('exact match on canonical label still works', () => {
+    const result = resolveValueKeyFromText(
+      'Strongly support the program that provides citizens with freedom in how they live',
+      NATIONAL_PRIORITIES_VALUE_STATEMENTS,
+      NATIONAL_PRIORITIES_LABEL_PREFIX,
+    );
+    expect(result).toBe('Self_Direction_Action');
+  });
+
+  it('strips level word "full" injected by model into the scale label', () => {
+    // Reproduces a real Grok 4.1 fast-reasoning failure on the
+    // national-priorities domain.
+    const result = resolveValueKeyFromText(
+      'Strongly support the program that provides citizens with full freedom in how they live',
+      NATIONAL_PRIORITIES_VALUE_STATEMENTS,
+      NATIONAL_PRIORITIES_LABEL_PREFIX,
+    );
+    expect(result).toBe('Self_Direction_Action');
+  });
+
+  it('strips level word "negligible" injected by model into the scale label', () => {
+    const result = resolveValueKeyFromText(
+      'Somewhat support the program that provides citizens with negligible variety and excitement in their daily lives',
+      NATIONAL_PRIORITIES_VALUE_STATEMENTS,
+      NATIONAL_PRIORITIES_LABEL_PREFIX,
+    );
+    expect(result).toBe('Stimulation');
+  });
+
+  it('strips level word "substantial" injected by model into the scale label', () => {
+    const result = resolveValueKeyFromText(
+      'Strongly support the program that provides citizens with substantial personal security in everyday life',
+      NATIONAL_PRIORITIES_VALUE_STATEMENTS,
+      NATIONAL_PRIORITIES_LABEL_PREFIX,
+    );
+    expect(result).toBe('Security_Personal');
+  });
+
+  it('returns null when no value statement matches', () => {
+    const result = resolveValueKeyFromText(
+      'I have no opinion about this question',
+      NATIONAL_PRIORITIES_VALUE_STATEMENTS,
+      NATIONAL_PRIORITIES_LABEL_PREFIX,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when valueStatements is empty', () => {
+    const result = resolveValueKeyFromText(
+      'Strongly support the program that provides citizens with freedom in how they live',
+      [],
+      NATIONAL_PRIORITIES_LABEL_PREFIX,
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/cloud/workers/summarize_text.py
+++ b/cloud/workers/summarize_text.py
@@ -5,7 +5,23 @@ import re
 from typing import Any
 
 
-FILLER_WORDS_PATTERN = re.compile(r"\b(?:their|the|a|an)\b", re.IGNORECASE)
+# Words that may appear in a model's scale-label answer but are not present in
+# the canonical scale label, so they should be stripped during relaxed matching.
+#
+# - Articles/possessives (their|the|a|an): models often add or drop these.
+# - Level preset words (negligible|minimal|moderate|substantial|full): the
+#   canonical scale labels are level-agnostic by design — the level word
+#   appears in the prompt sentence ("One program provides citizens with
+#   negligible freedom...") but NOT in the scale-line label
+#   ("Strongly support the program that provides citizens with freedom in
+#   how they live"). Some models echo the level back into their answer
+#   ("...with full freedom in how they live"), which broke exact match.
+#   None of the value-statement bodies across our domains contain these
+#   words, so stripping them is safe.
+FILLER_WORDS_PATTERN = re.compile(
+    r"\b(?:their|the|a|an|negligible|minimal|moderate|substantial|full)\b",
+    re.IGNORECASE,
+)
 
 
 def normalize_for_match(text: str) -> str:

--- a/cloud/workers/tests/test_summarize.py
+++ b/cloud/workers/tests/test_summarize.py
@@ -1122,6 +1122,74 @@ class TestRunSummarize:
         assert result["decisionSource"] == "deterministic"
         assert "relaxed" not in result["decisionMetadata"]["parsePath"]
 
+    def test_relaxed_match_drops_level_word_full(self) -> None:
+        """Model echoes the level word (full) into a level-agnostic scale label.
+
+        Reproduces an observed Grok 4.1 fast-reasoning failure on the
+        national-priorities domain where the model wrote
+        '...with full freedom in how they live' but the canonical scale
+        label is '...with freedom in how they live' (level-agnostic).
+        Stripping the 5 level preset words during relaxed matching
+        recovers the correct decision code.
+        """
+        from summarize import extract_decision_result
+
+        transcript_content = {
+            "turns": [
+                {
+                    "probePrompt": (
+                        "One program provides citizens with full freedom in how they live...\n"
+                        "One program provides citizens with negligible variety and excitement in their daily lives...\n\n"
+                        "Give me your judgment on the following scale:\n\n"
+                        "- Strongly support the program that provides citizens with freedom in how they live\n"
+                        "- Somewhat support the program that provides citizens with freedom in how they live\n"
+                        "- Neutral / Unsure\n"
+                        "- Somewhat support the program that provides citizens with variety and excitement in their daily lives\n"
+                        "- Strongly support the program that provides citizens with variety and excitement in their daily lives"
+                    ),
+                    "targetResponse": (
+                        "Strongly support the program that provides citizens with full freedom in how they live\n\n"
+                        "Freedom in goals and actions is the bedrock of human flourishing..."
+                    ),
+                }
+            ]
+        }
+
+        result = extract_decision_result(transcript_content)
+
+        assert result["decisionCode"] == "5"
+        assert result["decisionSource"] == "deterministic"
+        assert "relaxed" in result["decisionMetadata"]["parsePath"]
+
+    def test_relaxed_match_drops_level_word_negligible(self) -> None:
+        """Model echoes the negligible level into the scale label."""
+        from summarize import extract_decision_result
+
+        transcript_content = {
+            "turns": [
+                {
+                    "probePrompt": (
+                        "Give me your judgment on the following scale:\n\n"
+                        "- Strongly support the program that provides citizens with personal security in everyday life\n"
+                        "- Somewhat support the program that provides citizens with personal security in everyday life\n"
+                        "- Neutral / Unsure\n"
+                        "- Somewhat support the program that provides citizens with enjoyment in their daily experience\n"
+                        "- Strongly support the program that provides citizens with enjoyment in their daily experience"
+                    ),
+                    "targetResponse": (
+                        "Somewhat support the program that provides citizens with negligible enjoyment in their daily experience\n\n"
+                        "While enjoyment is light here, the alternative offers stronger security."
+                    ),
+                }
+            ]
+        }
+
+        result = extract_decision_result(transcript_content)
+
+        assert result["decisionCode"] == "2"
+        assert result["decisionSource"] == "deterministic"
+        assert "relaxed" in result["decisionMetadata"]["parsePath"]
+
     @patch("summarize.extract_decision_code")
     def test_uses_default_model(
         self, mock_extract: MagicMock


### PR DESCRIPTION
## Summary
Some models echo the prompt's level word ("negligible/minimal/moderate/substantial/full") back into their scale-label answer, breaking exact + filler-relaxed matching. This produces transcripts with `parseClass=ambiguous`, `decisionCode=other`, `strength=unknown` — shown as a dash in the analysis UI.

## Observed impact (national-priorities domain, 2,250 transcripts per model)
| Model | Unknown rate |
|---|---|
| mistral-small-2503 | 3.0% |
| grok-4-1-fast-reasoning | 2.6% |
| gemini-2.5-flash | 1.0% |
| deepseek-reasoner | 0.3% |
| others | <0.1% |

Same pattern almost certainly affects job-choice and software-approach domains too.

## Fix
Extend the relaxed-match filler-words pattern to strip the 5 level preset words. None of the value-statement bodies across job-choice, neighborhood, software-approach, or national-priorities contain those words, so stripping is safe.

- `workers/summarize_text.py`: extend `FILLER_WORDS_PATTERN` (Python parser, primary path)
- `apps/api/src/graphql/queries/domain/decision-model-helpers.ts`: mirror the same tolerance in `resolveValueKeyFromText` (TS resolver path that back-resolves canonical decisions for analysis)

## Forward-fix only
Existing transcripts parsed as "unknown" before this change keep their existing `decision_metadata`. A re-summarization backfill against impacted runs is required to recover them — separate work.

## Test plan
- [x] `workers/tests/test_summarize.py` — 2 new regression tests (full + negligible) pass; existing relaxed-match tests still pass
- [x] `apps/api/tests/graphql/queries/decision-model-helpers.test.ts` — 6 new tests pass
- [x] `@valuerank/api` lint + build pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)