### PR TITLE
fix(feature-factory): unblock judge panel + review regeneration loops

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_judge.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_judge.py
@@ -980,12 +980,16 @@ def run_judge(
         return 2
 
     if _stage_int(stage_state, "judge_rounds") >= 3:
-        payload = state.get("last_action_result")
-        if not isinstance(payload, dict) or not payload.get("next"):
-            payload = _build_exhausted_payload(slug, stage, state, stage_state)
-            with with_locked_state(slug) as locked_state:
-                _ensure_stage_state(locked_state, stage)
-                locked_state["last_action_result"] = payload
+        # Always recompute the exhausted payload when the judge cap is hit.
+        # An earlier loop iteration may have stored last_action_result["next"]
+        # as "judge_panel" (the call the orchestrator was told to run again
+        # after the spec was edited). After the 3-round cap, the correct next
+        # action is whatever the workflow recommends for the exhausted state
+        # (usually the next stage's authoring), not another judge round.
+        payload = _build_exhausted_payload(slug, stage, state, stage_state)
+        with with_locked_state(slug) as locked_state:
+            _ensure_stage_state(locked_state, stage)
+            locked_state["last_action_result"] = payload
         if json_output:
             print(json.dumps(payload, indent=2))
         else:

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review.py
@@ -228,6 +228,9 @@ def repair_checkpoint_args(slug: str, stage: str, state: dict[str, object]) -> a
         repair_timeout_seconds=300,
         allow_large_diff_rerun=bool(diff_budget.get("artifact_changed_since_codex")),
         fallback=False,
+        json=False,
+        no_auto_context=False,
+        fast=False,
     )
 
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_judge.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_judge.py
@@ -197,6 +197,79 @@ class FactoryJudgeTests(unittest.TestCase):
         self.assertEqual(rc, 2)
         self.assertEqual(stdout.getvalue().strip(), "→ next: checkpoint")
 
