### PR TITLE
[codex] Fix circumplex loading timing

### DIFF
--- a/cloud/apps/web/src/components/models/CircumplexMatrix.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexMatrix.tsx
@@ -8,8 +8,8 @@ type Props = {
   excludedValues: Set<ValueKey>;
 };
 
-const CELL_SIZE = 34;
-const LABEL_SIZE = 128;
+const CELL_SIZE = 48;
+const LABEL_SIZE = 148;
 const MARGIN = 10;
 
 function clamp(value: number): number {
@@ -33,6 +33,10 @@ function colorForCorrelation(value: number | null): string {
   return `rgb(${r}, ${g}, ${b})`;
 }
 
+function textColorForCorrelation(value: number): string {
+  return Math.abs(value) >= 0.65 ? '#ffffff' : '#111827';
+}
+
 export function CircumplexMatrix({ matrix, pairTrialCounts, valueOrder, excludedValues }: Props) {
   const width = LABEL_SIZE + (valueOrder.length * CELL_SIZE) + MARGIN * 2;
   const height = LABEL_SIZE + (valueOrder.length * CELL_SIZE) + MARGIN * 2;
@@ -41,10 +45,13 @@ export function CircumplexMatrix({ matrix, pairTrialCounts, valueOrder, excluded
     <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
       <div className="mb-3">
         <h2 className="text-lg font-semibold text-gray-900">Value-profile correlation matrix</h2>
-        <p className="text-sm text-gray-600">Short labels use the shipped ValueRank label map; the tooltip spells out the full Schwartz names.</p>
+        <p className="text-sm text-gray-600">
+          Each cell is a Pearson correlation between two values&apos; win-rate profiles, not the direct win rate between those two values.
+          Higher green means this model treats the values similarly across their other matchups.
+        </p>
       </div>
       <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${width} ${height}`} className="block min-w-[640px]">
+        <svg viewBox={`0 0 ${width} ${height}`} className="block min-w-[760px]">
           <defs>
             <pattern id="circumplex-hatch" patternUnits="userSpaceOnUse" width="6" height="6" patternTransform="rotate(45)">
               <rect width="6" height="6" fill="rgba(255,255,255,0.22)" />
@@ -107,11 +114,18 @@ export function CircumplexMatrix({ matrix, pairTrialCounts, valueOrder, excluded
                     <text x={x + CELL_SIZE / 2} y={y + CELL_SIZE / 2 + 4} textAnchor="middle" className="fill-gray-500 text-[11px]">
                       —
                     </text>
-                  ) : lowCount ? (
-                    <text x={x + CELL_SIZE / 2} y={y + CELL_SIZE / 2 + 4} textAnchor="middle" className="fill-gray-700 text-[9px] font-medium">
-                      n={trials}
+                  ) : (
+                    <text
+                      x={x + CELL_SIZE / 2}
+                      y={y + CELL_SIZE / 2 + 4}
+                      textAnchor="middle"
+                      className="text-[10px] font-semibold"
+                      fill={textColorForCorrelation(cell)}
+                      pointerEvents="none"
+                    >
+                      {cell.toFixed(2)}
                     </text>
-                  ) : null}
+                  )}
                 </g>
               );
             })

--- a/cloud/apps/web/src/components/models/CircumplexModelCard.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexModelCard.tsx
@@ -26,26 +26,26 @@ export function CircumplexModelCard({ result }: Props) {
         </div>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)]">
+      <div className="space-y-4">
         <CircumplexMatrix
           matrix={result.profileCorrelationMatrix}
           pairTrialCounts={result.pairTrialCounts}
           valueOrder={result.valueOrder as ValueKey[]}
           excludedValues={toExcludedSet(result.excludedValues)}
         />
-        <div className="space-y-4">
-        <CircumplexMdsScatter
-          mds={result.mds2d}
-          excludedValues={result.excludedValues as ValueKey[]}
-          mdsWarning={result.mdsWarning ?? null}
-          mdsStress={result.mdsStress ?? 0}
-        />
-        <CircumplexVerdictPanel
-          rho={result.spearmanRho ?? null}
-          p={result.spearmanP ?? null}
-          verdictBand={result.verdictBand}
-          excludedValues={result.excludedValues as ValueKey[]}
-        />
+        <div className="grid gap-4 xl:grid-cols-[minmax(320px,0.95fr)_minmax(0,1fr)]">
+          <CircumplexMdsScatter
+            mds={result.mds2d}
+            excludedValues={result.excludedValues as ValueKey[]}
+            mdsWarning={result.mdsWarning ?? null}
+            mdsStress={result.mdsStress ?? 0}
+          />
+          <CircumplexVerdictPanel
+            rho={result.spearmanRho ?? null}
+            p={result.spearmanP ?? null}
+            verdictBand={result.verdictBand}
+            excludedValues={result.excludedValues as ValueKey[]}
+          />
         </div>
       </div>
     </section>

--- a/cloud/apps/web/src/pages/ModelsCircumplex.tsx
+++ b/cloud/apps/web/src/pages/ModelsCircumplex.tsx
@@ -95,9 +95,12 @@ export function ModelsCircumplex() {
     minTrialsPerValue: threshold,
   }), [rosterIds, selectedSignature, threshold]);
 
+  const circumplexReady = rosterIds.length > 0 && (signatureParam != null || defaultSignature != null);
+
   const [{ data: circumplexData, fetching: circumplexLoading, error: circumplexError }] = useQuery<CircumplexAnalysisQueryResult, CircumplexAnalysisQueryVariables>({
     query: CIRCUMPLEX_ANALYSIS_QUERY,
     variables: circumplexVariables,
+    pause: !circumplexReady,
     requestPolicy: 'cache-and-network',
   });
 

--- a/cloud/apps/web/tests/components/models/CircumplexMatrix.test.tsx
+++ b/cloud/apps/web/tests/components/models/CircumplexMatrix.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CircumplexMatrix } from '../../../src/components/models/CircumplexMatrix';
+import type { ValueKey } from '../../../src/data/domainAnalysisData';
+
+const valueOrder: ValueKey[] = [
+  'Self_Direction_Action',
+  'Universalism_Nature',
+  'Benevolence_Dependability',
+];
+
+describe('CircumplexMatrix', () => {
+  it('labels cells as profile correlations and renders numeric values in cells', () => {
+    render(
+      <CircumplexMatrix
+        matrix={[
+          [1, 0.73, -0.42],
+          [0.73, 1, 0.25],
+          [-0.42, 0.25, 1],
+        ]}
+        pairTrialCounts={[
+          [0, 30, 30],
+          [30, 0, 8],
+          [30, 8, 0],
+        ]}
+        valueOrder={valueOrder}
+        excludedValues={new Set()}
+      />,
+    );
+
+    expect(screen.getByText(/not the direct win rate/i)).toBeInTheDocument();
+    expect(screen.getAllByText('0.73')).toHaveLength(2);
+    expect(screen.getAllByText('-0.42')).toHaveLength(2);
+    expect(screen.getAllByText('0.25')).toHaveLength(2);
+    expect(screen.queryByText('n=8')).not.toBeInTheDocument();
+  });
+});

--- a/cloud/apps/web/tests/pages/ModelsCircumplex.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsCircumplex.test.tsx
@@ -144,4 +144,41 @@ describe('ModelsCircumplex', () => {
     expect(screen.getByText(/Computing circumplex fit across models/i)).toBeInTheDocument();
     expect(screen.getByText(/2 models on/i)).toBeInTheDocument();
   });
+
+  it('waits to start the circumplex query until model ids are available', () => {
+    let circumplexPause: boolean | undefined;
+
+    useQueryMock.mockImplementation((args: { query: unknown; pause?: boolean }) => {
+      if (args.query === LLM_MODELS_QUERY) {
+        return [{
+          data: undefined,
+          fetching: true,
+          error: undefined,
+        }];
+      }
+
+      if (args.query === CIRCUMPLEX_ANALYSIS_QUERY) {
+        circumplexPause = args.pause;
+        return [{
+          data: undefined,
+          fetching: false,
+          error: undefined,
+        }];
+      }
+
+      return [{ data: undefined, fetching: false, error: undefined }];
+    });
+
+    render(
+      <MemoryRouter
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+        initialEntries={['/models/circumplex?signature=vnewtd&n=5&methodology=closed']}
+      >
+        <ModelsCircumplex />
+      </MemoryRouter>,
+    );
+
+    expect(circumplexPause).toBe(true);
+    expect(screen.getByRole('progressbar', { name: /estimated circumplex loading progress/i })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Pause the circumplex query until model ids are available so the loading screen can show reliably.
- Keep the value-profile matrix full width, move the circle plot below it, and show numbers in every cell.
- Add coverage for the loading pause and the matrix copy.

## Why
The circumplex page could fall through to an empty-state path before the roster finished loading because the analysis query started too early with an empty model list. This makes the loading bar behave like a real loading state again instead of flashing past it.

## User impact
- Users should now see the estimated loading screen while the page is still gathering model ids and circumplex data.
- The matrix is easier to scan because every cell shows its correlation value.
- The circle plot no longer competes for width with the matrix.

## Validation
- `cd cloud && npx turbo lint --filter=@valuerank/web` ✅ warnings only
- `cd cloud && npx turbo test --filter=@valuerank/web` ✅
- `cd cloud && npx turbo build --filter=@valuerank/web` ✅
- `cd cloud/apps/web && ../../node_modules/.bin/vitest run tests/components/models/CircumplexMatrix.test.tsx tests/components/models/CircumplexLoadingProgress.test.tsx tests/pages/ModelsCircumplex.test.tsx` ✅
- `cd cloud/apps/web && ../../node_modules/.bin/eslint src/components/models/CircumplexMatrix.tsx src/components/models/CircumplexModelCard.tsx src/pages/ModelsCircumplex.tsx --ext .ts,.tsx` ✅