### PR TITLE
docs(architecture): refresh README and architecture docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-# Cloud ValueRank Documentation
+# ValueRank Documentation
 
-> Cloud-native platform for evaluating how AI models prioritize moral values in ethical dilemmas.
+> Platform for evaluating how AI models prioritize moral values in ethical dilemmas.
 
-Cloud ValueRank transforms the CLI pipeline into an experiment-driven platform with a web UI, GraphQL API, MCP integration, and Python workers. It provides a "nutrition label for AI behavior" - making value alignment comparable across models.
+ValueRank presents each model with scenarios where two moral values conflict (e.g., safety vs. freedom) and records how the model reasons through the tradeoff. It exposes a web UI for humans, a GraphQL API, and an MCP server for AI agents — all backed by Postgres, PgBoss queues, and Python workers.
 
 ## Quick Links
 
@@ -11,24 +11,29 @@ Cloud ValueRank transforms the CLI pipeline into an experiment-driven platform w
 | [Architecture Overview](./architecture/overview.md) | System components and request flows |
 | [Data Model](./architecture/data-model.md) | Database schema and relationships |
 | [Tech Stack](./architecture/tech-stack.md) | Technologies and rationale |
+| [Canonical Glossary](./canonical-glossary.md) | Terminology (Definition↔Vignette, Dimension↔Attribute, …) |
 | [GraphQL API](./api/graphql-schema.md) | Types, queries, mutations |
-| [MCP Tools](./api/mcp-tools.md) | AI agent integration |
-| [Local Development](./workflow/operations/local-development.md) | Getting started guide |
-| [Workflow Docs](./workflow/README.md) | Agent process, plans, Feature Factory |
+| [MCP Tools](./api/mcp-tools.md) | AI-agent tool reference |
+| [REST Endpoints](./api/rest-endpoints.md) | Auth, export, import, OData |
+| [Queue System](./backend/queue-system.md) | PgBoss handlers and job types |
+| [Python Workers](./backend/python-workers.md) | Worker scripts |
+| [LLM Providers](./backend/llm-providers.md) | Provider configuration |
+| [Workflow Docs](./workflow/README.md) | Feature Factory, plans, handoffs |
 
 ---
 
-## What Is Cloud ValueRank?
+## What is ValueRank?
 
-Cloud ValueRank measures how AI models respond to moral dilemmas. It presents scenarios where two moral values conflict (e.g., safety vs. freedom) and records how each model reasons through the tradeoff.
+ValueRank measures how AI models respond to moral dilemmas and makes value alignment comparable across models.
 
 **Key capabilities:**
 
-- **Definition authoring** - Create moral dilemma templates with configurable dimensions
-- **Scenario expansion** - Generate variants from templates using LLM assistance
-- **Run execution** - Probe multiple AI models with scenarios in parallel
-- **Analysis** - Statistical analysis of model responses with visualizations
-- **MCP integration** - AI agents can query results and author new definitions
+- **Definitions (a.k.a. "Vignettes")** — moral-dilemma templates with configurable dimensions, preambles, and severity presets.
+- **Domains** — collections of related definitions sharing a context, value statements, preamble, and level preset. Each run snapshots the exact config it used.
+- **Scenario expansion** — LLM-assisted generation of concrete variants from a template.
+- **Runs** — probe multiple AI models in parallel via PgBoss + Python workers.
+- **Summarization & analysis** — deterministic decision-code extraction (with LLM fallback), per-run statistics, cross-run aggregates, paired-vignette comparisons.
+- **MCP integration** — AI agents can list, start, and author runs via OAuth 2.1 or API keys.
 
 ## Getting Started
 
@@ -36,37 +41,33 @@ Cloud ValueRank measures how AI models respond to moral dilemmas. It presents sc
 
 - Node.js 20+
 - Docker and Docker Compose
-- API keys for LLM providers (OpenAI, Anthropic, etc.)
+- API keys for LLM providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Mistral as needed)
 
 ### Quick Start
 
 ```bash
-# Clone and setup
 cd cloud
 npm install
 
-# Start PostgreSQL
-docker-compose up -d postgres
+# Start Postgres (+ PgBouncer)
+docker compose up -d
 
-# Push schema to database
-npm run db:push
-
-# Seed initial data
+# Apply migrations and seed
+npm run db:migrate
 npm run db:seed
 
-# Start development servers
+# Start all dev servers
 npm run dev
 ```
 
 This starts:
-- **API server** at http://localhost:3031 (GraphQL at `/graphql`)
-- **Web frontend** at http://localhost:3030
+
+- **API** at http://localhost:3031 (GraphQL at `/graphql`, MCP at `/mcp`)
+- **Web** at http://localhost:3030
 
 ### Test Credentials
 
-After seeding, log in with:
-- **Email:** `dev@valuerank.ai`
-- **Password:** `development`
+See `MEMORY.md` → "Dev Account" for local login credentials.
 
 ---
 
@@ -74,16 +75,16 @@ After seeding, log in with:
 
 ```
                     ┌──────────────────────────────────────────┐
-                    │            Cloud ValueRank               │
+                    │              ValueRank                    │
                     └──────────────────────────────────────────┘
                                        │
         ┌──────────────────────────────┼──────────────────────────────┐
         │                              │                              │
         ▼                              ▼                              ▼
 ┌───────────────┐            ┌─────────────────┐            ┌───────────────┐
-│  Web Frontend │            │   GraphQL API   │            │  MCP Server   │
-│  (React/Vite) │───────────▶│   (Express)     │◀───────────│  (Stdio)      │
-│  :3030        │            │   :3031         │            │               │
+│  Web (React)  │            │ Express API     │            │ MCP over HTTP │
+│  :3030        │───────────▶│ /graphql /api/* │◀───────────│ /mcp (OAuth   │
+│               │            │ /mcp  :3031     │            │  2.1 or key)  │
 └───────────────┘            └────────┬────────┘            └───────────────┘
                                       │
                     ┌─────────────────┼─────────────────┐
@@ -91,48 +92,51 @@ After seeding, log in with:
                     ▼                 ▼                 ▼
             ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
             │  PostgreSQL  │  │   PgBoss     │  │   Python     │
-            │  Database    │  │   Queue      │  │   Workers    │
-            └──────────────┘  └──────────────┘  └──────────────┘
-                                      │
-                                      ▼
-                             ┌──────────────────┐
-                             │   LLM Providers  │
-                             │ OpenAI, Anthropic│
-                             │ Google, xAI, etc │
-                             └──────────────────┘
+            │  (PgBouncer) │  │   (in-proc)  │  │   Workers    │
+            └──────────────┘  └──────┬───────┘  └──────┬───────┘
+                                     │                 │
+                                     └────────┬────────┘
+                                              ▼
+                                     ┌──────────────────┐
+                                     │   LLM Providers  │
+                                     │ OpenAI, Anthropic│
+                                     │ Google, xAI,     │
+                                     │ DeepSeek, Mistral│
+                                     └──────────────────┘
 ```
 
 ### Components
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| **Web Frontend** | `apps/web/` | React SPA for definitions, runs, analysis |
-| **GraphQL API** | `apps/api/` | Backend server with GraphQL, auth, queue |
-| **Database Package** | `packages/db/` | Prisma schema and shared queries |
-| **Shared Package** | `packages/shared/` | Logger, errors, environment utilities |
-| **Python Workers** | `workers/` | Probe scenarios, analyze results, summarize |
+| **Web** | `cloud/apps/web/` | React SPA (urql + GraphQL codegen) |
+| **API** | `cloud/apps/api/` | Express + GraphQL + MCP + queue orchestrator + Python spawner |
+| **Database package** | `cloud/packages/db/` | Prisma schema and generated client |
+| **Shared package** | `cloud/packages/shared/` | Logger, errors, env helpers |
+| **Python workers** | `cloud/workers/` | Probe, summarize, analyze, expand scenarios, token stats |
 
 ---
 
 ## Documentation Structure
 
 ```
-cloud/docs/
+docs/
 ├── README.md                    # This file
+├── canonical-glossary.md        # Terminology source of truth
 ├── architecture/
 │   ├── overview.md              # System architecture
 │   ├── data-model.md            # Database schema
 │   └── tech-stack.md            # Technologies
 ├── api/
 │   ├── graphql-schema.md        # GraphQL reference
-│   ├── rest-endpoints.md        # Auth, export, import
+│   ├── rest-endpoints.md        # Auth, export, import, OData
 │   └── mcp-tools.md             # MCP tool reference
 ├── frontend/
 │   ├── pages-and-routes.md      # App structure
 │   ├── components.md            # UI components
 │   └── state-management.md      # urql, auth
 ├── backend/
-│   ├── queue-system.md          # PgBoss, job types
+│   ├── queue-system.md          # PgBoss handlers, job types
 │   ├── python-workers.md        # Worker scripts
 │   └── llm-providers.md         # Provider configuration
 ├── features/
@@ -140,105 +144,54 @@ cloud/docs/
 │   ├── runs.md                  # Run execution
 │   ├── analysis.md              # Analysis pipeline
 │   ├── export-import.md         # CLI compatibility
-│   └── authentication.md        # JWT, API keys
-├── operations/
-│   ├── local-development.md     # Docker, npm scripts
-│   ├── deployment.md            # Railway configuration
-│   └── testing.md               # Test suites
-├── deferred/
-│   └── future-features.md       # Planned but not implemented
-└── preplanning/
-    └── [original design docs]   # Reference for design rationale
+│   └── authentication.md        # JWT, API keys, OAuth
+├── workflow/                    # Agent process, Feature Factory, rules
+├── preplanning/                 # Original design docs (historical)
+├── values-summary.md            # Value definitions and tensions
+└── valuerank_prd.yaml           # Product requirements
 ```
 
 ---
 
 ## Core Concepts
 
-### Definitions
+### Definitions (Vignettes)
 
-A **definition** is a moral dilemma template that specifies:
+A **definition** is a moral-dilemma template with:
 
-- **Preamble** - Instructions to the AI model
-- **Template** - The scenario text with placeholders
-- **Dimensions** - Variables that create scenario variants
+- **Preamble** — shared instructions to the model (reusable across definitions via `PreambleVersion`).
+- **Template** — the scenario text with placeholders.
+- **Dimensions** — variables that produce scenario variants.
+- **Level preset** — canonical L1–L5 severity labels (reusable via `LevelPresetVersion`).
 
-Definitions support versioning through forking - create new versions while preserving the parent chain.
+Definitions support forking, so new versions preserve the parent chain.
 
 ### Scenarios
 
-**Scenarios** are concrete instances generated from a definition by expanding dimensions. For example, a template with 2 dimensions, each with 3 levels, produces 9 scenario variants.
+Concrete instances generated from a definition by expanding its dimensions. Paired/flipped scenarios support order-effect analysis.
+
+### Domains
+
+A **domain** groups related definitions under a shared **context**, **value statements**, default **preamble**, default **level preset**, and default model list. When a run starts, the exact combination of these is frozen into a `DomainConfigSnapshot` so results stay reproducible.
 
 ### Runs
 
-A **run** executes scenarios against one or more AI models. Each run:
+A **run** probes one or more models against a set of scenarios:
 
-1. Probes models with scenarios (parallel processing via PgBoss)
-2. Records transcripts with model responses
-3. Generates summaries (canonical decision meaning, compatibility scores, key reasoning)
-4. Triggers analysis (statistics, visualizations)
+1. **Probe** — parallel jobs via PgBoss, executed by `probe.py`, producing a `Transcript` and a `ProbeResult` per (scenario × model × sample).
+2. **Summarize** — deterministic decision-code extraction with LLM fallback (`decision_code`, `decision_text`, `decision_metadata`).
+3. **Analyze** — cached per-run stats, cross-run aggregates, and domain-level snapshots.
+
+Runs are categorized (`PILOT`, `PRODUCTION`, `REPLICATION`, `VALIDATION`) and can be grouped into a `DomainEvaluation`.
 
 ### Analysis
 
