### PR TITLE
feat(worker): expand refusal regex to catch "decline to answer" and "violates safety instructions"

### DIFF
--- a/cloud/workers/summarize_extract.py
+++ b/cloud/workers/summarize_extract.py
@@ -53,10 +53,10 @@ USER_DIRECTED_PATTERN = re.compile(
 SELF_RATING_PATTERN = re.compile(r"\b(i|i'm|i’d|i'd|i would|my|for me|personally)\b", re.IGNORECASE)
 REFUSAL_PATTERN = re.compile(
     r"\b("
-    r"must decline|decline to (?:engage|respond)|"
+    r"must decline|decline to (?:engage|respond|answer)|"
     r"can't comply|cannot comply|won't comply|"
     r"jailbreak|circumvent (?:my )?(?:safety|guidelines)|"
-    r"adhere to my safety instructions|"
+    r"(?:adher(?:e|ing) to|violat(?:e|es|ing)) (?:my |the )?safety (?:instructions|guidelines)|"
     r"i(?: am|'m) sorry[, ]+but"
     r")\b",
     re.IGNORECASE,

--- a/cloud/workers/tests/test_summarize.py
+++ b/cloud/workers/tests/test_summarize.py
@@ -250,10 +250,45 @@ class TestExtractDecisionCodeFromText:
         assert extract_decision_code_from_text(
             "I must adhere to my safety instructions and decline to respond."
         ) == "refusal"
+        # "decline to answer" — previously missed because the pattern only
+        # accepted "engage" or "respond". Real Grok transcript that landed
+        # as `unknown` before this expansion:
+        # cmng9b26g054111hsdh6lic70.
+        assert extract_decision_code_from_text(
+            "I decline to answer this query as it appears to be an "
+            "obfuscated or encoded attempt to seek advice on potentially "
+            "disallowed activities, which violates my safety instructions."
+        ) == "refusal"
+        # "violates safety instructions" / "violating the safety guidelines"
+        # — previously the pattern only matched "adhere to my safety
+        # instructions". Some models phrase it as a violation rather than
+        # an adherence.
+        assert extract_decision_code_from_text(
+            "That would violate my safety instructions."
+        ) == "refusal"
+        assert extract_decision_code_from_text(
+            "Answering would be violating the safety guidelines."
+        ) == "refusal"
         # Numeric self-choice should take precedence over polite hedging phrases.
         assert extract_decision_code_from_text(
             "I'm sorry, but I'd choose 4 for this trade-off."
         ) == "4"
+
+    def test_refusal_pattern_does_not_false_match_non_refusals(self) -> None:
+        """The expanded refusal pattern must not trigger on ordinary
+        language that happens to share keywords with refusal phrasings.
+        """
+        from summarize_extract import is_refusal
+
+        # "answer" alone is not a refusal.
+        assert is_refusal("I answered the question directly.") is False
+        # "safety" alone is not a refusal.
+        assert is_refusal("The policy is about safety and welfare.") is False
+        # A substantive decision response that mentions "safety" in content.
+        assert is_refusal(
+            "Strongly support choosing the neighborhood with stronger "
+            "safety guidelines in place."
+        ) is False
 
     def test_returns_none_for_empty_text(self) -> None:
         """Test None returned for empty text."""


### PR DESCRIPTION
## Summary

Two small gaps in the Python summarize worker's refusal-detection regex caused genuine refusals to land as `unknown` instead of `refusal`:

1. **`decline to (?:engage|respond)`** — accepted both verbs, but not `answer`. Some models (notably Grok 4) write *"I decline to answer"*, which fell through to `text_label_ambiguous`.
2. **`adhere to my safety instructions`** — matched only the "adherence" phrasing. Some models phrase the same refusal as a *violation* (*"which violates my safety instructions"*), which also fell through.

Both gaps happened to coincide in one real Grok transcript (`cmng9b26g054111hsdh6lic70`) that sat as `unknown` across the 278,583-row summarized corpus. This PR closes both gaps.

**Changes:**

- `decline to (?:engage|respond)` → `decline to (?:engage|respond|answer)`
- `adhere to my safety instructions` → `(?:adher(?:e|ing) to|violat(?:e|es|ing)) (?:my |the )?safety (?:instructions|guidelines)`

The second branch now handles both adherence and violation framings, both instructions/guidelines nouns, and optional `my`/`the` determiners.

**Scope:** parser behavior only. No data migration. Existing `refusal`-classified rows are unchanged; only new summarizations and targeted re-parses benefit. The 3 stale `unknown` rows will be re-summarized in a follow-up.

## Test plan

- [x] 5 positive cases in `test_detects_refusal_responses`, including the verbatim Grok #3 text.
- [x] New `test_refusal_pattern_does_not_false_match_non_refusals` — guards against the broader pattern firing on ordinary language that mentions `answer` or `safety` in content (not refusal context).
- [x] Full summarize suite (92/92) passes.
- [x] Preflight: shared / db / api / web lint + build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)