### PR TITLE
fix(ff-judge-panel): tolerate markdown fences + JSON-Schema metadata in judge output

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_judge.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_judge.py
@@ -426,10 +426,41 @@ def _validate_verdict(verdict: dict) -> str | None:
                 return f"evidence item missing string field: {key}"
     if not isinstance(verdict["timestamp"], str) or not verdict["timestamp"].strip():
         return "timestamp must be a non-empty string"
+    # Tolerate harmless JSON-Schema metadata fields that judges sometimes
+    # echo back when the prompt includes the full schema (Claude in particular
+    # has been observed emitting `$schema` and `$id` alongside valid verdicts).
+    # These have no semantic meaning for the vote, so stripping them silently
+    # is correct and avoids false-block schema_violation fallbacks.
+    IGNORABLE_METADATA_FIELDS = {"$schema", "$id", "$comment", "title", "description"}
+    for meta_field in IGNORABLE_METADATA_FIELDS & set(verdict):
+        verdict.pop(meta_field, None)
     extra = set(verdict) - set(required)
     if extra:
         return f"unexpected fields in verdict: {sorted(extra)}"
     return None
+
+
+def _strip_markdown_json_fences(raw: str) -> str:
+    """Strip a leading ```json / ``` code fence + trailing ``` if present.
+
+    Claude and some Codex versions wrap JSON tool-use output in markdown
+    code fences by default. The first production run (migration against
+    orchestrator-split + finding-2-graphql-tightening) hit 2/6 schema_violation
+    fallbacks purely because of fence wrapping; the actual JSON content was
+    valid and substantive.
+    """
+    if not raw:
+        return raw
+    text = raw.strip()
+    if text.startswith("```"):
+        newline = text.find("\n")
+        if newline != -1:
+            text = text[newline + 1 :]
+        else:
+            text = text[3:]
+    if text.endswith("```"):
+        text = text[:-3]
+    return text.strip()
 
 
 def _attempt_model_call(
@@ -499,8 +530,9 @@ def _attempt_model_call(
     stderr = result.stderr or ""
     if result.returncode != 0:
         return None, stdout, stderr or f"non-zero exit status {result.returncode}"
+    cleaned = _strip_markdown_json_fences(stdout)
     try:
-        verdict = json.loads(stdout)
+        verdict = json.loads(cleaned)
     except Exception as exc:
         return None, stdout, str(exc)
     if not isinstance(verdict, dict):

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_judge.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_judge.py
@@ -593,5 +593,86 @@ class FactoryJudgeTests(unittest.TestCase):
         self.assertIn("operator_id", uses[0])
 
 
+class ValidateVerdictMetadataTests(unittest.TestCase):
+    """Regression tests for $schema / $id / title tolerance in _validate_verdict.
+
+    Claude has been observed echoing JSON-Schema metadata fields ($schema,
+    $id) back into the verdict when the prompt appendix includes the full
+    schema. These fields have no semantic meaning; stripping them before
+    the extra-fields check prevents false-block schema_violation fallbacks.
+    """
+
+    def _valid_verdict_with(self, **extras: object) -> dict:
+        base = {
+            "judge": "completeness",
+            "model": "gpt-5.4-mini",
+            "verdict": "proceed",
+            "confidence": 3,
+            "reasoning": "placeholder reasoning long enough to pass the minimum-length check",
+            "evidence": [{"artifact": "spec", "section": "FR-1", "quote": "X"}],
+            "timestamp": "2026-04-19T00:00:00Z",
+        }
+        base.update(extras)
+        return base
+
+    def test_bare_valid_verdict_passes(self) -> None:
+        self.assertIsNone(JUDGE._validate_verdict(self._valid_verdict_with()))
+
+    def test_schema_metadata_field_tolerated(self) -> None:
+        v = self._valid_verdict_with(**{"$schema": "http://json-schema.org/draft-07/schema#"})
+        self.assertIsNone(JUDGE._validate_verdict(v))
+        self.assertNotIn("$schema", v)  # stripped in place
+
+    def test_id_and_title_tolerated(self) -> None:
+        v = self._valid_verdict_with(**{"$id": "x", "title": "y", "description": "z"})
+        self.assertIsNone(JUDGE._validate_verdict(v))
+
+    def test_non_metadata_extra_still_rejected(self) -> None:
+        v = self._valid_verdict_with(verdict_extra_field="nope")
+        err = JUDGE._validate_verdict(v)
+        self.assertIsNotNone(err)
+        self.assertIn("verdict_extra_field", err)
+
+
+class StripMarkdownJsonFencesTests(unittest.TestCase):
+    """Regression tests for the post-migration fix to _strip_markdown_json_fences.
+
+    Claude (and some Codex CLI output modes) wrap JSON verdicts in
+    ```json ... ``` markdown fences by default. The first production run
+    of the migration script hit 2/6 schema_violation fallbacks purely
+    because the fence wrapping was not being stripped before json.loads.
+    """
+
+    def test_plain_json_passes_through(self) -> None:
+        raw = '{"verdict":"proceed","confidence":3}'
+        self.assertEqual(JUDGE._strip_markdown_json_fences(raw), raw)
+
+    def test_json_fence_with_language_tag_stripped(self) -> None:
+        raw = '```json\n{"verdict":"block","confidence":4}\n```'
+        stripped = JUDGE._strip_markdown_json_fences(raw)
+        self.assertEqual(stripped, '{"verdict":"block","confidence":4}')
+        # And the parser can now load it.
+        self.assertEqual(json.loads(stripped)["verdict"], "block")
+
+    def test_json_fence_without_language_tag_stripped(self) -> None:
+        raw = '```\n{"verdict":"proceed","confidence":2}\n```'
+        stripped = JUDGE._strip_markdown_json_fences(raw)
+        self.assertEqual(stripped, '{"verdict":"proceed","confidence":2}')
+
+    def test_surrounding_whitespace_stripped(self) -> None:
+        raw = '   \n\n```json\n{"verdict":"proceed","confidence":5}\n```\n\n  '
+        stripped = JUDGE._strip_markdown_json_fences(raw)
+        self.assertEqual(stripped, '{"verdict":"proceed","confidence":5}')
+
+    def test_empty_input_returns_empty(self) -> None:
+        self.assertEqual(JUDGE._strip_markdown_json_fences(""), "")
+
+    def test_only_opening_fence_still_stripped(self) -> None:
+        # Malformed but we handle it: strip the opening fence even if no closer.
+        raw = '```json\n{"verdict":"proceed"}'
+        stripped = JUDGE._strip_markdown_json_fences(raw)
+        self.assertEqual(stripped, '{"verdict":"proceed"}')
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #693. First production run of the judge panel (migration against orchestrator-split + finding-2-graphql-tightening) hit 2 schema_violation false-blocks from one valid-content judge output. Two distinct parser bugs surfaced:

1. **Markdown code fences** — Claude wraps JSON in ` \`\`\`json ... \`\`\` ` by default. Raw stdout was valid JSON content wrapped in fences; `json.loads` rejected the outer ` \`\`\` `. Fix: `_strip_markdown_json_fences` helper called before parsing. Handles language-tagged fences, bare fences, surrounding whitespace, and malformed (unclosed) opening fences.

2. **JSON-Schema metadata fields** — Claude echoed `\$schema` back when the retry appendix included the full schema file. Our extra-fields check rejected the verdict even though content was correct. Fix: strip `\$schema` / `\$id` / `\$comment` / `title` / `description` before extra-fields validation. Genuine unknown fields still fail validation as before.

## Why it matters

Before this PR: the first migration run advanced only 1 of 2 blocked features, with both feature verdicts losing one judge's signal to false-blocks. After the fixes (verified locally), the re-run of orchestrator-split advanced cleanly with 2/3 proceed.

## Test plan
- [x] 83 tests pass (10 new regression tests, 73 from the original judge-panel PR)
- [x] Manual re-run of migration on orchestrator-split produced expected advance verdict
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)