-The **analysis pipeline** computes:
-
-- Decision distributions across models
-- Agreement/disagreement metrics
-- Scenario-by-scenario breakdowns
-- Visualization data for charts
-
----
-
-## Implementation Status
-
-Per `specs/high-level.md`, the following stages are complete:
-
-| Stage | Feature | Status |
-|-------|---------|--------|
-| 1-4 | Scaffolding, Database, GraphQL, Auth | ✅ |
-| 5-6 | Queue System, Python Workers | ✅ |
-| 7-8 | Frontend Foundation, Definition UI | ✅ |
-| 9 | Run Execution & Basic Export | ✅ |
-| 11 | Analysis System & Visualizations | ✅ |
-| 12, 14 | MCP Read & Write Tools | ✅ |
-| 13 | Run Comparison | ✅ |
-| 15 | Data Export & CLI Compatibility | ✅ |
-| 16 (partial) | Cost Estimation & Sampling | ✅ |
-| 17 | Production Deployment (Railway) | ✅ |
-| 17 | Parallel Summarization | ✅ |
-| 18 | MCP Operations Tools | ✅ |
-
-**Deferred:**
-- Stage 10: Experiment Framework
-- Stage 16 (remaining): Batch Processing, Cost Dashboard
-
-See [Future Features](./deferred/future-features.md) for details on deferred work.
-
----
-
-## Reference: Preplanning Documents
-
-The original design documents are preserved in `preplanning/`:
-
-| Document | Current Relevance |
-|----------|-------------------|
-| [architecture-overview.md](./preplanning/architecture-overview.md) | Still accurate, minor changes noted |
-| [database-design.md](./preplanning/database-design.md) | Schema evolved (added LlmProvider, LlmModel) |
-| [api-queue-system.md](./preplanning/api-queue-system.md) | Implemented as designed |
-| [authentication.md](./preplanning/authentication.md) | Implemented as designed |
-| [frontend-design.md](./preplanning/frontend-design.md) | Most components implemented |
-| [mcp-interface.md](./preplanning/mcp-interface.md) | Both read and write tools implemented |
-| [deployment.md](./preplanning/deployment.md) | Railway used instead of Docker Compose for production |
-| [product-spec.md](./preplanning/product-spec.md) | Experiment framework deferred |
+The analysis pipeline computes decision distributions, agreement metrics, scenario-level breakdowns, net-weighted condition scores, paired-vignette stability, and visualization payloads. Results are cached by input hash and code version in `AnalysisResult` and `AssumptionAnalysisSnapshot`.
 
 ---
 
 ## Contributing
 
-See [CLAUDE.md](../CLAUDE.md) (the project constitution) for:
-
-- File size limits
-- TypeScript standards
-- Testing requirements
-- Logging standards
-- Database access patterns
+- Project constitution: [cloud/CLAUDE.md](../cloud/CLAUDE.md) (file-size limits, TypeScript standards, testing, logging, DB patterns, preflight gate).
+- Agent working contract: [AGENTS.md](../AGENTS.md) (communication, delivery paths, memory policy).
+- Terminology: [canonical-glossary.md](./canonical-glossary.md).

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,197 +1,181 @@
 # Data Model
 
-> PostgreSQL schema for Cloud ValueRank
+> PostgreSQL schema for ValueRank.
 
-This document describes the database schema, entity relationships, and data patterns used in Cloud ValueRank.
+**Schema location:** `cloud/packages/db/prisma/schema.prisma`
 
-**Schema location:** `packages/db/prisma/schema.prisma`
+This document reflects the schema as of 2026-04. Use `npx prisma studio` or open the schema file directly for the authoritative view.
 
 ---
 
-## Entity Relationship Overview
+## Entity Groups
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                           AUTHENTICATION                                 │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                          │
-│  ┌──────────┐           ┌──────────┐                                    │
-│  │   User   │──────────▶│  ApiKey  │                                    │
-│  └──────────┘   1:N     └──────────┘                                    │
-│                                                                          │
+│ AUTHENTICATION                                                           │
+│   User ──< ApiKey                                                        │
+│   User ──< AuditLog                                                      │
+│   OAuthClient ──< OAuthRefreshToken                                      │
 └─────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                            CORE DOMAIN                                   │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                          │
-│  ┌────────────┐        ┌────────────┐        ┌────────────┐             │
-│  │ Definition │───────▶│  Scenario  │        │    Tag     │             │
-│  │            │  1:N   │            │        │            │             │
-│  └─────┬──────┘        └─────┬──────┘        └─────┬──────┘             │
-│        │                     │                     │                     │
-│        │ parent_id           │                     │                     │
-│        ▼ (self-ref)          │                     │                     │
-│  ┌────────────┐              │               ┌─────┴──────┐             │
-│  │ Definition │              │               │DefinitionTag│             │
-│  └────────────┘              │               │  (join)    │             │
-│        │                     │               └────────────┘             │
-│        │ 1:N                 │                                          │
-│        ▼                     │                                          │
-│  ┌────────────┐              │                                          │
-│  │    Run     │◀─────────────┘                                          │
-│  │            │◀───────────────────────────────┐                        │
-│  └─────┬──────┘               1:N              │                        │
-│        │                                       │                        │
-│        │ 1:N                             ┌─────┴──────┐                 │
-│        ▼                                 │RunScenario │                 │
-│  ┌────────────┐                          │ Selection  │                 │
-│  │ Transcript │                          └────────────┘                 │
-│  └────────────┘                                                         │
-│        │                                                                 │
-│        ▼ N:1                                                            │
-│  ┌────────────┐                                                         │
-│  │  Scenario  │                                                         │
-│  └────────────┘                                                         │
-│                                                                          │
+│ REUSABLE CONTENT (domain building blocks)                                │
+│                                                                           │
+│   Preamble ──< PreambleVersion                                            │
+│   LevelPreset ──< LevelPresetVersion                                      │
+│   Domain ──< DomainContext                                                │
+│   Domain ──< ValueStatement ──< ValueStatementVersion                     │
+│   Domain + PreambleVersion + LevelPresetVersion + DomainContext           │
+│     + ValueStatementVersion[]  ─►  DomainConfigSnapshot (fingerprinted)  │
+│                                                                           │
+│   Domain.default{PreambleVersion, LevelPresetVersion, Context, ModelIds}  │
+│     — used when launching a new Run for that domain                      │
 └─────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                         ANALYSIS & EXPERIMENTS                           │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                          │
-│  ┌────────────┐        ┌────────────┐                                   │
-│  │ Experiment │───────▶│    Run     │ (N:1)                             │
-│  │            │───────▶│RunComparison│ (1:N)                            │
-│  └────────────┘        └────────────┘                                   │
-│                                                                          │
-│  ┌────────────┐        ┌────────────┐                                   │
-│  │    Run     │───────▶│ Analysis   │ (1:N)                             │
-│  │            │        │  Result    │                                   │
-│  └────────────┘        └────────────┘                                   │
-│                                                                          │
+│ CORE DOMAIN                                                               │
+│                                                                           │
+│   Definition ──< Scenario                                                 │
+│   Definition ──< Run                                                      │
+│   Definition ── parent (self-ref, version tree)                           │
+│   Definition → Domain, DomainContext, PreambleVersion, LevelPresetVersion │
+│                                                                           │
+│   Tag ──< DefinitionTag, RunTag                                           │
+│                                                                           │
+│   Run → DomainConfigSnapshot (captured at launch)                         │
+│   Run ──< Transcript                                                      │
+│   Run ──< ProbeResult (success/failure per probe)                         │
+│   Run ──< RunScenarioSelection                                            │
+│   Run ──< AnalysisResult                                                  │
+│                                                                           │
+│   Transcript → Scenario                                                   │
+│                                                                           │
+│   AssumptionVignetteSelection  — keyed by (assumptionKey, definitionId)  │
+│   AssumptionScenarioPair       — source/variant scenario links           │
+│   AssumptionAnalysisSnapshot   — cached paired analysis                  │
 └─────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                           LLM CONFIGURATION                              │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                          │
-│  ┌────────────┐        ┌────────────┐                                   │
-│  │LlmProvider │───────▶│  LlmModel  │ (1:N)                             │
-│  │            │        │            │                                   │
-│  └────────────┘        └────────────┘                                   │
-│                                                                          │
-│  ┌────────────┐        ┌────────────┐                                   │
-│  │   Rubric   │        │SystemSetting│                                   │
-│  └────────────┘        └────────────┘                                   │
-│                                                                          │
+│ EVALUATION GROUPS                                                         │
+│                                                                           │
+│   DomainEvaluation ──< DomainEvaluationRun ──> Run                        │
+│   Experiment ──< Run, RunComparison (legacy, lightly used)                │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│ ANALYSIS CACHE                                                            │
+│                                                                           │
+│   AnalysisResult               (per Run, versioned by code_version)       │
+│   AssumptionAnalysisSnapshot   (per assumptionKey × config)               │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│ LLM CONFIGURATION & COST VISIBILITY                                       │
+│                                                                           │
+│   LlmProvider ──< LlmModel                                                │
+│   LlmProvider ──< ProviderBalanceSyncLog                                  │
+│   LlmModel ──< ModelTokenStatistics (per model, optionally per def)       │
+│                                                                           │
+│   Rubric, Cohort, SystemSetting                                           │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## Tables
+## Authentication
 
-### Authentication
+### `users`
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | cuid | PK |
+| `email` | string | unique |
+| `password_hash` | string | bcrypt |
+| `name` | string? | |
+| `last_login_at`, `password_changed_at` | datetime? | |
+| `created_at`, `updated_at` | datetime | |
 
-#### `users`
+Users own many audit relations (`createdBy…`, `deletedBy…`) on Definition, Run, Tag, LlmModel, DomainEvaluation, ProviderBalanceSyncLog.
 
-User accounts for the internal team.
+### `api_keys`
+| `id` · `user_id` · `name` · `key_hash` (unique) · `key_prefix` (varchar 12) · `last_used` · `expires_at` · `created_at` |
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `email` | string | Unique email address |
-| `password_hash` | string | bcrypt hashed password |
-| `name` | string? | Display name |
-| `last_login_at` | datetime? | Last login timestamp |
-| `created_at` | datetime | Creation timestamp |
-| `updated_at` | datetime | Last update timestamp |
+### `oauth_clients` / `oauth_refresh_tokens`
 
-#### `api_keys`
-
-API keys for MCP and programmatic access.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `user_id` | fk → users | Owner |
-| `name` | string | Key name/description |
-| `key_hash` | string | SHA-256 hash of key |
-| `key_prefix` | varchar(12) | First 12 chars for identification |
-| `last_used` | datetime? | Last usage timestamp |
-| `expires_at` | datetime? | Expiration (null = never) |
-| `created_at` | datetime | Creation timestamp |
+OAuth 2.1 Dynamic Client Registration support for MCP. Clients store `client_id`, hashed `client_secret`, redirect URIs, and scopes (`mcp:read mcp:write`). Refresh tokens store hash, client, user, scope, resource, and expiration.
 
 ---
 
-### Core Domain
+## Reusable Content (Domain Building Blocks)
 
-#### `definitions`
+### `domains`
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | cuid | PK |
+| `name`, `normalized_name` (unique) | string | |
+| `default_preamble_version_id`, `default_level_preset_version_id`, `default_context_id` | fk? | defaults used when starting a run for this domain |
+| `default_model_ids` | string[] | |
+| `sentence_prefix`, `label_prefix` | string? | UI display |
+| `created_at`, `updated_at` | datetime | |
 
