### PR TITLE
[codex] Add circumplex loading progress

### DIFF
--- a/cloud/apps/web/src/components/models/CircumplexLoadingProgress.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexLoadingProgress.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+
+type LoadingStage = 'prepare' | 'analyze';
+
+type Props = {
+  stage: LoadingStage;
+  modelCount: number;
+  signature: string;
+  threshold: number;
+};
+
+const stageCopy: Record<LoadingStage, { label: string; initialProgress: number }> = {
+  prepare: {
+    label: 'Preparing model and signature data',
+    initialProgress: 15,
+  },
+  analyze: {
+    label: 'Computing circumplex fit across models',
+    initialProgress: 35,
+  },
+};
+
+function useEstimatedProgress(initialProgress: number): number {
+  const [progress, setProgress] = useState(initialProgress);
+
+  useEffect(() => {
+    const startedAt = Date.now();
+    setProgress(initialProgress);
+
+    const interval = window.setInterval(() => {
+      const elapsedMs = Date.now() - startedAt;
+      const easedProgress = initialProgress + (92 - initialProgress) * (1 - Math.exp(-elapsedMs / 9000));
+      setProgress((current) => Math.max(current, Math.min(92, Math.round(easedProgress))));
+    }, 500);
+
+    return () => window.clearInterval(interval);
+  }, [initialProgress]);
+
+  return progress;
+}
+
+export function CircumplexLoadingProgress({ stage, modelCount, signature, threshold }: Props) {
+  const { label, initialProgress } = stageCopy[stage];
+  const progress = useEstimatedProgress(initialProgress);
+  const modelText = modelCount === 1 ? '1 model' : `${modelCount} models`;
+
+  return (
+    <div className="flex min-h-[320px] items-center justify-center px-4 py-12">
+      <section className="w-full max-w-xl rounded-2xl border border-teal-100 bg-white p-6 shadow-sm">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-teal-700">Loading Circumplex</p>
+          <h2 className="text-xl font-semibold text-gray-950">{label}</h2>
+          <p className="text-sm leading-6 text-gray-600">
+            Estimated progress for {modelText} on <span className="font-medium text-gray-800">{signature}</span>
+            {' '}with at least {threshold} trials per value.
+          </p>
+        </div>
+
+        <div className="mt-6" aria-live="polite">
+          <div className="mb-2 flex items-center justify-between text-sm">
+            <span className="font-medium text-gray-700">Estimated progress</span>
+            <span className="font-semibold text-teal-700">{progress}%</span>
+          </div>
+          <div
+            aria-label="Estimated circumplex loading progress"
+            aria-valuemax={100}
+            aria-valuemin={0}
+            aria-valuenow={progress}
+            className="h-3 overflow-hidden rounded-full bg-gray-100"
+            role="progressbar"
+          >
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-teal-500 via-cyan-500 to-emerald-400 transition-[width] duration-500 ease-out"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+
+        <p className="mt-4 text-xs leading-5 text-gray-500">
+          This is an estimate while the server aggregates transcript data. The full report appears as soon as the analysis response returns.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/cloud/apps/web/src/pages/ModelsCircumplex.tsx
+++ b/cloud/apps/web/src/pages/ModelsCircumplex.tsx
@@ -3,7 +3,6 @@ import { useQuery } from 'urql';
 import { X } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
-import { Loading } from '../components/ui/Loading';
 import { Button } from '../components/ui/Button';
 import { Select } from '../components/ui/Select';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
@@ -18,6 +17,7 @@ import { CircumplexThresholdControl } from '../components/models/CircumplexThres
 import { CircumplexModelPicker } from '../components/models/CircumplexModelPicker';
 import { CircumplexMethodologyPanel } from '../components/models/CircumplexMethodologyPanel';
 import { CircumplexModelCard } from '../components/models/CircumplexModelCard';
+import { CircumplexLoadingProgress } from '../components/models/CircumplexLoadingProgress';
 
 function parseCommaList(value: string | null): string[] {
   if (value == null || value.trim() === '') return [];
@@ -217,7 +217,18 @@ export function ModelsCircumplex() {
   }
 
   if (loading) {
-    return <Loading text="Loading circumplex report..." />;
+    const loadingStage = (signaturesLoading && signatures.length === 0) || (rosterLoading && roster.length === 0)
+      ? 'prepare'
+      : 'analyze';
+
+    return (
+      <CircumplexLoadingProgress
+        modelCount={rosterIds.length}
+        signature={selectedSignature}
+        stage={loadingStage}
+        threshold={threshold}
+      />
+    );
   }
 
   const hasAnySignatureData = analysisModels.some((result) => result.trialsPerValue.some((entry) => entry.trials > 0));

--- a/cloud/apps/web/tests/components/models/CircumplexLoadingProgress.test.tsx
+++ b/cloud/apps/web/tests/components/models/CircumplexLoadingProgress.test.tsx
@@ -1,0 +1,29 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CircumplexLoadingProgress } from '../../../src/components/models/CircumplexLoadingProgress';
+
+describe('CircumplexLoadingProgress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-21T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows an estimated percent and advances while loading', () => {
+    render(<CircumplexLoadingProgress modelCount={4} signature="vnewtd" stage="analyze" threshold={5} />);
+
+    const progress = screen.getByRole('progressbar', { name: /estimated circumplex loading progress/i });
+    expect(progress).toHaveAttribute('aria-valuenow', '35');
+    expect(screen.getByText(/4 models on/i)).toBeInTheDocument();
+    expect(screen.getByText(/This is an estimate/i)).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(Number(progress.getAttribute('aria-valuenow'))).toBeGreaterThan(35);
+  });
+});

