### PR TITLE
fix(models-circumplex): translate LlmModel.id to modelId for transcripts

### DIFF
--- a/cloud/apps/api/src/graphql/queries/circumplex-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/circumplex-analysis.ts
@@ -156,21 +156,28 @@ builder.queryField('circumplexAnalysis', (t) =>
         };
       }
 
-      const [models, pairwiseMap] = await Promise.all([
-        db.llmModel.findMany({
-          where: { id: { in: modelIds } },
-          include: { provider: true },
-        }) as Promise<ModelRow[]>,
-        aggregatePairwiseWinRates({ modelIds, signature }),
-      ]);
+      // The client passes cuid primary keys (LlmModel.id). Transcripts store the
+      // string modelId (LlmModel.modelId — e.g. "claude-sonnet-4-5"). We need both:
+      // look up LlmModel rows by cuid to get metadata, and use the string modelId
+      // to filter transcripts in the aggregation layer.
+      const models = await (db.llmModel.findMany({
+        where: { id: { in: modelIds } },
+        include: { provider: true },
+      }) as Promise<ModelRow[]>);
+      const transcriptModelIds = models.map((model) => model.modelId);
+      const pairwiseMap = await aggregatePairwiseWinRates({ modelIds: transcriptModelIds, signature });
 
       const modelById = new Map(models.map((model) => [model.id, model] as const));
       const eligible: CircumplexResultShape[] = [];
       const insufficient: CircumplexInsufficientModelShape[] = [];
 
       for (const modelId of modelIds) {
-        const pairwise = pairwiseMap.get(modelId) ?? createEmptyPairwiseMatrix();
         const model = modelById.get(modelId);
+        // The pairwiseMap is keyed by the TRANSCRIPT modelId (string name), not
+        // the LlmModel cuid. Look up the pairwise matrix via the model's string
+        // name, not its cuid.
+        const transcriptKey = model?.modelId ?? modelId;
+        const pairwise = pairwiseMap.get(transcriptKey) ?? createEmptyPairwiseMatrix();
         const modelLabel = model?.displayName ?? model?.modelId ?? modelId;
         const providerName = model?.provider.displayName ?? model?.provider.name ?? 'Unknown provider';
 


### PR DESCRIPTION
## Summary

Hotfix for the hotfix. Production `/models/circumplex` still shows "No models have circumplex data" because of an ID-type mismatch:

- The client picker passes `LlmModel.id` (cuid primary key, e.g. `cmizgrpix000b2e7hh7a8m5hc`).
- Transcripts store `modelId` as the string name (e.g. `claude-sonnet-4-5`).
- The resolver was forwarding the cuid directly to the transcript filter, getting zero matches, and classifying every model as `no_transcripts_for_signature`.

## Fix

Resolve LlmModel rows by cuid first, extract their `modelId` string, pass those strings to the aggregation layer. Map pairwise results back through the cuid for the response.

## Production smoke test (per new PR #720 rule)

Against the currently-deployed resolver, with string modelIds (the non-broken path):
```
circumplexAnalysis(modelIds: ["claude-sonnet-4-5", "gpt-5.1"], signature: "v1td") →
  claude-sonnet-4-5 → rho = -0.11, verdict = not_evident
  gpt-5.1 → rho = -0.18, verdict = not_evident
```

With cuids (the UI path — what's broken):
```
circumplexAnalysis(modelIds: ["cmizgrpix000b2e7hh7a8m5hc"], signature: "v1td") →
  insufficient: reason = no_transcripts_for_signature, trials all 0
```

The fix makes both paths equivalent.

## Postmortem note

This is precisely the class of bug the pre-merge smoke test rule (#720) is designed to catch. I only smoke-tested with string model names in my earlier verification, not the cuid path the UI actually uses. Will feed into ongoing workflow improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)