-Moral dilemma templates with versioning through parent references.
+### `domain_contexts`
+Freeform context blocks attached to a domain (e.g. “U.S. public K-12 schools, 2024”). Versioned by bumping `version`.
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `parent_id` | fk → definitions? | Fork parent (for version tree) |
-| `name` | string | Human-readable name |
-| `content` | jsonb | Definition content (see JSONB Schema below) |
-| `created_at` | datetime | Creation timestamp |
-| `updated_at` | datetime | Last update timestamp |
-| `last_accessed_at` | datetime? | For usage tracking |
-| `deleted_at` | datetime? | **Soft delete** timestamp |
+### `value_statements` / `value_statement_versions`
+Per-domain canonical value definitions (one row per token), each with an append-only version history.
 
-**Relationships:**
-- Self-referential parent/children for version tree
-- 1:N to runs, scenarios, definition_tags
+### `domain_config_snapshots`
+Fingerprinted combination of (`preamble_version_id`, `level_preset_version_id`, `context_id`, `value_statement_version_ids[]`) for a domain. Unique on `(domain_id, fingerprint)`. A `Run` references the snapshot it launched under so analysis remains reproducible.
 
-#### `tags`
+### `preambles` / `preamble_versions`
+Shared system-prompt blocks. `PreambleVersion.version` is a user-facing label (e.g. a timestamp). Referenced by `Definition`, `Domain.default`, and `DomainConfigSnapshot`.
 
-Organizational tags for definitions.
+### `level_presets` / `level_preset_versions`
+Canonical L1–L5 severity labels. Each version holds `l1..l5` strings. Referenced by `Definition`, `Domain.default`, and `DomainConfigSnapshot`.
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `name` | string | Unique tag name |
-| `created_at` | datetime | Creation timestamp |
+---
 
-#### `definition_tags`
+## Core Domain
 
-Join table linking definitions to tags.
+### `definitions`
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | cuid | PK |
+| `parent_id` | fk → definitions? | version tree |
+| `domain_id`, `domain_context_id` | fk? | domain linkage |
+| `preamble_version_id`, `level_preset_version_id` | fk? | currently selected building blocks |
+| `name` | string | |
+| `content` | jsonb | see JSONB section |
+| `expansion_progress`, `expansion_debug` | jsonb? | scenario-expansion state |
+| `version` | int | internal revision counter |
+| `created_by_user_id`, `deleted_by_user_id` | fk? | audit |
+| `created_at`, `updated_at`, `last_accessed_at`, `deleted_at` | datetime | soft delete |
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `definition_id` | fk → definitions | Definition |
-| `tag_id` | fk → tags | Tag |
-| `created_at` | datetime | Creation timestamp |
-| `deleted_at` | datetime? | **Soft delete** timestamp |
+### `scenarios`
+| `id` · `definition_id` · `name` · `content` jsonb · `orientation_flipped` bool · `created_at` · `deleted_at`? |
 
-**Unique constraint:** (definition_id, tag_id)
+Scenarios are concrete variants generated from a definition. `orientation_flipped` marks order-reversed pairs used for order-effect analysis.
 
-#### `runs`
+### `tags`, `definition_tags`, `run_tags`
+Shared tag vocabulary; both definitions and runs can be tagged. `definition_tags` is soft-deletable; `run_tags` is hard-deletable.
 
-Pipeline executions against a definition.
+### `runs`
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | cuid | PK |
+| `name` | string? | human label |
+| `definition_id` | fk | |
+| `experiment_id` | fk? | legacy |
+| `domain_config_snapshot_id` | fk? | captured at launch |
+| `status` | `RunStatus` | PENDING, RUNNING, PAUSED, SUMMARIZING, COMPLETED, FAILED, CANCELLED |
+| `run_category` | `RunCategory` | PILOT, PRODUCTION, REPLICATION, VALIDATION, UNKNOWN_LEGACY |
+| `config` | jsonb | models, sample count, temperature, maxTurns, etc. |
+| `progress`, `summarize_progress` | jsonb? | orchestrator tracking |
+| `stalled_models` | string[] | pre-computed for UI alerts |
+| `retention_days`, `archive_permanently` | int? / bool | retention policy |
+| `created_by_user_id`, `deleted_by_user_id` | fk? | audit |
+| `started_at`, `completed_at`, `created_at`, `updated_at`, `last_accessed_at`, `deleted_at` | datetime | |
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `definition_id` | fk → definitions | Source definition |
-| `experiment_id` | fk → experiments? | Parent experiment (optional) |
-| `status` | enum | PENDING, RUNNING, PAUSED, SUMMARIZING, COMPLETED, FAILED, CANCELLED |
-| `config` | jsonb | Runtime configuration snapshot |
-| `progress` | jsonb? | Progress tracking data |
-| `started_at` | datetime? | When processing began |
-| `completed_at` | datetime? | When processing finished |
-| `created_at` | datetime | Creation timestamp |
-| `updated_at` | datetime | Last update timestamp |
-| `last_accessed_at` | datetime? | For usage tracking |
-| `deleted_at` | datetime? | **Soft delete** timestamp |
-| `retention_days` | int? | Days until archival (null = permanent) |
-| `archive_permanently` | boolean | Never delete (default: true) |
-
-**Run Status Lifecycle:**
+**Run lifecycle:**
 ```
 PENDING → RUNNING → SUMMARIZING → COMPLETED
                  ↘ PAUSED → RUNNING
@@ -199,184 +183,101 @@ PENDING → RUNNING → SUMMARIZING → COMPLETED
                  ↘ CANCELLED
 ```
 
-#### `transcripts`
-
-Individual model responses to scenarios.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `run_id` | fk → runs | Parent run |
-| `scenario_id` | fk → scenarios? | Source scenario |
-| `model_id` | string | Provider model identifier |
-| `model_version` | string? | Specific model version |
-| `definition_snapshot` | jsonb? | Definition at execution time |
-| `content` | jsonb | Transcript data (messages, choices) |
-| `turn_count` | int | Number of conversation turns |
-| `token_count` | int | Total tokens used |
-| `duration_ms` | int | Execution duration |
-| `created_at` | datetime | Creation timestamp |
-| `last_accessed_at` | datetime? | For usage tracking |
-| `content_expires_at` | datetime? | Content pruning date |
-| `decision_code` | string? | Extracted decision (1-5 or "other") |
+### `transcripts`
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | cuid | PK |
+| `run_id`, `scenario_id` | fk | |
+| `model_id`, `model_version` | string | |
+| `sample_index` | int | 0..N-1 for multi-sample runs |
+| `definition_snapshot` | jsonb? | definition as of run time |
+| `content` | jsonb | messages + finishReason |
+| `turn_count`, `token_count`, `duration_ms` | int | |
+| `estimated_cost` | float? | USD |
+| `decision_code` | string? | 1–5 rating or "other" |
+| `decision_code_source` | string? | `deterministic` / `llm` / `manual` / `error` |
 | `decision_text` | string? | LLM-generated summary |
-| `summarized_at` | datetime? | When summary was generated |
+| `decision_metadata` | jsonb? | structured extraction output (e.g. canonical meaning, compatibility) |
+| `summarized_at` | datetime? | |
+| `content_expires_at` | datetime? | content pruning |
+| `created_at`, `last_accessed_at`, `deleted_at` | datetime | soft delete |
 
-#### `scenarios`
+### `probe_results`
+Per-probe success/failure record, separate from the transcript it produced. Used for dead-letter tracking and cost reporting.
 
-Generated scenario variants from definitions.
+| `id` · `run_id` · `scenario_id` · `model_id` · `sample_index` · `status` (`SUCCESS`/`FAILED`) · `transcript_id?` · `duration_ms?` · `input_tokens?` · `output_tokens?` · `error_code?` · `error_message?` · `retry_count` · `created_at` · `completed_at?` · `deleted_at?` |
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `definition_id` | fk → definitions | Source definition |
-| `name` | string | Scenario identifier |
-| `content` | jsonb | Scenario content |
-| `created_at` | datetime | Creation timestamp |
-| `deleted_at` | datetime? | **Soft delete** timestamp |
+Unique on `(run_id, scenario_id, model_id, sample_index)`.
 
-#### `run_scenario_selections`
+### `run_scenario_selections`
+Join table recording which scenarios were sampled into a run. Unique on `(run_id, scenario_id)`.
 
-Tracks which scenarios were included in a run (for sampling).
+### Assumption / paired-vignette tables
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `run_id` | fk → runs | Run |
-| `scenario_id` | fk → scenarios | Included scenario |
-| `created_at` | datetime | Creation timestamp |
-
-**Unique constraint:** (run_id, scenario_id)
+- `assumption_vignette_selections` — `(assumption_key, definition_id)` pairs selected for a given assumption study.
+- `assumption_scenario_pairs` — source ↔ variant scenario pairs for paired comparisons, with optional equivalence-review fields (`status`, `reviewed_by`, `reviewed_at`, `notes`).
+- `assumption_analysis_snapshots` — cached analysis outputs per `(assumptionKey, analysisType, inputHash, configSignature)`, status `CURRENT` / `SUPERSEDED`.
 
 ---
 
-### Analysis & Experiments
+## Evaluation Groups
 
-#### `experiments`
+### `domain_evaluations`
+A coordinated batch of runs launched together for a domain, with one `config_snapshot` captured at launch and a `scope_category` (`PILOT`, `PRODUCTION`, `REPLICATION`, `VALIDATION`). Status follows `PENDING → RUNNING → COMPLETED | FAILED | CANCELLED`.
 
-Group related runs for systematic comparison. **Note: Currently scaffolded but not fully implemented.**
+### `domain_evaluation_runs`
+Join table `DomainEvaluation` ↔ `Run` (unique on `run_id`), freezing `definition_id`, `definition_name`, and `domain_id` as they were at launch time.
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `name` | string | Experiment name |
-| `hypothesis` | string? | Research hypothesis |
-| `analysis_plan` | jsonb? | Statistical plan |
-| `created_at` | datetime | Creation timestamp |
-| `updated_at` | datetime | Last update timestamp |
-
-#### `run_comparisons`
-
-Delta analysis between two runs. **Note: Currently scaffolded but not fully implemented.**
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `experiment_id` | fk → experiments? | Parent experiment |
-| `baseline_run_id` | fk → runs | Baseline run |
-| `comparison_run_id` | fk → runs | Comparison run |
-| `delta_data` | jsonb? | Computed differences |
-| `created_at` | datetime | Creation timestamp |
-
-#### `analysis_results`
-
-Cached analysis computations with versioning.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `run_id` | fk → runs | Analyzed run |
-| `analysis_type` | string | Type identifier (e.g., "basic") |
-| `input_hash` | string | Hash of input data (for cache invalidation) |
-| `code_version` | string | Analysis code version |
-| `output` | jsonb | Analysis results |
-| `status` | enum | CURRENT, SUPERSEDED |
-| `created_at` | datetime | Creation timestamp |
-
-**Analysis caching pattern:**
-1. Compute hash of transcript data
-2. Check if analysis exists with same input_hash and code_version
-3. If exists and CURRENT, return cached result
-4. Otherwise, compute new analysis and mark old as SUPERSEDED
-
-#### `cohorts`
-
-Groups for segment analysis. **Note: Currently scaffolded but not actively used.**
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `name` | string | Cohort name |
-| `criteria` | jsonb | Membership criteria |
-| `created_at` | datetime | Creation timestamp |
-| `updated_at` | datetime | Last update timestamp |
+### `experiments`, `run_comparisons`
+Scaffolded for future use. `experiments` groups runs for systematic comparison; `run_comparisons` stores delta analyses. Present in schema but lightly used in product today.
 
 ---
 
-### LLM Configuration
+## Analysis Cache
 
-#### `llm_providers`
+### `analysis_results`
+| `id` · `run_id` · `analysis_type` · `input_hash` · `code_version` · `output` jsonb · `status` (`CURRENT`/`SUPERSEDED`) · `created_at` · `deleted_at?` |
 