+    def test_judge_at_cap_recomputes_fresh_next_action(self) -> None:
+        """After judge_rounds >= 3, subsequent judge calls must recompute the
+        exhausted-payload next_action instead of returning a stale value left
+        over from an earlier loop iteration.
+
+        Regression test for the infinite-loop bug where
+        `last_action_result["next"] == "judge_panel"` (set by an earlier
+        checkpoint at the cap) was returned verbatim by judge, causing the
+        orchestrator to be told "run judge_panel" forever.
+        """
+        stage_state = _stage_state(3, 3)
+        stage_state["judge_verdicts"] = [
+            [
+                {
+                    "judge": "completeness",
+                    "model": "gpt-5.4-mini",
+                    "verdict": "block",
+                    "confidence": 4,
+                    "reasoning": "Round 3 block example.",
+                    "evidence": [],
+                    "timestamp": "2026-04-18T10:00:00Z",
+                },
+                {
+                    "judge": "restatement",
+                    "model": "gpt-5.4",
+                    "verdict": "block",
+                    "confidence": 4,
+                    "reasoning": "Round 3 block example.",
+                    "evidence": [],
+                    "timestamp": "2026-04-18T10:00:00Z",
+                },
+                {
+                    "judge": "implementation-risk",
+                    "model": "claude-sonnet-4-6",
+                    "verdict": "proceed",
+                    "confidence": 4,
+                    "reasoning": "Round 3 proceed example.",
+                    "evidence": [],
+                    "timestamp": "2026-04-18T10:00:00Z",
+                },
+            ]
+        ]
+        _write_workflow(self._tmpdir.name, stage_state, [])
+
+        # Simulate the stale state the prior buggy flow would leave behind.
+        state_path = FACTORY_STATE.factory_state_path(SLUG)
+        workflow_state = json.loads(state_path.read_text(encoding="utf-8"))
+        workflow_state["last_action_result"] = {
+            "next": "judge_panel",
+            "reason": "stale remnant from earlier loop",
+            "blockers": [],
+            "outcome": "rejudge",
+        }
+        FACTORY_STATE.atomic_json_write(state_path, workflow_state)
+
+        def _side_effect(cmd, *args, **kwargs):
+            if cmd[0] == "git":
+                return _make_git_response(cmd, Path(self._tmpdir.name))
+            raise AssertionError("judge must not call any model when at cap")
+
+        with patch.object(JUDGE.subprocess, "run", side_effect=_side_effect), \
+            patch.object(JUDGE, "stage_manifest_state", side_effect=_fake_stage_manifest_state):
+            with contextlib.redirect_stdout(io.StringIO()) as stdout, contextlib.redirect_stderr(io.StringIO()):
+                rc = JUDGE.run_judge(SLUG, STAGE)
+
+        self.assertEqual(rc, 0)
+        # The runner must advance rather than regurgitate the stale
+        # "judge_panel" next action. "repair_plan_checkpoint" or similar
+        # forward-progressing action is expected here.
+        self.assertNotEqual(stdout.getvalue().strip(), "→ next: judge_panel")
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertNotEqual(state["last_action_result"]["next"], "judge_panel")
+
     def test_judge_dispatches_three_parallel(self) -> None:
         stage_state = _stage_state(3)
         review_specs = [

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_workflow_utils.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_workflow_utils.py
@@ -1,0 +1,109 @@
+"""Tests for review-lens/scripts/workflow_utils.py."""
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+WORKFLOW_UTILS_PATH = (
+    Path(__file__).resolve().parents[3] / "review-lens" / "scripts" / "workflow_utils.py"
+)
+WORKFLOW_UTILS_SPEC = importlib.util.spec_from_file_location(
+    "workflow_utils_for_tests", WORKFLOW_UTILS_PATH
+)
+assert WORKFLOW_UTILS_SPEC and WORKFLOW_UTILS_SPEC.loader
+WORKFLOW_UTILS = importlib.util.module_from_spec(WORKFLOW_UTILS_SPEC)
+sys.modules[WORKFLOW_UTILS_SPEC.name] = WORKFLOW_UTILS
+WORKFLOW_UTILS_SPEC.loader.exec_module(WORKFLOW_UTILS)
+
+
+class NormalizedArtifactTextTests(unittest.TestCase):
+    """The Review Reconciliation section is orchestrator-added metadata. Its
+    content must not participate in artifact hashes — otherwise every
+    reconciliation edit invalidates the reviews and creates an infinite loop.
+    Regression tests cover every stage that authors can add a reconciliation
+    section to.
+    """
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+
+    def _write(self, name: str, body: str) -> Path:
+        path = Path(self._tmpdir.name) / name
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def _assert_reconciliation_stripped(self, stage: str) -> None:
+        body_without = "# Artifact\n\nSubstantive body.\n\n## Next Steps\n\nMore.\n"
+        reconciliation = (
+            "## Review Reconciliation\n\n"
+            "- review: reviews/a.review.md | status: accepted | note: note one\n"
+        )
+        # When reconciliation is at the end:
+        path_tail = self._write(f"{stage}-tail.md", body_without + "\n" + reconciliation)
+        self.assertEqual(
+            WORKFLOW_UTILS.normalized_artifact_hash(stage, self._write(f"{stage}-plain.md", body_without)),
+            WORKFLOW_UTILS.normalized_artifact_hash(stage, path_tail),
+            f"stage={stage}: trailing Review Reconciliation must not affect hash",
+        )
+        # When another section follows reconciliation:
+        path_mid = self._write(
+            f"{stage}-mid.md",
+            "# Artifact\n\nSubstantive body.\n\n"
+            + reconciliation
+            + "\n## Next Steps\n\nMore.\n",
+        )
+        self.assertEqual(
+            WORKFLOW_UTILS.normalized_artifact_hash(stage, self._write(f"{stage}-plain.md", body_without)),
+            WORKFLOW_UTILS.normalized_artifact_hash(stage, path_mid),
+            f"stage={stage}: inlined Review Reconciliation must not affect hash",
+        )
+
+    def test_plan_reconciliation_stripped(self) -> None:
+        self._assert_reconciliation_stripped("plan")
+
+    def test_spec_reconciliation_stripped(self) -> None:
+        """Regression: prior implementation only stripped Reconciliation for
+        the plan stage, which caused spec adversarial reviews to be marked
+        stale every time the orchestrator recorded a reconciliation."""
+        self._assert_reconciliation_stripped("spec")
+
+    def test_tasks_reconciliation_stripped(self) -> None:
+        self._assert_reconciliation_stripped("tasks")
+
+    def test_closeout_reconciliation_stripped(self) -> None:
+        self._assert_reconciliation_stripped("closeout")
+
+    def test_body_without_reconciliation_unchanged(self) -> None:
+        body = "# Artifact\n\nNo reconciliation section here.\n"
+        path = self._write("plain.md", body)
+        # Hash must be the sha256 of the raw text byte-for-byte
+        import hashlib
+
+        expected = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        for stage in ("spec", "plan", "tasks", "closeout", "diff"):
+            self.assertEqual(
+                WORKFLOW_UTILS.normalized_artifact_hash(stage, path),
+                expected,
+                f"stage={stage}: text without reconciliation must hash to raw sha",
+            )
+
+    def test_change_to_substantive_body_changes_hash(self) -> None:
+        """Make sure stripping reconciliation doesn't accidentally strip the
+        substantive body or collapse different artifacts into the same hash."""
+        body_a = "# Artifact\n\nBody A.\n\n## Review Reconciliation\n\n- review: a\n"
+        body_b = "# Artifact\n\nBody B.\n\n## Review Reconciliation\n\n- review: a\n"
+        path_a = self._write("a.md", body_a)
+        path_b = self._write("b.md", body_b)
+        for stage in ("spec", "plan", "tasks", "closeout"):
+            self.assertNotEqual(
+                WORKFLOW_UTILS.normalized_artifact_hash(stage, path_a),
+                WORKFLOW_UTILS.normalized_artifact_hash(stage, path_b),
+                f"stage={stage}: substantive body differences must change hash",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/workflow_utils.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/workflow_utils.py
@@ -37,7 +37,15 @@ def resolve_stored_path(raw: str, repo_root: Path, stored_repo_root: str = "") -
 
 def normalized_artifact_text(stage: str, path: Path) -> str:
     text = path.read_text(encoding="utf-8")
-    if stage != "plan" or "## Review Reconciliation" not in text:
+    # Strip the Review Reconciliation section from the hash computation for
+    # every artifact stage, not just plan. Previously this stripping was
+    # plan-only, which caused spec (and tasks, and closeout) adversarial
+    # reviews to be marked "stale" every time the orchestrator added a
+    # reconciliation entry — creating an infinite loop where the reviews
+    # could never converge. The Review Reconciliation section is
+    # orchestrator-added metadata and its content has no bearing on whether
+    # a review of the artifact's substantive content is still valid.
+    if "## Review Reconciliation" not in text:
         return text
     before, remainder = text.split("## Review Reconciliation", 1)
     trailing = remainder.split("\n## ", 1)


### PR DESCRIPTION
## Summary
Four tooling bugs that together made it impossible for a spec stage to converge once any reconciliation was recorded. Surfaced while running the factory workflow for a substantive refactor spec today (`decision-cache-single-source`), where the workflow entered an infinite "judge_panel → edit → judge_panel" loop without substantive progress.

## The four bugs
| # | File | Bug |
|---|---|---|
| 1 | `review-lens/scripts/run_codex_review.py` | Missing `import sys` — Codex adversarial review crashed at startup with NameError. Gemini review still ran, leaving the checkpoint half-populated. |
| 2 | `feature-factory/scripts/factory_cmd_judge.py` | When `judge_rounds >= 3`, `run_judge` returned a stale `last_action_result["next"]` value (set to `"judge_panel"` by the prior cap-hit path). Subsequent judge calls infinitely reported "→ next: judge_panel" instead of advancing. |
| 3 | `review-lens/scripts/workflow_utils.py` | `normalized_artifact_text` stripped the `## Review Reconciliation` section from the hash only for the `plan` stage. For spec/tasks/closeout, every reconciliation edit changed the artifact SHA, marking adversarial reviews stale. This forced regeneration, which then left the restatement judge with no "prior findings" history, making it always block. |
| 4 | `feature-factory/scripts/factory_review.py` | `repair_checkpoint_args` built an `argparse.Namespace` without `json`, `no_auto_context`, or `fast` — the `repair` command crashed with AttributeError downstream. |

## Root cause
Bugs 2 + 3 together. Bug 3 meant any spec edit (including the orchestrator's own reconciliation writes) invalidated reviews. Bug 2 meant once the checkpoint-level cap was hit, the runner couldn't exit the judge_panel loop because it was reading a stale "next" value.

## Tests
- `test_factory_cmd_judge.test_judge_at_cap_recomputes_fresh_next_action` — regression for bug 2.
- `tests/test_workflow_utils.py` (new) — 6 tests covering reconciliation stripping across all stages, plus an invariant that substantive body changes still affect the hash.
- All existing 22 judge tests + 6 new workflow-utils tests pass (28 total).

## Test plan
- [x] New + existing tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)