### PR TITLE
[codex] Clean up models circumplex layout

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -85,6 +85,8 @@ Once the above are resolved:
 
 **Update (2026-04-19):** ff-judge-panel slice 10 migration script + SKILL.md update + smoke test are implemented locally. Migration dry-run reports the two blocked workflows cleanly as missing in this worktree, the judge smoke test passes with stub judges, and the Feature Factory scripts test suite is green.
 
+**Update (2026-04-21):** Local Feature Factory run `models-circumplex-layout-cleanup` is implemented on `codex/models-circumplex-layout-cleanup`. The Circumplex page now keeps signature, minimum-trials, and methodology controls in one header box; uses a dropdown + tooltip help for methodology state; collapses model selection into a compact details row; and stacks selected model cards full width. Targeted web tests pass in the clean worktree. Next: repair the inherited partial review artifacts, then run the diff checkpoint and delivery steps.
+
 ### What We Keep (Differentiated)
 - Mandatory discovery phase — catches bad requirements early
 - Multi-agent adversarial review (Gemini + Codex attack, Claude judges)

--- a/cloud/apps/web/src/components/models/CircumplexMethodologyPanel.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexMethodologyPanel.tsx
@@ -1,58 +1,93 @@
+import { Info } from 'lucide-react';
+import { Select } from '../ui/Select';
+import { Tooltip } from '../ui/Tooltip';
+import { Button } from '../ui/Button';
+
 type Props = {
   open: boolean;
   onToggleOpen: (open: boolean) => void;
 };
 