-Supported LLM providers and their rate limits.
+Caching pattern: compute `input_hash` over transcripts + config, look up by `(analysis_type, input_hash, code_version, status=CURRENT)`; compute on miss and mark the old row `SUPERSEDED`.
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `name` | string | Unique identifier (e.g., "openai") |
-| `display_name` | string | Human-readable name (e.g., "OpenAI") |
-| `max_parallel_requests` | int | Concurrent request limit |
-| `requests_per_minute` | int | Rate limit |
-| `is_enabled` | boolean | Whether provider is active |
-| `created_at` | datetime | Creation timestamp |
-| `updated_at` | datetime | Last update timestamp |
+### `assumption_analysis_snapshots`
+Same shape for paired-vignette analysis, keyed by `assumption_key` instead of `run_id`.
 
-#### `llm_models`
+---
 
-Individual models within providers.
+## LLM Configuration & Cost Visibility
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `provider_id` | fk → llm_providers | Parent provider |
-| `model_id` | string | API model identifier |
-| `display_name` | string | Human-readable name |
-| `cost_input_per_million` | decimal | Input token cost |
-| `cost_output_per_million` | decimal | Output token cost |
-| `status` | enum | ACTIVE, DEPRECATED |
-| `is_default` | boolean | Default selection |
-| `created_at` | datetime | Creation timestamp |
-| `updated_at` | datetime | Last update timestamp |
+### `llm_providers`
+`id`, unique `name` (`openai`, `anthropic`, …), `display_name`, `max_parallel_requests`, `requests_per_minute`, `is_enabled`, `balance` (Decimal(10,4)), timestamps.
 
-**Unique constraint:** (provider_id, model_id)
+### `provider_balance_sync_logs`
+Audit trail of manual balance entries: `system_balance_at_sync`, `entered_balance`, `delta`, `synced_at`, `created_by_user_id`.
 
-#### `rubrics`
+### `llm_models`
+| `id` · `provider_id` · `model_id` (API id) · `display_name` · `cost_input_per_million` · `cost_output_per_million` · `status` (`ACTIVE`/`DEPRECATED`) · `is_default` · `api_config` jsonb · `created_by_user_id` · timestamps |
 
-Values rubric versions for analysis.
+Unique on `(provider_id, model_id)`.
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `version` | int | Unique version number |
-| `content` | jsonb | Rubric definition |
-| `created_at` | datetime | Creation timestamp |
+### `model_token_statistics`
+Rolling average input/output tokens per `(model_id, definition_id?)` for cost prediction. Populated by the `compute_token_stats` queue job.
 
-#### `system_settings`
+### `rubrics`, `cohorts`, `system_settings`
+- `rubrics` — values rubric versions (jsonb content, unique `version` int).
+- `cohorts` — segment definitions (name + jsonb criteria). Currently scaffolded.
+- `system_settings` — jsonb key/value store for runtime toggles.
 
-Key-value store for system configuration.
+---
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | cuid | Primary key |
-| `key` | string | Unique setting key |
-| `value` | jsonb | Setting value |
-| `updated_at` | datetime | Last update timestamp |
+## Audit Logging
+
+### `audit_logs`
+Append-only record of domain-object actions. `action` is a free string (`CREATE` / `UPDATE` / `DELETE` / `ACTION`), plus `entity_type`, `entity_id`, optional `user_id`, and jsonb `metadata`.
 
 ---
 
 ## JSONB Schema Patterns
 
-### Definition Content
-
+### Definition content
 ```json
 {
   "preamble": "You are being asked to reason about a moral dilemma...",
@@ -385,33 +286,28 @@ Key-value store for system configuration.
     {
       "name": "situation",
       "levels": [
-        {"score": 1, "label": "minor", "options": ["small spill", "loose tile"]},
+        {"score": 1, "label": "minor",  "options": ["small spill", "loose tile"]},
         {"score": 5, "label": "severe", "options": ["gas leak", "structural damage"]}
       ]
     }
   ],
-  "matchingRules": {
-    "type": "cartesian"
-  },
-  "valueConflict": {
-    "value1": "Physical_Safety",
-    "value2": "Economics"
-  }
+  "matchingRules": { "type": "cartesian" },
+  "valueConflict": { "value1": "Physical_Safety", "value2": "Economics" }
 }
 ```
 
-### Run Config
-
+### Run config
 ```json
 {
   "models": ["gpt-4o", "claude-3-5-sonnet-latest"],
   "samplePercentage": 100,
-  "temperature": 0.7
+  "samplesPerScenario": 1,
+  "temperature": 0.7,
+  "maxTurns": 1
 }
 ```
 
-### Run Progress
-
+### Run progress
 ```json
 {
   "total": 20,
@@ -424,8 +320,7 @@ Key-value store for system configuration.
 }
 ```
 
-### Transcript Content
-
+### Transcript content
 ```json
 {
   "messages": [
@@ -437,97 +332,76 @@ Key-value store for system configuration.
 }
 ```
 
-### Analysis Output
-
+### Transcript `decision_metadata`
 ```json
 {
-  "decisionCounts": {"1": 5, "2": 8, "3": 12, "4": 3, "5": 2},
-  "agreementScore": 0.73,
-  "methodsDocumentation": "Analysis computed using...",
-  "visualizationData": {
-    "decisionDistribution": [...],
-    "modelScenarioMatrix": [...]
-  }
+  "canonicalMeaning": "prioritize safety",
+  "compatibility": { "Physical_Safety": 0.9, "Economics": -0.3 },
+  "keyReasoning": "Acted to prevent physical harm ..."
 }
 ```
 
 ---
 
+## Enums
+
+| Enum | Values |
+|------|--------|
+| `RunStatus` | PENDING, RUNNING, PAUSED, SUMMARIZING, COMPLETED, FAILED, CANCELLED |
+| `RunCategory` | PILOT, PRODUCTION, REPLICATION, VALIDATION, UNKNOWN_LEGACY |
+| `DomainEvaluationStatus` | PENDING, RUNNING, COMPLETED, FAILED, CANCELLED |
+| `DomainEvaluationScopeCategory` | PILOT, PRODUCTION, REPLICATION, VALIDATION |
+| `ProbeResultStatus` | SUCCESS, FAILED |
+| `AnalysisStatus` | CURRENT, SUPERSEDED |
+| `AssumptionAnalysisStatus` | CURRENT, SUPERSEDED |
+| `LlmModelStatus` | ACTIVE, DEPRECATED |
+
+---
+
 ## Soft Delete Pattern
 
-Three tables use soft delete via `deleted_at` timestamp:
+Tables with a `deleted_at` column:
 
-- `definitions` - Preserves version history
-- `scenarios` - Preserves transcript references
-- `definition_tags` - Preserves tag associations
+- `definitions`, `definition_tags`, `scenarios`
+- `transcripts`, `probe_results`, `analysis_results`, `assumption_analysis_snapshots`
+- `runs`, `domain_evaluations`, `domain_evaluation_runs`
 
 **Rules:**
-1. Records are never physically deleted
-2. **All queries must filter** `WHERE deleted_at IS NULL`
-3. GraphQL resolvers apply this filter automatically
-4. `deleted_at` is NOT exposed in the GraphQL API
-5. Cascading: when parent is deleted, related records are also soft-deleted
 
-```typescript
-// Querying (always filter deleted)
-const definitions = await prisma.definition.findMany({
-  where: { deletedAt: null }
-});
-
-// Deleting (set timestamp, don't delete)
-await prisma.definition.update({
-  where: { id },
-  data: { deletedAt: new Date() }
-});
-```
+1. Never physically delete — set `deleted_at` instead.
+2. All queries must filter `WHERE deleted_at IS NULL` (resolvers enforce this automatically).
+3. `deleted_at` is not exposed in the GraphQL schema.
+4. Cascade via application logic: soft-deleting a parent soft-deletes related rows.
 
 ---
 
 ## Access Tracking
 
-Major entities include `last_accessed_at` timestamp:
-- Updated on read operations (view, export, analysis)
-- Enables identification of unused data
-- Useful for future pruning decisions
+Major entities (`definitions`, `runs`, `transcripts`) include `last_accessed_at` updated on read. Used to identify cold data for future pruning; combined with `retention_days` / `archive_permanently` on runs.
 
 ---
 
-## Indexes
+## Key Indexes
 
-Key indexes for performance:
-
-| Table | Index | Purpose |
-|-------|-------|---------|
-| definitions | `parent_id` | Version tree queries |
-| runs | `definition_id`, `experiment_id`, `status` | Filtering |
-| transcripts | `run_id`, `scenario_id`, `model_id` | Lookups |
-| scenarios | `definition_id` | Definition scenarios |
-| analysis_results | `run_id`, `analysis_type`, `status` | Cache lookup |
-| api_keys | `key_prefix`, `user_id` | Authentication |
-
----
-
-## Differences from Original Design
-
-The schema evolved from the [original database design](../preplanning/database-design.md):
-
-| Addition | Reason |
-|----------|--------|
-| `LlmProvider`, `LlmModel` tables | Database-driven provider/model configuration |
-| `RunScenarioSelection` table | Track sampled scenarios per run |
-| `SystemSetting` table | Runtime configuration |
-| Summary fields on Transcript | Store decision codes and summaries |
-
-| Simplification | Reason |
-|----------------|--------|
-| No `ltree` extension | Recursive CTEs sufficient for our queries |
-| No `created_by` on most tables | Single-tenant, less audit trail needed |
-| Simpler experiment schema | Feature deferred |
+| Table | Indexes | Purpose |
+|-------|---------|---------|
+| definitions | `parent_id`, `domain_id`, `domain_context_id`, `preamble_version_id`, `level_preset_version_id` | version tree + domain filters |
+| runs | `definition_id`, `experiment_id`, `status`, `run_category`, `domain_config_snapshot_id` | dashboards |
+| transcripts | `run_id`, `scenario_id`, `model_id`, `sample_index`, `deleted_at` | probe lookups, soft-delete |
+| probe_results | `run_id`, `scenario_id`, `model_id`, `status`, `sample_index` | job retry + cost |
+| scenarios | `definition_id` | expansion listing |
+| analysis_results | `run_id`, `analysis_type`, `status`, `deleted_at` | cache lookup |
+| domain_config_snapshots | unique `(domain_id, fingerprint)`, `(domain_id, created_at DESC)` | reproducibility |
+| domain_evaluations | `domain_id`, `scope_category`, `status`, `created_by_user_id` | filters |
+| assumption_analysis_snapshots | `(assumption_key, analysis_type, input_hash, status)` | cache |
+| audit_logs | `(entity_type, entity_id)`, `user_id`, `created_at`, `action` | audit search |
+| api_keys | `key_prefix`, `user_id` | auth lookups |
 
 ---
 
 ## Related Documentation
 
-- [Architecture Overview](./overview.md) - System components
-- [Tech Stack](./tech-stack.md) - Technology choices
-- [Original Database Design](../preplanning/database-design.md) - Design rationale
+- [Architecture Overview](./overview.md) — components and flows
+- [Tech Stack](./tech-stack.md) — technology choices
+- [Canonical Glossary](../canonical-glossary.md) — Definition↔Vignette, Dimension↔Attribute terminology
+- [Original Database Design](../preplanning/database-design.md) — historical rationale (superseded where it conflicts with this doc)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-> Cloud ValueRank is a cloud-native platform for evaluating how AI models prioritize moral values in ethical dilemmas.
+> ValueRank is a platform for evaluating how AI models prioritize moral values in ethical dilemmas.
 
 This document describes the system architecture, component responsibilities, and how data flows through the system.
 
