### PR TITLE
[codex] Add review attempt telemetry

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/tests/test_run_factory_repair.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/tests/test_run_factory_repair.py
@@ -30,6 +30,24 @@ CMD_IMPLEMENT_MODULE = sys.modules["factory_cmd_implement"]
 NEXT_ACTION_MODULE = sys.modules["factory_next_action"]
 PARALLEL_MODULE = sys.modules["factory_parallel"]
 
+REVIEW_LENS_SCRIPTS = Path(__file__).resolve().parents[2] / "review-lens" / "scripts"
+if str(REVIEW_LENS_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(REVIEW_LENS_SCRIPTS))
+
+
+def load_review_lens_module(name: str):
+    path = REVIEW_LENS_SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+REPAIR_MODULE = load_review_lens_module("repair_review_checkpoint")
+ATTEMPTS_MODULE = load_review_lens_module("review_attempts")
+
 
 def stage_state(
     *,
@@ -51,6 +69,75 @@ def stage_state(
 
 
 class RepairDecisionTests(unittest.TestCase):
+    class _FakeLockedState:
+        def __init__(self) -> None:
+            self.state: dict[str, object] = {}
+
+        def __enter__(self) -> dict[str, object]:
+            return self.state
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    def test_partial_artifact_repair_expands_review_budgets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            artifact = repo_root / "docs" / "workflow" / "feature-runs" / "demo" / "tasks.md"
+            artifact.parent.mkdir(parents=True)
+            artifact.write_text("x" * 1500, encoding="utf-8")
+            review = artifact.parent / "reviews" / "tasks.codex.md"
+            review.parent.mkdir()
+            review.write_text(
+                "\n".join(
+                    [
+                        "---",
+                        'coverage_status: "partial"',
+                        'coverage_note: "artifact exceeded max_artifact_chars and was narrowed"',
+                        "---",
+                        "body",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            spec = {"path": str(review.relative_to(repo_root)), "context_paths": []}
+            checkpoint = {"stage": "tasks", "max_artifact_chars": 500, "max_total_chars": 1000}
+
+            with patch.object(REPAIR_MODULE, "REPO_ROOT", repo_root):
+                expanded = REPAIR_MODULE.expanded_checkpoint_for_partial_artifact(spec, artifact, checkpoint)
+
+            self.assertIsNotNone(expanded)
+            assert expanded is not None
+            self.assertGreaterEqual(expanded["max_artifact_chars"], 2500)
+            self.assertGreaterEqual(expanded["max_total_chars"], 12500)
+
+    def test_partial_context_repair_does_not_expand_artifact_budget(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            artifact = repo_root / "docs" / "workflow" / "feature-runs" / "demo" / "tasks.md"
+            artifact.parent.mkdir(parents=True)
+            artifact.write_text("x" * 1500, encoding="utf-8")
+            review = artifact.parent / "reviews" / "tasks.codex.md"
+            review.parent.mkdir()
+            review.write_text(
+                "\n".join(
+                    [
+                        "---",
+                        'coverage_status: "partial"',
+                        'coverage_note: "context exceeded max_context_chars and was narrowed"',
+                        "---",
+                        "body",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            spec = {"path": str(review.relative_to(repo_root)), "context_paths": []}
+            checkpoint = {"stage": "tasks", "max_artifact_chars": 500, "max_total_chars": 1000}
+
+            with patch.object(REPAIR_MODULE, "REPO_ROOT", repo_root):
+                expanded = REPAIR_MODULE.expanded_checkpoint_for_partial_artifact(spec, artifact, checkpoint)
+
+            self.assertIsNone(expanded)
+
     def test_repair_checkpoint_args_preserves_required_reviews(self) -> None:
         manifest = {
             "required_reviews": [
@@ -593,6 +680,10 @@ class RepairDecisionTests(unittest.TestCase):
             merge_when_green=False,
             auto_merge=False,
             dry_run=False,
+            override_judges=False,
+            reason=None,
+            resume_merge_wait=False,
+            refresh=False,
         )
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_root = Path(temp_dir)
@@ -1171,6 +1262,10 @@ class RepairDecisionTests(unittest.TestCase):
             merge_when_green=False,
             auto_merge=False,
             dry_run=True,
+            override_judges=False,
+            reason=None,
+            resume_merge_wait=False,
+            refresh=False,
         )
         fake_manifest_path = MagicMock()
         fake_manifest_path.exists.return_value = True
@@ -1292,6 +1387,7 @@ class RepairDecisionTests(unittest.TestCase):
             gemini_retries=1,
             repair_timeout_seconds=30,
             fallback=True,
+            json=False,
             use_existing_artifact=True,
             allow_large_diff_rerun=False,
             required_reviews=None,
@@ -1347,6 +1443,8 @@ class RepairDecisionTests(unittest.TestCase):
                 CMD_CHECKPOINT_MODULE, "record_checkpoint_fallback"
             ) as record_fallback, patch.object(
                 CMD_CHECKPOINT_MODULE, "run_checkpoint_fallback", return_value=(False, "boom")
+            ), patch.object(
+                CMD_CHECKPOINT_MODULE, "with_locked_state", return_value=self._FakeLockedState()
             ), patch.object(
                 CMD_CHECKPOINT_MODULE.subprocess, "run", return_value=SimpleNamespace(returncode=1, stdout="", stderr="repair failed")
             ):
@@ -1417,6 +1515,7 @@ class RepairDecisionTests(unittest.TestCase):
             gemini_retries=1,
             repair_timeout_seconds=30,
             fallback=False,
+            json=False,
             use_existing_artifact=False,
             allow_large_diff_rerun=False,
             required_reviews=None,
@@ -1513,6 +1612,8 @@ class RepairDecisionTests(unittest.TestCase):
             ), patch.object(
                 CMD_CHECKPOINT_MODULE, "update_workflow_state", return_value={}
             ), patch.object(
+                CMD_CHECKPOINT_MODULE, "with_locked_state", return_value=self._FakeLockedState()
+            ), patch.object(
                 CMD_CHECKPOINT_MODULE.subprocess, "run", side_effect=fake_run
             ):
                 exit_code = MODULE.command_checkpoint(args)
@@ -1521,6 +1622,53 @@ class RepairDecisionTests(unittest.TestCase):
         joined = "\n".join(" ".join(cmd) for cmd in commands)
         self.assertIn("--base-ref", joined)
         self.assertIn("abc123def4567890", joined)
+
+
+class ReviewAttemptTelemetryTests(unittest.TestCase):
+    def test_review_attempt_record_infers_slug_and_omits_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            review_path = repo_root / "docs" / "workflow" / "feature-runs" / "demo" / "reviews" / "spec.codex.md"
+            review_path.parent.mkdir(parents=True)
+
+            record = ATTEMPTS_MODULE.review_attempt_record(
+                repo_root=repo_root,
+                reviewer="codex",
+                model="gpt-test",
+                stage="spec",
+                lens="risk",
+                artifact_chars=100,
+                context_chars=20,
+                total_chars=120,
+                max_artifact_chars=1000,
+                max_context_chars=1000,
+                max_total_chars=2000,
+                coverage_status="full",
+                coverage_note="",
+                result="passed",
+                exit_code=0,
+                duration_seconds=1.23456,
+                artifact_sha256="abc123",
+                review_path=review_path,
+            )
+
+        self.assertEqual(record["slug"], "demo")
+        self.assertEqual(record["review_path"], "docs/workflow/feature-runs/demo/reviews/spec.codex.md")
+        self.assertEqual(record["duration_seconds"], 1.235)
+        self.assertNotIn("prompt", record)
+        self.assertNotIn("artifact_text", record)
+        self.assertNotIn("review_body", record)
+
+    def test_append_review_attempt_writes_central_jsonl(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            record = {"slug": "demo", "result": "passed"}
+
+            ATTEMPTS_MODULE.append_review_attempt(record, repo_root)
+
+            log_path = repo_root / "docs" / "workflow" / "operations" / "review-attempts.jsonl"
+            self.assertTrue(log_path.exists())
+            self.assertEqual(json.loads(log_path.read_text(encoding="utf-8")), record)
 
 
 class CheckpointMarkerTests(unittest.TestCase):

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/repair_review_checkpoint.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/repair_review_checkpoint.py
@@ -14,9 +14,11 @@ VERIFY = SCRIPT_DIR / "verify_review_checkpoint.py"
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from workflow_utils import normalized_artifact_hash, resolve_stored_path
+from workflow_utils import normalized_artifact_hash, normalized_artifact_text, resolve_stored_path
 
 REPO_ROOT = SCRIPT_DIR.parents[5]
+REPAIR_LIMIT_BUFFER_CHARS = 1000
+REPAIR_MIN_TOTAL_BUFFER_CHARS = 10000
 
 
 def sha256_file(path: Path) -> str:
@@ -63,6 +65,45 @@ def review_is_healthy(spec: dict, artifact_path: Path) -> bool:
         if not raw_output or not resolve_stored_path(raw_output, REPO_ROOT, data.get("repo_root", "")).exists():
             return False
     return True
+
+
+def partial_coverage_reason(spec: dict) -> str:
+    review_path = resolve_stored_path(spec["path"], REPO_ROOT)
+    if not review_path.exists():
+        return ""
+    try:
+        data, _ = parse_frontmatter(review_path)
+    except Exception:
+        return ""
+    if data.get("coverage_status") != "partial":
+        return ""
+    return data.get("coverage_note", "")
+
+
+def context_chars(spec: dict) -> int:
+    total = 0
+    for raw_path in spec.get("context_paths", []):
+        path = resolve_stored_path(raw_path, REPO_ROOT)
+        if path.exists():
+            total += len(path.read_text(encoding="utf-8"))
+    return total
+
+
+def expanded_checkpoint_for_partial_artifact(spec: dict, artifact_path: Path, checkpoint: dict) -> dict | None:
+    if "artifact exceeded max_artifact_chars" not in partial_coverage_reason(spec):
+        return None
+
+    artifact_chars = len(normalized_artifact_text(checkpoint["stage"], artifact_path))
+    expanded = dict(checkpoint)
+    expanded["max_artifact_chars"] = max(
+        int(checkpoint.get("max_artifact_chars") or 0),
+        artifact_chars + REPAIR_LIMIT_BUFFER_CHARS,
+    )
+    expanded["max_total_chars"] = max(
+        int(checkpoint.get("max_total_chars") or 0),
+        expanded["max_artifact_chars"] + context_chars(spec) + REPAIR_MIN_TOTAL_BUFFER_CHARS,
+    )
+    return expanded
 
 
 def run_gemini(
@@ -156,12 +197,21 @@ def main() -> int:
     for spec in checkpoint.get("required_reviews", []):
         if review_is_healthy(spec, artifact_path):
             continue
+        review_checkpoint = expanded_checkpoint_for_partial_artifact(spec, artifact_path, checkpoint)
+        if review_checkpoint:
+            print(
+                f"repair expanding artifact budget for {spec['path']} to "
+                f"{review_checkpoint['max_artifact_chars']} chars",
+                file=sys.stderr,
+            )
+        else:
+            review_checkpoint = checkpoint
         if spec.get("reviewer") == "gemini":
             try:
                 run_gemini(
                     spec,
                     artifact_path,
-                    checkpoint,
+                    review_checkpoint,
                     workspace_dir,
                     args.gemini_timeout_seconds,
                     args.gemini_retries,
@@ -175,7 +225,7 @@ def main() -> int:
                 run_codex(
                     spec,
                     artifact_path,
-                    checkpoint,
+                    review_checkpoint,
                     workspace_dir,
                 )
             except subprocess.TimeoutExpired:

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/review_attempts.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/review_attempts.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Central metadata logging for review runner attempts.
+
+This stores only sizes, model metadata, result status, and paths. It does not
+store prompt text, artifact contents, review bodies, secrets, or credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from workflow_utils import repo_relative_path
+
+
+def review_attempt_log_path(repo_root: Path) -> Path:
+    return repo_root / "docs" / "workflow" / "operations" / "review-attempts.jsonl"
+
+
+def infer_slug(review_path: Path, repo_root: Path) -> str:
+    rel = repo_relative_path(review_path, repo_root)
+    parts = Path(rel).parts
+    feature_runs = ("docs", "workflow", "feature-runs")
+    for idx in range(len(parts) - len(feature_runs)):
+        if parts[idx : idx + len(feature_runs)] == feature_runs:
+            slug_idx = idx + len(feature_runs)
+            return parts[slug_idx] if slug_idx < len(parts) else ""
+    return ""
+
+
+def append_review_attempt(record: dict[str, Any], repo_root: Path) -> None:
+    path = review_attempt_log_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+
+
+def review_attempt_record(
+    *,
+    repo_root: Path,
+    reviewer: str,
+    model: str,
+    stage: str,
+    lens: str,
+    artifact_chars: int,
+    context_chars: int,
+    total_chars: int,
+    max_artifact_chars: int,
+    max_context_chars: int,
+    max_total_chars: int,
+    coverage_status: str,
+    coverage_note: str,
+    result: str,
+    exit_code: int,
+    duration_seconds: float,
+    artifact_sha256: str,
+    review_path: Path,
+    error_summary: str = "",
+) -> dict[str, Any]:
+    return {
+        "timestamp": int(time.time()),
+        "slug": infer_slug(review_path, repo_root),
+        "stage": stage,
+        "reviewer": reviewer,
+        "model": model,
+        "lens": lens,
+        "artifact_chars": artifact_chars,
+        "context_chars": context_chars,
+        "total_chars": total_chars,
+        "max_artifact_chars": max_artifact_chars,
+        "max_context_chars": max_context_chars,
+        "max_total_chars": max_total_chars,
+        "coverage_status": coverage_status,
+        "coverage_note": coverage_note,
+        "result": result,
+        "exit_code": exit_code,
+        "duration_seconds": round(duration_seconds, 3),
+        "artifact_sha256": artifact_sha256,
+        "review_path": repo_relative_path(review_path, repo_root),
+        "error_summary": error_summary,
+    }

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 from run_gemini_review import (
@@ -31,9 +32,11 @@ if str(FEATURE_FACTORY_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(FEATURE_FACTORY_SCRIPTS))
 
 from factory_telemetry import record_ai_call
+from review_attempts import append_review_attempt, review_attempt_record
 
 
 def main() -> int:
+    started_at = time.monotonic()
     parser = argparse.ArgumentParser()
     parser.add_argument("--artifact", required=True)
     parser.add_argument("--lens", required=True)
@@ -127,12 +130,42 @@ def main() -> int:
         total_context_chars += len(text)
         extra_context.append((ctx_path.name, text))
 
+    def log_attempt(result_name: str, exit_code: int, error_summary: str = "") -> None:
+        try:
+            append_review_attempt(
+                review_attempt_record(
+                    repo_root=repo_root,
+                    reviewer="codex",
+                    model=args.model,
+                    stage=args.stage,
+                    lens=args.lens,
+                    artifact_chars=len(source_artifact_text),
+                    context_chars=total_context_chars,
+                    total_chars=len(source_artifact_text) + total_context_chars,
+                    max_artifact_chars=args.max_artifact_chars,
+                    max_context_chars=args.max_context_chars,
+                    max_total_chars=args.max_total_chars,
+                    coverage_status=metadata.get("coverage_status", ""),
+                    coverage_note=metadata.get("coverage_note", ""),
+                    result=result_name,
+                    exit_code=exit_code,
+                    duration_seconds=time.monotonic() - started_at,
+                    artifact_sha256=source_artifact_hash,
+                    review_path=output_path,
+                    error_summary=error_summary,
+                ),
+                repo_root,
+            )
+        except Exception as exc:
+            print(f"warning: failed to log review attempt metadata: {exc}", file=sys.stderr)
+
     if len(artifact_text) + total_context_chars > args.max_total_chars:
         write_failure(
             output_path,
             metadata,
             f"Combined prompt content still exceeds max_total_chars ({len(artifact_text) + total_context_chars} > {args.max_total_chars}) after narrowing.",
         )
+        log_attempt("failed", 2, "combined prompt content exceeds max_total_chars")
         return 2
 
     prompt = "\n".join(
@@ -205,6 +238,7 @@ def main() -> int:
             stdout_path,
             stderr_path,
         )
+        log_attempt("timeout", 3, "Codex review timed out")
         return 3
     if result.returncode != 0:
         last_message_path.unlink(missing_ok=True)
@@ -215,6 +249,7 @@ def main() -> int:
             stdout_path,
             stderr_path,
         )
+        log_attempt("failed", 4, "Codex review failed")
         return 4
 
     try:
@@ -229,6 +264,7 @@ def main() -> int:
             stdout_path,
             stderr_path,
         )
+        log_attempt("malformed", 5, f"Codex output did not match the required review format: {exc}")
         return 5
 
     raw_path.write_text(response, encoding="utf-8")
@@ -256,6 +292,7 @@ def main() -> int:
     write_report(output_path, metadata, body)
     last_message_path.unlink(missing_ok=True)
     print(str(output_path))
+    log_attempt("partial" if metadata.get("coverage_status") == "partial" else "passed", 0)
     return 0
 
 

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/run_gemini_review.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/run_gemini_review.py
@@ -21,6 +21,7 @@ if str(FEATURE_FACTORY_SCRIPTS) not in sys.path:
 from workflow_utils import normalized_artifact_text, repo_relative_path
 from factory_state import load_workflow_state
 from factory_telemetry import record_ai_call
+from review_attempts import append_review_attempt, review_attempt_record
 
 
 BASE_REF_CANDIDATES = ["origin/main", "origin/master", "main", "master"]
@@ -468,6 +469,7 @@ def prompt_for(stage: str, lens: str, artifact_label: str, artifact_text: str, e
 
 
 def main() -> int:
+    started_at = time.monotonic()
     parser = argparse.ArgumentParser()
     parser.add_argument("--artifact", required=True)
     parser.add_argument("--lens", required=True)
@@ -569,12 +571,42 @@ def main() -> int:
         total_context_chars += len(text)
         extra_context.append((ctx_path.name, text))
 
+    def log_attempt(result_name: str, exit_code: int, error_summary: str = "") -> None:
+        try:
+            append_review_attempt(
+                review_attempt_record(
+                    repo_root=repo_root,
+                    reviewer="gemini",
+                    model=args.model,
+                    stage=args.stage,
+                    lens=args.lens,
+                    artifact_chars=len(source_artifact_text),
+                    context_chars=total_context_chars,
+                    total_chars=len(source_artifact_text) + total_context_chars,
+                    max_artifact_chars=args.max_artifact_chars,
+                    max_context_chars=args.max_context_chars,
+                    max_total_chars=args.max_total_chars,
+                    coverage_status=metadata.get("coverage_status", ""),
+                    coverage_note=metadata.get("coverage_note", ""),
+                    result=result_name,
+                    exit_code=exit_code,
+                    duration_seconds=time.monotonic() - started_at,
+                    artifact_sha256=source_artifact_hash,
+                    review_path=output_path,
+                    error_summary=error_summary,
+                ),
+                repo_root,
+            )
+        except Exception as exc:
+            print(f"warning: failed to log review attempt metadata: {exc}", file=sys.stderr)
+
     if len(artifact_text) + total_context_chars > args.max_total_chars:
         write_failure(
             output_path,
             metadata,
             f"Combined prompt content still exceeds max_total_chars ({len(artifact_text) + total_context_chars} > {args.max_total_chars}) after narrowing.",
         )
+        log_attempt("failed", 2, "combined prompt content exceeds max_total_chars")
         return 2
 
     prompt = prompt_for(args.stage, args.lens, artifact_label, artifact_text, extra_context)
@@ -646,6 +678,7 @@ def main() -> int:
             metadata,
             str(exc),
         )
+        log_attempt("timeout", 3, str(exc))
         return 3
     finally:
         if lock_path and owner_pid is not None:
@@ -661,6 +694,7 @@ def main() -> int:
             stdout_path,
             stderr_path,
         )
+        log_attempt("failed", 3, f"Gemini review failed after {args.retries + 1} attempt(s)")
         return 3
 
     stdout_path.write_text(result.stdout, encoding="utf-8")
@@ -676,6 +710,7 @@ def main() -> int:
             stdout_path,
             stderr_path,
         )
+        log_attempt("malformed", 4, f"Gemini output could not be parsed as JSON: {exc}")
         return 4
 
     response = payload.get("response", "").strip()
@@ -689,6 +724,7 @@ def main() -> int:
             stdout_path,
             stderr_path,
         )
+        log_attempt("malformed", 5, f"Gemini output did not match the required review format: {exc}")
         return 5
     stats = payload.get("stats", {})
     raw_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
@@ -717,6 +753,7 @@ def main() -> int:
     )
     write_report(output_path, metadata, body)
     print(str(output_path))
+    log_attempt("partial" if metadata.get("coverage_status") == "partial" else "passed", 0)
     return 0
 
 

--- a/docs/workflow/operations/review-attempts.md
+++ b/docs/workflow/operations/review-attempts.md
@@ -1,0 +1,18 @@
+# Review Attempts Log
+
+Feature Factory review runners append metadata to `review-attempts.jsonl`.
+
+This is a central learning log. It is intentionally outside individual feature-run
+folders so old run cleanup does not erase the size and reliability history.
+
+The log stores one JSON object per review attempt. It records sizes, stage, reviewer,
+model, lens, coverage, result, duration, exit code, artifact hash, and review path.
+
+It must not store prompt text, artifact contents, review bodies, secrets, or credentials.
+
+Use this log to answer questions like:
+
+- which artifact sizes usually pass for each model
+- where partial reviews happen most often
+- whether failures are caused by size, timeout, malformed output, or runner errors
+- whether specs, plans, tasks, and diffs need different limits


### PR DESCRIPTION
## Summary

Adds central metadata logging for Feature Factory review attempts so we can learn which artifact sizes, models, stages, and outcomes pass or fail without storing prompt text, artifact contents, review bodies, secrets, or credentials.

Also teaches checkpoint repair to recover from artifact-size partial reviews by expanding artifact and total-character budgets on retry when the prior partial review was caused by `max_artifact_chars`.

## Why

Feature Factory was stopping mid-flow when reviewers produced partial artifacts for large inputs. We needed two changes: a durable central history outside per-feature review folders, and a safer repair path for the common case where the artifact was simply too large for the first review budget.

## Validation

- `python3 -m pytest docs/workflow/operations/codex-skills/feature-factory/tests/test_run_factory_repair.py` -> 126 passed
- `python3 -m py_compile docs/workflow/operations/codex-skills/review-lens/scripts/review_attempts.py docs/workflow/operations/codex-skills/review-lens/scripts/run_gemini_review.py docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py docs/workflow/operations/codex-skills/review-lens/scripts/repair_review_checkpoint.py`
- `git diff --cached --check`
