### PR TITLE
feat(models-consistency): signature dropdown, default to vnewtd

### DIFF
--- a/cloud/apps/web/src/components/models/ConsistencyFilters.tsx
+++ b/cloud/apps/web/src/components/models/ConsistencyFilters.tsx
@@ -5,22 +5,28 @@ type Option = { value: string; label: string };
 type ConsistencyFiltersProps = {
   domainId: string | null;
   providerId: string | null;
+  signature: string;
   minScenarios: number;
   domainOptions: Option[];
   providerOptions: Option[];
+  signatureOptions: Option[];
   onDomainChange: (value: string | null) => void;
   onProviderChange: (value: string | null) => void;
+  onSignatureChange: (value: string) => void;
   onMinScenariosChange: (value: number) => void;
 };
 
 export function ConsistencyFilters({
   domainId,
   providerId,
+  signature,
   minScenarios,
   domainOptions,
   providerOptions,
+  signatureOptions,
   onDomainChange,
   onProviderChange,
+  onSignatureChange,
   onMinScenariosChange,
 }: ConsistencyFiltersProps) {
   return (
@@ -32,6 +38,14 @@ export function ConsistencyFilters({
             value={domainId ?? 'all'}
             onChange={(value) => onDomainChange(value === 'all' ? null : value)}
             options={[{ value: 'all', label: 'All domains' }, ...domainOptions]}
+          />
+        </div>
+        <div className="min-w-[220px] flex-1">
+          <Select
+            label="Signature"
+            value={signature}
+            onChange={(value) => onSignatureChange(value)}
+            options={signatureOptions}
           />
         </div>
         <div className="min-w-[220px] flex-1">

--- a/cloud/apps/web/src/pages/ModelsConsistency.tsx
+++ b/cloud/apps/web/src/pages/ModelsConsistency.tsx
@@ -8,6 +8,7 @@ import {
   DOMAIN_AVAILABLE_SIGNATURES_QUERY,
   type DomainAvailableSignaturesQueryResult,
 } from '../api/operations/domainAnalysis';
+import { formatSignatureOptionLabel } from '../utils/domainAnalysisUtils';
 import {
   MODELS_CONSISTENCY_QUERY,
   type ModelsConsistencyQueryResult,
@@ -47,14 +48,33 @@ export function ModelsConsistency() {
     requestPolicy: 'cache-and-network',
   });
 
-  const signatureChoice = signatureParam
-    ?? (hasDomainParam && domainParam === 'all'
-      ? DEFAULT_SIGNATURE
-      : signatureError != null
-        ? DEFAULT_SIGNATURE
-      : signatureData != null
-        ? signatureData.domainAvailableSignatures[0]?.signature ?? DEFAULT_SIGNATURE
-        : null);
+  const availableSignatures = useMemo(
+    () => signatureData?.domainAvailableSignatures ?? [],
+    [signatureData],
+  );
+
+  const signatureOptions = useMemo(
+    () => availableSignatures.map((option) => ({
+      value: option.signature,
+      label: formatSignatureOptionLabel(option),
+    })),
+    [availableSignatures],
+  );
+
+  // Default picker: honor ?signature URL param first. Otherwise prefer the
+  // canonical "vnewest @ default temperature" signature if it is actually
+  // offered for this domain; fall back to the first available signature;
+  // fall back to DEFAULT_SIGNATURE constant only when nothing is loaded yet.
+  const signatureChoice = (() => {
+    if (signatureParam != null) return signatureParam;
+    if (hasDomainParam && domainParam === 'all') return DEFAULT_SIGNATURE;
+    if (signatureError != null) return DEFAULT_SIGNATURE;
+    if (signatureData == null) return null;
+    if (availableSignatures.some((option) => option.signature === DEFAULT_SIGNATURE)) {
+      return DEFAULT_SIGNATURE;
+    }
+    return availableSignatures[0]?.signature ?? DEFAULT_SIGNATURE;
+  })();
   const selectedSignature = signatureChoice ?? DEFAULT_SIGNATURE;
 
   useEffect(() => {
@@ -134,6 +154,12 @@ export function ModelsConsistency() {
     setMinScenarios(value);
   };
 
+  const handleSignatureChange = (value: string) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('signature', value);
+    setSearchParams(next, { replace: true });
+  };
+
   // Order matters: surface errors and empty-domain state BEFORE the loading
   // spinner so a failed useDomains() or an empty domain list does not leave
   // the page stuck on an infinite loading state.
@@ -159,11 +185,14 @@ export function ModelsConsistency() {
       <ConsistencyFilters
         domainId={urlDomainId}
         providerId={providerId}
+        signature={selectedSignature}
         minScenarios={minScenarios}
         domainOptions={buildDomainOptions(domains)}
         providerOptions={providerOptions}
+        signatureOptions={signatureOptions}
         onDomainChange={handleDomainChange}
         onProviderChange={handleProviderChange}
+        onSignatureChange={handleSignatureChange}
         onMinScenariosChange={handleMinScenariosChange}
       />
 


### PR DESCRIPTION
## Summary

Users landing on \`/models/consistency\` at a signature that has no data (e.g. \`vnewt0\` on a domain whose runs are all under \`v1td\`) hit an all-rows "no-repeat-coverage" empty state with no way to switch signatures from the page itself.

Fix: add a Signature dropdown to the Consistency filters and default to \`vnewtd\` (v-newest @ default temperature) when the domain offers it.

## Changes

- \`ConsistencyFilters.tsx\`: new Signature select alongside Domain / Provider / Min n. Options come from \`DOMAIN_AVAILABLE_SIGNATURES_QUERY\` (same source the Matrix uses), labels via \`formatSignatureOptionLabel\`.
- \`ModelsConsistency.tsx\`:
  - Default picker now prefers \`vnewtd\` when the domain's available signatures include it, falling back to the first available signature
  - Changing the dropdown writes \`?signature=<sig>\` into the URL (replace, not push) so links remain shareable

## Test plan

- [x] Web lint: 0 errors
- [x] Web build: clean
- [ ] Post-deploy: open \`/models/consistency\` with no \`?signature\` param → lands on \`vnewtd\`
- [ ] Post-deploy: with \`?signature=vnewt0\` (empty data) → dropdown shows \`vnewt0\` as selected; switching to \`v1td\` populates the scatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)