### PR TITLE
feat(worker): add anchor-tier parser for paraphrased scale-label responses

### DIFF
--- a/cloud/workers/summarize.py
+++ b/cloud/workers/summarize.py
@@ -22,6 +22,7 @@ from summarize_extract import (
     extract_leading_text_label_decision,
     extract_leading_text_label_decision_relaxed,
     extract_text_label_decision,
+    extract_text_label_decision_anchor,
     extract_text_label_decision_distinctive_tail,
     extract_text_label_decision_relaxed,
     is_refusal,
@@ -152,6 +153,26 @@ def extract_decision_result(transcript_content: dict[str, Any]) -> dict[str, Any
                             matched_label = tail_matched_label
                             parse_class = "exact"
                             parse_path = "text_label_distinctive_tail"
+                        else:
+                            # LAST-tier matcher. Anchors on per-label
+                            # distinctive content tokens (label tokens minus
+                            # tokens common to every label in the scale).
+                            # Catches rephrasings like noun→pronoun collapse
+                            # ("how the neighborhood is run" → "how it is
+                            # run") where the token set is still sufficient
+                            # to identify the label uniquely. Tagged as
+                            # fallback_resolved (lower confidence than the
+                            # strict tiers above).
+                            anchor_code, anchor_matched_label = (
+                                extract_text_label_decision_anchor(
+                                    response_text, scale_labels
+                                )
+                            )
+                            if anchor_code is not None:
+                                decision_code = anchor_code
+                                matched_label = anchor_matched_label
+                                parse_class = "fallback_resolved"
+                                parse_path = "text_label_anchor"
 
     is_refusal_response = is_refusal(response_text)
     if parse_class == "ambiguous" and is_refusal_response:

--- a/cloud/workers/summarize_extract.py
+++ b/cloud/workers/summarize_extract.py
@@ -335,6 +335,134 @@ def extract_text_label_decision_distinctive_tail(
     return None, None
 
 
+def _anchor_match_candidate(
+    candidate: str,
+    label_token_sets: list[tuple[dict[str, str], set[str]]],
+    common_tokens: set[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Inner anchor matcher: token-set subset match for a single candidate
+    string against pre-computed label token sets.
+    """
+    from summarize_text import normalize_for_relaxed_match
+
+    candidate_norm = normalize_for_relaxed_match(candidate)
+    if not candidate_norm:
+        return None, None
+    candidate_tokens = set(candidate_norm.split())
+
+    # Minimum distinctive-token count for a match to count. Below this, a
+    # short label like "Neutral / Unsure" can match on 2 incidental tokens
+    # that appear in the candidate as a quoted mention or passing reference
+    # — a false positive. 3 is a balance: still admits substantive content
+    # labels, rejects thin anchors. Short labels are still handled by the
+    # earlier exact / leading / relaxed tiers when the response endorses
+    # them literally.
+    MIN_DISTINCTIVE_TOKENS = 3
+
+    matches: list[tuple[int, dict[str, str]]] = []
+    for entry, label_tokens in label_token_sets:
+        distinctive = label_tokens - common_tokens
+        if len(distinctive) < MIN_DISTINCTIVE_TOKENS:
+            continue
+        if distinctive.issubset(candidate_tokens):
+            matches.append((len(distinctive), entry))
+
+    if not matches:
+        return None, None
+
+    # Prefer the most specific label (largest distinctive set matched).
+    matches.sort(key=lambda x: x[0], reverse=True)
+    top_count = matches[0][0]
+    top_matches = [e for c, e in matches if c == top_count]
+    if len(top_matches) != 1:
+        return None, None
+
+    matched = top_matches[0]
+    return matched.get("code"), matched.get("label")
+
+
+def extract_text_label_decision_anchor(
+    text: str, scale_labels: list[dict[str, str]]
+) -> tuple[Optional[str], Optional[str]]:
+    """LAST-tier matcher. Anchors on each label's distinctive content tokens.
+
+    Motivation: models sometimes rephrase the probe's canonical scale label,
+    substituting a pronoun for a repeated noun, inserting a level word, or
+    reordering filler. Strict and relaxed substring matching fail on these,
+    even though the content signal is clear. Example:
+
+      label:  "Strongly support choosing the neighborhood with authority
+               over how the neighborhood is run"
+      model:  "Strongly support choosing the neighborhood with substantial
+               authority over how it is run"
+
+    Algorithm:
+      1. Normalize each label with the relaxed filler strip. Build a token
+         set per label.
+      2. Compute `common_tokens` — tokens that appear in EVERY label in the
+         scale. These are scale-wide noise (e.g. "choosing", "is") and
+         don't distinguish one label from another.
+      3. For each label, `distinctive_tokens = label_tokens − common_tokens`.
+         This is the anchor set — the content the model must reproduce to
+         pick this label.
+      4. Take candidate strings from `leading_response_candidates(text)` —
+         the first line / first segment, with and without prefix stripping.
+         Matching against the FULL response text is unsafe: essay-style
+         answers discuss both values in the vignette, so both sides'
+         distinctive tokens end up present in the full response and the
+         algorithm would pick whichever label's token set is largest
+         rather than which value the model endorsed.
+      5. For each candidate (in order), a label is a "match" if ALL its
+         distinctive tokens are a subset of the candidate's tokens.
+      6. Winner = matching label with the MOST distinctive tokens matched.
+         Handles "strongly support X" vs "somewhat support X" nesting: the
+         weaker label's distinctive tokens are a subset of the stronger
+         label's, so both match — the stronger wins because it has more
+         matched distinctive tokens.
+      7. If two labels tie at the top for a candidate, skip that candidate
+         (ambiguous) and try the next one. Return the first candidate that
+         produces a unique winner.
+      8. Labels with fewer than 3 distinctive tokens are skipped — short
+         labels like "Neutral / Unsure" can false-match on incidental
+         mentions.
+
+    Runs AFTER extract_text_label_decision, _relaxed, and _distinctive_tail
+    have all returned None. Tagged `fallback_resolved` by the caller.
+    """
+    from summarize_text import leading_response_candidates, normalize_for_relaxed_match
+
+    if not text or not scale_labels:
+        return None, None
+
+    # Pre-compute per-label token sets and the across-all-labels common set.
+    # These are scale-level invariants — computed once, reused per candidate.
+    label_token_sets: list[tuple[dict[str, str], set[str]]] = []
+    for entry in scale_labels:
+        label = entry.get("label", "")
+        if not label:
+            continue
+        label_norm = normalize_for_relaxed_match(label)
+        if not label_norm:
+            continue
+        tokens = set(label_norm.split())
+        if not tokens:
+            continue
+        label_token_sets.append((entry, tokens))
+
+    if len(label_token_sets) < 2:
+        return None, None
+
+    common_tokens: set[str] = set.intersection(*(ts for _, ts in label_token_sets))
+
+    # Try each leading candidate in order; first unique winner wins.
+    for candidate, _used_prefix_stripping in leading_response_candidates(text):
+        code, label = _anchor_match_candidate(candidate, label_token_sets, common_tokens)
+        if code is not None:
+            return code, label
+
+    return None, None
+
+
 def extract_leading_decision_code(text: str) -> Optional[str]:
     for candidate, _used_prefix_stripping in leading_response_candidates(text):
         decision_code = extract_explicit_leading_decision_code(candidate)

--- a/cloud/workers/tests/test_summarize.py
+++ b/cloud/workers/tests/test_summarize.py
@@ -1337,6 +1337,225 @@ class TestRunSummarize:
         assert result["decisionSource"] == "deterministic"
         assert result["decisionMetadata"]["parsePath"] == "text_label_distinctive_tail"
 
+    def test_anchor_recovers_when_response_has_preamble(self) -> None:
+        """LAST-tier anchor matcher recovers a response that contains every
+        content word of a label but in a form no stricter tier can parse.
+
+        Here the response opens with a preamble ("My view is this.") which
+        pushes the actual decision into the second sentence. That second
+        sentence does NOT start with "Strongly support"/"Somewhat support"
+        (it starts with "I strongly support"), so distinctive_tail skips it
+        — distinctive_tail requires segments to begin with the exact support
+        prefix. Strict and relaxed substring matching also fail because the
+        label contains "neighborhood" twice but the response collapses the
+        second occurrence to "it". The anchor matcher's token-set subset
+        logic catches this: the label's distinctive-token set is still a
+        subset of the response's tokens.
+        """
+        from summarize import extract_decision_result
+
+        transcript_content = {
+            "turns": [
+                {
+                    "probePrompt": (
+                        "Give me your judgment on the following scale:\n\n"
+                        "- Strongly support choosing the neighborhood with authority over how the neighborhood is run\n"
+                        "- Somewhat support choosing the neighborhood with authority over how the neighborhood is run\n"
+                        "- Neutral / Unsure\n"
+                        "- Somewhat support choosing the neighborhood where people have freedom in how they live\n"
+                        "- Strongly support choosing the neighborhood where people have freedom in how they live"
+                    ),
+                    "targetResponse": (
+                        "My view is this. I strongly support choosing the neighborhood "
+                        "with authority over how it is run."
+                    ),
+                }
+            ]
+        }
+
+        result = extract_decision_result(transcript_content)
+
+        # Bullet-formatted probes have codes assigned in reverse order by
+        # collect_scale_labels (first bullet = code "5"). The response
+        # endorses "authority" strongly → matches the first bullet → code "5".
+        assert result["decisionCode"] == "5"
+        assert result["decisionSource"] == "deterministic"
+        assert result["decisionMetadata"]["parseClass"] == "fallback_resolved"
+        assert result["decisionMetadata"]["parsePath"] == "text_label_anchor"
+
+    def test_anchor_prefers_most_specific_label(self) -> None:
+        """When a weaker label's distinctive tokens are a subset of a
+        stronger label's (e.g. "Somewhat support X" vs "Strongly support X"),
+        the anchor matcher must pick the MORE specific label if the response
+        contains its extra distinguishing tokens ("Strongly").
+
+        This is the tie-break mechanism: a response that contains every
+        content word of label-5 (and thus necessarily every content word
+        of label-4 too) should resolve to label-5, not ambiguously tie.
+        """
+        from summarize_extract import extract_text_label_decision_anchor
+
+        scale_labels = [
+            {"code": "1", "label": "Strongly support choosing the neighborhood with authority over how the neighborhood is run"},
+            {"code": "2", "label": "Somewhat support choosing the neighborhood with authority over how the neighborhood is run"},
+            {"code": "3", "label": "Neutral / Unsure"},
+            {"code": "4", "label": "Somewhat support choosing the neighborhood where people have freedom in how they live"},
+            {"code": "5", "label": "Strongly support choosing the neighborhood where people have freedom in how they live"},
+        ]
+        # "Strongly" is in the response → must pick code=5, not code=4.
+        response = (
+            "Strongly support choosing the neighborhood where people have full "
+            "freedom in how they live"
+        )
+
+        code, matched_label = extract_text_label_decision_anchor(response, scale_labels)
+
+        assert code == "5"
+        assert matched_label == scale_labels[4]["label"]
+
+    def test_anchor_returns_none_when_response_lacks_distinctive_tokens(self) -> None:
+        """If the response doesn't contain ALL distinctive tokens of any
+        label, the anchor matcher must return None rather than guess.
+        """
+        from summarize_extract import extract_text_label_decision_anchor
+
+        scale_labels = [
+            {"code": "1", "label": "Strongly support choosing the neighborhood with authority over how the neighborhood is run"},
+            {"code": "2", "label": "Somewhat support choosing the neighborhood with authority over how the neighborhood is run"},
+            {"code": "3", "label": "Neutral / Unsure"},
+            {"code": "4", "label": "Somewhat support choosing the neighborhood where people have freedom in how they live"},
+            {"code": "5", "label": "Strongly support choosing the neighborhood where people have freedom in how they live"},
+        ]
+        response = "I would pick something in the middle"
+
+        code, matched_label = extract_text_label_decision_anchor(response, scale_labels)
+
+        assert code is None
+        assert matched_label is None
+
+    def test_anchor_skips_labels_with_too_few_distinctive_tokens(self) -> None:
+        """Anchor requires at least 3 distinctive tokens per label. A short
+        label like "Neutral / Unsure" has only 2 distinctive tokens and so
+        is skipped — otherwise it could match on an incidental quoted
+        mention in an ambiguous response (e.g. "the 'Neutral / Unsure'
+        option comes closest, but..."). Short labels are still matched by
+        the earlier exact / leading / relaxed tiers when the response
+        actually endorses them.
+        """
+        from summarize_extract import extract_text_label_decision_anchor
+
+        scale_labels = [
+            {"code": "1", "label": "Strongly support taking the job with substantial recognition for expertise"},
+            {"code": "2", "label": "Somewhat support taking the job with substantial recognition for expertise"},
+            {"code": "3", "label": "Neutral / Unsure"},
+            {"code": "4", "label": "Somewhat support taking the job with moderate personal enjoyment"},
+            {"code": "5", "label": "Strongly support taking the job with moderate personal enjoyment"},
+        ]
+        # Response only mentions the neutral label's tokens incidentally —
+        # does NOT endorse it. Must return None rather than false-match code 3.
+        response = (
+            "I am torn here. The scale phrase 'Neutral / Unsure' comes "
+            "closest, but I would want to explain the tradeoff first."
+        )
+
+        code, matched_label = extract_text_label_decision_anchor(response, scale_labels)
+
+        assert code is None
+        assert matched_label is None
+
+    def test_anchor_ignores_tokens_from_body_of_essay_style_response(self) -> None:
+        """REGRESSION: an earlier iteration of the anchor matcher applied its
+        token-subset logic to the FULL response text. Essay-style answers
+        discuss both sides of the value tradeoff as part of justifying a
+        choice — so both sides' distinctive tokens end up present in the
+        full response, and the matcher picked whichever label's token set
+        was largest rather than the one actually endorsed.
+
+        This is the real Mistral transcript (id cmo2qc73428at4wef9ieszg5l):
+        the model clearly endorsed "authority" in the opening sentence,
+        then spent the rest of the essay explaining why — which included
+        a concession paragraph beginning "While variety and excitement in
+        daily life may provide short-term stimulation...". That paragraph
+        mentions every distinctive token of the OPPOSITE label (variety /
+        excitement / daily / life).
+
+        Anchor must look only at the leading decision sentence. The body
+        of the essay is commentary, not endorsement.
+        """
+        from summarize import extract_decision_result
+
+        transcript_content = {
+            "turns": [
+                {
+                    "probePrompt": (
+                        "Please answer the question.\n\n"
+                        "Give me your judgment on the following scale:\n\n"
+                        "- Strongly support choosing the neighborhood with variety and excitement in daily life\n"
+                        "- Somewhat support choosing the neighborhood with variety and excitement in daily life\n"
+                        "- Neutral / Unsure\n"
+                        "- Somewhat support choosing the neighborhood with authority over how the neighborhood is run\n"
+                        "- Strongly support choosing the neighborhood with authority over how the neighborhood is run"
+                    ),
+                    "targetResponse": (
+                        "**Level of Support:** Strongly support choosing the "
+                        "neighborhood with substantial authority over how it is run.\n\n"
+                        "A neighborhood that grants residents significant authority "
+                        "over its governance fosters a deeper sense of agency, "
+                        "belonging, and long-term satisfaction. While variety and "
+                        "excitement in daily life may provide short-term "
+                        "stimulation, the ability to shape one's environment — "
+                        "through decision-making, community initiatives, or policy "
+                        "influence — creates lasting fulfillment."
+                    ),
+                }
+            ]
+        }
+
+        result = extract_decision_result(transcript_content)
+
+        # Authority bullet is position 5 in the scale list → code "1" under
+        # collect_scale_labels' reverse bullet mapping.
+        assert result["decisionCode"] == "1"
+        assert result["decisionMetadata"]["matchedLabel"] == (
+            "Strongly support choosing the neighborhood with authority "
+            "over how the neighborhood is run"
+        )
+        assert result["decisionMetadata"]["parsePath"] == "text_label_anchor"
+
+    def test_anchor_only_runs_after_stricter_tiers_fail(self) -> None:
+        """The anchor matcher is LAST-tier. When a response matches the label
+        exactly (or via any earlier tier), the parse path must be one of the
+        stricter tiers, NOT `text_label_anchor`.
+        """
+        from summarize import extract_decision_result
+
+        transcript_content = {
+            "turns": [
+                {
+                    "probePrompt": (
+                        "Give me your judgment on the following scale:\n\n"
+                        "- Strongly support choosing the neighborhood with authority over how the neighborhood is run\n"
+                        "- Somewhat support choosing the neighborhood with authority over how the neighborhood is run\n"
+                        "- Neutral / Unsure\n"
+                        "- Somewhat support choosing the neighborhood where people have freedom in how they live\n"
+                        "- Strongly support choosing the neighborhood where people have freedom in how they live"
+                    ),
+                    # Exact match for label-1.
+                    "targetResponse": (
+                        "Strongly support choosing the neighborhood with authority "
+                        "over how the neighborhood is run"
+                    ),
+                }
+            ]
+        }
+
+        result = extract_decision_result(transcript_content)
+
+        # First bullet = code "5" under collect_scale_labels' reverse mapping.
+        assert result["decisionCode"] == "5"
+        assert result["decisionMetadata"]["parsePath"] != "text_label_anchor"
+        assert result["decisionMetadata"]["parseClass"] == "exact"
+
     @patch("summarize.extract_decision_code")
     def test_uses_default_model(
         self, mock_extract: MagicMock


### PR DESCRIPTION
## Summary

Adds a last-tier text-label matcher to the summarize worker that recovers decisions when the model endorses a scale position using content words that match the canonical label but in a form the strict / relaxed / distinctive-tail tiers cannot parse.

Motivating case (real production Mistral transcript `cmo2qc73428at4wef9ieszg5l`):

- **Canonical label:** *Strongly support choosing the neighborhood with authority over how the neighborhood is run*
- **Model wrote:** *Level of Support: Strongly support choosing the neighborhood with substantial authority over how it is run.*

Three things combine to defeat all existing tiers:

1. Inserted level word: `substantial`
2. Noun → pronoun collapse: `the neighborhood` → `it`
3. Leading prefix: `Level of Support:` pushes the segment past `distinctive_tail`'s prefix filter

**Algorithm** (`extract_text_label_decision_anchor`):

1. For each label, compute its distinctive token set: `label_tokens − tokens_common_across_all_labels`.
2. Iterate over `leading_response_candidates(text)` — the first line / first segment, with and without the leading-prefix stripper applied.
3. A label is a candidate if all its distinctive tokens are a subset of the candidate's tokens.
4. Winner = candidate with the most matched distinctive tokens (breaks the nested-subset case of "strongly support X" vs "support X").
5. Require ≥ 3 distinctive tokens to prevent short labels like *Neutral / Unsure* from false-matching on incidental quoted mentions.

**Why leading-only matching matters:** essay-style responses discuss both values in the vignette as part of explaining a choice. Applying token-subset logic to the full response text causes both sides' distinctive tokens to match — the algorithm would then pick whichever label's token set is largest rather than which value the model actually endorsed. Restricting to the leading candidate ensures only the endorsement drives the match.

Tagged `parseClass=fallback_resolved`, `parsePath=text_label_anchor` — lower confidence than the strict tiers above it.

## Test plan

- [x] 6 new unit tests covering: real-Mistral regression (verbatim probe + response from prod), preamble-before-decision recovery, specificity tie-break, no-match safety, min-distinctive-tokens guard, "only runs after strict tiers fail" wiring invariant.
- [x] Full summarize test suite (91/91) passes.
- [x] Full worker test suite (292/292) passes.
- [x] Preflight: shared / db / api / web lint + build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)