### PR TITLE
fix(models-circumplex): query primary runs, not aggregate rollups

### DIFF
--- a/cloud/apps/api/src/services/circumplex/aggregation.ts
+++ b/cloud/apps/api/src/services/circumplex/aggregation.ts
@@ -97,9 +97,13 @@ export async function aggregatePairwiseWinRates(args: {
     return output;
   }
 
+  // Circumplex needs raw transcripts. Aggregate-tagged runs are rollups that
+  // reference sourceRunIds — they don't have transcripts directly. We need
+  // the PRIMARY runs that actually produced transcripts. We filter out the
+  // aggregate rollups (config.isAggregate === true) to avoid double-counting
+  // their source data, then pick the ones that match the requested signature.
   const runs = (await db.run.findMany({
     where: {
-      tags: { some: { tag: { name: 'Aggregate' } } },
       status: 'COMPLETED',
       deletedAt: null,
     },
@@ -111,12 +115,14 @@ export async function aggregatePairwiseWinRates(args: {
     },
   })) as RunRow[];
 
-  // Belt-and-suspenders: the WHERE clause already filters on status/deletedAt,
-  // but we re-check after selection in case of future schema changes. The
-  // runMatchesSignature check is the critical one — WHERE cannot express it
-  // because signature is synthesized from config.
   const scopedRunIds = runs
-    .filter((run) => run.status === 'COMPLETED' && run.deletedAt == null && runMatchesSignature(run.config, args.signature))
+    .filter((run) => {
+      if (run.status !== 'COMPLETED' || run.deletedAt != null) return false;
+      // Skip aggregate-rollup runs — their transcripts (if any) duplicate source runs.
+      const config = run.config as { isAggregate?: boolean } | null;
+      if (config?.isAggregate === true) return false;
+      return runMatchesSignature(run.config, args.signature);
+    })
     .map((run) => run.id);
   for (const runId of scopedRunIds) {
     scopedRunIdSet.add(runId);


### PR DESCRIPTION
## Summary

Production hotfix for #716. The `/models/circumplex` page was showing "No models have circumplex data for this signature" for every available signature — every model came back with 0 trials.

## Root cause

The `aggregation.ts` Prisma query filtered for runs tagged `'Aggregate'`. Those are rollup runs that reference `sourceRunIds` — they don't hold transcripts directly. The transcripts live on the PRIMARY runs that the aggregate rollups point to. We were querying the wrong run class.

## Fix

Drop the `'Aggregate'` tag filter and explicitly skip runs with `config.isAggregate === true`. This queries the primary runs that actually produced transcripts, and signature matching still scopes the result set.

## Verification

- Local build ✓
- 19/19 circumplex unit tests pass
- Production smoke test needed after deploy: `/models/circumplex?signature=v1td&n=5` should populate models

## Why review didn't catch this

The `aggregation.test.ts` mocks used fixture runs with my (wrong) assumption about the run schema baked in. The fix needed comparison against production data, not just spec-implied behavior. Postmortem follow-up: add an integration test that hits a real DB fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)