--- a/cloud/apps/web/tests/pages/ModelsCircumplex.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsCircumplex.test.tsx
@@ -104,4 +104,44 @@ describe('ModelsCircumplex', () => {
     expect(screen.getByText('Model A')).toBeInTheDocument();
     expect(screen.getByText('Model B')).toBeInTheDocument();
   });
+
+  it('shows estimated progress while circumplex data is loading', () => {
+    useQueryMock.mockImplementation((args: { query: unknown }) => {
+      if (args.query === LLM_MODELS_QUERY) {
+        return [{
+          data: {
+            llmModels: [
+              { id: 'model-a', isDefault: true },
+              { id: 'model-b', isDefault: false },
+            ],
+          },
+          fetching: false,
+          error: undefined,
+        }];
+      }
+
+      if (args.query === CIRCUMPLEX_ANALYSIS_QUERY) {
+        return [{
+          data: undefined,
+          fetching: true,
+          error: undefined,
+        }];
+      }
+
+      return [{ data: undefined, fetching: false, error: undefined }];
+    });
+
+    render(
+      <MemoryRouter
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+        initialEntries={['/models/circumplex?signature=vnewtd&n=5&methodology=closed']}
+      >
+        <ModelsCircumplex />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('progressbar', { name: /estimated circumplex loading progress/i })).toHaveAttribute('aria-valuenow', '35');
+    expect(screen.getByText(/Computing circumplex fit across models/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 models on/i)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Add a stage-aware estimated loading progress bar for the Models / Circumplex page.
- Replace the generic spinner while circumplex data is loading.
- Cover the new component and page loading state with tests.

## Why
The circumplex API returns the full analysis in one response, so the page can sit in a long loading state. This gives users visible feedback that work is still happening and labels the percentage as an estimate.

## User impact
- Shows an estimated percent while the report loads.
- Shows the selected signature, threshold, and model count when available.
- Clarifies that the final report appears when the server response finishes.

## Validation
- `cd cloud && npx turbo lint --filter=@valuerank/web` ✅ warnings only
- `cd cloud && npx turbo test --filter=@valuerank/web` ✅
- `cd cloud && npx turbo build --filter=@valuerank/web` ✅
- `cd cloud/apps/web && ../../node_modules/.bin/vitest run tests/components/models/CircumplexLoadingProgress.test.tsx tests/pages/ModelsCircumplex.test.tsx tests/components/models/CircumplexMethodologyPanel.test.tsx tests/components/models/CircumplexModelPicker.test.tsx` ✅