### PR TITLE
[codex] Add circumplex overlay chart

### DIFF
--- a/cloud/apps/web/src/components/models/CircumplexMdsScatter.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexMdsScatter.tsx
@@ -1,80 +1,164 @@
+import type { CircumplexResult } from '../../api/operations/circumplex';
 import { VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
 import { formatFullSchwartzValueName } from '../../utils/schwartz';
-import type { CircumplexMdsCoord } from '../../api/operations/circumplex';
 
 type Props = {
-  mds: CircumplexMdsCoord[];
-  excludedValues: ValueKey[];
-  mdsWarning: string | null;
-  mdsStress: number;
+  results: CircumplexResult[];
 };
 
-const SIZE = 360;
-const CENTER = SIZE / 2;
-const RADIUS = 120;
+const VIEW_BOX_WIDTH = 960;
+const VIEW_BOX_HEIGHT = 640;
+const CENTER_X = 360;
+const CENTER_Y = 310;
+const RADIUS = 180;
+const LABEL_RADIUS = 236;
+
+const SERIES_COLORS = ['#0f766e', '#2563eb', '#7c3aed', '#c2410c', '#db2777', '#059669'];
 
 function format(value: number): string {
   return value.toFixed(2);
 }
 
-export function CircumplexMdsScatter({ mds, excludedValues, mdsWarning, mdsStress }: Props) {
-  if (mdsWarning != null) {
-    return (
-      <section className="rounded-xl border border-amber-200 bg-amber-50 p-4 md:p-5">
-        <h2 className="text-lg font-semibold text-amber-950">2D embedding warning</h2>
-        <p className="mt-2 text-sm text-amber-900">{mdsWarning}</p>
-        <p className="mt-2 text-xs text-amber-800">Stress: {format(mdsStress)}</p>
-      </section>
-    );
+function polarToCartesian(angleRadians: number, radius: number): { x: number; y: number } {
+  return {
+    x: CENTER_X + Math.cos(angleRadians) * radius,
+    y: CENTER_Y - Math.sin(angleRadians) * radius,
+  };
+}
+
+function labelAnchor(angleRadians: number): 'start' | 'middle' | 'end' {
+  const cosine = Math.cos(angleRadians);
+  if (cosine > 0.25) return 'start';
+  if (cosine < -0.25) return 'end';
+  return 'middle';
+}
+
+function buildPath(points: Array<{ x: number; y: number }>, closePath: boolean): string {
+  if (points.length === 0) return '';
+  const segments = points.map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x.toFixed(2)} ${point.y.toFixed(2)}`);
+  if (closePath && points.length > 2) {
+    segments.push('Z');
+  }
+  return segments.join(' ');
+}
+
+export function CircumplexMdsScatter({ results }: Props) {
+  if (results.length === 0) {
+    return null;
   }
 
+  const valueOrder = (results[0]?.valueOrder ?? []) as ValueKey[];
+  const canonicalValues = valueOrder ?? [];
   const maxAbs = Math.max(
     1,
-    ...mds.flatMap((point) => [Math.abs(point.x), Math.abs(point.y)]),
+    ...results.flatMap((result) => (result.mds2d ?? []).flatMap((point) => [Math.abs(point.x), Math.abs(point.y)])),
   );
   const scale = RADIUS / maxAbs;
+  const warnings = results.filter((result) => result.mdsWarning != null);
 
   return (
     <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
-      <div className="mb-3">
-        <h2 className="text-lg font-semibold text-gray-900">Classical MDS</h2>
-        <p className="text-sm text-gray-600">The dotted circle shows the theoretical order. Stress: {format(mdsStress)}.</p>
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Classical MDS overlay</h2>
+          <p className="text-sm text-gray-600">
+            The dotted ring is the theoretical circumplex. Colored paths show the selected models, all aligned to the same value order.
+          </p>
+        </div>
+        <p className="text-xs text-gray-500">Select more models below to layer them on the same circle.</p>
       </div>
+
       <div className="overflow-x-auto">
-        <svg viewBox={`0 0 ${SIZE} ${SIZE}`} className="block min-w-[320px]">
-          <defs>
-            <marker id="circumplex-arrow" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-              <path d="M0,0 L8,4 L0,8 z" fill="#94a3b8" />
-            </marker>
-          </defs>
+        <svg
+          viewBox={`0 0 ${VIEW_BOX_WIDTH} ${VIEW_BOX_HEIGHT}`}
+          className="block h-auto w-full"
+          data-testid="circumplex-overlay-chart"
+          role="img"
+          aria-label="Circumplex classical MDS overlay chart"
+        >
+          <circle cx={CENTER_X} cy={CENTER_Y} r={RADIUS} fill="none" stroke="#cbd5e1" strokeDasharray="5 5" />
+          <line x1={CENTER_X - RADIUS - 24} y1={CENTER_Y} x2={CENTER_X + RADIUS + 24} y2={CENTER_Y} stroke="#e2e8f0" />
+          <line x1={CENTER_X} y1={CENTER_Y - RADIUS - 24} x2={CENTER_X} y2={CENTER_Y + RADIUS + 24} stroke="#e2e8f0" />
 
-          <circle cx={CENTER} cy={CENTER} r={RADIUS} fill="none" stroke="#cbd5e1" strokeDasharray="4 4" />
-          <line x1={CENTER - RADIUS - 20} y1={CENTER} x2={CENTER + RADIUS + 20} y2={CENTER} stroke="#e2e8f0" />
-          <line x1={CENTER} y1={CENTER - RADIUS - 20} x2={CENTER} y2={CENTER + RADIUS + 20} stroke="#e2e8f0" />
-
-          {mds.map((point) => {
-            const x = CENTER + point.x * scale;
-            const y = CENTER - point.y * scale;
-            const radius = Math.hypot(point.x, point.y);
-            const offAxis = Math.abs(radius - 1);
+          {canonicalValues.map((valueKey, index) => {
+            const angle = (-Math.PI / 2) + ((Math.PI * 2 * index) / canonicalValues.length);
+            const labelPoint = polarToCartesian(angle, LABEL_RADIUS);
+            const guidePoint = polarToCartesian(angle, RADIUS);
             return (
-              <g key={point.valueKey}>
-            <circle cx={x} cy={y} r="6" fill="#0f766e" stroke="#083344" strokeWidth="1.5">
-              <title>
-                    {`${formatFullSchwartzValueName(point.valueKey as ValueKey)} · theoretical angle ${point.theoreticalAngleDeg.toFixed(0)}° · empirical (${point.x.toFixed(2)}, ${point.y.toFixed(2)}) · off-axis ${offAxis.toFixed(2)}`}
-              </title>
-            </circle>
-                <text x={x + 8} y={y - 8} className="fill-gray-700 text-[10px] font-medium">
-                  {VALUE_LABELS[point.valueKey as ValueKey]}
+              <g key={valueKey}>
+                <circle cx={guidePoint.x} cy={guidePoint.y} r="4.5" fill="#ffffff" stroke="#94a3b8" strokeWidth="1.5">
+                  <title>{formatFullSchwartzValueName(valueKey)}</title>
+                </circle>
+                <text
+                  x={labelPoint.x}
+                  y={labelPoint.y + 3}
+                  textAnchor={labelAnchor(angle)}
+                  className="fill-gray-700 text-[10px] font-medium"
+                >
+                  {VALUE_LABELS[valueKey]}
                 </text>
+              </g>
+            );
+          })}
+
+          {results.map((result, seriesIndex) => {
+            const color = SERIES_COLORS[seriesIndex % SERIES_COLORS.length]!;
+            const pointCoords = (result.mds2d ?? []).map((point) => {
+              const x = CENTER_X + point.x * scale;
+              const y = CENTER_Y - point.y * scale;
+              return { x, y, point };
+            });
+            const pathData = buildPath(pointCoords.map((entry) => ({ x: entry.x, y: entry.y })), true);
+            const stressLabel = `stress ${format(result.mdsStress ?? 0)}`;
+
+            return (
+              <g key={result.modelId}>
+                {pathData !== '' && (
+                  <path
+                    d={pathData}
+                    fill="none"
+                    stroke={color}
+                    strokeWidth="2.5"
+                    strokeOpacity="0.55"
+                    strokeLinejoin="round"
+                    strokeLinecap="round"
+                  />
+                )}
+
+                {pointCoords.map(({ x, y, point }) => (
+                  <circle key={`${result.modelId}:${point.valueKey}`} cx={x} cy={y} r="5.5" fill={color} stroke="#ffffff" strokeWidth="1.5">
+                    <title>
+                      {`${result.modelLabel} · ${formatFullSchwartzValueName(point.valueKey as ValueKey)} · empirical (${point.x.toFixed(2)}, ${point.y.toFixed(2)}) · ${stressLabel}`}
+                    </title>
+                  </circle>
+                ))}
               </g>
             );
           })}
         </svg>
       </div>
-      {excludedValues.length > 0 && (
-        <p className="mt-3 text-xs text-gray-500">
-          Excluded from the scatter: {excludedValues.map((valueKey) => VALUE_LABELS[valueKey]).join(', ')}.
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {results.map((result, index) => {
+          const color = SERIES_COLORS[index % SERIES_COLORS.length]!;
+          return (
+            <div
+              key={result.modelId}
+              className="flex items-center gap-2 rounded-full border border-gray-200 bg-gray-50 px-3 py-1.5 text-xs text-gray-700"
+            >
+              <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+              <span className="font-medium">{result.modelLabel}</span>
+              <span className="text-gray-500">{result.providerName}</span>
+              <span className="text-gray-400">ρ {result.spearmanRho == null ? '—' : result.spearmanRho.toFixed(2)}</span>
+              <span className="text-gray-400">stress {format(result.mdsStress ?? 0)}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      {warnings.length > 0 && (
+        <p className="mt-3 text-xs text-amber-700">
+          2D embedding warning for {warnings.map((result) => result.modelLabel).join(', ')}.
         </p>
       )}
     </section>

--- a/cloud/apps/web/src/components/models/CircumplexMethodologyPanel.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexMethodologyPanel.tsx
@@ -19,7 +19,7 @@ const methodologyTooltip = (
       <strong>Closed:</strong> keeps the header compact and hides the longer methodology notes.
     </p>
     <p>
-      <strong>Open:</strong> shows the full explanation in the same top box as the signature and threshold controls.
+      <strong>Open:</strong> shows the full explanation in the same controls area.
     </p>
   </div>
 );

--- a/cloud/apps/web/src/components/models/CircumplexModelCard.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexModelCard.tsx
@@ -1,5 +1,4 @@
 import { CircumplexMatrix } from './CircumplexMatrix';
-import { CircumplexMdsScatter } from './CircumplexMdsScatter';
 import { CircumplexVerdictPanel } from './CircumplexVerdictPanel';
 import type { CircumplexResult } from '../../api/operations/circumplex';
 import type { ValueKey } from '../../data/domainAnalysisData';
@@ -33,20 +32,12 @@ export function CircumplexModelCard({ result }: Props) {
           valueOrder={result.valueOrder as ValueKey[]}
           excludedValues={toExcludedSet(result.excludedValues)}
         />
-        <div className="grid gap-4 xl:grid-cols-[minmax(320px,0.95fr)_minmax(0,1fr)]">
-          <CircumplexMdsScatter
-            mds={result.mds2d}
-            excludedValues={result.excludedValues as ValueKey[]}
-            mdsWarning={result.mdsWarning ?? null}
-            mdsStress={result.mdsStress ?? 0}
-          />
-          <CircumplexVerdictPanel
-            rho={result.spearmanRho ?? null}
-            p={result.spearmanP ?? null}
-            verdictBand={result.verdictBand}
-            excludedValues={result.excludedValues as ValueKey[]}
-          />
-        </div>
+        <CircumplexVerdictPanel
+          rho={result.spearmanRho ?? null}
+          p={result.spearmanP ?? null}
+          verdictBand={result.verdictBand}
+          excludedValues={result.excludedValues as ValueKey[]}
+        />
       </div>
     </section>
   );

--- a/cloud/apps/web/src/components/models/CircumplexModelPicker.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexModelPicker.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { Check, ChevronDown, Lock } from 'lucide-react';
 import { Badge } from '../ui/Badge';
 import { Button } from '../ui/Button';
+import { Select } from '../ui/Select';
 import type { CircumplexInsufficientModel, CircumplexResult } from '../../api/operations/circumplex';
 
 type Props = {
@@ -11,6 +12,10 @@ type Props = {
   onToggle: (modelId: string) => void;
   onSelectAll: () => void;
   onClear: () => void;
+  signatureOptions: Array<{ value: string; label: string }>;
+  selectedSignature: string;
+  onSignatureChange: (value: string) => void;
+  asSection?: boolean;
 };
 
 function trialsLabel(model: CircumplexInsufficientModel): string {
@@ -21,7 +26,18 @@ function trialsLabel(model: CircumplexInsufficientModel): string {
   return `Below threshold · n=${total}`;
 }
 
-export function CircumplexModelPicker({ eligible, insufficient, selectedModelIds, onToggle, onSelectAll, onClear }: Props) {
+export function CircumplexModelPicker({
+  eligible,
+  insufficient,
+  selectedModelIds,
+  onToggle,
+  onSelectAll,
+  onClear,
+  signatureOptions,
+  selectedSignature,
+  onSignatureChange,
+  asSection = true,
+}: Props) {
   const [open, setOpen] = useState(false);
   const allSelected = eligible.length > 0 && selectedModelIds.length === eligible.length;
   const anySelected = selectedModelIds.length > 0;
@@ -37,8 +53,10 @@ export function CircumplexModelPicker({ eligible, insufficient, selectedModelIds
       ? selectedLabels[0] ?? '1 model selected'
       : `${selectedLabels.length} selected: ${selectedLabels.slice(0, 2).join(', ')}${selectedLabels.length > 2 ? ', ...' : ''}`;
 
+  const Wrapper = asSection ? 'section' : 'div';
+
   return (
-    <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+    <Wrapper className={asSection ? 'rounded-xl border border-gray-200 bg-white p-4 md:p-5' : ''}>
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold text-gray-900">Models</h2>
@@ -135,8 +153,25 @@ export function CircumplexModelPicker({ eligible, insufficient, selectedModelIds
               </div>
             </div>
           )}
+
+          <div className="border-t border-gray-200 pt-4">
+            <div className="flex flex-wrap items-end gap-4">
+              <div className="min-w-[220px]">
+                <Select
+                  label="Signature"
+                  options={signatureOptions}
+                  value={selectedSignature}
+                  onChange={onSignatureChange}
+                  placeholder="Select signature"
+                />
+              </div>
+              <p className="text-xs text-gray-500">
+                Analysis is shown for signature <span className="font-medium text-gray-700">{selectedSignature}</span>.
+              </p>
+            </div>
+          </div>
         </div>
       )}
-    </section>
+    </Wrapper>
   );
 }

--- a/cloud/apps/web/src/components/models/CircumplexThresholdControl.tsx
+++ b/cloud/apps/web/src/components/models/CircumplexThresholdControl.tsx
@@ -14,7 +14,6 @@ export function CircumplexThresholdControl({ value, onChange }: Props) {
       label="Minimum trials per value"
       value={String(value)}
       onChange={(event) => onChange(Number.parseInt(event.target.value, 10) || 1)}
-      helperText="Values below the threshold are excluded from the picker."
       className="max-w-[220px]"
     />
   );

--- a/cloud/apps/web/src/pages/ModelsCircumplex.tsx
+++ b/cloud/apps/web/src/pages/ModelsCircumplex.tsx
@@ -4,7 +4,6 @@ import { X } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { Button } from '../components/ui/Button';
-import { Select } from '../components/ui/Select';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import {
   CIRCUMPLEX_ANALYSIS_QUERY,
@@ -210,8 +209,6 @@ export function ModelsCircumplex() {
     setSearchParams(params, { replace: true });
   };
 
-  const signatureOptions = signatures.map((signature) => ({ value: signature, label: signature }));
-
   if (signaturesError != null || rosterError != null || circumplexError != null) {
     return (
       <ErrorMessage
@@ -238,41 +235,11 @@ export function ModelsCircumplex() {
   const hasAnySignatureData = analysisModels.some((result) => result.trialsPerValue.some((entry) => entry.trials > 0));
   const noEligibleModels = eligibleModels.length === 0;
   const noSignatureData = !hasAnySignatureData && roster.length > 0;
+  const signatureOptions = signatures.map((signature) => ({ value: signature, label: signature }));
 
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Models / Circumplex</h1>
-        <p className="text-sm text-gray-600">
-          Check whether a model&apos;s own pairwise choices form Schwartz&apos;s circumplex structure.
-        </p>
-      </div>
-
-      <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
-        <div className="flex flex-wrap items-start gap-4">
-          <div className="w-full md:w-60">
-            <Select
-              label="Signature"
-              options={signatureOptions}
-              value={selectedSignature}
-              onChange={handleSignatureChange}
-              placeholder="Select signature"
-            />
-          </div>
-          <CircumplexThresholdControl value={threshold} onChange={handleThresholdChange} />
-          <CircumplexMethodologyPanel
-            open={methodologyParam === 'open'}
-            onToggleOpen={(open) => {
-              const params = new URLSearchParams(searchParams);
-              params.set('methodology', open ? 'open' : 'closed');
-              setSearchParams(params, { replace: true });
-            }}
-          />
-        </div>
-        <p className="mt-3 text-sm text-gray-600">
-          Eligible models must have at least {threshold} trials on each of the 10 Schwartz values.
-        </p>
-      </section>
+      {selectedResults.length > 0 && <CircumplexMdsScatter results={selectedResults} />}
 
       {selectionNotice != null && (
         <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
@@ -300,44 +267,66 @@ export function ModelsCircumplex() {
       ) : noSignatureData ? (
         <section className="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-600">
           <p className="font-medium text-gray-900">No models have circumplex data for this signature.</p>
-          <p className="mt-1">Try another signature from the dropdown above.</p>
+          <p className="mt-1">Try another signature from the dropdown below.</p>
         </section>
       ) : (
-        <>
-          <CircumplexModelPicker
-            eligible={eligibleModels.map((entry) => entry.result)}
-            insufficient={insufficientModels.map((entry) => {
-              const status = entry.status;
-              return {
-                modelId: entry.result.modelId,
-                modelLabel: entry.result.modelLabel,
-                providerName: entry.result.providerName,
-                reason: status.eligible ? 'below_threshold' : status.reason,
-                trialsPerValue: entry.result.trialsPerValue,
-              };
-            })}
-            selectedModelIds={selectedModelIds}
-            onToggle={handleToggleModel}
-            onSelectAll={handleSelectAll}
-            onClear={handleClearSelection}
-          />
+        <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+          <div className="space-y-2">
+            <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Models / Circumplex</h1>
+            <p className="text-sm text-gray-600">
+              Check whether a model&apos;s own pairwise choices form Schwartz&apos;s circumplex structure.
+            </p>
+          </div>
 
-          {hiddenCount > 0 && (
-            <p className="text-sm text-gray-600">{hiddenCount} model{hiddenCount === 1 ? '' : 's'} hidden due to insufficient data.</p>
-          )}
+          <div className="mt-4 flex flex-wrap items-start gap-4">
+            <CircumplexThresholdControl value={threshold} onChange={handleThresholdChange} />
+            <CircumplexMethodologyPanel
+              open={methodologyParam === 'open'}
+              onToggleOpen={(open) => {
+                const params = new URLSearchParams(searchParams);
+                params.set('methodology', open ? 'open' : 'closed');
+                setSearchParams(params, { replace: true });
+              }}
+            />
+          </div>
 
           {noEligibleModels ? (
-            <section className="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-600">
+            <section className="mt-5 rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-600">
               <p className="font-medium text-gray-900">No models meet the current threshold.</p>
               <p className="mt-1">Lower the threshold to widen the picker.</p>
             </section>
           ) : selectedResults.length === 0 ? (
-            <section className="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-600">
+            <section className="mt-5 rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-600">
               <p className="font-medium text-gray-900">Pick one or more models to see the circumplex panel.</p>
             </section>
           ) : (
-            <div className="space-y-4">
-              <CircumplexMdsScatter results={selectedResults} />
+            <div className="mt-5 space-y-4">
+              <CircumplexModelPicker
+                eligible={eligibleModels.map((entry) => entry.result)}
+                insufficient={insufficientModels.map((entry) => {
+                  const status = entry.status;
+                  return {
+                    modelId: entry.result.modelId,
+                    modelLabel: entry.result.modelLabel,
+                    providerName: entry.result.providerName,
+                    reason: status.eligible ? 'below_threshold' : status.reason,
+                    trialsPerValue: entry.result.trialsPerValue,
+                  };
+                })}
+                selectedModelIds={selectedModelIds}
+                onToggle={handleToggleModel}
+                onSelectAll={handleSelectAll}
+                onClear={handleClearSelection}
+                signatureOptions={signatureOptions}
+                selectedSignature={selectedSignature}
+                onSignatureChange={handleSignatureChange}
+                asSection={false}
+              />
+
+              {hiddenCount > 0 && (
+                <p className="text-sm text-gray-600">{hiddenCount} model{hiddenCount === 1 ? '' : 's'} hidden due to insufficient data.</p>
+              )}
+
               <div data-testid="circumplex-model-card-stack" className="space-y-4">
                 {selectedResults.map((result) => (
                   <CircumplexModelCard key={result.modelId} result={result} />
@@ -345,7 +334,7 @@ export function ModelsCircumplex() {
               </div>
             </div>
           )}
-        </>
+        </section>
       )}
     </div>
   );

--- a/cloud/apps/web/src/pages/ModelsCircumplex.tsx
+++ b/cloud/apps/web/src/pages/ModelsCircumplex.tsx
@@ -16,6 +16,7 @@ import { useAvailableSignatures } from '../hooks/useAvailableSignatures';
 import { CircumplexThresholdControl } from '../components/models/CircumplexThresholdControl';
 import { CircumplexModelPicker } from '../components/models/CircumplexModelPicker';
 import { CircumplexMethodologyPanel } from '../components/models/CircumplexMethodologyPanel';
+import { CircumplexMdsScatter } from '../components/models/CircumplexMdsScatter';
 import { CircumplexModelCard } from '../components/models/CircumplexModelCard';
 import { CircumplexLoadingProgress } from '../components/models/CircumplexLoadingProgress';
 
@@ -335,10 +336,13 @@ export function ModelsCircumplex() {
               <p className="font-medium text-gray-900">Pick one or more models to see the circumplex panel.</p>
             </section>
           ) : (
-            <div data-testid="circumplex-model-card-stack" className="space-y-4">
-              {selectedResults.map((result) => (
-                <CircumplexModelCard key={result.modelId} result={result} />
-              ))}
+            <div className="space-y-4">
+              <CircumplexMdsScatter results={selectedResults} />
+              <div data-testid="circumplex-model-card-stack" className="space-y-4">
+                {selectedResults.map((result) => (
+                  <CircumplexModelCard key={result.modelId} result={result} />
+                ))}
+              </div>
             </div>
           )}
         </>

--- a/cloud/apps/web/tests/components/models/CircumplexMdsScatter.test.tsx
+++ b/cloud/apps/web/tests/components/models/CircumplexMdsScatter.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { CircumplexResult } from '../../../src/api/operations/circumplex';
+import { CircumplexMdsScatter } from '../../../src/components/models/CircumplexMdsScatter';
+import type { ValueKey } from '../../../src/data/domainAnalysisData';
+
+function buildResult(modelId: string, modelLabel: string, shift: number): CircumplexResult {
+  const valueOrder: ValueKey[] = [
+    'Self_Direction_Action',
+    'Universalism_Nature',
+    'Benevolence_Dependability',
+  ];
+
+  return {
+    modelId,
+    modelLabel,
+    providerName: 'openai',
+    signature: 'vnewtd',
+    valueOrder,
+    profileCorrelationMatrix: [],
+    pairTrialCounts: [],
+    excludedValues: [],
+    spearmanRho: 0.72,
+    spearmanP: 0.01,
+    verdictBand: 'clear',
+    mds2d: [
+      { valueKey: 'Self_Direction_Action', x: 0 + shift, y: 0.9, theoreticalAngleDeg: 90 },
+      { valueKey: 'Universalism_Nature', x: 0.75 + shift, y: -0.1, theoreticalAngleDeg: 18 },
+      { valueKey: 'Benevolence_Dependability', x: -0.6 + shift, y: -0.5, theoreticalAngleDeg: -54 },
+    ],
+    mdsStress: 0.12,
+    mdsWarning: null,
+    trialsPerValue: [],
+  } as unknown as CircumplexResult;
+}
+
+describe('CircumplexMdsScatter', () => {
+  it('renders the theoretical circle and overlays multiple selected models', () => {
+    render(
+      <CircumplexMdsScatter
+        results={[
+          buildResult('model-a', 'Model A', 0),
+          buildResult('model-b', 'Model B', 0.12),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('circumplex-overlay-chart')).toBeInTheDocument();
+    expect(screen.getByText('Classical MDS overlay')).toBeInTheDocument();
+    expect(screen.getByText('Model A')).toBeInTheDocument();
+    expect(screen.getByText('Model B')).toBeInTheDocument();
+    expect(screen.getByText('Self-Direction')).toBeInTheDocument();
+    expect(screen.getByText('Universalism')).toBeInTheDocument();
+  });
+});

--- a/cloud/apps/web/tests/components/models/CircumplexModelPicker.test.tsx
+++ b/cloud/apps/web/tests/components/models/CircumplexModelPicker.test.tsx
@@ -35,11 +35,15 @@ describe('CircumplexModelPicker', () => {
         onToggle={() => {}}
         onSelectAll={() => {}}
         onClear={() => {}}
+        signatureOptions={[{ value: 'vnewtd', label: 'vnewtd' }]}
+        selectedSignature="vnewtd"
+        onSignatureChange={() => {}}
       />,
     );
 
     expect(screen.getByText('Model A')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /select all/i })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Signature')).not.toBeInTheDocument();
 
     await act(async () => {
       await user.click(screen.getByRole('button', { name: /model details/i }));
@@ -48,6 +52,9 @@ describe('CircumplexModelPicker', () => {
     expect(screen.getByRole('button', { name: /select all/i })).toBeInTheDocument();
     expect(screen.getByText(/hidden from selection/i)).toBeInTheDocument();
     expect(screen.getByText('Model C')).toBeInTheDocument();
+
+    expect(screen.getByText('Signature')).toBeInTheDocument();
+    expect(screen.getByText(/analysis is shown for signature/i)).toBeInTheDocument();
   });
 
   it('keeps the existing toggle callback for eligible model buttons', async () => {
@@ -62,6 +69,9 @@ describe('CircumplexModelPicker', () => {
         onToggle={handleToggle}
         onSelectAll={() => {}}
         onClear={() => {}}
+        signatureOptions={[{ value: 'vnewtd', label: 'vnewtd' }]}
+        selectedSignature="vnewtd"
+        onSignatureChange={() => {}}
       />,
     );
 

--- a/cloud/apps/web/tests/pages/ModelsCircumplex.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsCircumplex.test.tsx
@@ -4,8 +4,45 @@ import { MemoryRouter } from 'react-router-dom';
 import { ModelsCircumplex } from '../../src/pages/ModelsCircumplex';
 import { LLM_MODELS_QUERY } from '../../src/api/operations/llm';
 import { CIRCUMPLEX_ANALYSIS_QUERY } from '../../src/api/operations/circumplex';
+import type { CircumplexResult } from '../../src/api/operations/circumplex';
 
 const useQueryMock = vi.fn();
+
+function buildCircumplexResult(modelId: string, modelLabel: string): CircumplexResult {
+  return {
+    modelId,
+    modelLabel,
+    providerName: 'openai',
+    signature: 'vnewtd',
+    valueOrder: ['Self_Direction_Action', 'Universalism_Nature', 'Benevolence_Dependability'],
+    profileCorrelationMatrix: [
+      [1, 0.7, 0.2],
+      [0.7, 1, 0.1],
+      [0.2, 0.1, 1],
+    ],
+    pairTrialCounts: [
+      [0, 20, 20],
+      [20, 0, 20],
+      [20, 20, 0],
+    ],
+    excludedValues: [],
+    spearmanRho: -0.61,
+    spearmanP: 0.012,
+    verdictBand: 'clear',
+    mds2d: [
+      { valueKey: 'Self_Direction_Action', x: 0, y: 1, theoreticalAngleDeg: 90 },
+      { valueKey: 'Universalism_Nature', x: 0.8, y: -0.1, theoreticalAngleDeg: 18 },
+      { valueKey: 'Benevolence_Dependability', x: -0.6, y: -0.4, theoreticalAngleDeg: -54 },
+    ],
+    mdsStress: 0.08,
+    mdsWarning: null,
+    trialsPerValue: [
+      { valueKey: 'Self_Direction_Action', trials: 8 },
+      { valueKey: 'Universalism_Nature', trials: 8 },
+      { valueKey: 'Benevolence_Dependability', trials: 8 },
+    ],
+  } as CircumplexResult;
+}
 
 vi.mock('urql', async () => {
   const actual = await vi.importActual<typeof import('urql')>('urql');
@@ -53,22 +90,7 @@ describe('ModelsCircumplex', () => {
         return [{
           data: {
             circumplexAnalysis: {
-              models: [
-                {
-                  modelId: 'model-a',
-                  modelLabel: 'Model A',
-                  providerName: 'openai',
-                  signature: 'vnewtd',
-                  trialsPerValue: [{ valueKey: 'Achievement', trials: 8 }],
-                },
-                {
-                  modelId: 'model-b',
-                  modelLabel: 'Model B',
-                  providerName: 'anthropic',
-                  signature: 'vnewtd',
-                  trialsPerValue: [{ valueKey: 'Achievement', trials: 8 }],
-                },
-              ],
+              models: [buildCircumplexResult('model-a', 'Model A'), buildCircumplexResult('model-b', 'Model B')],
               insufficient: [],
             },
           },
@@ -101,8 +123,9 @@ describe('ModelsCircumplex', () => {
     const stack = screen.getByTestId('circumplex-model-card-stack');
     expect(stack).toHaveClass('space-y-4');
     expect(stack).not.toHaveClass('xl:grid-cols-2');
-    expect(screen.getByText('Model A')).toBeInTheDocument();
-    expect(screen.getByText('Model B')).toBeInTheDocument();
+    expect(screen.getByTestId('circumplex-overlay-chart')).toBeInTheDocument();
+    expect(screen.getAllByText('Model A').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Model B').length).toBeGreaterThan(0);
   });
 
   it('shows estimated progress while circumplex data is loading', () => {

--- a/cloud/apps/web/tests/pages/ModelsCircumplex.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsCircumplex.test.tsx
@@ -114,11 +114,11 @@ describe('ModelsCircumplex', () => {
     );
 
     const methodologyLabel = screen.getByText('How this is computed');
-    const signatureLabel = screen.getByText('Signature');
     const thresholdLabel = screen.getByText('Minimum trials per value');
+    const pickerMock = screen.getByText('Mock circumplex model picker');
 
-    expect(signatureLabel.closest('section')).toBe(thresholdLabel.closest('section'));
     expect(thresholdLabel.closest('section')).toBe(methodologyLabel.closest('section'));
+    expect(pickerMock.closest('section')).toBe(thresholdLabel.closest('section'));
 
     const stack = screen.getByTestId('circumplex-model-card-stack');
     expect(stack).toHaveClass('space-y-4');
@@ -126,6 +126,8 @@ describe('ModelsCircumplex', () => {
     expect(screen.getByTestId('circumplex-overlay-chart')).toBeInTheDocument();
     expect(screen.getAllByText('Model A').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Model B').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Values below the threshold/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Eligible models must have at least/i)).not.toBeInTheDocument();
   });
 
   it('shows estimated progress while circumplex data is loading', () => {


### PR DESCRIPTION
This updates the Models / Circumplex page to make the MDS view easier to read and compare.

What changed:
- Replaced the per-card MDS scatter with a full-width overlay chart.
- Drew the theoretical circumplex as a dotted guide ring.
- Let selected models superimpose their classical MDS points on the same plot.
- Kept the selected model cards stacked below the chart for the detailed matrix and fit summary.

Why:
- The old layout was cluttered and hard to compare across models.
- The new chart makes the circumplex shape the main visual and keeps model comparisons on one shared graph.

Validation:
- `cd cloud && npx turbo lint --filter=@valuerank/web`
- `cd cloud && npx turbo test --filter=@valuerank/web`
- `cd cloud && npx turbo build --filter=@valuerank/web`
- Focused Vitest for the overlay chart and circumplex page tests
