### PR TITLE
perf(models-circumplex): parallelize per-model transcript queries

### DIFF
--- a/cloud/apps/api/src/services/circumplex/aggregation.ts
+++ b/cloud/apps/api/src/services/circumplex/aggregation.ts
@@ -135,9 +135,11 @@ export async function aggregatePairwiseWinRates(args: {
   // row carries a large JSON blob (definitionSnapshot + decisionMetadata), so
   // fetching 20+ models × thousands of trials in one shot blows past Prisma's
   // napi-to-rust string buffer limit and crashes. Per-model keeps each query's
-  // result set bounded.
-  for (const modelId of args.modelIds) {
-    const transcripts = (await db.transcript.findMany({
+  // result set bounded. Parallelize across models so wall-clock stays under
+  // browser timeout — at ~6-8s per model, 20 serial = ~2 min (timeout),
+  // parallel = ~8-10s (limited by connection pool).
+  const transcriptBatches = await Promise.all(
+    args.modelIds.map(async (modelId) => (await db.transcript.findMany({
       where: {
         runId: { in: scopedRunIds },
         modelId,
@@ -156,8 +158,10 @@ export async function aggregatePairwiseWinRates(args: {
           },
         },
       },
-    })) as TranscriptRow[];
+    })) as TranscriptRow[]),
+  );
 
+  for (const transcripts of transcriptBatches) {
     for (const transcript of transcripts) {
       if (!scopedRunIdSet.has(transcript.runId)) continue;
       if (!modelIdSet.has(transcript.modelId)) continue;


### PR DESCRIPTION
## Summary

#722 split the aggregation into per-model queries to avoid Prisma's napi buffer limit, but left them sequential. At ~8s per model × 20 models, full-roster queries exceeded the browser GraphQL timeout, so the UI kept hitting the empty state.

## Fix

Use \`Promise.all\` over \`args.modelIds\`. Wall-clock drops from O(N × per-model) to O(per-model) limited only by the DB connection pool. Expected ~8-12s for the full 20-model roster.

## Longer-term follow-up

Per-request live aggregation will keep getting slower as the transcript volume grows. The right answer is pre-caching the 10×10 matrix per (model, signature) via the existing aggregate-analysis pipeline — tracked as a follow-up after this unblocks the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)