+const METHODOLOGY_OPTIONS = [
+  { value: 'closed', label: 'Closed' },
+  { value: 'open', label: 'Open' },
+] as const;
+
+const methodologyTooltip = (
+  <div className="space-y-2">
+    <p>
+      <strong>Closed:</strong> keeps the header compact and hides the longer methodology notes.
+    </p>
+    <p>
+      <strong>Open:</strong> shows the full explanation in the same top box as the signature and threshold controls.
+    </p>
+  </div>
+);
+
 export function CircumplexMethodologyPanel({ open, onToggleOpen }: Props) {
   return (
-    <details
-      open={open}
-      onToggle={(event) => onToggleOpen(event.currentTarget.open)}
-      className="rounded-xl border border-gray-200 bg-white p-4 md:p-5"
-    >
-      <summary className="cursor-pointer list-none">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">How this is computed</h2>
-            <p className="text-sm text-gray-600">Structural similarity, not direct head-to-head dominance.</p>
-          </div>
-          <span className="text-xs font-medium uppercase tracking-[0.16em] text-gray-500">
-            {open ? 'Open' : 'Closed'}
-          </span>
-        </div>
-      </summary>
-
-      <div className="mt-4 space-y-4 text-sm leading-6 text-gray-700">
-        <p>
-          A value profile is the row of win rates for one value against the other nine values.
-          We compare those profiles with Pearson correlation so the question becomes:
-          do two values face the same allies and enemies across the value space?
-          That is different from asking whether one value wins more often in a direct matchup.
-        </p>
-        <p>
-          Example: Universalism — Nature and Benevolence — Dependability can tie head-to-head in a
-          particular pair, yet still have similar profiles if they both tend to beat the same
-          opponents and lose to the same opponents. That structural similarity is what circumplex
-          theory predicts.
-        </p>
-        <p>
-          This report applies Schwartz&apos;s circular-value theory to LLM forced-choice behavior,
-          which is a novel use of the method rather than a previously validated measure for models.
-          See Schwartz, 2012, <a
-            href="https://doi.org/10.9707/2307-0919.1116"
-            target="_blank"
-            rel="noreferrer"
-            className="font-medium text-teal-700 hover:underline"
+    <div className="min-w-[220px] flex-1">
+      <div className="mb-1 flex items-center gap-1.5">
+        <label className="block text-sm font-medium text-gray-700">How this is computed</label>
+        <Tooltip
+          content={methodologyTooltip}
+          position="bottom"
+          variant="light"
+          className="max-w-xs px-3 py-3 text-xs leading-relaxed"
+        >
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 min-h-0 min-w-0 text-gray-400 hover:bg-transparent hover:text-gray-600"
+            aria-label="Methodology display options"
           >
-            doi:10.9707/2307-0919.1116
-          </a>.
-        </p>
-        <p>
-          The raw Spearman ρ and p-value are shown next to the verdict band.
-          The cutoffs are editorial, not psychometric, and the p-value should be read as
-          directional only because the pairwise observations are not independent.
-        </p>
+            <Info className="h-4 w-4" />
+          </Button>
+        </Tooltip>
       </div>
-    </details>
+
+      <Select
+        options={[...METHODOLOGY_OPTIONS]}
+        value={open ? 'open' : 'closed'}
+        onChange={(value) => onToggleOpen(value === 'open')}
+      />
+
+      {open && (
+        <div className="mt-4 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm leading-6 text-gray-700">
+          <div className="space-y-4">
+            <p>
+              A value profile is the row of win rates for one value against the other nine values.
+              We compare those profiles with Pearson correlation so the question becomes:
+              do two values face the same allies and enemies across the value space?
+              That is different from asking whether one value wins more often in a direct matchup.
+            </p>
+            <p>
+              Example: Universalism — Nature and Benevolence — Dependability can tie head-to-head in a
+              particular pair, yet still have similar profiles if they both tend to beat the same
+              opponents and lose to the same opponents. That structural similarity is what circumplex
+              theory predicts.
+            </p>
+            <p>
+              This report applies Schwartz&apos;s circular-value theory to LLM forced-choice behavior,
+              which is a novel use of the method rather than a previously validated measure for models.
+              See Schwartz, 2012, <a
+                href="https://doi.org/10.9707/2307-0919.1116"
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium text-teal-700 hover:underline"
+              >
+                doi:10.9707/2307-0919.1116
+              </a>.
+            </p>
+            <p>
+              The raw Spearman ρ and p-value are shown next to the verdict band.
+              The cutoffs are editorial, not psychometric, and the p-value should be read as
+              directional only because the pairwise observations are not independent.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/cloud/apps/web/src/components/models/CircumplexModelCard.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexModelCard.tsx
@@ -14,7 +14,7 @@ function toExcludedSet(values: string[]): Set<ValueKey> {
 
 export function CircumplexModelCard({ result }: Props) {
   return (
-    <section className="rounded-2xl border border-gray-200 bg-white p-4 md:p-5">
+    <section className="w-full rounded-2xl border border-gray-200 bg-white p-4 md:p-5">
       <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
         <div>
           <h2 className="text-xl font-semibold text-gray-900">{result.modelLabel}</h2>

--- a/cloud/apps/web/src/components/models/CircumplexModelPicker.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexModelPicker.tsx
@@ -1,4 +1,5 @@
-import { Check, Lock } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Check, ChevronDown, Lock } from 'lucide-react';
 import { Badge } from '../ui/Badge';
 import { Button } from '../ui/Button';
 import type { CircumplexInsufficientModel, CircumplexResult } from '../../api/operations/circumplex';
@@ -21,82 +22,119 @@ function trialsLabel(model: CircumplexInsufficientModel): string {
 }
 
 export function CircumplexModelPicker({ eligible, insufficient, selectedModelIds, onToggle, onSelectAll, onClear }: Props) {
+  const [open, setOpen] = useState(false);
   const allSelected = eligible.length > 0 && selectedModelIds.length === eligible.length;
   const anySelected = selectedModelIds.length > 0;
+  const selectedLabels = useMemo(
+    () => eligible
+      .filter((model) => selectedModelIds.includes(model.modelId))
+      .map((model) => model.modelLabel),
+    [eligible, selectedModelIds],
+  );
+  const summary = selectedLabels.length === 0
+    ? 'No models selected'
+    : selectedLabels.length === 1
+      ? selectedLabels[0] ?? '1 model selected'
+      : `${selectedLabels.length} selected: ${selectedLabels.slice(0, 2).join(', ')}${selectedLabels.length > 2 ? ', ...' : ''}`;
 
   return (
     <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold text-gray-900">Models</h2>
-          <p className="text-sm text-gray-600">Select one or more eligible models to compare their circumplex fit.</p>
+          <p className="text-sm text-gray-600">Open the picker to add or remove circumplex cards.</p>
         </div>
         <div className="flex items-center gap-2">
           <Badge variant="neutral" size="sm">{eligible.length} eligible</Badge>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            disabled={allSelected || eligible.length === 0}
-            onClick={onSelectAll}
-            className="text-xs"
-          >
-            Select all
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            disabled={!anySelected}
-            onClick={onClear}
-            className="text-xs"
-          >
-            Clear
-          </Button>
+          {insufficient.length > 0 && <Badge variant="warning" size="sm">{insufficient.length} hidden</Badge>}
         </div>
       </div>
 
-      <div className="mt-4 grid gap-3 md:grid-cols-2">
-        {eligible.map((model) => {
-          const selected = selectedModelIds.includes(model.modelId);
-          return (
-            <Button
-              key={model.modelId}
-              type="button"
-              variant={selected ? 'secondary' : 'ghost'}
-              className={`justify-start border px-3 py-2 text-left ${selected ? 'border-teal-300 bg-teal-50 text-teal-950' : 'border-gray-200 bg-white text-gray-800 hover:bg-gray-50'}`}
-              onClick={() => onToggle(model.modelId)}
-            >
-              <Check className={`mr-2 h-4 w-4 ${selected ? 'opacity-100' : 'opacity-0'}`} />
-              <span className="truncate">
-                <span className="font-medium">{model.modelLabel}</span>
-                <span className="ml-2 text-xs text-gray-500">{model.providerName}</span>
-              </span>
-            </Button>
-          );
-        })}
-      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        className="mt-4 flex w-full items-center justify-between rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-left hover:bg-gray-100"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-gray-900">Model details</div>
+          <div className="mt-1 truncate text-sm text-gray-600">{summary}</div>
+        </div>
+        <ChevronDown className={`h-4 w-4 shrink-0 text-gray-500 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </Button>
 
-      {insufficient.length > 0 && (
-        <div className="mt-5 border-t border-gray-200 pt-4">
-          <div className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700">
-            <Lock className="h-4 w-4" />
-            Hidden from selection
+      {open && (
+        <div className="mt-4 space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-xs text-gray-600">Select one or more eligible models to compare their circumplex fit.</p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={allSelected || eligible.length === 0}
+                onClick={onSelectAll}
+                className="text-xs"
+              >
+                Select all
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={!anySelected}
+                onClick={onClear}
+                className="text-xs"
+              >
+                Clear
+              </Button>
+            </div>
           </div>
-          <div className="grid gap-2 md:grid-cols-2">
-            {insufficient.map((model) => (
-              <div key={model.modelId} className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-600">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <div className="font-medium text-gray-800">{model.modelLabel}</div>
-                    <div className="text-xs text-gray-500">{model.providerName}</div>
-                  </div>
-                  <Badge variant="warning" size="sm">{model.reason.replace(/_/g, ' ')}</Badge>
-                </div>
-                <div className="mt-1 text-xs text-gray-500">{trialsLabel(model)}</div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            {eligible.map((model) => {
+              const selected = selectedModelIds.includes(model.modelId);
+              return (
+                <Button
+                  key={model.modelId}
+                  type="button"
+                  variant={selected ? 'secondary' : 'ghost'}
+                  className={`justify-start border px-3 py-2 text-left ${selected ? 'border-teal-300 bg-teal-50 text-teal-950' : 'border-gray-200 bg-white text-gray-800 hover:bg-gray-50'}`}
+                  onClick={() => onToggle(model.modelId)}
+                >
+                  <Check className={`mr-2 h-4 w-4 ${selected ? 'opacity-100' : 'opacity-0'}`} />
+                  <span className="truncate">
+                    <span className="font-medium">{model.modelLabel}</span>
+                    <span className="ml-2 text-xs text-gray-500">{model.providerName}</span>
+                  </span>
+                </Button>
+              );
+            })}
+          </div>
+
+          {insufficient.length > 0 && (
+            <div className="border-t border-gray-200 pt-4">
+              <div className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700">
+                <Lock className="h-4 w-4" />
+                Hidden from selection
               </div>
-            ))}
-          </div>
+              <div className="grid gap-2 md:grid-cols-2">
+                {insufficient.map((model) => (
+                  <div key={model.modelId} className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-600">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="font-medium text-gray-800">{model.modelLabel}</div>
+                        <div className="text-xs text-gray-500">{model.providerName}</div>
+                      </div>
+                      <Badge variant="warning" size="sm">{model.reason.replace(/_/g, ' ')}</Badge>
+                    </div>
+                    <div className="mt-1 text-xs text-gray-500">{trialsLabel(model)}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </section>

--- a/cloud/apps/web/src/pages/ModelsCircumplex.tsx
+++ b/cloud/apps/web/src/pages/ModelsCircumplex.tsx
@@ -233,34 +233,31 @@ export function ModelsCircumplex() {
         </p>
       </div>
 
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
-        <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
-          <div className="flex flex-wrap items-end gap-4">
-            <div className="w-60">
-              <Select
-                label="Signature"
-                options={signatureOptions}
-                value={selectedSignature}
-                onChange={handleSignatureChange}
-                placeholder="Select signature"
-              />
-            </div>
-            <CircumplexThresholdControl value={threshold} onChange={handleThresholdChange} />
+      <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+        <div className="flex flex-wrap items-start gap-4">
+          <div className="w-full md:w-60">
+            <Select
+              label="Signature"
+              options={signatureOptions}
+              value={selectedSignature}
+              onChange={handleSignatureChange}
+              placeholder="Select signature"
+            />
           </div>
-          <p className="mt-3 text-sm text-gray-600">
-            Eligible models must have at least {threshold} trials on each of the 10 Schwartz values.
-          </p>
-        </section>
-
-        <CircumplexMethodologyPanel
-          open={methodologyParam === 'open'}
-          onToggleOpen={(open) => {
-            const params = new URLSearchParams(searchParams);
-            params.set('methodology', open ? 'open' : 'closed');
-            setSearchParams(params, { replace: true });
-          }}
-        />
-      </div>
+          <CircumplexThresholdControl value={threshold} onChange={handleThresholdChange} />
+          <CircumplexMethodologyPanel
+            open={methodologyParam === 'open'}
+            onToggleOpen={(open) => {
+              const params = new URLSearchParams(searchParams);
+              params.set('methodology', open ? 'open' : 'closed');
+              setSearchParams(params, { replace: true });
+            }}
+          />
+        </div>
+        <p className="mt-3 text-sm text-gray-600">
+          Eligible models must have at least {threshold} trials on each of the 10 Schwartz values.
+        </p>
+      </section>
 
       {selectionNotice != null && (
         <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
@@ -324,7 +321,7 @@ export function ModelsCircumplex() {
               <p className="font-medium text-gray-900">Pick one or more models to see the circumplex panel.</p>
             </section>
           ) : (
-            <div className="grid gap-4 xl:grid-cols-2">
+            <div data-testid="circumplex-model-card-stack" className="space-y-4">
               {selectedResults.map((result) => (
                 <CircumplexModelCard key={result.modelId} result={result} />
               ))}

--- a/cloud/apps/web/tests/components/models/CircumplexMethodologyPanel.test.tsx
+++ b/cloud/apps/web/tests/components/models/CircumplexMethodologyPanel.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CircumplexMethodologyPanel } from '../../../src/components/models/CircumplexMethodologyPanel';
+
+describe('CircumplexMethodologyPanel', () => {
+  it('shows tooltip help for both open and closed options', async () => {
+    const user = userEvent.setup();
+
+    render(<CircumplexMethodologyPanel open={false} onToggleOpen={() => {}} />);
+
+    await act(async () => {
+      await user.hover(screen.getByRole('button', { name: /methodology display options/i }));
+    });
+
+    expect(await screen.findByText(/closed:/i)).toBeInTheDocument();
+    expect(screen.getByText(/open:/i)).toBeInTheDocument();
+  });
+
+  it('changes methodology mode through the dropdown', async () => {
+    const user = userEvent.setup();
+    const handleToggleOpen = vi.fn();
+
+    render(<CircumplexMethodologyPanel open={false} onToggleOpen={handleToggleOpen} />);
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /closed/i }));
+    });
+    await act(async () => {
+      await user.click(screen.getByRole('option', { name: 'Open' }));
+    });
+
+    expect(handleToggleOpen).toHaveBeenCalledWith(true);
+  });
+
+  it('renders the methodology text inline when open', () => {
+    render(<CircumplexMethodologyPanel open={true} onToggleOpen={() => {}} />);
+
+    expect(screen.getByText(/a value profile is the row of win rates/i)).toBeInTheDocument();
+    expect(screen.getByText(/structural similarity/i)).toBeInTheDocument();
+  });
+});

--- a/cloud/apps/web/tests/components/models/CircumplexModelPicker.test.tsx
+++ b/cloud/apps/web/tests/components/models/CircumplexModelPicker.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CircumplexModelPicker } from '../../../src/components/models/CircumplexModelPicker';
+import type { CircumplexInsufficientModel, CircumplexResult } from '../../../src/api/operations/circumplex';
+
+function buildEligibleModel(modelId: string, modelLabel: string): CircumplexResult {
+  return {
+    modelId,
+    modelLabel,
+    providerName: 'openai',
+    trialsPerValue: [],
+  } as unknown as CircumplexResult;
+}
+
+function buildInsufficientModel(modelId: string, modelLabel: string): CircumplexInsufficientModel {
+  return {
+    modelId,
+    modelLabel,
+    providerName: 'openai',
+    reason: 'below_threshold',
+    trialsPerValue: [{ valueKey: 'Achievement', trials: 3 }],
+  } as unknown as CircumplexInsufficientModel;
+}
+
+describe('CircumplexModelPicker', () => {
+  it('starts compact and expands into the picker details', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CircumplexModelPicker
+        eligible={[buildEligibleModel('model-a', 'Model A'), buildEligibleModel('model-b', 'Model B')]}
+        insufficient={[buildInsufficientModel('model-c', 'Model C')]}
+        selectedModelIds={['model-a']}
+        onToggle={() => {}}
+        onSelectAll={() => {}}
+        onClear={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Model A')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /select all/i })).not.toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /model details/i }));
+    });
+
+    expect(screen.getByRole('button', { name: /select all/i })).toBeInTheDocument();
+    expect(screen.getByText(/hidden from selection/i)).toBeInTheDocument();
+    expect(screen.getByText('Model C')).toBeInTheDocument();
+  });
+
+  it('keeps the existing toggle callback for eligible model buttons', async () => {
+    const user = userEvent.setup();
+    const handleToggle = vi.fn();
+
+    render(
+      <CircumplexModelPicker
+        eligible={[buildEligibleModel('model-a', 'Model A'), buildEligibleModel('model-b', 'Model B')]}
+        insufficient={[]}
+        selectedModelIds={['model-a']}
+        onToggle={handleToggle}
+        onSelectAll={() => {}}
+        onClear={() => {}}
+      />,
+    );
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /model details/i }));
+    });
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /Model B/i }));
+    });
+
+    expect(handleToggle).toHaveBeenCalledWith('model-b');
+  });
+});

--- a/cloud/apps/web/tests/pages/ModelsCircumplex.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsCircumplex.test.tsx
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ModelsCircumplex } from '../../src/pages/ModelsCircumplex';
+import { LLM_MODELS_QUERY } from '../../src/api/operations/llm';
+import { CIRCUMPLEX_ANALYSIS_QUERY } from '../../src/api/operations/circumplex';
+
+const useQueryMock = vi.fn();
+
+vi.mock('urql', async () => {
+  const actual = await vi.importActual<typeof import('urql')>('urql');
+  return {
+    ...actual,
+    useQuery: (args: unknown) => useQueryMock(args),
+  };
+});
+
+vi.mock('../../src/hooks/useAvailableSignatures', () => ({
+  useAvailableSignatures: () => ({
+    signatures: ['vnewtd'],
+    defaultSignature: 'vnewtd',
+    loading: false,
+    error: undefined,
+  }),
+}));
+
+vi.mock('../../src/components/models/CircumplexModelPicker', () => ({
+  CircumplexModelPicker: () => <div>Mock circumplex model picker</div>,
+}));
+
+vi.mock('../../src/components/models/CircumplexModelCard', () => ({
+  CircumplexModelCard: ({ result }: { result: { modelLabel: string } }) => <div>{result.modelLabel}</div>,
+}));
+
+describe('ModelsCircumplex', () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    useQueryMock.mockImplementation((args: { query: unknown }) => {
+      if (args.query === LLM_MODELS_QUERY) {
+        return [{
+          data: {
+            llmModels: [
+              { id: 'model-a', isDefault: true },
+              { id: 'model-b', isDefault: false },
+            ],
+          },
+          fetching: false,
+          error: undefined,
+        }];
+      }
+
+      if (args.query === CIRCUMPLEX_ANALYSIS_QUERY) {
+        return [{
+          data: {
+            circumplexAnalysis: {
+              models: [
+                {
+                  modelId: 'model-a',
+                  modelLabel: 'Model A',
+                  providerName: 'openai',
+                  signature: 'vnewtd',
+                  trialsPerValue: [{ valueKey: 'Achievement', trials: 8 }],
+                },
+                {
+                  modelId: 'model-b',
+                  modelLabel: 'Model B',
+                  providerName: 'anthropic',
+                  signature: 'vnewtd',
+                  trialsPerValue: [{ valueKey: 'Achievement', trials: 8 }],
+                },
+              ],
+              insufficient: [],
+            },
+          },
+          fetching: false,
+          error: undefined,
+        }];
+      }
+
+      return [{ data: undefined, fetching: false, error: undefined }];
+    });
+  });
+
+  it('keeps the header controls in one box and stacks selected cards vertically', () => {
+    render(
+      <MemoryRouter
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+        initialEntries={['/models/circumplex?signature=vnewtd&models=model-a,model-b&n=5&methodology=closed']}
+      >
+        <ModelsCircumplex />
+      </MemoryRouter>,
+    );
+
+    const methodologyLabel = screen.getByText('How this is computed');
+    const signatureLabel = screen.getByText('Signature');
+    const thresholdLabel = screen.getByText('Minimum trials per value');
+
+    expect(signatureLabel.closest('section')).toBe(thresholdLabel.closest('section'));
+    expect(thresholdLabel.closest('section')).toBe(methodologyLabel.closest('section'));
+
+    const stack = screen.getByTestId('circumplex-model-card-stack');
+    expect(stack).toHaveClass('space-y-4');
+    expect(stack).not.toHaveClass('xl:grid-cols-2');
+    expect(screen.getByText('Model A')).toBeInTheDocument();
+    expect(screen.getByText('Model B')).toBeInTheDocument();
+  });
+});

--- a/docs/workflow/feature-runs/models-circumplex-layout-cleanup/plan.md
+++ b/docs/workflow/feature-runs/models-circumplex-layout-cleanup/plan.md
@@ -1,0 +1,21 @@
+# Plan
+
+## Approach
+1. Collapse the current top-row layout in `ModelsCircumplex.tsx` into one standard-width control card that holds signature, threshold, and methodology controls together.
+2. Replace `CircumplexMethodologyPanel`'s `details`-style open/closed affordance with a small dropdown-oriented control plus tooltip content that explains what each state does.
+3. Rework `CircumplexModelPicker` into a compact expandable selector row so model selection is available but less visually heavy.
+4. Change the selected-card container from a two-column grid to a single-column stack and adjust the card internals only as needed for the new width.
+5. Add focused UI tests for the merged header controls, compact picker behavior, and stacked selected-card layout.
+
+## Design Notes
+- Keep the page at the standard layout width; do not widen the route.
+- Reuse existing `Select`, `Tooltip`, and button primitives instead of inventing new control patterns.
+- Because the custom `Select` component cannot attach tooltips to individual list items, the tooltip content should explain both dropdown states next to the control.
+- Preserve URL-driven state for `signature`, `n`, `methodology`, and `models`.
+- Preserve the current insufficient-model filtering rules and notice behavior.
+
+## Risk Controls
+- Keep the methodology dropdown values aligned with the existing URL contract: `open` and `closed`.
+- Do not change circumplex query variables or eligibility classification logic.
+- Keep picker actions deterministic by preserving the existing model ordering/normalization helper behavior.
+- Add tests around the compact picker and stacked cards so layout cleanup does not break selection behavior.

--- a/docs/workflow/feature-runs/models-circumplex-layout-cleanup/spec.md
+++ b/docs/workflow/feature-runs/models-circumplex-layout-cleanup/spec.md
@@ -1,0 +1,37 @@
+# Spec
+
+## Goal
+Make the `Models / Circumplex` page easier to scan by tightening the header controls, replacing the methodology open/closed affordance with a dropdown + tooltips, and stacking selected model cards at the standard page width.
+
+## Discovery
+- The request is clear enough to proceed without extra questions.
+- Assumptions carried in:
+  - The target surface is `origin/main`'s `/models/circumplex` route, not the matrix or consistency pages.
+  - The change is presentation-only. We keep the current circumplex query, thresholds, and verdict logic unless a tiny UI-only type helper is needed.
+  - "Models should have a details line" means the bulky picker becomes a compact expandable selection row instead of a standalone large section.
+
+## Scope
+- `cloud/apps/web/src/pages/ModelsCircumplex.tsx`
+- `cloud/apps/web/src/components/models/CircumplexMethodologyPanel.tsx`
+- `cloud/apps/web/src/components/models/CircumplexModelPicker.tsx`
+- `cloud/apps/web/src/components/models/CircumplexModelCard.tsx`
+- `cloud/apps/web/tests/components/models/*` as needed for the new layout/controls
+
+## Behavior
+- The top controls for `Signature`, `Minimum trials per value`, and `How this is computed` must live in one shared header box.
+- The methodology control must use a dropdown instead of the current `details` open/closed treatment.
+- The methodology control must provide tooltip copy that explains both `Open` and `Closed` states in plain language.
+- The old standalone methodology panel card must be removed from the top row.
+- Model selection must move into a compact expandable line so the picker does not dominate the page before a user chooses models.
+- The model selection control must still support multi-select, `Select all`, and `Clear`.
+- Eligible/insufficient model messaging must stay available, but hidden models should not crowd the default page state.
+- Selected circumplex model cards must render one per row at the normal page content width.
+- Additional selected models must stack underneath the previous card instead of forming a two-column grid.
+- Existing circumplex result content inside each card stays functionally the same unless a small spacing/layout adjustment is required by the new full-width card format.
+
+## Acceptance Criteria
+- The page renders one unified header control box instead of separate control and methodology boxes.
+- The methodology state is controlled by a dropdown and includes tooltip help for both choices.
+- The model picker appears as a compact expandable row and still supports multi-select actions.
+- Two or more selected models render as full-width cards stacked vertically.
+- Existing circumplex data loading, eligibility filtering, and verdict content still work.

--- a/docs/workflow/feature-runs/models-circumplex-layout-cleanup/state.json
+++ b/docs/workflow/feature-runs/models-circumplex-layout-cleanup/state.json
@@ -1,0 +1,152 @@
+{
+  "review_policy": {
+    "sensitive": false,
+    "large_structural": false,
+    "performance_sensitive": false,
+    "extra_gemini_lenses": []
+  },
+  "blocked": {
+    "active": false,
+    "reason": "",
+    "updated_at": 0
+  },
+  "discovery": {
+    "version": 2,
+    "required": false,
+    "complete": true,
+    "question_count": 0,
+    "asked_count": 0,
+    "questions": [],
+    "assumptions": [],
+    "summary": "",
+    "updated_at": 0,
+    "answers": {},
+    "non_goals": [],
+    "acceptance_criteria": [],
+    "unresolved": []
+  },
+  "delivery": {},
+  "dirty_overrides": {},
+  "checkpoint_fallback": {},
+  "parallel_analysis": {
+    "reviewed": false,
+    "found": false,
+    "note": "",
+    "updated_at": 0
+  },
+  "init_head_sha": "",
+  "token_usage": [
+    {
+      "stage": "spec",
+      "round": 1,
+      "activity_type": "adversarial_review",
+      "model": "gpt-5.4-mini",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cost_usd_estimate": null,
+      "timestamp": "2026-04-21T14:44:51.208407Z",
+      "started_at": "2026-04-21T14:43:29.731928Z",
+      "ended_at": "2026-04-21T14:44:51.208407Z",
+      "duration_seconds": 81.475853,
+      "agent_id": null,
+      "artifact_sha_at_time": "0d8118dcfc81b2ad50514b0fc29be9aa749c2632d0cca1446b4fced7383e2746",
+      "parse_error": "no Codex token block found in stderr"
+    },
+    {
+      "stage": "spec",
+      "round": 1,
+      "activity_type": "adversarial_review",
+      "model": "gpt-5.4-mini",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cost_usd_estimate": null,
+      "timestamp": "2026-04-21T14:45:57.927587Z",
+      "started_at": "2026-04-21T14:44:51.351937Z",
+      "ended_at": "2026-04-21T14:45:57.927587Z",
+      "duration_seconds": 66.5751,
+      "agent_id": null,
+      "artifact_sha_at_time": "0d8118dcfc81b2ad50514b0fc29be9aa749c2632d0cca1446b4fced7383e2746",
+      "parse_error": "no Codex token block found in stderr"
+    },
+    {
+      "stage": "spec",
+      "round": 1,
+      "activity_type": "adversarial_review",
+      "model": "gpt-5.4-mini",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cost_usd_estimate": null,
+      "timestamp": "2026-04-21T14:53:37.163322Z",
+      "started_at": "2026-04-21T14:51:48.397545Z",
+      "ended_at": "2026-04-21T14:53:37.163322Z",
+      "duration_seconds": 108.764977,
+      "agent_id": null,
+      "artifact_sha_at_time": "0d8118dcfc81b2ad50514b0fc29be9aa749c2632d0cca1446b4fced7383e2746",
+      "parse_error": "no Codex token block found in stderr"
+    },
+    {
+      "stage": "spec",
+      "round": 1,
+      "activity_type": "adversarial_review",
+      "model": "gpt-5.4-mini",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cost_usd_estimate": null,
+      "timestamp": "2026-04-21T14:54:29.169842Z",
+      "started_at": "2026-04-21T14:53:37.315158Z",
+      "ended_at": "2026-04-21T14:54:29.169842Z",
+      "duration_seconds": 51.854281,
+      "agent_id": null,
+      "artifact_sha_at_time": "0d8118dcfc81b2ad50514b0fc29be9aa749c2632d0cca1446b4fced7383e2746",
+      "parse_error": "no Codex token block found in stderr"
+    },
+    {
+      "stage": "spec",
+      "round": 1,
+      "activity_type": "adversarial_review",
+      "model": "gemini-2.5-pro",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cost_usd_estimate": null,
+      "timestamp": "2026-04-21T14:56:29.351671Z",
+      "started_at": "2026-04-21T14:54:29.341495Z",
+      "ended_at": "2026-04-21T14:56:29.351671Z",
+      "duration_seconds": 120.009298,
+      "agent_id": null,
+      "artifact_sha_at_time": "0d8118dcfc81b2ad50514b0fc29be9aa749c2632d0cca1446b4fced7383e2746",
+      "parse_error": "no Gemini token stats found in stdout"
+    },
+    {
+      "stage": "spec",
+      "round": 1,
+      "activity_type": "adversarial_review",
+      "model": "gemini-2.5-pro",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cost_usd_estimate": null,
+      "timestamp": "2026-04-21T14:58:29.363807Z",
+      "started_at": "2026-04-21T14:56:29.354246Z",
+      "ended_at": "2026-04-21T14:58:29.363807Z",
+      "duration_seconds": 120.0088,
+      "agent_id": null,
+      "artifact_sha_at_time": "0d8118dcfc81b2ad50514b0fc29be9aa749c2632d0cca1446b4fced7383e2746",
+      "parse_error": "no Gemini token stats found in stdout"
+    }
+  ],
+  "stages": {
+    "spec": {
+      "adversarial_rounds": 0,
+      "judge_rounds": 0,
+      "judge_verdicts": [],
+      "annotations": [],
+      "unresolved_concerns": [],
+      "adversarial_sha_history": [
+        "0d8118dcfc81b2ad50514b0fc29be9aa749c2632d0cca1446b4fced7383e2746",
+        "0d8118dcfc81b2ad50514b0fc29be9aa749c2632d0cca1446b4fced7383e2746"
+      ],
+      "initial_sha": "0d8118dcfc81b2ad50514b0fc29be9aa749c2632d0cca1446b4fced7383e2746"
+    }
+  },
+  "schema_version": 2,
+  "spec_adversarial_rounds": 0
+}

--- a/docs/workflow/feature-runs/models-circumplex-layout-cleanup/tasks.md
+++ b/docs/workflow/feature-runs/models-circumplex-layout-cleanup/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+1. [CHECKPOINT] Merge the top controls into one Circumplex header box.
+   - Update `cloud/apps/web/src/pages/ModelsCircumplex.tsx` so `Signature`, `Minimum trials per value`, and `How this is computed` render in one shared header section.
+   - Remove the old side-by-side top grid with a separate methodology panel card.
+   - Keep the current URL-backed state wiring for signature, threshold, and methodology.
+   - Estimated diff: ~120 lines.
+
+2. [CHECKPOINT] Replace the bulky methodology/picker UI with compact controls.
+   - Rework `cloud/apps/web/src/components/models/CircumplexMethodologyPanel.tsx` into a compact control surface that uses a dropdown and tooltip help for both `Open` and `Closed`.
+   - Rework `cloud/apps/web/src/components/models/CircumplexModelPicker.tsx` into an expandable compact selector row with the existing multi-select actions.
+   - Keep insufficient-model context available without overwhelming the default state.
+   - Estimated diff: ~180 lines.
+
+3. [CHECKPOINT] Stack selected circumplex cards full-width and verify behavior.
+   - Update `cloud/apps/web/src/pages/ModelsCircumplex.tsx` and `cloud/apps/web/src/components/models/CircumplexModelCard.tsx` so selected cards render one per row.
+   - Add focused tests under `cloud/apps/web/tests/components/models/` for the merged header controls, compact picker behavior, and stacked card layout.
+   - Run targeted web tests plus a web build/type-safe verification for the touched files.
+   - Estimated diff: ~180 lines.


### PR DESCRIPTION
## Summary
- clean up the `Models / Circumplex` page layout so the header controls line up in one box
- replace the methodology open/closed details treatment with a dropdown plus tooltip help
- collapse model selection into a compact `Model details` row and stack selected model cards full width
- add focused tests for the merged header controls, compact picker behavior, and stacked card layout
- record the local Feature Factory run artifacts for `models-circumplex-layout-cleanup`

## Why
The Circumplex page felt visually cluttered. The top controls were split across separate boxes, the model picker dominated the page before any selection, and selected model cards were sharing a grid instead of using the normal page width.

## User Impact
- people now see `Signature`, `Minimum trials per value`, and `How this is computed` together in the same top section
- methodology state is easier to understand through a dropdown and tooltip copy for both `Open` and `Closed`
- model selection starts compact and expands only when needed
- each selected model gets a full-width card, with additional cards stacked below

## Validation
- `cd cloud && npx turbo lint --filter=@valuerank/web` ✅
- `cd cloud && npx turbo test --filter=@valuerank/web` ✅
- `cd cloud && npx turbo build --filter=@valuerank/web` ✅
- `cd cloud/apps/web && ../../node_modules/.bin/vitest run tests/components/models/CircumplexMethodologyPanel.test.tsx tests/components/models/CircumplexModelPicker.test.tsx tests/pages/ModelsCircumplex.test.tsx` ✅

## Notes
- the Feature Factory review checkpoint artifacts under `docs/workflow/feature-runs/models-circumplex-layout-cleanup/reviews/` are not included in this PR; the existing local run still needs checkpoint repair if we want that workflow state fully green