@@ -11,44 +11,60 @@ This document describes the system architecture, component responsibilities, and
 The same architecture runs locally (Docker Compose) and in production (Railway):
 
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                           Cloud ValueRank                                │
-│              (Local: Docker Compose / Production: Railway)               │
-├─────────────────────────────────────────────────────────────────────────┤
-│                                                                          │
-│  ┌──────────────┐         ┌──────────────────────────────────────────┐  │
-│  │   Frontend   │────────▶│     GraphQL API (POST /graphql)          │  │
-│  │  (apps/web)  │         │     - Schema introspection for LLMs      │  │
-│  │  JWT Auth    │         │     - Single endpoint for all queries    │  │
-│  │  :3030       │         │     :3001                                │  │
-│  └──────────────┘         └──────────────────┬───────────────────────┘  │
-│                                              │                           │
-│  ┌──────────────┐                            │                           │
-│  │  Local LLM   │────────────────────────────┤ (same GraphQL endpoint)  │
-│  │  via MCP     │                            │                           │
-│  │  API Key     │                            │                           │
-│  └──────────────┘                            │                           │
-│                                              │                           │
-│              ┌───────────────────────────────┴───────────────┐           │
-│              ▼                                               ▼           │
-│       ┌──────────────┐                          ┌──────────────┐        │
-│       │  PostgreSQL  │                          │   Workers    │        │
-│       │  + PgBoss    │◀─────────────────────────│  (Python)    │        │
-│       │  + Users     │       queue polling      └──────┬───────┘        │
-│       │  :5433       │                                 │                │
-│       └──────────────┘                                 ▼                │
-│                                               ┌──────────────┐          │
-│                                               │ LLM Providers│          │
-│                                               │ (OpenAI, etc)│          │
-│                                               └──────────────┘          │
-└─────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                              ValueRank                                        │
+│              (Local: Docker Compose / Production: Railway)                    │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                               │
+│  ┌──────────────┐         ┌──────────────────────────────────────────────┐   │
+│  │   Web App    │────────▶│   Express API  (apps/api)   :3031            │   │
+│  │  (apps/web)  │         │   ├─ /graphql   (GraphQL Yoga + Pothos)      │   │
+│  │  React/Vite  │         │   ├─ /api/*     (auth, export, csv, import,  │   │
+│  │  JWT Auth    │         │   │              odata)                      │   │
+│  │  :3030       │         │   ├─ /mcp       (MCP Streamable HTTP)        │   │
+│  └──────────────┘         │   ├─ /oauth/*   (OAuth 2.1 for MCP)          │   │
+│                           │   ├─ /admin     (admin tools)                │   │
+│  ┌──────────────┐         │   └─ /health                                 │   │
+│  │  AI Agent    │────────▶│                                              │   │
+│  │  (Claude.ai, │ OAuth   │   Auth: JWT cookies, API keys,               │   │
+│  │   Claude     │ 2.1 or  │         OAuth 2.1 bearer tokens              │   │
+│  │   Code, etc) │ API key │                                              │   │
+│  └──────────────┘         └──────────────────┬───────────────────────────┘   │
+│                                              │                                │
+│              ┌───────────────────────────────┴───────────────┐                │
+│              ▼                                               ▼                │
+│       ┌──────────────┐                            ┌──────────────┐            │
+│       │  PostgreSQL  │                            │   Queue      │            │
+│       │  (via        │                            │ Orchestrator │            │
+│       │  PgBouncer)  │◀───────────────────────────│ + PgBoss     │            │
+│       │              │      queue polling         │ (in-process) │            │
+│       │  :5433       │                            └──────┬───────┘            │
+│       └──────────────┘                                   │                    │
+│                                                          ▼                    │
+│                                                 ┌──────────────┐              │
+│                                                 │   Python     │              │
+│                                                 │   Workers    │              │
+│                                                 │   (spawned)  │              │
+│                                                 └──────┬───────┘              │
+│                                                        │                      │
+│                                                        ▼                      │
+│                                                 ┌──────────────┐              │
+│                                                 │ LLM Providers│              │
+│                                                 │ OpenAI /     │              │
+│                                                 │ Anthropic /  │              │
+│                                                 │ Google / xAI │              │
+│                                                 │ DeepSeek /   │              │
+│                                                 │ Mistral      │              │
+│                                                 └──────────────┘              │
+└──────────────────────────────────────────────────────────────────────────────┘
 
 Monorepo Structure (Turborepo):
-├── apps/api      → Express + GraphQL API + PgBoss queue handlers
-├── apps/web      → React + Vite frontend
-├── packages/db   → Prisma schema + shared database queries
-├── packages/shared → Logger, errors, environment utilities
-└── workers/      → Python scripts for LLM interactions
+cloud/
+├── apps/api           → Express + GraphQL + MCP + queue orchestrator
+├── apps/web           → React + Vite SPA (with GraphQL codegen)
+├── packages/db        → Prisma schema + generated client + seed data
+├── packages/shared    → Logger, errors, env utilities (TypeScript)
+└── workers/           → Python scripts for LLM probe / summarize / analyze
 ```
 
 ---
@@ -57,138 +73,172 @@ Monorepo Structure (Turborepo):
 
 ### Web Frontend (`apps/web/`)
 
-**Technology:** React 18 + TypeScript + Vite + Tailwind CSS
+**Technology:** React 18 + TypeScript + Vite + Tailwind CSS + urql + GraphQL codegen
 
-**Purpose:** Single-page application for:
-- Viewing and editing definitions
-- Starting and monitoring runs
-- Viewing analysis results and visualizations
-- Managing settings and API keys
+**Purpose:** Single-page application for authoring content, running evaluations, and reviewing analysis.
 
 **Key features:**
 - JWT authentication via auth context
-- GraphQL data fetching with urql
+- GraphQL data fetching with urql; typed documents generated from the live schema (`src/generated/`)
 - Monaco editor for definition content
-- Recharts for analysis visualizations
+- Recharts + virtualized tables for analysis views
+- Radix popovers, `class-variance-authority`, `tailwind-merge`, `date-fns`, `html-to-image` for rich UI
 
-**Pages:**
-| Page | Route | Purpose |
-|------|-------|---------|
-| Dashboard | `/` | Overview and recent activity |
-| Definitions | `/definitions` | List and search definitions |
-| Definition Detail | `/definitions/:id` | View/edit definition, start runs |
-| Runs | `/runs` | List all runs |
-| Run Detail | `/runs/:id` | View progress, transcripts, analysis |
-| Settings | `/settings` | API keys, preferences |
-| Login | `/login` | Authentication |
+**Pages (routes in `src/App.tsx`):**
+
+| Area | Routes |
+|------|--------|
+| Auth | `/login` |
+| Dashboard | `/` |
+| Definitions (a.k.a. "Vignettes") | `/definitions`, `/definitions/:id`, `/definitions/:id/start-paired-batch`, `/paired-vignette/new` |
+| Domains | `/domains`, `/domains/manage`, `/domains/:id/start`, `/domains/:id/status`, `/domains/:id/analysis`, `/domains/:id/coverage`, `/domains/:id/analysis/:value` |
+| Reusable content | `/preambles`, `/level-presets`, `/domain-contexts`, `/value-statements` |
+| Runs & Analysis | `/runs`, `/runs/:id`, `/analysis`, `/analysis/:id`, `/analysis/:id/conditions/:conditionId`, `/analysis/:id/transcripts` |
+| Archive | `/archive` |
+| Surveys | `/survey`, `/survey/results` |
+| Settings | `/settings/account`, `/settings/system-health`, `/settings/models`, `/settings/infrastructure`, `/settings/api-keys` |
+| Misc | `/status`, `/start`, `/models`, `*` (NotFound) |
+
+Note: the UI uses "Vignette" for user-friendliness, but database, GraphQL, and internal code still say "Definition" (see `docs/canonical-glossary.md`).
 
 ---
 
-### GraphQL API (`apps/api/`)
+### API Server (`apps/api/`)
 
-**Technology:** Express + GraphQL Yoga + Pothos Schema Builder
+**Technology:** Express 4 + GraphQL Yoga 5 + Pothos 3 (code-first schema) + PgBoss 12
 
 **Purpose:** Central API server handling:
-- GraphQL queries and mutations
-- JWT and API key authentication
-- Job queue management (PgBoss)
-- Worker orchestration
-- MCP server (stdio-based)
 
-**Key directories:**
+- GraphQL queries and mutations (single endpoint used by web and MCP)
+- JWT, API key, and OAuth 2.1 authentication
+- Queue orchestration (PgBoss, in-process)
+- Python worker spawning
+- MCP server (HTTP transport with OAuth or API keys)
+- REST endpoints for auth, export, import, OData, and admin
+
+**Source layout (`apps/api/src/`):**
+
 ```
 apps/api/src/
-├── graphql/           # Schema, types, resolvers
-│   ├── types/         # GraphQL type definitions
-│   ├── queries/       # Query resolvers
-│   ├── mutations/     # Mutation resolvers
-│   └── dataloaders/   # N+1 prevention
-├── queue/             # PgBoss handlers
-│   ├── handlers/      # Job type handlers
-│   ├── orchestrator.ts # Worker spawning logic
-│   └── spawn.ts       # Python process management
-├── mcp/               # MCP server implementation
-│   ├── tools/         # Read and write tools
-│   └── resources/     # Authoring guides, examples
-├── routes/            # REST endpoints (auth, export, import)
-├── services/          # Business logic
-│   ├── analysis/      # Analysis triggering and caching
-│   ├── export/        # MD, YAML, CSV export
-│   ├── import/        # Definition import
-│   └── health/        # System health checks
-└── auth/              # Authentication middleware
+├── auth/              # JWT and API key middleware
+├── cli/               # Admin scripts: create-user, normalize-aggregate-analysis-output,
+│                      # decision-model-shadow-validation
+├── config/            # Typed config loading
+├── graphql/           # Pothos schema builder
+│   ├── builder.ts
+│   ├── context.ts
+│   ├── types/         # GraphQL object types
+│   ├── queries/       # Query resolvers (definition, domain, run, analysis, …)
+│   ├── mutations/     # Mutation resolvers (definition, run, domain, paired-vignette, …)
+│   ├── dataloaders/   # N+1 prevention
+│   └── utils/
+├── mcp/               # MCP server (HTTP + stdio)
+│   ├── server.ts
+│   ├── tools/         # 40+ read & write tools
+│   ├── resources/     # Authoring guides, examples, value-pair / preamble templates
+│   ├── oauth/         # OAuth 2.1 (PKCE, Dynamic Client Registration, refresh tokens)
+│   ├── rate-limit.ts
+│   └── auth.ts
+├── middleware/        # Shared Express middleware
+├── queue/             # PgBoss orchestrator + handlers + Python spawner
+│   ├── boss.ts
+│   ├── orchestrator.ts
+│   ├── spawn.ts
+│   ├── types.ts
+│   └── handlers/      # See Queue Handlers below
+├── routes/            # REST endpoints (auth, export, csv, import, odata, admin)
+└── services/          # Business logic (analysis, domain, run, scenario, decision-model,
+                        # probe-result, rate-limiter, preamble, export, import, audit, …)
 ```
 
 **Endpoints:**
+
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/graphql` | POST | GraphQL operations |
-| `/api/auth/login` | POST | JWT login |
-| `/api/auth/register` | POST | User registration |
-| `/api/export/definition/:id` | GET | Export as Markdown |
-| `/api/export/scenarios/:id` | GET | Export as YAML |
-| `/api/import/definition` | POST | Import from Markdown |
+| `/graphql` | GET/POST | GraphQL operations (auth required except introspection) |
+| `/mcp` | POST | MCP Streamable HTTP (OAuth 2.1 or API key) |
+| `/oauth/authorize` · `/oauth/token` · `/oauth/register` | POST/GET | OAuth 2.1 (PKCE + Dynamic Client Registration) for Claude.ai |
+| `/.well-known/oauth-authorization-server` | GET | RFC 8414 metadata |
+| `/.well-known/oauth-protected-resource` | GET | RFC 9728 metadata |
+| `/api/auth/login` · `/api/auth/register` · etc. | POST | JWT auth |
+| `/api/export/*` | GET | Markdown / YAML / CSV / ZIP export |
+| `/api/csv/*` | GET | CSV feeds |
+| `/api/import/*` | POST | Definition import |
+| `/api/odata/*` | GET | OData feeds (BI tools) |
+| `/admin/*` | various | Admin-only tooling |
 | `/health` | GET | System health check |
 
 ---
 
 ### Database Package (`packages/db/`)
 
-**Technology:** Prisma ORM + PostgreSQL
+**Technology:** Prisma 5 ORM + PostgreSQL 15
 
-**Purpose:** Shared database access layer:
-- Prisma schema definition
-- Generated Prisma client
-- Common query patterns
-- Seed data
+**Purpose:** Shared database access layer — Prisma schema, generated client, seed data.
 
 **Schema location:** `packages/db/prisma/schema.prisma`
 
-See [Data Model](./data-model.md) for detailed schema documentation.
+See [Data Model](./data-model.md) for entity details.
+
+Connections:
+- App traffic goes through **PgBouncer** via `DATABASE_URL` (prepared statements disabled).
+- Migrations use the direct connection via `DIRECT_URL`.
 
 ---
 
 ### Shared Package (`packages/shared/`)
 
-**Purpose:** Cross-cutting utilities:
+Cross-cutting TypeScript utilities:
 
 ```typescript
-// Logger (pino-based)
-import { createLogger } from '@valuerank/shared';
-const log = createLogger('my-service');
-
-// Error classes
-import { AppError, NotFoundError, ValidationError } from '@valuerank/shared';
-
-// Environment utilities
-import { getEnv, getEnvOrThrow } from '@valuerank/shared';
+import { createLogger, AppError, NotFoundError, ValidationError, getEnv } from '@valuerank/shared';
 ```
+
+- Structured logger (pino)
+- Typed error classes with HTTP status codes
+- Environment parsing helpers
 
 ---
 
 ### Python Workers (`workers/`)
 
-**Technology:** Python 3 + standard library + requests
+**Technology:** Python 3.10+, with provider SDKs and shared adapters in `workers/common/`.
 
-**Purpose:** Execute long-running LLM operations:
+**Purpose:** Execute LLM-bound work that's awkward in Node (provider SDKs, large prompts, CPU-bound analysis).
 
 | Worker | File | Purpose |
 |--------|------|---------|
-| Probe | `probe.py` | Send scenarios to models, record responses |
-| Analyze | `analyze_basic.py` | Compute statistics from transcripts |
-| Summarize | `summarize.py` | Generate decision codes from transcripts |
-| Health Check | `health_check.py` | Verify environment setup |
+| Probe | `probe.py` | Send a scenario to a model, record the transcript |
+| Summarize | `summarize.py`, `summarize_batch.py`, `summarize_extract.py`, `summarize_llm.py`, `summarize_text.py` | Generate decision code + summary per transcript (deterministic extraction + LLM fallback) |
+| Analyze (basic) | `analyze_basic.py`, `analyze_basic_aggregation.py`, `analyze_basic_metadata.py` | Compute statistics, aggregations, and metadata from transcripts |
+| Expand scenarios | `generate_scenarios.py` | Generate scenario variants from a definition template |
+| Token stats | `compute_token_stats.py` | Refresh `ModelTokenStatistics` from transcripts |
+| Canary | `canary_runner.py` | Provider health canaries |
+| Health | `health_check.py` | Verify environment / provider connectivity |
 
 **Communication pattern:**
-1. TypeScript orchestrator receives job from PgBoss
-2. Spawns Python process with JSON input on stdin
-3. Python worker executes, writes JSON to stdout
-4. Orchestrator parses output, updates database
 
-This approach gives us:
-- Native PgBoss integration (TypeScript)
-- Python ecosystem for LLM adapters (compatible with CLI pipeline)
-- Simple debugging (JSON stdin/stdout)
+1. API receives a GraphQL mutation or queue event.
+2. A PgBoss handler runs in-process inside the API; it spawns a Python process with JSON on stdin.
+3. Python worker runs, writes JSON to stdout.
+4. Handler parses output, persists results via Prisma, updates progress.
+
+---
+
+## Queue Handlers
+
+All queue handling is in-process (no separate worker container). PgBoss polls the same PostgreSQL database. Job types (`apps/api/src/queue/types.ts`):
+
+| Job type | Handler | Triggered by |
+|----------|---------|--------------|
+| `probe_scenario` | `probe-scenario/` → `probe.py` | Run start / retry |
+| `summarize_transcript` | `summarize-transcript.ts` → `summarize.py` | Transcript saved or forced rerun |
+| `analyze_basic` | `analyze-basic.ts`, `analyze-basic-data.ts` | Summarization complete, or manual rerun |
+| `expand_scenarios` | `expand-scenarios.ts` → `generate_scenarios.py` | Definition create / update / fork |
+| `compute_token_stats` | `compute-token-stats.ts` → `compute_token_stats.py` | Run completion (cost visibility) |
+| `probe_dead_letter` | `probe-dead-letter.ts` | Probe retries exhausted |
+| `aggregate_analysis` | `aggregate-analysis.ts` | Cross-run aggregation per (definition × preamble × temp) |
+| `refresh_domain_analysis_snapshot` | `refresh-domain-analysis-snapshot.ts` | Domain-evaluation analysis refresh |
 
 ---
 
@@ -197,50 +247,55 @@ This approach gives us:
 ### Starting a Run
 
 ```
-┌────────┐     ┌─────────┐     ┌──────────┐     ┌─────────┐
-│ Web UI │────▶│ GraphQL │────▶│ Database │────▶│ PgBoss  │
-└────────┘     │ Mutation│     │ Create   │     │ Enqueue │
-               └─────────┘     │ Run      │     │ Jobs    │
-                               └──────────┘     └────┬────┘
-                                                     │
-                                                     ▼
-                               ┌──────────┐     ┌─────────┐
-                               │ Update   │◀────│ Worker  │
-                               │ Progress │     │ Process │
-                               └──────────┘     └─────────┘
+┌────────┐     ┌─────────┐     ┌──────────┐     ┌─────────────┐
+│ Web UI │────▶│ GraphQL │────▶│ Database │────▶│ PgBoss      │
+└────────┘     │ startRun│     │ create   │     │ enqueue     │
+               └─────────┘     │ Run +    │     │ probe jobs  │
+                               │ snapshot │     └──────┬──────┘
+                               │ scenarios│            │
+                               └──────────┘            ▼
+                                              ┌──────────────┐
+                                     ┌────────│ probe job    │
+                                     │        │ spawns Python│
+                                     ▼        └──────────────┘
+                              ┌──────────────┐
+                              │ Transcript + │
+                              │ ProbeResult  │
+                              │ written      │
+                              └──────┬───────┘
+                                     ▼
+                              enqueue summarize_transcript, then
+                              analyze_basic → aggregate_analysis
+                              → refresh_domain_analysis_snapshot
+                              (for domain-scoped runs)
 ```
 
-1. User clicks "Start Run" in web UI
-2. `startRun` mutation creates Run record with PENDING status
-3. Mutation enqueues `probe_scenario` jobs for each model×scenario pair
-4. PgBoss workers pick up jobs, spawn Python probe.py
-5. Python worker calls LLM provider, returns transcript
-6. Orchestrator updates Transcript and Run.progress
-7. When all probes complete, status changes to SUMMARIZING
-8. Summarize jobs run, then status becomes COMPLETED
-9. Analysis is auto-triggered
+1. Mutation creates `Run` with `PENDING` status, snapshots the domain config into `DomainConfigSnapshot`, records sampled scenarios in `RunScenarioSelection`.
+2. `probe_scenario` jobs are enqueued per (scenario × model × sampleIndex).
+3. Probe handler spawns `probe.py`, persists a `Transcript` and a `ProbeResult` row.
+4. Summarization jobs compute `decisionCode`, `decisionText`, and `decisionMetadata` via deterministic extraction first, then LLM fallback when needed.
+5. Once summarization completes, `analyze_basic` computes per-run statistics, then `aggregate_analysis` updates cross-run snapshots.
+6. Domain-scope runs also enqueue `refresh_domain_analysis_snapshot`.
 
 ### Querying Data via MCP
 
 ```
-┌────────────┐     ┌────────────┐     ┌─────────┐
-│ Local LLM  │────▶│ MCP Server │────▶│ GraphQL │
-│ (Claude)   │     │ (stdio)    │     │ Query   │
-└────────────┘     └────────────┘     └────┬────┘
-                                           │
-                                           ▼
-                   ┌────────────┐     ┌─────────┐
-                   │ Format for │◀────│ Database│
-                   │ Token Size │     │ Query   │
-                   └────────────┘     └─────────┘
+┌────────────┐   OAuth 2.1    ┌────────────┐     ┌─────────┐
+│ Claude.ai  │─── bearer ────▶│ MCP HTTP   │────▶│ GraphQL │
+│ / Claude   │   or API key   │ /mcp       │     │ resolver│
+│ Code / …   │                │ (Streamable│     └────┬────┘
+└────────────┘                │  HTTP)     │          │
+                              └────────────┘          ▼
+                                     ▲          ┌─────────┐
+                                     │          │ Postgres│
+                                     └──────────│ Prisma  │
+                                      formatted └─────────┘
+                                      for tokens
 ```
 
-1. User asks Claude about ValueRank data
-2. Claude calls MCP tool (e.g., `list_runs`)
-3. MCP server authenticates via API key
-4. Server executes GraphQL query
-5. Results are formatted for token efficiency (<5KB)
-6. Claude receives structured response
+1. The agent discovers the server via `/.well-known/oauth-protected-resource`, registers a client (RFC 7591), and completes a PKCE code exchange to get a bearer token. API-key auth is still supported for backwards compatibility.
+2. Tool calls hit `/mcp`. A tool registry in `mcp/tools/` maps each tool (e.g. `list_runs`, `start_run`) to a GraphQL query or mutation.
+3. Responses are shaped for token-efficient agent consumption (target <5 KB per response).
 
 ---
 
@@ -248,44 +303,40 @@ This approach gives us:
 
 ### GraphQL over REST
 
-**Why:** LLMs can introspect the schema and construct precise queries. Single endpoint simplifies auth and MCP integration. Flexible data fetching critical for token budgets.
+LLMs can introspect the schema and construct precise queries. A single endpoint simplifies auth and MCP integration. Flexible data fetching is critical for token budgets.
 
-### PgBoss over Redis
+### PgBoss over Redis/BullMQ
 
-**Why:** Uses same PostgreSQL database - no additional infrastructure. Built-in retry, priority queues, scheduling. Transactional with application data.
+Reuses the app Postgres — no extra infrastructure. Built-in retry, priority, scheduling, and transactional semantics with app data. Orchestrator runs inside the API process.
 
-### TypeScript Orchestrator + Python Workers
+### TypeScript orchestrator + Python workers
 
-**Why:** Best of both worlds. TypeScript handles PgBoss natively. Python workers reuse LLM adapters from CLI tool. JSON stdin/stdout is simple and debuggable.
+TypeScript owns request handling, schema, and queue bookkeeping. Python owns provider SDKs and statistical analysis. JSON stdin/stdout keeps the boundary simple and debuggable.
 
-### Single Tenant Architecture
+### HTTP MCP with OAuth 2.1
 
-**Why:** Internal team tool. All users share one workspace, all data visible to all users. No tenant_id columns, no ACLs needed.
+We moved off stdio-only to a Streamable-HTTP MCP server so remote agents (Claude.ai, Claude Code, Codex) can connect. We implement OAuth 2.1 with PKCE and Dynamic Client Registration; API-key auth is retained for local and programmatic use.
 
-### JSONB for Flexible Schema
+### Domain config snapshots
 
-**Why:** Definition content structure varies by scenario type. JSONB provides schema flexibility without migrations. `schema_version` field enables future migrations at read time.
+A `Run` captures the exact combination of `Preamble` / `LevelPreset` / `DomainContext` / `ValueStatement` versions it used into a `DomainConfigSnapshot`. This makes cross-run comparisons reproducible even as the underlying configuration changes.
 
----
+### Single-tenant architecture
 
-## Deviations from Original Design
+Internal research tool. All users share one workspace; there are no `tenant_id` columns or per-row ACLs. `AuditLog` and `createdByUserId` fields record who did what.
 
-The system was built following the [preplanning documents](../preplanning/), with these notable changes:
+### JSONB for flexible schema
 
-| Original Design | Current Implementation | Reason |
-|-----------------|----------------------|--------|
-| Docker Compose for production | Railway | Simpler deployment, better DX |
-| Separate worker container | Spawned Python processes | Simpler architecture, same outcome |
-| Experiment framework | Deferred | Focused on core features first |
-| Run comparison | Deferred | Focused on core features first |
+Definition, transcript, scenario, and analysis payloads all use JSONB. A `version` / `schema_version` field is stored alongside each payload for future read-time migrations.
 
 ---
 
 ## Related Documentation
 
-- [Data Model](./data-model.md) - Database schema details
-- [Tech Stack](./tech-stack.md) - Technology choices
-- [Queue System](../backend/queue-system.md) - PgBoss configuration
-- [Python Workers](../backend/python-workers.md) - Worker implementation
-
-See also: [Original Architecture Overview](../preplanning/architecture-overview.md) for design rationale
+- [Data Model](./data-model.md) — entity schema and relationships
+- [Tech Stack](./tech-stack.md) — technology choices
+- [Queue System](../backend/queue-system.md) — PgBoss configuration and handlers
+- [Python Workers](../backend/python-workers.md) — worker implementation
+- [MCP Tools](../api/mcp-tools.md) — tool and resource reference
+- [Canonical Glossary](../canonical-glossary.md) — terminology (Definition↔Vignette, Dimension↔Attribute, …)
+- Original design: [Preplanning Docs](../preplanning/) — useful for rationale, but superseded where they conflict

--- a/docs/architecture/tech-stack.md
+++ b/docs/architecture/tech-stack.md
@@ -1,348 +1,271 @@
 # Tech Stack
 
-> Technologies used in Cloud ValueRank and the rationale for each choice
+> Technologies used in ValueRank and the rationale for each choice.
 
 ---
 
 ## Overview
 
-Cloud ValueRank is built as a TypeScript-first monorepo with Python workers for LLM operations. The stack prioritizes:
+ValueRank is a TypeScript-first monorepo with Python workers for LLM-bound work. The stack prioritizes:
 
-- **Developer experience** - Hot reload, type safety, familiar tools
-- **Operational simplicity** - Single database, minimal infrastructure
-- **Token efficiency** - GraphQL for flexible queries, structured responses
-- **CLI compatibility** - Python workers can share adapters with the CLI pipeline
-
----
-
-## Core Technologies
-
-### Runtime & Package Management
-
-| Technology | Version | Purpose |
-|------------|---------|---------|
-| **Node.js** | 20+ | JavaScript runtime |
-| **npm** | 10.2 | Package manager |
-| **Turborepo** | 2.3 | Monorepo build orchestration |
-| **TypeScript** | 5.3 | Type-safe JavaScript |
-| **Python** | 3.10+ | Worker scripts for LLM operations |
-
-**Rationale:**
-- Node.js 20 LTS provides stable ES module support
-- Turborepo enables cached builds across packages
-- TypeScript catches errors at compile time
-- Python workers reuse LLM adapters from the CLI pipeline
+- **Developer experience** — hot reload, end-to-end types, familiar tools
+- **Operational simplicity** — single Postgres, no separate worker process
+- **Token efficiency** — GraphQL for flexible queries, token-budgeted MCP responses
+- **Python interop** — workers reuse provider SDKs and analysis code from the original CLI pipeline
 
 ---
 
-### API Server
+## Runtime & Package Management
 
 | Technology | Version | Purpose |
 |------------|---------|---------|
-| **Express** | 4.18 | HTTP server framework |
-| **GraphQL Yoga** | 5.1 | GraphQL server |
-| **Pothos** | 3.41 | Schema builder (type-safe) |
-| **DataLoader** | 2.2 | N+1 query prevention |
-| **Zod** | 3.22 | Input validation |
+| Node.js | 20 LTS | JavaScript runtime |
+| npm | 10+ | Package manager / workspaces |
+| Turborepo | 2.x | Monorepo orchestration + caching |
+| TypeScript | 5.3 | Type-safe JS |
+| Python | 3.10+ | Workers for LLM and statistics |
 
-**Rationale:**
+---
 
-**Express over Fastify:**
-- Mature ecosystem, extensive middleware
-- Team familiarity
-- No need for Fastify's extra performance
+## API Server (`apps/api`)
 
-**GraphQL over REST:**
-- LLMs can introspect schema and construct precise queries
-- Single endpoint simplifies MCP integration
-- Flexible data fetching critical for token budgets
-- Nested relationships in single query
+| Technology | Version | Purpose |
+|------------|---------|---------|
+| Express | 4.18 | HTTP server |
+| GraphQL Yoga | 5.1 | GraphQL server |
+| Pothos | 3.41 (`@pothos/core`, `plugin-prisma`, `plugin-validation`) | Code-first schema |
+| DataLoader | 2.2 | N+1 prevention |
+| Zod | 3.22 | Input validation |
+| pg-boss | 12.5 | Postgres-backed job queue |
+| `@modelcontextprotocol/sdk` | 1.24 | MCP server |
+| jsonwebtoken | 9.0 | JWT auth |
+| bcrypt | 5.1 | Password hashing |
+| express-rate-limit | 7.1 | Request rate limiting |
+| cors | 2.8 | CORS middleware (exposes `Content-Disposition`) |
+| compression | 1.8 | gzip/br response compression |
+| dotenv | 17.2 | Env loading for CLI scripts |
+| adm-zip | 0.5 | Export bundle zipping |
+| exceljs | 4.4 | XLSX export |
+| bottleneck | 2.19 | Per-provider rate-limit / concurrency control |
+| yaml | 2.8 | Definition import/export |
 
-**Pothos over SDL-first:**
-- Type-safe schema definition
-- Better IDE support
-- No schema drift
+**Design notes:**
+
+- **GraphQL over REST** — LLMs introspect the schema; single endpoint simplifies MCP and web auth.
+- **Pothos over SDL-first** — type-safe, no schema drift, good IDE support.
+- **Express over Fastify** — mature ecosystem and team familiarity outweigh Fastify's perf wins.
+- **In-process PgBoss** — queue orchestrator runs inside the API; simpler deploy than a separate worker service.
 
 ```typescript
-// Example: Type-safe schema with Pothos
+// Pothos example
 const Definition = builder.prismaObject('Definition', {
   fields: (t) => ({
     id: t.exposeID('id'),
     name: t.exposeString('name'),
-    content: t.field({
-      type: 'JSON',
-      resolve: (def) => def.content,
-    }),
+    content: t.field({ type: 'JSON', resolve: (d) => d.content }),
   }),
 });
 ```
 
 ---
 
-### Database
+## Database (`packages/db`)
 
 | Technology | Version | Purpose |
 |------------|---------|---------|
-| **PostgreSQL** | 15+ | Primary database |
-| **Prisma** | 5.7 | ORM and query builder |
-| **PgBoss** | 12.5 | Job queue (PostgreSQL-backed) |
+| PostgreSQL | 15+ | Primary store |
+| PgBouncer | — | Transaction-pooled connections for the app |
+| Prisma | 5.7 | ORM / migrations / typed client |
 
 **Rationale:**
 
-**PostgreSQL over MongoDB:**
-- Definition versioning requires DAG queries (ancestry, descendants)
-- Recursive CTEs handle version trees efficiently
-- JSONB provides schema flexibility without migrations
-- Single database for both app data and job queue
-
-**PgBoss over BullMQ/Redis:**
-- Uses same PostgreSQL - no additional infrastructure
-- Built-in retry, scheduling, priority queues
-- Transactional with application data
-- Simpler operational model
-
-**Prisma over raw SQL:**
-- Type-safe queries
-- Migration management
-- Generated TypeScript types
+- **PostgreSQL over MongoDB** — definition DAGs need recursive CTEs; JSONB gives schema flexibility without migrations; same DB serves the queue.
+- **PgBouncer** — app goes through the pooler (`DATABASE_URL` with `?pgbouncer=true`, prepared statements off). Migrations use a direct connection (`DIRECT_URL`).
+- **Prisma Migrate only** — never `db push` in shared envs. Production runs `prisma migrate deploy` on startup.
 
 ---
 
-### Frontend
+## Frontend (`apps/web`)
 
 | Technology | Version | Purpose |
 |------------|---------|---------|
-| **React** | 18.2 | UI framework |
-| **Vite** | 5.0 | Build tool and dev server |
-| **TypeScript** | 5.3 | Type safety |
-| **Tailwind CSS** | 3.3 | Utility-first styling |
-| **urql** | 4.0 | GraphQL client |
-| **React Router** | 6.21 | Client-side routing |
-| **Monaco Editor** | 4.7 | Code/definition editing |
-| **Recharts** | 3.5 | Data visualization |
-| **Lucide** | 0.294 | Icons |
+| React | 18.2 | UI framework |
+| Vite | 5.0 | Dev server + bundler |
+| TypeScript | 5.3 | Type safety |
+| Tailwind CSS | 3.3 | Utility-first styling |
+| urql | 4.0 | GraphQL client |
+| `@urql/exchange-auth` | 2.1 | JWT auth exchange |
+| GraphQL Code Generator | 6.x (`client-preset`, `typescript-urql`) | Typed documents from schema |
+| React Router | 6.21 | Client-side routing |
+| Monaco Editor | 4.7 | Definition editing |
+| Recharts | 3.5 | Charts |
+| `@tanstack/react-virtual` | 3.13 | Virtualized tables |
+| Radix Popover | 1.1 | Accessible primitives |
+| `class-variance-authority`, `clsx`, `tailwind-merge` | latest | Styling helpers |
+| `date-fns` | 4.1 | Date formatting |
+| `html-to-image`, `html2canvas` | latest | Chart export |
+| Lucide | 0.294 | Icons |
 
 **Rationale:**
 
-**React over alternatives:**
-- Team familiarity
-- Component reuse from DevTool
-- Extensive ecosystem
-
-**Vite over CRA/Webpack:**
-- Fast hot reload
-- Modern ES module handling
-- Simpler configuration
-
-**urql over Apollo:**
-- Lighter weight
-- Simpler caching model
-- Good TypeScript support
-
-**Tailwind over CSS-in-JS:**
-- Consistent design system
-- No runtime overhead
-- Easy responsive design
+- **Vite over CRA/Webpack** — fast HMR, ESM-native, minimal config.
+- **urql over Apollo** — lighter, simpler cache; pairs well with GraphQL codegen.
+- **Codegen workflow** — `npm run codegen` in `apps/web` writes `src/generated/`; `npm run verify` enforces that generated output is up to date.
+- **Tailwind + CVA** — design tokens in Tailwind; component variants via `class-variance-authority`.
 
 ---
 
-### Authentication
+## Authentication
 
 | Technology | Version | Purpose |
 |------------|---------|---------|
-| **bcrypt** | 5.1 | Password hashing |
-| **jsonwebtoken** | 9.0 | JWT creation/verification |
-| **express-rate-limit** | 7.1 | Request rate limiting |
+| bcrypt | 5.1 | Password hashing |
+| jsonwebtoken | 9.0 | JWT signing/verification |
+| express-rate-limit | 7.1 | Brute-force protection |
 
-**Rationale:**
-- JWT for stateless authentication
-- bcrypt for secure password storage
-- Rate limiting protects against abuse
+**Auth channels:**
+
+- **Web:** JWT (HTTP-only cookie).
+- **Programmatic / MCP (legacy):** API keys (hashed in `api_keys`).
+- **Remote MCP agents (Claude.ai / Claude Code / Codex):** OAuth 2.1 with PKCE and RFC 7591 Dynamic Client Registration. Metadata exposed at `/.well-known/oauth-authorization-server` (RFC 8414) and `/.well-known/oauth-protected-resource` (RFC 9728). Implementation in `apps/api/src/mcp/oauth/`.
 
 ---
 
-### MCP Integration
+## MCP Integration
 
 | Technology | Version | Purpose |
 |------------|---------|---------|
-| **@modelcontextprotocol/sdk** | 1.24 | MCP server implementation |
+| `@modelcontextprotocol/sdk` | 1.24 | MCP server protocol |
 
-**Rationale:**
-- Official MCP SDK for protocol compliance
-- Stdio transport for local LLM integration
-- Enables AI agents to query and author data
+- **Transport:** Streamable HTTP at `POST /mcp` (remote) + stdio for local development.
+- **Tools:** 40+ read/write tools live in `apps/api/src/mcp/tools/` (definitions, runs, models, queue, transcripts, pairwise outcomes, etc.). They reuse the GraphQL resolvers.
+- **Resources:** authoring guide, annotated examples, value-pair catalog, preamble templates (`mcp/resources/`).
+- **Rate limiting:** 120 req/min per API key (in `mcp/rate-limit.ts`).
 
 ---
 
-### Testing
+## Python Workers (`workers/`)
+
+| Package | Purpose |
+|---------|---------|
+| `anthropic`, `openai`, `google-generativeai`, plus HTTP-based adapters for xAI / DeepSeek / Mistral | Provider clients |
+| `requests` | HTTP |
+| `PyYAML` | definition I/O |
+| `pytest` | tests in `workers/tests/` |
+
+Adapters live in `workers/common/llm_adapters/`. Statistics helpers live in `workers/stats/`.
+
+Workers expose a JSON-in/JSON-out protocol so the TypeScript orchestrator can spawn and parse them without sharing process state.
+
+---
+
+## Testing
 
 | Technology | Version | Purpose |
 |------------|---------|---------|
-| **Vitest** | 2.1 | Test runner |
-| **@testing-library/react** | 14.1 | React component testing |
-| **supertest** | 6.3 | HTTP assertion library |
-| **pytest** | 7+ | Python test runner |
+| Vitest | 2.1 (api) / 1.x (web) | Unit + integration tests |
+| `@testing-library/react` | 14.1 | Component testing |
+| supertest | 6.3 | HTTP assertions |
+| jsdom | 23 | DOM for web tests |
+| pytest | 7+ | Python worker tests |
+| `@vitest/coverage-v8` | — | Coverage |
 
-**Rationale:**
-- Vitest is fast and Vite-native
-- Testing Library encourages user-centric tests
-- supertest enables API integration tests
-
----
-
-### Development Tools
-
-| Technology | Version | Purpose |
-|------------|---------|---------|
-| **ESLint** | 8.56 | Linting |
-| **Prettier** | 3.2 | Code formatting |
-| **tsx** | 4.6 | TypeScript execution |
-| **pino** | 8+ | Structured logging |
+Coverage targets (per `cloud/CLAUDE.md`): 80 % line, 75 % branch, 80 % function minimum.
 
 ---
 
-### Infrastructure
+## Development & Tooling
 
 | Technology | Purpose |
 |------------|---------|
-| **Docker Compose** | Local development |
-| **Railway** | Production deployment |
-
-**Railway over other platforms:**
-- Simple deployment model
-- Good developer experience
-- PostgreSQL included
-- No container management needed
+| ESLint 8, Prettier 3 | Lint / format |
+| `tsx` 4 | TypeScript execution for dev and scripts |
+| `pino` 8 (via `@valuerank/shared`) | Structured logging |
+| Docker Compose | Local Postgres (+ PgBouncer) |
+| Railway | Production deployment (Postgres + API) |
 
 ---
 
-## Package Dependencies by App
-
-### API (`@valuerank/api`)
-
-```json
-{
-  "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.24.3",
-    "@pothos/core": "^3.41.0",
-    "@pothos/plugin-prisma": "^3.65.0",
-    "@pothos/plugin-validation": "^3.10.1",
-    "bcrypt": "^5.1.1",
-    "cors": "^2.8.5",
-    "dataloader": "^2.2.2",
-    "express": "^4.18.2",
-    "express-rate-limit": "^7.1.5",
-    "graphql": "^16.8.1",
-    "graphql-yoga": "^5.1.1",
-    "jsonwebtoken": "^9.0.2",
-    "pg-boss": "^12.5.2",
-    "yaml": "^2.8.2",
-    "zod": "^3.22.4"
-  }
-}
-```
-
-### Web (`@valuerank/web`)
-
-```json
-{
-  "dependencies": {
-    "@monaco-editor/react": "^4.7.0",
-    "@urql/exchange-auth": "^2.1.6",
-    "graphql": "^16.8.0",
-    "lucide-react": "^0.294.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.0",
-    "recharts": "^3.5.1",
-    "urql": "^4.0.0"
-  }
-}
-```
-
-### Database (`@valuerank/db`)
-
-```json
-{
-  "dependencies": {
-    "@prisma/client": "^5.7.0"
-  }
-}
-```
-
-### Python Workers
+## Type-Safe End-to-End
 
 ```
-# workers/requirements.txt
-requests>=2.31.0
-PyYAML>=6.0
-anthropic>=0.25.0
-openai>=1.12.0
-google-generativeai>=0.4.0
+Prisma schema
+   ▼  (prisma generate)
+@valuerank/db client
+   ▼  (Pothos plugin-prisma)
+GraphQL schema
+   ▼  (GraphQL Code Generator — web only)
+Typed urql documents
+   ▼
+React components
 ```
+
+This chain means a schema change surfaces as a TypeScript error in the API resolvers, the web codegen step, and the React call sites.
 
 ---
 
-## Architectural Patterns
-
-### Type-Safe End-to-End
-
-The stack enables type safety from database to UI:
-
-```
-Prisma Schema → Generated Types → Pothos Schema → GraphQL → urql Codegen → React
-```
-
-### Structured Logging
-
-All logging uses pino for structured JSON output:
+## Structured Logging
 
 ```typescript
 import { createLogger } from '@valuerank/shared';
-const log = createLogger('service-name');
-
-log.info({ userId, action: 'login' }, 'User logged in');
+const log = createLogger('runs');
+log.info({ runId, userId }, 'Run created');
+log.error({ err, config }, 'Failed to create run');
 ```
 
-### Error Handling
+Always object-then-message. Never `console.log`.
 
-Custom error classes with codes and status:
+---
+
+## Error Handling
 
 ```typescript
 import { NotFoundError, ValidationError } from '@valuerank/shared';
-
 throw new NotFoundError('Definition', id);
 throw new ValidationError('Invalid dimensions', errors);
 ```
+
+A global Express error middleware maps `AppError` subclasses to HTTP status + code.
 
 ---
 
 ## Configuration
 
-### Environment Variables
+### Ports
+
+| Service | Port |
+|---------|------|
+| Web (Vite) | 3030 |
+| API (Express + GraphQL + MCP) | 3031 |
+| Postgres (Docker Compose) | 5433 |
+| PgBouncer (Docker Compose) | 6432 |
+
+### Environment variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `DATABASE_URL` | Yes | PostgreSQL connection string |
-| `JWT_SECRET` | Yes | Secret for JWT signing (32+ chars) |
-| `OPENAI_API_KEY` | For runs | OpenAI API key |
-| `ANTHROPIC_API_KEY` | For runs | Anthropic API key |
-| `GOOGLE_API_KEY` | For runs | Google AI API key |
-| `XAI_API_KEY` | For runs | xAI API key |
-| `DEEPSEEK_API_KEY` | For runs | DeepSeek API key |
-| `MISTRAL_API_KEY` | For runs | Mistral API key |
-| `PORT` | No | API server port (default: 3001) |
-| `LOG_LEVEL` | No | Logging level (default: info) |
+| `DATABASE_URL` | yes | App Postgres URL (via PgBouncer, `?pgbouncer=true`) |
+| `DIRECT_URL` | yes | Direct Postgres URL for Prisma Migrate |
+| `JWT_SECRET` | yes | 32+ chars |
+| `OPENAI_API_KEY` | for runs | OpenAI |
+| `ANTHROPIC_API_KEY` | for runs | Anthropic |
+| `GOOGLE_API_KEY` | for runs | Google AI |
+| `XAI_API_KEY` | for runs | xAI |
+| `DEEPSEEK_API_KEY` | for runs | DeepSeek |
+| `MISTRAL_API_KEY` | for runs | Mistral |
+| `PORT` | no | API port (default 3031) |
+| `LOG_LEVEL` | no | pino level |
 
-### Database Connection
-
-Development and test databases run on port 5433:
+### Example local URLs
 
 ```bash
-# Development
-DATABASE_URL="postgresql://valuerank:valuerank@localhost:5433/valuerank"
+# App traffic (via PgBouncer)
+DATABASE_URL="postgresql://valuerank:valuerank@localhost:6432/valuerank?pgbouncer=true"
 
-# Test
+# Direct connection for migrations
+DIRECT_URL="postgresql://valuerank:valuerank@localhost:5433/valuerank"
+
+# Test database (direct, no pooler)
 DATABASE_URL="postgresql://valuerank:valuerank@localhost:5433/valuerank_test"
 ```
 
@@ -353,7 +276,7 @@ DATABASE_URL="postgresql://valuerank:valuerank@localhost:5433/valuerank_test"
 | Component | Minimum | Recommended |
 |-----------|---------|-------------|
 | Node.js | 20.0 | 20 LTS |
-| npm | 10.0 | 10.2 |
+| npm | 10.0 | 10+ |
 | PostgreSQL | 14 | 15 |
 | Python | 3.10 | 3.11 |
 
@@ -361,7 +284,8 @@ DATABASE_URL="postgresql://valuerank:valuerank@localhost:5433/valuerank_test"
 
 ## Related Documentation
 
-- [Architecture Overview](./overview.md) - System components
-- [Data Model](./data-model.md) - Database schema
-- [Local Development](../operations/local-development.md) - Setup guide
-- [Project Constitution](../../CLAUDE.md) - Coding standards
+- [Architecture Overview](./overview.md)
+- [Data Model](./data-model.md)
+- [Queue System](../backend/queue-system.md)
+- [LLM Providers](../backend/llm-providers.md)
+- [Project Constitution](../../cloud/CLAUDE.md) — coding standards, preflight gate


### PR DESCRIPTION
## Summary

- Updates `docs/README.md`: removes stale "Cloud ValueRank" branding, adds canonical glossary link, corrects Quick Start commands, adds REST/queue/worker doc links
- Updates `docs/architecture/overview.md`, `data-model.md`, `tech-stack.md`: reflects current system (MCP over HTTP + OAuth 2.1, PgBouncer, PgBoss in-process, Python workers, all LLM providers)

These changes were authored during the orchestrator-split planning session but are unrelated to that feature — keeping them separate to avoid polluting that PR's diff.

## Validation

Docs-only change. No code, no tests, no schema changes.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)