### PR TITLE
Add all-domains scope to domain analysis

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/domain/analysis.ts
+++ b/cloud/apps/api/src/graphql/mutations/domain/analysis.ts
@@ -24,6 +24,7 @@ builder.mutationField('refreshDomainAnalysis', (t) =>
         : null;
 
       const queued = await queueDomainAnalysisRefresh({
+        scope: 'DOMAIN',
         domainId,
         signature,
         reason: 'manual-refresh',
@@ -37,7 +38,11 @@ builder.mutationField('refreshDomainAnalysis', (t) =>
         };
       }
 
-      await refreshDomainAnalysisSnapshot(domainId, signature);
+      await refreshDomainAnalysisSnapshot({
+        scope: 'DOMAIN',
+        domainId,
+        requestedSignature: signature,
+      });
       return {
         success: true,
         mode: 'REFRESHED' as const,

--- a/cloud/apps/api/src/graphql/queries/domain/analysis/domain-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/analysis/domain-analysis.ts
@@ -6,17 +6,20 @@ import {
 import {
   parseDomainAnalysisScoreMethod,
 } from '../shared.js';
+import { parseDomainAnalysisScope } from '../../../../services/analysis/domain-analysis-scope.js';
 
 builder.queryField('domainAnalysis', (t) =>
   t.field({
     type: DomainAnalysisResultRef,
     args: {
       domainId: t.arg.id({ required: true }),
+      scope: t.arg.string({ required: false }),
       scoreMethod: t.arg.string({ required: false }),
       signature: t.arg.string({ required: false }),
     },
     resolve: async (_root, args, ctx) => {
       const domainId = String(args.domainId);
+      const scope = parseDomainAnalysisScope(args.scope);
       const scoreMethod = parseDomainAnalysisScoreMethod(args.scoreMethod);
       const requestedSignature = typeof args.signature === 'string' && args.signature.trim() !== ''
         ? args.signature.trim()
@@ -25,6 +28,7 @@ builder.queryField('domainAnalysis', (t) =>
         ctx.log.warn({ domainId }, 'domainAnalysis called without signature; defaulting to first vnew signature');
       }
       return getDomainAnalysisResult({
+        scope,
         domainId,
         requestedSignature,
         scoreMethod,

--- a/cloud/apps/api/src/graphql/queries/domain/planning.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/planning.ts
@@ -1,5 +1,5 @@
 import { db, Prisma } from '@valuerank/db';
-import { AuthenticationError, NotFoundError } from '@valuerank/shared';
+import { AuthenticationError } from '@valuerank/shared';
 import { builder } from '../../builder.js';
 import {
   DomainEvaluationCostEstimateRef,
@@ -8,15 +8,13 @@ import {
   DomainTrialRunStatusRef,
 } from './types.js';
 import {
-  hydrateDefinitionAncestors,
-  selectLatestDefinitionPerLineage,
-} from './shared.js';
-import {
   buildAvailableSignatureOptions,
   buildTrialRunStatusRows,
 } from './planning-utils.js';
 import { resolveRunAnalysisStatuses } from '../../../services/run/analysis-status.js';
 import { buildDomainEstimate } from './planning-estimate.js';
+import { parseDomainAnalysisScope } from '../../../services/analysis/domain-analysis-scope.js';
+import { resolveDomainAnalysisScopeDefinitions } from '../../../services/analysis/domain-analysis-scope-loader.js';
 
 builder.queryField('domainTrialsPlan', (t) =>
   t.field({
@@ -207,35 +205,20 @@ builder.queryField('domainAvailableSignatures', (t) =>
     type: [DomainAvailableSignatureRef],
     args: {
       domainId: t.arg.id({ required: true }),
+      scope: t.arg.string({ required: false }),
     },
     resolve: async (_root, args, ctx) => {
       if (!ctx.user) {
         throw new AuthenticationError('Authentication required');
       }
       const domainId = String(args.domainId);
-      const domain = await db.domain.findUnique({ where: { id: domainId } });
-      if (!domain) throw new NotFoundError('Domain', domainId);
-
-      const definitions = await db.definition.findMany({
-        where: { domainId, deletedAt: null },
-        select: {
-          id: true,
-          name: true,
-          parentId: true,
-          version: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-      });
-      if (definitions.length === 0) return [];
-
-      const definitionsById = await hydrateDefinitionAncestors(definitions);
-      const latestDefinitions = selectLatestDefinitionPerLineage(definitions, definitionsById);
-      const latestDefinitionIds = latestDefinitions.map((definition) => definition.id);
+      const scope = parseDomainAnalysisScope(args.scope);
+      const scopeData = await resolveDomainAnalysisScopeDefinitions({ scope, domainId });
+      if (scopeData.latestDefinitionIds.length === 0) return [];
 
       const runs = await db.run.findMany({
         where: {
-          definitionId: { in: latestDefinitionIds },
+          definitionId: { in: scopeData.latestDefinitionIds },
           status: 'COMPLETED',
           deletedAt: null,
         },

--- a/cloud/apps/api/src/graphql/queries/domain/shared.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/shared.ts
@@ -45,6 +45,7 @@ export type DomainAnalysisScoreMethod = 'LOG_ODDS' | 'FULL_BT';
 
 export type DefinitionRow = {
   id: string;
+  domainId: string | null;
   name?: string;
   parentId: string | null;
   version: number;

--- a/cloud/apps/api/src/graphql/queries/domain/types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/types.ts
@@ -28,7 +28,7 @@ import type {
 import type {
   DomainAnalysisContributionSummary,
   DomainAnalysisExcludedDataSummary,
-} from '../../services/analysis/domain-analysis-cache-types.js';
+} from '../../../services/analysis/domain-analysis-cache-types.js';
 
 export {
   DomainAnalysisConditionDetailRef,

--- a/cloud/apps/api/src/graphql/queries/domain/types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/types.ts
@@ -25,6 +25,10 @@ import type {
   DomainEvaluationEstimateModel,
   DomainTrialRunStatus,
 } from './shared.js';
+import type {
+  DomainAnalysisContributionSummary,
+  DomainAnalysisExcludedDataSummary,
+} from '../../services/analysis/domain-analysis-cache-types.js';
 
 export {
   DomainAnalysisConditionDetailRef,
@@ -45,6 +49,8 @@ export type DomainAnalysisCacheStatus = 'FRESH' | 'UPDATING' | 'OUT_OF_DATE';
 export type DomainAnalysisResult = {
   domainId: string;
   domainName: string;
+  contributionSummary: DomainAnalysisContributionSummary[];
+  excludedDataSummary: DomainAnalysisExcludedDataSummary[];
   totalDefinitions: number;
   targetedDefinitions: number;
   coveredDefinitions: number;
@@ -70,6 +76,8 @@ export const DomainAnalysisValueScoreRef = builder.objectRef<DomainAnalysisValue
 export const DomainAnalysisModelRef = builder.objectRef<DomainAnalysisModel>('DomainAnalysisModel');
 export const DomainAnalysisUnavailableModelRef = builder.objectRef<DomainAnalysisUnavailableModel>('DomainAnalysisUnavailableModel');
 export const DomainAnalysisMissingDefinitionRef = builder.objectRef<DomainAnalysisMissingDefinition>('DomainAnalysisMissingDefinition');
+export const DomainAnalysisContributionSummaryRef = builder.objectRef<DomainAnalysisContributionSummary>('DomainAnalysisContributionSummary');
+export const DomainAnalysisExcludedDataSummaryRef = builder.objectRef<DomainAnalysisExcludedDataSummary>('DomainAnalysisExcludedDataSummary');
 export const DomainAnalysisResultRef = builder.objectRef<DomainAnalysisResult>('DomainAnalysisResult');
 export const DomainAvailableSignatureRef = builder.objectRef<DomainAvailableSignature>('DomainAvailableSignature');
 export const DomainTrialPlanModelRef = builder.objectRef<DomainTrialPlanModel>('DomainTrialPlanModel');
@@ -81,6 +89,8 @@ export const DomainEvaluationEstimateDefinitionRef = builder.objectRef<DomainEva
 export const DomainEvaluationCostEstimateRef = builder.objectRef<DomainEvaluationCostEstimate>('DomainEvaluationCostEstimate');
 export const DomainTrialModelStatusRef = builder.objectRef<DomainTrialModelStatus>('DomainTrialModelStatus');
 export const DomainTrialRunStatusRef = builder.objectRef<DomainTrialRunStatus>('DomainTrialRunStatus');
+const resolveContributionSummary = (parent: DomainAnalysisResult): DomainAnalysisContributionSummary[] => parent.contributionSummary;
+const resolveExcludedDataSummary = (parent: DomainAnalysisResult): DomainAnalysisExcludedDataSummary[] => parent.excludedDataSummary;
 
 builder.objectType(RankingShapeRef, {
   fields: (t) => ({
@@ -209,10 +219,36 @@ builder.objectType(DomainAnalysisMissingDefinitionRef, {
   }),
 });
 
+builder.objectType(DomainAnalysisContributionSummaryRef, {
+  fields: (t) => ({
+    domainId: t.exposeString('domainId'),
+    domainName: t.exposeString('domainName'),
+    rawTrialCount: t.exposeFloat('rawTrialCount'),
+    share: t.exposeFloat('share'),
+  }),
+});
+
+builder.objectType(DomainAnalysisExcludedDataSummaryRef, {
+  fields: (t) => ({
+    domainId: t.exposeString('domainId'),
+    domainName: t.exposeString('domainName'),
+    reasonCode: t.exposeString('reasonCode'),
+    count: t.exposeFloat('count'),
+  }),
+});
+
 builder.objectType(DomainAnalysisResultRef, {
   fields: (t) => ({
     domainId: t.exposeID('domainId'),
     domainName: t.exposeString('domainName'),
+    contributionSummary: t.field({
+      type: [DomainAnalysisContributionSummaryRef],
+      resolve: resolveContributionSummary,
+    }),
+    excludedDataSummary: t.field({
+      type: [DomainAnalysisExcludedDataSummaryRef],
+      resolve: resolveExcludedDataSummary,
+    }),
     totalDefinitions: t.exposeInt('totalDefinitions'),
     targetedDefinitions: t.exposeInt('targetedDefinitions'),
     coveredDefinitions: t.exposeInt('coveredDefinitions'),

--- a/cloud/apps/api/src/graphql/queries/models-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/models-analysis.ts
@@ -1,7 +1,7 @@
 import { db } from '@valuerank/db';
 import { getModelsFromDatabase } from '../../config/models.js';
 import { buildAssumptionKey, parseSnapshotOutput } from '../../services/analysis/domain-analysis-snapshot-builder.js';
-import { DOMAIN_ANALYSIS_SNAPSHOT_TYPE } from '../../services/analysis/domain-analysis-cache-types.js';
+import { DOMAIN_ANALYSIS_ASSUMPTION_PREFIX, DOMAIN_ANALYSIS_SNAPSHOT_TYPE } from '../../services/analysis/domain-analysis-cache-types.js';
 import { DOMAIN_ANALYSIS_VALUE_KEYS, type DomainAnalysisValueKey } from './domain-analysis-values.js';
 import { builder } from '../builder.js';
 import {
@@ -85,9 +85,9 @@ builder.queryField('modelsAnalysis', (t) =>
       const snapshots = await db.assumptionAnalysisSnapshot.findMany({
         where: {
           assumptionKey: domainId != null
-            ? buildAssumptionKey(domainId)
+            ? buildAssumptionKey('DOMAIN', domainId)
             : {
-                startsWith: buildAssumptionKey(''),
+                startsWith: `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:`,
               },
           analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
           ...(signature != null ? { configSignature: signature } : {}),

--- a/cloud/apps/api/src/queue/handlers/analyze-basic.ts
+++ b/cloud/apps/api/src/queue/handlers/analyze-basic.ts
@@ -264,11 +264,13 @@ export function createAnalyzeBasicHandler(): PgBoss.WorkHandler<AnalyzeBasicJobD
               const exactSignature = formatTrialSignature(requestedExactVersion, temperature);
               await Promise.all([
                 queueDomainAnalysisRefresh({
+                  scope: 'DOMAIN',
                   domainId,
                   signature: formatVnewSignature(temperature),
                   reason: 'analysis-complete',
                 }),
                 queueDomainAnalysisRefresh({
+                  scope: 'DOMAIN',
                   domainId,
                   signature: exactSignature,
                   reason: 'analysis-complete',

--- a/cloud/apps/api/src/queue/handlers/refresh-domain-analysis-snapshot.ts
+++ b/cloud/apps/api/src/queue/handlers/refresh-domain-analysis-snapshot.ts
@@ -8,10 +8,14 @@ const log = createLogger('queue:refresh-domain-analysis-snapshot');
 export function createRefreshDomainAnalysisSnapshotHandler(): PgBoss.WorkHandler<RefreshDomainAnalysisSnapshotJobData> {
   return async (jobs: PgBoss.Job<RefreshDomainAnalysisSnapshotJobData>[]) => {
     for (const job of jobs) {
-      const { domainId, signature, reason } = job.data;
-      log.info({ jobId: job.id, domainId, signature, reason }, 'Refreshing domain analysis snapshot');
-      await refreshDomainAnalysisSnapshot(domainId, signature);
-      log.info({ jobId: job.id, domainId, signature, reason }, 'Domain analysis snapshot refreshed');
+      const { scope, domainId, signature, reason } = job.data;
+      log.info({ jobId: job.id, scope, domainId, signature, reason }, 'Refreshing domain analysis snapshot');
+      await refreshDomainAnalysisSnapshot({
+        scope,
+        domainId,
+        requestedSignature: signature,
+      });
+      log.info({ jobId: job.id, scope, domainId, signature, reason }, 'Domain analysis snapshot refreshed');
     }
   };
 }

--- a/cloud/apps/api/src/queue/types.ts
+++ b/cloud/apps/api/src/queue/types.ts
@@ -66,6 +66,7 @@ export type AggregateAnalysisJobData = {
 };
 
 export type RefreshDomainAnalysisSnapshotJobData = {
+  scope: 'DOMAIN' | 'ALL_DOMAINS';
   domainId: string;
   signature: string | null;
   reason: string;

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
@@ -5,6 +5,7 @@ import type {
   DomainAnalysisValueCounts,
   resolveSignatureRuns,
 } from '../../graphql/queries/domain/shared.js';
+import type { DomainAnalysisScope } from './domain-analysis-scope.js';
 
 export const DOMAIN_ANALYSIS_CACHE_STATUS = {
   FRESH: 'FRESH',
@@ -16,7 +17,7 @@ export type DomainAnalysisCacheStatus =
   (typeof DOMAIN_ANALYSIS_CACHE_STATUS)[keyof typeof DOMAIN_ANALYSIS_CACHE_STATUS];
 
 export const DOMAIN_ANALYSIS_SNAPSHOT_TYPE = 'domain_overview';
-export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.3.0';
+export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.4.0';
 export const DOMAIN_ANALYSIS_ASSUMPTION_PREFIX = 'domain-analysis';
 export const DOMAIN_ANALYSIS_NONE_SIGNATURE = '__none__';
 
@@ -32,15 +33,32 @@ export type DomainAnalysisSnapshotModel = {
   vignetteCount?: Record<string, number>;
 };
 
+export type DomainAnalysisContributionSummary = {
+  domainId: string;
+  domainName: string;
+  rawTrialCount: number;
+  share: number;
+};
+
+export type DomainAnalysisExcludedDataSummary = {
+  domainId: string;
+  domainName: string;
+  reasonCode: 'SCHEMA_INCOMPATIBLE' | 'NO_ANALYSIS';
+  count: number;
+};
+
 export type DomainAnalysisSnapshotOutput = {
   domainId: string;
   domainName: string;
+  scope: DomainAnalysisScope;
   totalDefinitions: number;
   targetedDefinitions: number;
   coveredDefinitions: number;
   definitionsWithAnalysis: number;
   missingDefinitions: DomainAnalysisMissingDefinition[];
   models: DomainAnalysisSnapshotModel[];
+  contributionSummary: DomainAnalysisContributionSummary[];
+  excludedDataSummary: DomainAnalysisExcludedDataSummary[];
 };
 
 export type AnalysisFingerprintRow = {
@@ -55,11 +73,14 @@ export type AnalysisOutputRow = {
 };
 
 export type DomainAnalysisPreparedState = {
+  scope: DomainAnalysisScope;
   domain: { id: string; name: string; defaultModelIds: string[] };
+  domains: Array<{ id: string; name: string; defaultModelIds: string[] }>;
   definitions: DefinitionRow[];
   latestDefinitions: DefinitionRow[];
   latestDefinitionIds: string[];
   definitionNameById: Map<string, string>;
+  definitionDomainIdById: Map<string, string>;
   resolvedSignatureRuns: Awaited<ReturnType<typeof resolveSignatureRuns>>;
   selectedSignature: string | null;
   configSignature: string;

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -32,17 +32,20 @@ import {
   buildSnapshotOutput,
   writeSnapshot,
 } from './domain-analysis-snapshot-builder.js';
+import type { DomainAnalysisScope } from './domain-analysis-scope.js';
+import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE } from './domain-analysis-scope.js';
 
 const log = createLogger('analysis:domain-cache');
 
 async function getCurrentSnapshot(
   client: SnapshotClient,
+  scope: DomainAnalysisScope,
   domainId: string,
   configSignature: string,
 ) {
   return client.assumptionAnalysisSnapshot.findFirst({
     where: {
-      assumptionKey: buildAssumptionKey(domainId),
+      assumptionKey: buildAssumptionKey(scope, domainId),
       analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
       configSignature,
       status: 'CURRENT',
@@ -79,9 +82,6 @@ function buildDomainAnalysisResultFromSnapshot(params: {
       const score = params.scoreMethod === 'FULL_BT'
         ? (btScores?.get(valueKey) ?? 0)
         : computeSmoothedLogOddsScore(wins, losses);
-      // Counts may be fractional after run-count normalisation (equal-weight per vignette).
-      // Fractional values (e.g. 10.5) signal that a vignette was run multiple times with
-      // mixed results — preserve the decimal so the UI can surface that inconsistency.
       return {
         valueKey,
         score,
@@ -127,7 +127,7 @@ function buildDomainAnalysisResultFromSnapshot(params: {
     .map((model) => ({
       model: model.modelId,
       label: model.displayName,
-      reason: 'No aggregate analysis data available for selected domain.',
+      reason: 'No aggregate analysis data available for selected scope.',
     }));
 
   const missingDefinitions = params.snapshot.missingDefinitions.map((missing) => ({
@@ -151,16 +151,19 @@ function buildDomainAnalysisResultFromSnapshot(params: {
     rankingShapeBenchmarks: benchmarks,
     clusterAnalysis,
     cacheStatus: params.cacheStatus,
+    contributionSummary: params.snapshot.contributionSummary ?? [],
+    excludedDataSummary: params.snapshot.excludedDataSummary ?? [],
   };
 }
 
 export async function queueDomainAnalysisRefresh(params: {
+  scope: DomainAnalysisScope;
   domainId: string;
   signature: string | null;
   reason: string;
 }): Promise<boolean> {
   if (!isBossRunning()) {
-    log.warn({ domainId: params.domainId, signature: params.signature, reason: params.reason }, 'Domain analysis refresh skipped because queue is unavailable');
+    log.warn({ scope: params.scope, domainId: params.domainId, signature: params.signature, reason: params.reason }, 'Domain analysis refresh skipped because queue is unavailable');
     return false;
   }
 
@@ -169,24 +172,34 @@ export async function queueDomainAnalysisRefresh(params: {
   await boss.send(
     'refresh_domain_analysis_snapshot',
     {
+      scope: params.scope,
       domainId: params.domainId,
       signature: params.signature,
       reason: params.reason,
     },
     {
       ...DEFAULT_JOB_OPTIONS.refresh_domain_analysis_snapshot,
-      singletonKey: `domain-analysis:${params.domainId}:${normalizedSignature}`,
+      singletonKey: `domain-analysis:${params.scope}:${params.scope === 'ALL_DOMAINS' ? DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE : params.domainId}:${normalizedSignature}`,
     },
   );
   return true;
 }
 
-export async function refreshDomainAnalysisSnapshot(domainId: string, requestedSignature: string | null) {
-  const state = await prepareDomainAnalysisState(domainId, requestedSignature);
+export async function refreshDomainAnalysisSnapshot(params: {
+  scope: DomainAnalysisScope;
+  domainId: string;
+  requestedSignature: string | null;
+}) {
+  const state = await prepareDomainAnalysisState({
+    scope: params.scope,
+    domainId: params.domainId,
+    requestedSignature: params.requestedSignature,
+  });
   const output = await buildSnapshotOutput(state);
   const snapshot = await db.$transaction((tx) => writeSnapshot({
     client: tx,
-    domainId,
+    scope: state.scope,
+    domainId: state.domain.id,
     configSignature: state.configSignature,
     inputHash: state.inputHash,
     output,
@@ -199,11 +212,16 @@ export async function refreshDomainAnalysisSnapshot(domainId: string, requestedS
 }
 
 export async function getDomainAnalysisResult(params: {
+  scope: DomainAnalysisScope;
   domainId: string;
   requestedSignature: string | null;
   scoreMethod: DomainAnalysisScoreMethod;
 }): Promise<DomainAnalysisResult> {
-  const state = await prepareDomainAnalysisState(params.domainId, params.requestedSignature);
+  const state = await prepareDomainAnalysisState({
+    scope: params.scope,
+    domainId: params.domainId,
+    requestedSignature: params.requestedSignature,
+  });
   const activeModels = await db.llmModel.findMany({
     where: { status: 'ACTIVE' },
     select: { modelId: true, displayName: true },
@@ -223,16 +241,18 @@ export async function getDomainAnalysisResult(params: {
       unavailableModels: activeModels.map((model) => ({
         model: model.modelId,
         label: model.displayName,
-        reason: 'No analyzed vignettes found in this domain.',
+        reason: 'No analyzed vignettes found in this scope.',
       })),
       generatedAt: new Date(),
       rankingShapeBenchmarks: { domainMeanTopGap: 0, domainStdTopGap: null, medianSpread: 0 },
-      clusterAnalysis: { clusters: [], faultLinesByPair: {}, defaultPair: null, skipped: true, skipReason: 'No vignettes found in this domain.' },
+      clusterAnalysis: { clusters: [], faultLinesByPair: {}, defaultPair: null, skipped: true, skipReason: 'No vignettes found in this scope.' },
       cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.FRESH,
+      contributionSummary: [],
+      excludedDataSummary: [],
     };
   }
 
-  const currentSnapshot = await getCurrentSnapshot(db, params.domainId, state.configSignature);
+  const currentSnapshot = await getCurrentSnapshot(db, state.scope, state.domain.id, state.configSignature);
   const parsedCurrent = currentSnapshot != null ? parseSnapshotOutput(currentSnapshot.output) : null;
 
   if (currentSnapshot != null && parsedCurrent != null && currentSnapshot.inputHash === state.inputHash) {
@@ -247,7 +267,8 @@ export async function getDomainAnalysisResult(params: {
 
   if (currentSnapshot != null && parsedCurrent != null) {
     const queued = await queueDomainAnalysisRefresh({
-      domainId: params.domainId,
+      scope: state.scope,
+      domainId: state.domain.id,
       signature: state.selectedSignature,
       reason: 'page-load-stale',
     });
@@ -260,7 +281,11 @@ export async function getDomainAnalysisResult(params: {
     });
   }
 
-  const refreshed = await refreshDomainAnalysisSnapshot(params.domainId, state.selectedSignature);
+  const refreshed = await refreshDomainAnalysisSnapshot({
+    scope: state.scope,
+    domainId: state.domain.id,
+    requestedSignature: state.selectedSignature,
+  });
   const parsedFresh = parseSnapshotOutput(refreshed.snapshot.output);
   if (parsedFresh == null) {
     throw new ValidationError('Domain analysis snapshot could not be parsed after refresh');

--- a/cloud/apps/api/src/services/analysis/domain-analysis-scope-loader.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-scope-loader.ts
@@ -1,0 +1,302 @@
+import { db } from '@valuerank/db';
+import { NotFoundError } from '@valuerank/shared';
+import { hydrateDefinitionAncestors, selectLatestDefinitionPerLineage } from '../../graphql/queries/domain/shared.js';
+import type { AnalysisOutputRow, DomainAnalysisContributionSummary, DomainAnalysisExcludedDataSummary } from './domain-analysis-cache-types.js';
+import {
+  type DomainAnalysisScope,
+  DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE,
+} from './domain-analysis-scope.js';
+import type { DomainAnalysisValuePair } from '../../graphql/queries/domain-analysis-values.js';
+
+export type DomainAnalysisScopeDefinitionSet = {
+  scope: DomainAnalysisScope;
+  domain: { id: string; name: string; defaultModelIds: string[] };
+  domains: Array<{ id: string; name: string; defaultModelIds: string[] }>;
+  definitions: Array<{
+    id: string;
+    domainId: string | null;
+    name: string;
+    parentId: string | null;
+    version: number;
+    createdAt: Date;
+    updatedAt: Date;
+  }>;
+  latestDefinitions: Array<{
+    id: string;
+    domainId: string | null;
+    name: string;
+    parentId: string | null;
+    version: number;
+    createdAt: Date;
+    updatedAt: Date;
+  }>;
+  latestDefinitionIds: string[];
+  definitionNameById: Map<string, string>;
+  definitionDomainIdById: Map<string, string>;
+};
+
+function parseCount(raw: unknown) {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { prioritized: 0, deprioritized: 0, neutral: 0 };
+  }
+  const record = raw as Record<string, unknown>;
+  const prioritized = typeof record.prioritized === 'number' && Number.isFinite(record.prioritized) ? record.prioritized : 0;
+  const deprioritized = typeof record.deprioritized === 'number' && Number.isFinite(record.deprioritized) ? record.deprioritized : 0;
+  const neutral = typeof record.neutral === 'number' && Number.isFinite(record.neutral) ? record.neutral : 0;
+  return { prioritized, deprioritized, neutral };
+}
+
+function getValueCountsFromAnalysis(output: unknown, modelId: string, valueKey: string) {
+  if (output == null || typeof output !== 'object' || Array.isArray(output)) {
+    return { prioritized: 0, deprioritized: 0, neutral: 0 };
+  }
+  const perModel = (output as { perModel?: unknown }).perModel;
+  if (perModel == null || typeof perModel !== 'object' || Array.isArray(perModel)) {
+    return { prioritized: 0, deprioritized: 0, neutral: 0 };
+  }
+  const modelData = (perModel as Record<string, unknown>)[modelId];
+  if (modelData == null || typeof modelData !== 'object' || Array.isArray(modelData)) {
+    return { prioritized: 0, deprioritized: 0, neutral: 0 };
+  }
+  const values = (modelData as { values?: unknown }).values;
+  if (values == null || typeof values !== 'object' || Array.isArray(values)) {
+    return { prioritized: 0, deprioritized: 0, neutral: 0 };
+  }
+
+  const valuesRecord = values as Record<string, unknown>;
+  const keyLower = valueKey.toLowerCase();
+  const valueData = valuesRecord[valueKey]
+    ?? Object.entries(valuesRecord).find(([k]) => k.toLowerCase() === keyLower)?.[1];
+  if (valueData == null || typeof valueData !== 'object' || Array.isArray(valueData)) {
+    return { prioritized: 0, deprioritized: 0, neutral: 0 };
+  }
+  return parseCount((valueData as { count?: unknown }).count);
+}
+
+function getRawTrialCountFromAnalysisRow(output: unknown, pair: DomainAnalysisValuePair): number {
+  if (output == null || typeof output !== 'object' || Array.isArray(output)) return 0;
+  const perModel = (output as { perModel?: unknown }).perModel;
+  if (perModel == null || typeof perModel !== 'object' || Array.isArray(perModel)) return 0;
+
+  let total = 0;
+  for (const modelId of Object.keys(perModel as Record<string, unknown>)) {
+    const counts = getValueCountsFromAnalysis(output, modelId, pair.valueA);
+    total += counts.prioritized + counts.deprioritized + counts.neutral;
+  }
+  return total;
+}
+
+export function buildContributionAndExcludedSummary(params: {
+  domainNameById: Map<string, string>;
+  definitionDomainIdById: Map<string, string>;
+  valuePairByDefinition: Map<string, DomainAnalysisValuePair>;
+  analysisRows: AnalysisOutputRow[];
+  filteredSourceRunDefinitionById: Map<string, string>;
+}): {
+  contributionSummary: DomainAnalysisContributionSummary[];
+  excludedDataSummary: DomainAnalysisExcludedDataSummary[];
+} {
+  const analysisRowsByRunId = new Map(params.analysisRows.map((row) => [row.runId, row]));
+  const contributionByDomain = new Map<string, number>();
+  const excludedByDomainReason = new Map<string, number>();
+
+  const addExcluded = (domainId: string, reasonCode: DomainAnalysisExcludedDataSummary['reasonCode']) => {
+    const key = `${domainId}::${reasonCode}`;
+    excludedByDomainReason.set(key, (excludedByDomainReason.get(key) ?? 0) + 1);
+  };
+
+  for (const [runId, definitionId] of params.filteredSourceRunDefinitionById.entries()) {
+    const domainId = params.definitionDomainIdById.get(definitionId);
+    if (domainId == null) continue;
+    const pair = params.valuePairByDefinition.get(definitionId);
+    const analysisRow = analysisRowsByRunId.get(runId);
+
+    if (pair == null) {
+      addExcluded(domainId, 'SCHEMA_INCOMPATIBLE');
+      continue;
+    }
+
+    if (analysisRow == null) {
+      addExcluded(domainId, 'NO_ANALYSIS');
+      continue;
+    }
+
+    const rawTrialCount = getRawTrialCountFromAnalysisRow(analysisRow.output, pair);
+    if (rawTrialCount <= 0) {
+      addExcluded(domainId, 'NO_ANALYSIS');
+      continue;
+    }
+
+    contributionByDomain.set(domainId, (contributionByDomain.get(domainId) ?? 0) + rawTrialCount);
+  }
+
+  const domainNameById = params.domainNameById;
+  const totalContribution = Array.from(contributionByDomain.values()).reduce((sum, value) => sum + value, 0);
+  const sortedContributions = Array.from(contributionByDomain.entries())
+    .map(([domainId, rawTrialCount]) => ({
+      domainId,
+      domainName: domainNameById.get(domainId) ?? domainId,
+      rawTrialCount,
+    }))
+    .sort((left, right) => right.rawTrialCount - left.rawTrialCount || left.domainName.localeCompare(right.domainName));
+
+  const topContributions = sortedContributions.slice(0, 5);
+  const remainingContribution = sortedContributions.slice(5).reduce((sum, entry) => sum + entry.rawTrialCount, 0);
+
+  const contributionSummary: DomainAnalysisContributionSummary[] = totalContribution > 0
+    ? [
+        ...topContributions.map((entry) => ({
+          domainId: entry.domainId,
+          domainName: entry.domainName,
+          rawTrialCount: entry.rawTrialCount,
+          share: entry.rawTrialCount / totalContribution,
+        })),
+        ...(remainingContribution > 0
+          ? [{
+              domainId: 'other-domains',
+              domainName: 'Other domains',
+              rawTrialCount: remainingContribution,
+              share: remainingContribution / totalContribution,
+            }]
+          : []),
+      ]
+    : [];
+
+  const excludedDataSummary: DomainAnalysisExcludedDataSummary[] = Array.from(excludedByDomainReason.entries())
+    .map(([key, count]) => {
+      const [domainId, reasonCode] = key.split('::');
+      return {
+        domainId,
+        domainName: domainNameById.get(domainId) ?? domainId,
+        reasonCode: reasonCode as DomainAnalysisExcludedDataSummary['reasonCode'],
+        count,
+      };
+    })
+    .sort((left, right) => right.count - left.count || left.domainName.localeCompare(right.domainName) || left.reasonCode.localeCompare(right.reasonCode));
+
+  return { contributionSummary, excludedDataSummary };
+}
+
+export async function resolveDomainAnalysisScopeDefinitions(params: {
+  scope: DomainAnalysisScope;
+  domainId: string;
+}): Promise<DomainAnalysisScopeDefinitionSet> {
+  if (params.scope === 'ALL_DOMAINS') {
+    const domains = await db.domain.findMany({
+      select: { id: true, name: true, defaultModelIds: true },
+      orderBy: [{ name: 'asc' }, { id: 'asc' }],
+    });
+
+    const definitions = domains.length === 0
+      ? []
+      : await db.definition.findMany({
+          where: { domainId: { in: domains.map((domain) => domain.id) }, deletedAt: null },
+          select: {
+            id: true,
+            domainId: true,
+            name: true,
+            parentId: true,
+            version: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        });
+
+    const definitionsById = await hydrateDefinitionAncestors(definitions);
+    const latestDefinitions = selectLatestDefinitionPerLineage(definitions, definitionsById).filter((definition) => definition.domainId != null) as Array<{
+      id: string;
+      domainId: string;
+      name: string;
+      parentId: string | null;
+      version: number;
+      createdAt: Date;
+      updatedAt: Date;
+    }>;
+    const latestDefinitionIds = latestDefinitions.map((definition) => definition.id);
+    const definitionNameById = new Map<string, string>(
+      definitions.map((definition) => [definition.id, definition.name ?? definition.id]),
+    );
+    const definitionsWithDomainId = definitions.filter((definition) => definition.domainId != null) as Array<{
+      id: string;
+      domainId: string;
+      name: string;
+      parentId: string | null;
+      version: number;
+      createdAt: Date;
+      updatedAt: Date;
+    }>;
+    const definitionDomainIdById = new Map<string, string>(
+      definitionsWithDomainId.map((definition) => [definition.id, definition.domainId]),
+    );
+
+    return {
+      scope: 'ALL_DOMAINS',
+      domain: { id: DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE, name: 'All domains', defaultModelIds: [] },
+      domains,
+      definitions,
+      latestDefinitions,
+      latestDefinitionIds,
+      definitionNameById,
+      definitionDomainIdById,
+    };
+  }
+
+  const domain = await db.domain.findUnique({
+    where: { id: params.domainId },
+    select: { id: true, name: true, defaultModelIds: true },
+  });
+  if (!domain) {
+    throw new NotFoundError('Domain', params.domainId);
+  }
+
+  const definitions = await db.definition.findMany({
+    where: { domainId: params.domainId, deletedAt: null },
+    select: {
+      id: true,
+      domainId: true,
+      name: true,
+      parentId: true,
+      version: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  const definitionsById = await hydrateDefinitionAncestors(definitions);
+  const latestDefinitions = selectLatestDefinitionPerLineage(definitions, definitionsById).filter((definition) => definition.domainId != null) as Array<{
+    id: string;
+    domainId: string;
+    name: string;
+    parentId: string | null;
+    version: number;
+    createdAt: Date;
+    updatedAt: Date;
+  }>;
+  const latestDefinitionIds = latestDefinitions.map((definition) => definition.id);
+  const definitionNameById = new Map<string, string>(
+    definitions.map((definition) => [definition.id, definition.name ?? definition.id]),
+  );
+  const definitionsWithDomainId = definitions.filter((definition) => definition.domainId != null) as Array<{
+    id: string;
+    domainId: string;
+    name: string;
+    parentId: string | null;
+    version: number;
+    createdAt: Date;
+    updatedAt: Date;
+  }>;
+  const definitionDomainIdById = new Map<string, string>(
+    definitionsWithDomainId.map((definition) => [definition.id, definition.domainId]),
+  );
+
+  return {
+    scope: 'DOMAIN',
+    domain,
+    domains: [domain],
+    definitions,
+    latestDefinitions,
+    latestDefinitionIds,
+    definitionNameById,
+    definitionDomainIdById,
+  };
+}

--- a/cloud/apps/api/src/services/analysis/domain-analysis-scope-loader.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-scope-loader.ts
@@ -164,11 +164,12 @@ export function buildContributionAndExcludedSummary(params: {
 
   const excludedDataSummary: DomainAnalysisExcludedDataSummary[] = Array.from(excludedByDomainReason.entries())
     .map(([key, count]) => {
-      const [domainId, reasonCode] = key.split('::');
+      const [domainId, reasonCode] = key.split('::') as [string, DomainAnalysisExcludedDataSummary['reasonCode']];
+      const domainName = domainNameById.get(domainId) ?? domainId;
       return {
         domainId,
-        domainName: domainNameById.get(domainId) ?? domainId,
-        reasonCode: reasonCode as DomainAnalysisExcludedDataSummary['reasonCode'],
+        domainName,
+        reasonCode,
         count,
       };
     })

--- a/cloud/apps/api/src/services/analysis/domain-analysis-scope.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-scope.ts
@@ -1,0 +1,11 @@
+export const DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE = 'all-domains' as const;
+
+export type DomainAnalysisScope = 'DOMAIN' | 'ALL_DOMAINS';
+
+export function parseDomainAnalysisScope(value: string | null | undefined): DomainAnalysisScope {
+  return value === DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE ? 'ALL_DOMAINS' : 'DOMAIN';
+}
+
+export function formatDomainAnalysisScope(scope: DomainAnalysisScope): string | null {
+  return scope === 'ALL_DOMAINS' ? DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE : null;
+}

--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
@@ -1,12 +1,5 @@
 import { db } from '@valuerank/db';
-import { NotFoundError } from '@valuerank/shared';
-import {
-  getMissingReasonLabel,
-  hydrateDefinitionAncestors,
-  resolveSignatureRuns,
-  resolveValuePairsInChunks,
-  selectLatestDefinitionPerLineage,
-} from '../../graphql/queries/domain/shared.js';
+import { getMissingReasonLabel, resolveSignatureRuns, resolveValuePairsInChunks } from '../../graphql/queries/domain/shared.js';
 import { computeAggregateFingerprint } from './aggregate/aggregate-helpers.js';
 import {
   DOMAIN_ANALYSIS_ASSUMPTION_PREFIX,
@@ -20,9 +13,16 @@ import {
   type SnapshotClient,
 } from './domain-analysis-cache-types.js';
 import { aggregateAnalysisRows } from './domain-analysis-snapshot-aggregator.js';
+import { type DomainAnalysisScope } from './domain-analysis-scope.js';
+import {
+  buildContributionAndExcludedSummary,
+  resolveDomainAnalysisScopeDefinitions,
+} from './domain-analysis-scope-loader.js';
 
-export function buildAssumptionKey(domainId: string): string {
-  return `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:${domainId}`;
+export function buildAssumptionKey(scope: DomainAnalysisScope, domainId: string): string {
+  return scope === 'ALL_DOMAINS'
+    ? `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:all-domains`
+    : `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:${domainId}`;
 }
 
 export function normalizeSignature(signature: string | null): string {
@@ -48,14 +48,16 @@ export function parseSnapshotOutput(raw: unknown): DomainAnalysisSnapshotOutput 
 }
 
 export function computeInputHash(params: {
-  domainId: string;
+  scope: DomainAnalysisScope;
+  domainIds: string[];
   signature: string;
   latestDefinitions: Array<{ id: string; updatedAt: Date }>;
   fingerprints: AnalysisFingerprintRow[];
 }): string {
   return computeAggregateFingerprint({
     codeVersion: DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION,
-    domainId: params.domainId,
+    scope: params.scope,
+    domainIds: params.domainIds.slice().sort(),
     signature: params.signature,
     definitions: params.latestDefinitions.map((definition) => ({
       id: definition.id,
@@ -68,69 +70,53 @@ export function computeInputHash(params: {
   }).slice(0, 16);
 }
 
-export async function prepareDomainAnalysisState(
-  domainId: string,
-  requestedSignature: string | null,
-): Promise<DomainAnalysisPreparedState> {
-  const domain = await db.domain.findUnique({
-    where: { id: domainId },
-    select: { id: true, name: true, defaultModelIds: true },
-  });
-  if (!domain) {
-    throw new NotFoundError('Domain', domainId);
-  }
-
-  const definitions = await db.definition.findMany({
-    where: { domainId, deletedAt: null },
-    select: {
-      id: true,
-      name: true,
-      parentId: true,
-      version: true,
-      createdAt: true,
-      updatedAt: true,
-    },
+export async function prepareDomainAnalysisState(params: {
+  scope: DomainAnalysisScope;
+  domainId: string;
+  requestedSignature: string | null;
+}): Promise<DomainAnalysisPreparedState> {
+  const scopeData = await resolveDomainAnalysisScopeDefinitions({
+    scope: params.scope,
+    domainId: params.domainId,
   });
 
-  const definitionsById = await hydrateDefinitionAncestors(definitions);
-  const latestDefinitions = selectLatestDefinitionPerLineage(definitions, definitionsById);
-  const latestDefinitionIds = latestDefinitions.map((definition) => definition.id);
-  const definitionNameById = new Map<string, string>(
-    definitions.map((definition) => [definition.id, definition.name ?? definition.id]),
-  );
-
-  const resolvedSignatureRuns = await resolveSignatureRuns(latestDefinitionIds, requestedSignature, domain.defaultModelIds);
+  const defaultModelIds = scopeData.scope === 'ALL_DOMAINS' ? [] : scopeData.domain.defaultModelIds;
+  const resolvedSignatureRuns = await resolveSignatureRuns(scopeData.latestDefinitionIds, params.requestedSignature, defaultModelIds);
   const selectedSignature = resolvedSignatureRuns.selectedSignature;
   const configSignature = normalizeSignature(selectedSignature);
 
   const fingerprintRows = resolvedSignatureRuns.filteredSourceRunIds.length === 0
     ? []
     : await db.analysisResult.findMany({
-      where: {
-        runId: { in: resolvedSignatureRuns.filteredSourceRunIds },
-        analysisType: 'basic',
-        status: 'CURRENT',
-        deletedAt: null,
-      },
-      select: {
-        runId: true,
-        inputHash: true,
-      },
-    });
+        where: {
+          runId: { in: resolvedSignatureRuns.filteredSourceRunIds },
+          analysisType: 'basic',
+          status: 'CURRENT',
+          deletedAt: null,
+        },
+        select: {
+          runId: true,
+          inputHash: true,
+        },
+      });
 
   const inputHash = computeInputHash({
-    domainId,
+    scope: scopeData.scope,
+    domainIds: scopeData.domains.map((domain) => domain.id),
     signature: configSignature,
-    latestDefinitions,
+    latestDefinitions: scopeData.latestDefinitions,
     fingerprints: fingerprintRows,
   });
 
   return {
-    domain,
-    definitions,
-    latestDefinitions,
-    latestDefinitionIds,
-    definitionNameById,
+    scope: scopeData.scope,
+    domain: scopeData.domain,
+    domains: scopeData.domains,
+    definitions: scopeData.definitions,
+    latestDefinitions: scopeData.latestDefinitions,
+    latestDefinitionIds: scopeData.latestDefinitionIds,
+    definitionNameById: scopeData.definitionNameById,
+    definitionDomainIdById: scopeData.definitionDomainIdById,
     resolvedSignatureRuns,
     selectedSignature,
     configSignature,
@@ -146,22 +132,31 @@ export async function buildSnapshotOutput(
   const analysisRows: AnalysisOutputRow[] = state.resolvedSignatureRuns.filteredSourceRunIds.length === 0
     ? []
     : await db.analysisResult.findMany({
-      where: {
-        runId: { in: state.resolvedSignatureRuns.filteredSourceRunIds },
-        analysisType: 'basic',
-        status: 'CURRENT',
-        deletedAt: null,
-      },
-      select: {
-        runId: true,
-        inputHash: true,
-        output: true,
-      },
-    });
+        where: {
+          runId: { in: state.resolvedSignatureRuns.filteredSourceRunIds },
+          analysisType: 'basic',
+          status: 'CURRENT',
+          deletedAt: null,
+        },
+        select: {
+          runId: true,
+          inputHash: true,
+          output: true,
+        },
+      });
 
   const { models, analyzedDefinitionIds } = aggregateAnalysisRows({
     analysisRows,
     valuePairByDefinition,
+    filteredSourceRunDefinitionById: state.resolvedSignatureRuns.filteredSourceRunDefinitionById,
+  });
+
+  const domainNameById = new Map(state.domains.map((domain) => [domain.id, domain.name]));
+  const { contributionSummary, excludedDataSummary } = buildContributionAndExcludedSummary({
+    domainNameById,
+    definitionDomainIdById: state.definitionDomainIdById,
+    valuePairByDefinition,
+    analysisRows,
     filteredSourceRunDefinitionById: state.resolvedSignatureRuns.filteredSourceRunDefinitionById,
   });
 
@@ -189,57 +184,35 @@ export async function buildSnapshotOutput(
   return {
     domainId: state.domain.id,
     domainName: state.domain.name,
+    scope: state.scope,
     totalDefinitions: state.definitions.length,
     targetedDefinitions: state.latestDefinitions.length,
     coveredDefinitions: state.resolvedSignatureRuns.coveredDefinitionIds.size,
     definitionsWithAnalysis: analyzedDefinitionIds.size,
     missingDefinitions,
     models,
+    contributionSummary,
+    excludedDataSummary,
   };
 }
 
-export async function writeSnapshot(params: {
+export function writeSnapshot(params: {
   client: SnapshotClient;
+  scope: DomainAnalysisScope;
   domainId: string;
   configSignature: string;
   inputHash: string;
   output: DomainAnalysisSnapshotOutput;
 }) {
-  const current = await params.client.assumptionAnalysisSnapshot.findFirst({
-    where: {
-      assumptionKey: buildAssumptionKey(params.domainId),
-      analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
-      configSignature: params.configSignature,
-      status: 'CURRENT',
-      deletedAt: null,
-    },
-    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-  });
-  if (current != null && current.inputHash === params.inputHash) {
-    return current;
-  }
-
-  await params.client.assumptionAnalysisSnapshot.updateMany({
-    where: {
-      assumptionKey: buildAssumptionKey(params.domainId),
-      analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
-      configSignature: params.configSignature,
-      status: 'CURRENT',
-      deletedAt: null,
-    },
-    data: {
-      status: 'SUPERSEDED',
-    },
-  });
-
   return params.client.assumptionAnalysisSnapshot.create({
     data: {
-      assumptionKey: buildAssumptionKey(params.domainId),
+      assumptionKey: buildAssumptionKey(params.scope, params.domainId),
       analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
       inputHash: params.inputHash,
       codeVersion: DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION,
       configSignature: params.configSignature,
       config: {
+        scope: params.scope,
         domainId: params.domainId,
         signature: params.configSignature,
       },

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -146,6 +146,15 @@ type ApiKey {
   name: String!
 }
 
+type AssumptionsTempZeroResult {
+  domainName: String!
+  generatedAt: DateTime!
+  note: String
+  preflight: TempZeroPreflight!
+  rows: [TempZeroRow!]!
+  summary: TempZeroSummary!
+}
+
 """Type of action that was audited"""
 enum AuditAction {
   ACTION
@@ -311,6 +320,15 @@ type CompletionEvent {
   success: Boolean!
 }
 
+type ConditionPlan {
+  conditionKey: String!
+  currentSEM: Float
+  currentSamples: Int!
+  neededSamples: Int!
+  scenarioId: String!
+  status: String!
+}
+
 """A scenario with high disagreement across models"""
 type ContestedScenario {
   modelScores: JSON!
@@ -388,6 +406,21 @@ input CreateDomainContextInput {
   text: String!
 }
 
+input CreatePairedVignetteInput {
+  contextId: ID!
+  domainId: ID!
+  levelPresetVersionId: ID
+  name: String!
+  preambleVersionId: ID
+  valueFirstId: ID!
+  valueSecondId: ID!
+}
+
+type CreatePairedVignetteResult {
+  definitionA: Definition!
+  definitionB: Definition!
+}
+
 input CreateLevelPresetInput {
   l1: String!
   l2: String!
@@ -418,21 +451,6 @@ input CreateLlmModelInput {
   setAsDefault: Boolean
 }
 
-input CreatePairedVignetteInput {
-  contextId: ID!
-  domainId: ID!
-  levelPresetVersionId: ID
-  name: String!
-  preambleVersionId: ID
-  valueFirstId: ID!
-  valueSecondId: ID!
-}
-
-type CreatePairedVignetteResult {
-  definitionA: Definition!
-  definitionB: Definition!
-}
-
 input CreatePreambleInput {
   content: String!
   name: String!
@@ -453,6 +471,18 @@ input CreateValueStatementInput {
 }
 
 scalar DateTime
+
+type DebugMismatchResult {
+  decisionCodes: [String]!
+  modelId: String!
+  promptHashes: [String]!
+  promptHashesMatch: Boolean
+  rawResponseSummary: String!
+  scenarioId: String!
+  systemFingerprints: [String]!
+  systemFingerprintsMatch: Boolean
+  transcriptCount: Int!
+}
 
 """
 A scenario definition that can be versioned through parent-child relationships
@@ -641,16 +671,13 @@ type Domain {
   defaultContextId: String
   defaultLevelPresetVersion: LevelPresetVersion
   defaultLevelPresetVersionId: String
-  defaultModelIds: [String!]!
   defaultPreambleVersion: PreambleVersion
   defaultPreambleVersionId: String
   definitionCount: Int!
   definitions: [Definition!]!
   id: ID!
-  labelPrefix: String
   name: String!
   normalizedName: String!
-  sentencePrefix: String
   updatedAt: DateTime!
 }
 
@@ -673,6 +700,8 @@ type DomainAnalysisConditionDetail {
 type DomainAnalysisConditionTranscript {
   content: JSON!
   createdAt: DateTime!
+  decisionCode: String
+  decisionCodeSource: String
   decisionModelV2: JSON
   durationMs: Int!
   id: ID!
@@ -681,6 +710,20 @@ type DomainAnalysisConditionTranscript {
   scenarioId: ID
   tokenCount: Int!
   turnCount: Int!
+}
+
+type DomainAnalysisContributionSummary {
+  domainId: String!
+  domainName: String!
+  rawTrialCount: Float!
+  share: Float!
+}
+
+type DomainAnalysisExcludedDataSummary {
+  count: Float!
+  domainId: String!
+  domainName: String!
+  reasonCode: String!
 }
 
 type DomainAnalysisMissingDefinition {
@@ -707,10 +750,12 @@ type DomainAnalysisRefreshResult {
 }
 
 type DomainAnalysisResult {
+  contributionSummary: [DomainAnalysisContributionSummary!]!
   cacheStatus: String!
   clusterAnalysis: ClusterAnalysis!
   coveredDefinitions: Int!
   definitionsWithAnalysis: Int!
+  excludedDataSummary: [DomainAnalysisExcludedDataSummary!]!
   domainId: ID!
   domainName: String!
   generatedAt: DateTime!
@@ -826,21 +871,16 @@ type DomainEvaluation {
   domainNameAtLaunch: String!
   failedDefinitions: Int!
   id: ID!
-  launchableDefinitionIds: [ID!]!
-  launchableDefinitions: [DomainEvaluationLaunchableDefinition!]!
   maxBudgetUsd: Float
   memberCount: Int!
   members: [DomainEvaluationMember!]!
   models: [String!]!
   projectedCostUsd: Float!
-  samplePercentage: Int
-  samplesPerScenario: Int
   scopeCategory: String!
   skippedForBudget: Int!
   startedAt: DateTime
   startedRuns: Int!
   status: String!
-  targetBatchCount: Int
   temperature: Float
 }
 
@@ -884,18 +924,11 @@ type DomainEvaluationEstimateModel {
   supportsTemperature: Boolean!
 }
 
-type DomainEvaluationLaunchableDefinition {
-  definitionId: ID!
-  definitionName: String!
-  pairKey: String
-}
-
 type DomainEvaluationMember {
   createdAt: DateTime!
   definitionIdAtLaunch: ID!
   definitionNameAtLaunch: String!
   domainIdAtLaunch: ID!
-  modelIds: [String!]!
   runCategory: String!
   runCompletedAt: DateTime
   runId: ID!
@@ -960,13 +993,12 @@ type DomainRunSummary {
 
 """Current domain settings: pickers and value statements with versions"""
 type DomainSettings {
-  contextId: String
-  defaultModelIds: [String!]!
-  domainId: ID!
   labelPrefix: String
+  sentencePrefix: String
+  contextId: String
+  domainId: ID!
   levelPresetVersionId: String
   preambleVersionId: String
-  sentencePrefix: String
   valueStatements: [ValueStatementWithVersions!]!
 }
 
@@ -1064,18 +1096,6 @@ type DomainValueCoverageResult {
   cells: [DomainValueCoverageCell!]!
   domainId: String!
   values: [String!]!
-}
-
-input EnsureDomainVignettePairInput {
-  domainId: ID!
-  valueFirstId: ID!
-  valueSecondId: ID!
-}
-
-type EnsureDomainVignettePairResult {
-  definitionAId: String
-  definitionBId: String
-  status: VignettePairStatus!
 }
 
 """Real-time execution metrics for monitoring parallel processing"""
@@ -1225,6 +1245,23 @@ type JobTypeStatus {
 
   """Job type name (e.g., probe_scenario)"""
   type: String!
+}
+
+type LaunchAssumptionsTempZeroPayload {
+  failedVignetteIds: [String!]!
+  modelCount: Int!
+  runIds: [String!]!
+  startedRuns: Int!
+  totalVignettes: Int!
+}
+
+type LaunchOrderInvariancePayload {
+  approvedPairs: Int!
+  failedDefinitionIds: [String!]!
+  modelCount: Int!
+  runIds: [String!]!
+  runsByVariantType: JSON!
+  startedRuns: Int!
 }
 
 """
@@ -1381,6 +1418,12 @@ type ModelCostEstimate {
   totalCost: Float!
 }
 
+type ModelPlan {
+  conditions: [ConditionPlan!]!
+  modelId: String!
+  totalNeededSamples: Int!
+}
+
 """Token usage statistics for a model, used for cost prediction"""
 type ModelTokenStats {
   """Average input tokens per probe based on historical data"""
@@ -1399,33 +1442,23 @@ type ModelTokenStats {
   sampleCount: Int!
 }
 
-"""A domain-level contribution for a model/value pair"""
-type ModelsAnalysisDomainBreakdown {
-  domainId: String!
-  domainName: String!
-  evidenceWeight: Int
-  winRate: Float!
+enum VignettePairStatus {
+  CREATED
+  UPDATED
+  SKIPPED
+  SKIPPED_HAS_RUNS
 }
 
-"""A model row in the models analysis matrix"""
-type ModelsAnalysisModelResult {
-  label: String!
-  modelId: String!
-  values: [ModelsAnalysisValueResult!]!
+type EnsureDomainVignettePairResult {
+  status: VignettePairStatus!
+  definitionAId: ID
+  definitionBId: ID
 }
 
-"""Cross-domain model analysis matrix results"""
-type ModelsAnalysisResult {
-  models: [ModelsAnalysisModelResult!]!
-}
-
-"""A model/value summary across eligible domains"""
-type ModelsAnalysisValueResult {
-  domains: [ModelsAnalysisDomainBreakdown!]!
-  eligibleDomainCount: Int!
-  pooledWinRate: Float
-  stabilityScore: Float
-  valueKey: String!
+input EnsureDomainVignettePairInput {
+  domainId: ID!
+  valueFirstId: ID!
+  valueSecondId: ID!
 }
 
 type Mutation {
@@ -1439,7 +1472,6 @@ type Mutation {
   ): Definition!
   assignDomainToDefinitions(definitionIds: [ID!]!, domainId: ID): DomainMutationResult!
   assignDomainToDefinitionsByFilter(domainId: ID, hasRuns: Boolean, rootOnly: Boolean, search: String, sourceDomainId: ID, tagIds: [ID!], withoutDomain: Boolean): DomainMutationResult!
-  backfillDomainEvaluationModels(definitionIds: [ID!], domainEvaluationId: ID!, modelIds: [String!]!, targetBatchCount: Int): DomainTrialRunResult!
 
   "\n      Cancel an evaluation run.\n\n      Jobs currently being processed will complete, but all pending jobs\n      will be removed from the queue. Completed results are preserved.\n\n      Requires authentication. Run must be in PENDING, RUNNING, or PAUSED state.\n    "
   cancelRun(
@@ -1479,12 +1511,13 @@ type Mutation {
   createDefinition(input: CreateDefinitionInput!): Definition!
   createDomain(name: String!): Domain!
   createDomainContext(input: CreateDomainContextInput!): DomainContext!
+  ensureDomainVignettePair(input: EnsureDomainVignettePairInput!): EnsureDomainVignettePairResult!
   createJobChoicePair(input: CreatePairedVignetteInput!): CreatePairedVignetteResult! @deprecated(reason: "Renamed to createPairedVignette")
+  createPairedVignette(input: CreatePairedVignetteInput!): CreatePairedVignetteResult!
   createLevelPreset(l1: String!, l2: String!, l3: String!, l4: String!, l5: String!, name: String!): LevelPreset!
 
   """Create a new LLM model under a provider"""
   createLlmModel(input: CreateLlmModelInput!): LlmModel!
-  createPairedVignette(input: CreatePairedVignetteInput!): CreatePairedVignetteResult!
 
   """Create a new preamble"""
   createPreamble(input: CreatePreambleInput!): Preamble!
@@ -1539,7 +1572,6 @@ type Mutation {
 
   """Duplicate a survey into a new survey family at version 1."""
   duplicateSurvey(id: ID!, name: String): Experiment!
-  ensureDomainVignettePair(input: EnsureDomainVignettePairInput!): EnsureDomainVignettePairResult!
 
   """Export a definition as markdown in devtool-compatible format"""
   exportDefinitionAsMd(
@@ -1557,6 +1589,8 @@ type Mutation {
   Fork an existing definition. By default inherits all content from parent (sparse v2 storage).
   """
   forkDefinition(input: ForkDefinitionInput!): Definition!
+  launchAssumptionsTempZero(force: Boolean = false): LaunchAssumptionsTempZeroPayload!
+  launchOrderInvariance(force: Boolean = false): LaunchOrderInvariancePayload!
 
   "\n      Pause the global job queue.\n\n      All job processing will stop until the queue is resumed.\n      Jobs will continue to be queued but not processed.\n\n      Requires authentication.\n    "
   pauseQueue: QueueStatus!
@@ -1584,7 +1618,6 @@ type Mutation {
     """The ID of the run to recover"""
     runId: ID!
   ): RecoverRunPayload!
-  refreshDomainAnalysis(domainId: ID!, signature: String): DomainAnalysisRefreshResult!
 
   """
   Manually trigger scenario regeneration for a definition. Queues a new expansion job.
@@ -1602,6 +1635,7 @@ type Mutation {
     """Tag to remove"""
     tagId: String!
   ): Definition!
+  refreshDomainAnalysis(domainId: ID!, signature: String): DomainAnalysisRefreshResult!
   renameDomain(id: ID!, name: String!): Domain!
 
   "\n      Restart summarization for a run.\n\n      Only works when run is in a terminal state (COMPLETED/FAILED/CANCELLED).\n      By default, only re-queues transcripts without summaries or with errors.\n      With force=true, re-queues all transcripts.\n\n      Requires authentication.\n    "
@@ -1622,6 +1656,7 @@ type Mutation {
     runId: ID!
   ): Run!
   retryDomainTrialCell(definitionId: ID!, domainId: ID!, modelId: String!, scopeCategory: String, temperature: Float): RetryDomainTrialCellResult!
+  reviewOrderInvariancePair(pairId: ID!, reviewNotes: String, reviewStatus: String!): ReviewOrderInvariancePairPayload!
 
   "\n      Revoke (delete) an API key.\n      Requires authentication and ownership of the key.\n\n      Returns true if the key was successfully revoked.\n      Throws NotFoundError if the key doesn't exist or belongs to another user.\n    "
   revokeApiKey(
@@ -1635,8 +1670,8 @@ type Mutation {
     """Model ID to set as default"""
     id: String!
   ): SetDefaultModelResult!
-  setDomainDefaults(defaultContextId: ID, defaultLevelPresetVersionId: ID, defaultModelIds: [String!], defaultPreambleVersionId: ID, id: ID!): Domain!
-  setDomainSettings(contextId: ID, defaultModelIds: [String!], domainId: ID!, labelPrefix: String, levelPresetVersionId: ID, preambleVersionId: ID, sentencePrefix: String, valueStatements: [ValueStatementInput!]!): Domain!
+  setDomainDefaults(defaultContextId: ID, defaultLevelPresetVersionId: ID, defaultPreambleVersionId: ID, id: ID!): Domain!
+  setDomainSettings(contextId: ID, domainId: ID!, labelPrefix: String, levelPresetVersionId: ID, preambleVersionId: ID, sentencePrefix: String, valueStatements: [ValueStatementInput!]!): Domain!
 
   """Set the budget balance for a provider (null disables budget tracking)"""
   setProviderBalance(
@@ -1701,6 +1736,7 @@ type Mutation {
   ): Definition!
   updateDomainContext(id: ID!, input: UpdateDomainContextInput!): DomainContext!
   updateJobChoicePair(input: UpdatePairedVignetteInput!): CreatePairedVignetteResult! @deprecated(reason: "Renamed to updatePairedVignette")
+  updatePairedVignette(input: UpdatePairedVignetteInput!): CreatePairedVignetteResult!
   updateLevelPreset(id: ID!, l1: String!, l2: String!, l3: String!, l4: String!, l5: String!): LevelPreset!
 
   """Update an LLM model (display name, costs, API config)"""
@@ -1716,7 +1752,6 @@ type Mutation {
     id: String!
     input: UpdateLlmProviderInput!
   ): LlmProvider!
-  updatePairedVignette(input: UpdatePairedVignetteInput!): CreatePairedVignetteResult!
 
   """Update a preamble (creates a new version)"""
   updatePreamble(id: ID!, input: UpdatePreambleInput!): Preamble!
@@ -1736,21 +1771,180 @@ type Mutation {
   """Update a system setting (creates if not exists)"""
   updateSystemSetting(input: UpdateSystemSettingInput!): SystemSetting!
 
-  "\n      Manually override a transcript's canonical decision.\n\n      Accepts one of four decisionStates: resolved, neutral, unknown, refusal.\n      For resolved, favoredValueKey (one of the vignette pair's two value tokens)\n      and strength (strong or lean) are also required. Server derives direction\n      (favor_first / favor_second) from favoredValueKey against the vignette pair.\n\n      If the run is already completed, this supersedes current analysis\n      and queues a recompute job.\n\n      Requires authentication.\n    "
+  "\n      Manually update a transcript decision code.\n\n      Accepts only positive integer decision codes.\n      If the run is already completed, this will supersede current analysis\n      and queue a recompute job.\n\n      Requires authentication.\n    "
   updateTranscriptDecision(
-    """One of: resolved, neutral, unknown, refusal"""
-    decisionState: String!
-
-    """Value key (pair.valueA or pair.valueB). Required when decisionState is resolved."""
-    favoredValueKey: String
-
-    """strong or lean. Required when decisionState is resolved."""
-    strength: String
+    """Decision code override (must be a positive integer)"""
+    decisionCode: String!
 
     """The ID of the transcript to update"""
     transcriptId: ID!
   ): Transcript!
   updateValueStatement(id: ID!, input: UpdateValueStatementInput!): ValueStatement!
+}
+
+type OrderInvarianceExclusionCount {
+  count: Int!
+  reason: String!
+}
+
+type OrderInvarianceLaunchRun {
+  completedAt: DateTime
+  completedTrials: Int!
+  failedTrials: Int!
+  isStalled: Boolean!
+  percentComplete: Float!
+  runId: ID!
+  startedAt: DateTime
+  status: String!
+  targetedTrials: Int!
+}
+
+type OrderInvarianceLaunchStatus {
+  activeRuns: Int!
+  completedRuns: Int!
+  completedTrials: Int!
+  failedRuns: Int!
+  failedTrials: Int!
+  failureSummaries: [String!]!
+  generatedAt: DateTime!
+  isComplete: Boolean!
+  percentComplete: Float!
+  runs: [OrderInvarianceLaunchRun!]!
+  stalledModels: [String!]!
+  targetedTrials: Int!
+  totalRuns: Int!
+}
+
+type OrderInvarianceModelMetrics {
+  matchCount: Int!
+  matchEligibleCount: Int!
+  matchRate: Float
+  modelId: String!
+  modelLabel: String!
+  pairLevelMarginSummary: PairLevelMarginSummary
+  scaleOrderEligibleCount: Int!
+  scaleOrderExcludedCount: Int!
+  scaleOrderPull: String!
+  scaleOrderReversalRate: Float
+  valueOrderEligibleCount: Int!
+  valueOrderExcludedCount: Int!
+  valueOrderPull: String!
+  valueOrderReversalRate: Float
+  withinCellDisagreementRate: Float
+}
+
+type OrderInvarianceResult {
+  generatedAt: DateTime!
+  modelMetrics: [OrderInvarianceModelMetrics!]!
+  rows: [OrderInvarianceRow!]!
+  summary: OrderInvarianceSummary!
+}
+
+type OrderInvarianceReviewResult {
+  generatedAt: DateTime!
+  summary: OrderInvarianceReviewSummary!
+  vignettes: [OrderInvarianceReviewVignette!]!
+}
+
+type OrderInvarianceReviewSummary {
+  approvedVignettes: Int!
+  launchReady: Boolean!
+  pendingVignettes: Int!
+  rejectedVignettes: Int!
+  reviewedVignettes: Int!
+  totalVignettes: Int!
+}
+
+type OrderInvarianceReviewVignette {
+  baselineName: String!
+  baselineText: String!
+  conditionKey: String!
+  conditionPairCount: Int!
+  flippedName: String!
+  flippedText: String!
+  pairId: ID!
+  reviewNotes: String
+  reviewStatus: String!
+  reviewedAt: DateTime
+  reviewedBy: String
+  sourceScenarioId: ID!
+  variantScenarioId: ID!
+  variantType: String
+  vignetteId: ID!
+  vignetteTitle: String!
+}
+
+type OrderInvarianceRow {
+  conditionKey: String!
+  isMatch: Boolean
+  majorityVoteBaseline: Int
+  majorityVoteFlipped: Int
+  mismatchType: String
+  modelId: String!
+  modelLabel: String!
+  ordinalDistance: Int
+  variantType: String
+  vignetteId: ID!
+  vignetteTitle: String!
+}
+
+type OrderInvarianceSummary {
+  comparablePairs: Int!
+  exactMatchRate: Float
+  excludedPairs: [OrderInvarianceExclusionCount!]!
+  matchComparablePairs: Int!
+  matchRate: Float
+  missingPairs: Int!
+  presentationComparablePairs: Int!
+  presentationEffectMAD: Float
+  presentationMissingPairs: Int!
+  qualifyingPairs: Int!
+  scaleComparablePairs: Int!
+  scaleEffectMAD: Float
+  scaleMissingPairs: Int!
+  sensitiveModelCount: Int!
+  sensitiveVignetteCount: Int!
+  status: String!
+  totalCandidatePairs: Int!
+}
+
+type OrderInvarianceTranscript {
+  attributeALevel: Int
+  attributeBLevel: Int
+  content: JSON
+  createdAt: DateTime!
+  decisionCode: String
+  decisionCodeSource: String
+  durationMs: Int!
+  estimatedCost: Float
+  id: ID!
+  lastAccessedAt: DateTime
+  modelId: String!
+  modelVersion: String
+  orderLabel: String!
+  runId: ID!
+  scenarioId: ID!
+  tokenCount: Int!
+  turnCount: Int!
+}
+
+type OrderInvarianceTranscriptResult {
+  attributeALabel: String
+  attributeBLabel: String
+  conditionKey: String!
+  generatedAt: DateTime!
+  modelId: String!
+  modelLabel: String!
+  transcripts: [OrderInvarianceTranscript!]!
+  vignetteId: ID!
+  vignetteTitle: String!
+}
+
+type PairLevelMarginSummary {
+  mean: Float
+  median: Float
+  p25: Float
+  p75: Float
 }
 
 """A reusable preamble that can be prepended to scenarios"""
@@ -1915,141 +2109,29 @@ type ProviderHealthStatus {
   remainingBudgetUsd: Float
 }
 
-type ConsistencyPerCondition {
-  matches: Int!
-  netPressureRank: Int!
-  scenarioId: String!
-  trials: Int!
+type ModelsAnalysisDomainBreakdown {
+  domainId: String!
+  domainName: String!
+  evidenceWeight: Int!
   winRate: Float!
 }
 
-type ConsistencyPerDomain {
-  ciHigh: Float!
-  ciLow: Float!
-  domainId: String!
-  domainName: String!
-  scenariosMeasured: Int!
-  value: Float!
-}
-
-type ConsistencyPerPair {
-  companionConditionIds: [String!]!
-  coherent: Boolean!
-  determinate: Boolean!
-  domainId: String!
-  pValue: Float
-  perCondition: [ConsistencyPerCondition!]!
-  primaryConditionIds: [String!]!
-  rho: Float
-  targetAnalysisRunId: String
-  targetCompanionRunId: String
-  valueKey: String!
-}
-
-type ConsistencyPerScenario {
-  ciHigh: Float!
-  ciLow: Float!
-  matches: Int!
-  p: Float!
-  scenarioId: String!
-  trials: Int!
-}
-
-type Coherence {
-  coherentPairs: Int!
-  determinatePairs: Int!
-  indeterminatePairs: Int!
-  perPair: [ConsistencyPerPair!]!
-  value: Float!
-}
-
-type InsufficientModel {
+type ModelsAnalysisModelResult {
   label: String!
   modelId: String!
-  providerName: String!
-  reason: String!
+  values: [ModelsAnalysisValueResult!]!
 }
 
-type ModelConsistency {
-  coherence: Coherence!
-  label: String!
-  modelId: String!
-  orderEffect: OrderEffect!
-  providerName: String!
-  repeatability: Repeatability!
+type ModelsAnalysisResult {
+  models: [ModelsAnalysisModelResult!]!
 }
 
-type ModelsConsistencyResult {
-  insufficient: [InsufficientModel!]!
-  models: [ModelConsistency!]!
-}
-
-type AvailableSignature {
-  mostRecentRunAt: DateTime
-  signature: String!
-}
-
-type CircumplexAnalysisResult {
-  eligibilityThreshold: Int!
-  insufficient: [CircumplexInsufficientModel!]!
-  models: [CircumplexResult!]!
-  signature: String!
-}
-
-type CircumplexInsufficientModel {
-  modelId: String!
-  modelLabel: String!
-  providerName: String!
-  reason: String!
-  trialsPerValue: [CircumplexPerValue!]!
-}
-
-type CircumplexMdsCoord {
-  theoreticalAngleDeg: Float!
+type ModelsAnalysisValueResult {
+  domains: [ModelsAnalysisDomainBreakdown!]!
+  eligibleDomainCount: Int!
+  pooledWinRate: Float
+  stabilityScore: Float
   valueKey: String!
-  x: Float!
-  y: Float!
-}
-
-type CircumplexPerValue {
-  trials: Int!
-  valueKey: String!
-}
-
-type CircumplexResult {
-  excludedValues: [String!]!
-  mds2d: [CircumplexMdsCoord!]!
-  mdsStress: Float!
-  mdsWarning: String
-  modelId: String!
-  modelLabel: String!
-  pairTrialCounts: [[Int!]!]!
-  profileCorrelationMatrix: [[Float]]!
-  providerName: String!
-  signature: String!
-  spearmanP: Float
-  spearmanRho: Float
-  trialsPerValue: [CircumplexPerValue!]!
-  valueOrder: [String!]!
-  verdictBand: String!
-}
-
-type OrderEffect {
-  flippedPct: Float!
-  noisyPct: Float!
-  notApplicable: Boolean!
-  samePct: Float!
-}
-
-type Repeatability {
-  betweenScenarioSd: Float!
-  ciHigh: Float!
-  ciLow: Float!
-  perDomain: [ConsistencyPerDomain!]!
-  perScenario: [ConsistencyPerScenario!]!
-  scenariosMeasured: Int!
-  value: Float!
-  withinScenarioSd: Float!
 }
 
 type Query {
@@ -2100,8 +2182,6 @@ type Query {
     status: String
   ): AnalysisFolderCounts!
 
-  availableSignatures: [AvailableSignature!]!
-
   """Fetch all analysis versions for a run, including superseded versions."""
   analysisHistory(
     """Maximum number of results (default: 10, max: 100)"""
@@ -2128,6 +2208,11 @@ type Query {
     """Number of results to skip (default: 0)"""
     offset: Int
   ): [ApiKey!]!
+  assumptionsOrderInvariance(directionOnly: Boolean, trimOutliers: Boolean): OrderInvarianceResult!
+  assumptionsOrderInvarianceLaunchStatus(runIds: [ID!]!): OrderInvarianceLaunchStatus!
+  assumptionsOrderInvarianceReview: OrderInvarianceReviewResult!
+  assumptionsOrderInvarianceTranscripts(conditionKey: String!, modelId: String!, vignetteId: ID!): OrderInvarianceTranscriptResult!
+  assumptionsTempZero(directionOnly: Boolean): AssumptionsTempZeroResult!
 
   "\n      Query audit logs with optional filters and pagination.\n\n      Returns a paginated connection with audit log entries.\n      Use the 'after' cursor for pagination through large result sets.\n    "
   auditLogs(
@@ -2152,8 +2237,8 @@ type Query {
     """Number of results to skip (default: 0)"""
     offset: Int
   ): [AvailableModel!]!
-  circumplexAnalysis(modelIds: [String!]!, minTrialsPerValue: Int, signature: String!): CircumplexAnalysisResult!
-  modelsConsistency(domainId: ID, minScenarios: Int, providerId: ID, signature: String!): ModelsConsistencyResult!
+  modelsAnalysis(domainId: ID): ModelsAnalysisResult!
+  debugAssumptionsMismatches(modelId: String!, scenarioId: String!): DebugMismatchResult!
 
   """Fetch a single definition by ID. Returns null if not found."""
   definition(
@@ -2240,10 +2325,10 @@ type Query {
     withoutDomain: Boolean
   ): [Definition!]!
   domain(id: ID!): Domain
-  domainAnalysis(domainId: ID!, scoreMethod: String, signature: String): DomainAnalysisResult!
+  domainAnalysis(domainId: ID!, scope: String, scoreMethod: String, signature: String): DomainAnalysisResult!
   domainAnalysisConditionTranscripts(definitionId: ID!, domainId: ID!, limit: Int, modelId: String!, scenarioId: ID, signature: String, valueKey: String!): [DomainAnalysisConditionTranscript!]!
   domainAnalysisValueDetail(domainId: ID!, modelId: String!, scoreMethod: String, signature: String, valueKey: String!): DomainAnalysisValueDetailResult!
-  domainAvailableSignatures(domainId: ID!): [DomainAvailableSignature!]!
+  domainAvailableSignatures(domainId: ID!, scope: String): [DomainAvailableSignature!]!
   domainConfigSnapshots(domainId: ID!, limit: Int): [DomainConfigSnapshotSummary!]!
   domainContext(id: ID!): DomainContext
   domainContexts(domainId: String): [DomainContext!]!
@@ -2375,13 +2460,6 @@ type Query {
     """Model IDs to get stats for (returns all if not specified)"""
     modelIds: [String!]
   ): [ModelTokenStats!]!
-  modelsAnalysis(
-    """Optional domain ID to scope the matrix to a single domain"""
-    domainId: ID
-
-    """Optional batch signature to filter snapshots (e.g. vnewtd, vnewt0)"""
-    signature: String
-  ): ModelsAnalysisResult!
 
   """Get a specific preamble by ID"""
   preamble(id: ID!): Preamble
@@ -2571,6 +2649,7 @@ type Query {
     """Search tags by name (contains match)"""
     search: String
   ): [Tag!]!
+  tempZeroVerificationReport: TempZeroVerificationReport
   valueStatement(id: ID!): ValueStatement
   valueStatements(domainId: ID!): [ValueStatement!]!
 
@@ -2712,6 +2791,12 @@ type RetryDomainTrialCellResult {
   success: Boolean!
 }
 
+type ReviewOrderInvariancePairPayload {
+  pairId: ID!
+  reviewStatus: String!
+  reviewedAt: DateTime!
+}
+
 """A saved record of a model evaluation or launch"""
 type Run {
   """Most recent analysis result for this run"""
@@ -2837,9 +2922,6 @@ type Run {
     """Number of transcripts to skip for pagination (default: 0)"""
     offset: Int
   ): [Transcript!]!
-
-  """Count of summarized transcripts that could not be scored"""
-  unresolvableTranscriptCount: UnresolvableCount
   updatedAt: DateTime!
 }
 
@@ -3041,6 +3123,86 @@ enum TaskStatus {
   RUNNING
 }
 
+type TempZeroDecision {
+  content: JSON
+  decision: String
+  label: String!
+  transcriptId: String
+}
+
+type TempZeroModelVerification {
+  adapterModes: [String!]!
+  decisionMatchRatePct: Float
+  fingerprintDriftPct: Float
+  modelId: String!
+  promptHashStabilityPct: Float
+  transcriptCount: Int!
+}
+
+type TempZeroPreflight {
+  estimatedCostUsd: Float
+  estimatedInputTokens: Int
+  estimatedOutputTokens: Int
+  models: [TempZeroPreflightModel!]!
+  projectedComparisons: Int!
+  projectedPromptCount: Int!
+  runsToLaunch: Int!
+  selectedSignature: String
+  title: String!
+  totalBatchesToRun: Int!
+  vignettes: [TempZeroPreflightVignette!]!
+}
+
+type TempZeroPreflightModel {
+  adapterMode: String
+  label: String!
+  modelId: String!
+}
+
+type TempZeroPreflightVignette {
+  batchesToRun: Int!
+  conditionCount: Int!
+  rationale: String!
+  title: String!
+  vignetteId: ID!
+}
+
+type TempZeroRow {
+  batch1: String
+  batch2: String
+  batch3: String
+  conditionKey: String!
+  decisions: [TempZeroDecision!]!
+  isMatch: Boolean!
+  mismatchType: String
+  modelId: String!
+  modelLabel: String!
+  vignetteId: ID!
+  vignetteTitle: String!
+}
+
+type TempZeroSummary {
+  batchesRun: Int!
+  comparisons: Int!
+  differenceRate: Float
+  excludedComparisons: Int!
+  matchRate: Float
+  modelsTested: Int!
+  status: String!
+  title: String!
+  vignettesTested: Int!
+  worstModelId: String
+  worstModelLabel: String
+  worstModelMatchRate: Float
+}
+
+type TempZeroVerificationReport {
+  batchTimestamp: DateTime
+  generatedAt: DateTime!
+  models: [TempZeroModelVerification!]!
+  transcriptCount: Int!
+}
+
 """A transcript from a model conversation during a run"""
 type Transcript {
   content: JSON!
@@ -3051,7 +3213,7 @@ type Transcript {
   decisionMetadata: JSON
 
   """
-  V2 decision envelope with raw evidence and canonical direction/strength decision
+  Feature-flagged V2 decision envelope with raw evidence and canonical compatibility data
   """
   decisionModelV2: JSON
   definitionSnapshot: JSON
@@ -3128,16 +3290,6 @@ type TriggerRecoveryPayload {
   recovered: Int!
 }
 
-type UnresolvableByModel {
-  count: Int!
-  modelId: String!
-}
-
-type UnresolvableCount {
-  byModel: [UnresolvableByModel!]!
-  total: Int!
-}
-
 input UpdateDefinitionContentInput {
   """
   List of fields to clear local override for (inherit from parent). Valid values: template, dimensions, matching_rules
@@ -3171,6 +3323,16 @@ input UpdateDefinitionInput {
 
 input UpdateDomainContextInput {
   text: String!
+}
+
+input UpdatePairedVignetteInput {
+  contextId: ID!
+  definitionId: ID!
+  levelPresetVersionId: ID
+  name: String!
+  preambleVersionId: ID
+  valueFirstId: ID!
+  valueSecondId: ID!
 }
 
 input UpdateLevelPresetInput {
@@ -3208,16 +3370,6 @@ input UpdateLlmProviderInput {
 
   """Rate limit (requests per minute)"""
   requestsPerMinute: Int
-}
-
-input UpdatePairedVignetteInput {
-  contextId: ID!
-  definitionId: ID!
-  levelPresetVersionId: ID
-  name: String!
-  preambleVersionId: ID
-  valueFirstId: ID!
-  valueSecondId: ID!
 }
 
 input UpdatePreambleInput {
@@ -3313,13 +3465,6 @@ type ValueStatementWithVersions {
   id: ID!
   previousContent: String
   token: String!
-}
-
-enum VignettePairStatus {
-  CREATED
-  SKIPPED
-  SKIPPED_HAS_RUNS
-  UPDATED
 }
 
 """Health status for Python workers"""

--- a/cloud/apps/web/src/api/operations/domainAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.graphql
@@ -1,7 +1,19 @@
-query DomainAnalysis($domainId: ID!, $scoreMethod: String, $signature: String) {
-  domainAnalysis(domainId: $domainId, scoreMethod: $scoreMethod, signature: $signature) {
+query DomainAnalysis($domainId: ID!, $scope: String, $scoreMethod: String, $signature: String) {
+  domainAnalysis(domainId: $domainId, scope: $scope, scoreMethod: $scoreMethod, signature: $signature) {
     domainId
     domainName
+    contributionSummary {
+      domainId
+      domainName
+      rawTrialCount
+      share
+    }
+    excludedDataSummary {
+      domainId
+      domainName
+      reasonCode
+      count
+    }
     totalDefinitions
     targetedDefinitions
     coveredDefinitions
@@ -185,8 +197,8 @@ query DomainAnalysisConditionTranscripts(
   }
 }
 
-query DomainAvailableSignatures($domainId: ID!) {
-  domainAvailableSignatures(domainId: $domainId) {
+query DomainAvailableSignatures($domainId: ID!, $scope: String) {
+  domainAvailableSignatures(domainId: $domainId, scope: $scope) {
     signature
     label
     isVirtual

--- a/cloud/apps/web/src/api/operations/domainAnalysis.ts
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.ts
@@ -111,6 +111,18 @@ export type ClusterAnalysis = {
 export type DomainAnalysisResult = {
   domainId: string;
   domainName: string;
+  contributionSummary: Array<{
+    domainId: string;
+    domainName: string;
+    rawTrialCount: number;
+    share: number;
+  }>;
+  excludedDataSummary: Array<{
+    domainId: string;
+    domainName: string;
+    reasonCode: string;
+    count: number;
+  }>;
   totalDefinitions: number;
   targetedDefinitions: number;
   coveredDefinitions: number;

--- a/cloud/apps/web/src/components/domains/DomainAnalysisScopeSummary.tsx
+++ b/cloud/apps/web/src/components/domains/DomainAnalysisScopeSummary.tsx
@@ -1,0 +1,70 @@
+import type { DomainAnalysisQueryResult } from '../../api/operations/domainAnalysis';
+
+type DomainAnalysisScopeSummaryProps = {
+  contributionSummary: DomainAnalysisQueryResult['domainAnalysis']['contributionSummary'];
+  excludedDataSummary: DomainAnalysisQueryResult['domainAnalysis']['excludedDataSummary'];
+};
+
+function formatReasonLabel(reasonCode: string): string {
+  return reasonCode.replace(/_/g, ' ').toLowerCase();
+}
+
+export function DomainAnalysisScopeSummary({
+  contributionSummary,
+  excludedDataSummary,
+}: DomainAnalysisScopeSummaryProps) {
+  const hasContributions = contributionSummary.length > 0;
+  const hasExcludedData = excludedDataSummary.length > 0;
+
+  return (
+    <div className="mt-3 rounded-lg border border-sky-100 bg-sky-50 p-3 text-xs text-sky-900">
+      <p className="font-semibold">Cross-domain summary</p>
+      {hasContributions ? (
+        <div className="mt-2 grid gap-3 md:grid-cols-2">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-sky-800">Included raw trials</p>
+            <ul className="mt-2 space-y-1.5">
+              {contributionSummary.map((entry) => (
+                <li key={`${entry.domainId}-${entry.domainName}`} className="flex items-center justify-between gap-3 rounded border border-sky-100 bg-white px-2 py-1.5">
+                  <span className="font-medium text-sky-950">{entry.domainName}</span>
+                  <span className="text-sky-800">
+                    {Math.round(entry.share * 1000) / 10}% · {entry.rawTrialCount.toFixed(1)} trials
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          {hasExcludedData && (
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-sky-800">Excluded data</p>
+              <ul className="mt-2 space-y-1.5">
+                {excludedDataSummary.map((entry) => (
+                  <li key={`${entry.domainId}-${entry.reasonCode}`} className="rounded border border-sky-100 bg-white px-2 py-1.5">
+                    <span className="font-medium text-sky-950">{entry.domainName}</span>{' '}
+                    <span className="text-sky-800">
+                      {formatReasonLabel(entry.reasonCode)} · {entry.count.toFixed(0)} runs
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className="mt-2 text-sky-800">
+          No included data remained after filtering for this signature.
+          {hasExcludedData ? ' The excluded-data summary below explains what was skipped.' : ''}
+        </p>
+      )}
+      {!hasContributions && hasExcludedData && (
+        <ul className="mt-3 space-y-1.5">
+          {excludedDataSummary.map((entry) => (
+            <li key={`${entry.domainId}-${entry.reasonCode}`} className="rounded border border-sky-100 bg-white px-2 py-1.5 text-sky-800">
+              {entry.domainName}: {formatReasonLabel(entry.reasonCode)} ({entry.count.toFixed(0)} runs)
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
@@ -51,12 +51,14 @@ type ValuePrioritiesSectionProps = {
   models: ModelEntry[];
   selectedDomainId: string;
   selectedSignature: string | null;
+  isReadOnly?: boolean;
 };
 
 export function ValuePrioritiesSection({
   models,
   selectedDomainId,
   selectedSignature,
+  isReadOnly = false,
 }: ValuePrioritiesSectionProps) {
   const navigate = useNavigate();
   const detailedTableRef = useRef<HTMLDivElement>(null);
@@ -137,7 +139,7 @@ export function ValuePrioritiesSection({
   }, [scoreMode, models.length]);
 
   const handleValueCellClick = (modelId: string, valueKey: ValueKey) => {
-    if (selectedDomainId === '') return;
+    if (isReadOnly || selectedDomainId === '') return;
     const params = new URLSearchParams({
       domainId: selectedDomainId,
       modelId,
@@ -338,7 +340,8 @@ export function ValuePrioritiesSection({
                           size="sm"
                           className="relative block h-full min-h-[34px] w-full rounded-none border border-transparent px-2 py-2 text-right text-xs text-gray-800 hover:border-sky-300 hover:bg-white/25 hover:underline focus-visible:!ring-1 focus-visible:!ring-sky-400"
                           onClick={() => handleValueCellClick(model.model, value)}
-                          disabled={selectedDomainId === ''}
+                          disabled={selectedDomainId === '' || isReadOnly}
+                          title={isReadOnly ? 'Value drill-down is unavailable in All domains mode' : undefined}
                       >
                           <span>
                             {(() => {

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -3828,12 +3828,13 @@ export type DeleteDomainContextMutation = { __typename?: 'Mutation', deleteDomai
 
 export type DomainAnalysisQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
+  scope?: InputMaybe<Scalars['String']['input']>;
   scoreMethod?: InputMaybe<Scalars['String']['input']>;
   signature?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type DomainAnalysisQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, definitionsWithAnalysis: number, cacheStatus: string, generatedAt: string, missingDefinitions: Array<{ __typename?: 'DomainAnalysisMissingDefinition', definitionId: string, definitionName: string, reasonCode: string, reasonLabel: string, missingAllModels: boolean, missingModelIds: Array<string>, missingModelLabels: Array<string> }>, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number }>, rankingShape: { __typename?: 'RankingShape', topStructure: string, bottomStructure: string, topGap: number, bottomGap: number, spread: number, steepness: number, dominanceZScore?: number | null } }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }>, rankingShapeBenchmarks: { __typename?: 'RankingShapeBenchmarks', domainMeanTopGap: number, domainStdTopGap?: number | null, medianSpread: number }, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } } };
+export type DomainAnalysisQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, contributionSummary: Array<{ __typename?: 'DomainAnalysisContributionSummary', domainId: string, domainName: string, rawTrialCount: number, share: number }>, excludedDataSummary: Array<{ __typename?: 'DomainAnalysisExcludedDataSummary', domainId: string, domainName: string, reasonCode: string, count: number }>, totalDefinitions: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, definitionsWithAnalysis: number, cacheStatus: string, generatedAt: string, missingDefinitions: Array<{ __typename?: 'DomainAnalysisMissingDefinition', definitionId: string, definitionName: string, reasonCode: string, reasonLabel: string, missingAllModels: boolean, missingModelIds: Array<string>, missingModelLabels: Array<string> }>, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number }>, rankingShape: { __typename?: 'RankingShape', topStructure: string, bottomStructure: string, topGap: number, bottomGap: number, spread: number, steepness: number, dominanceZScore?: number | null } }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }>, rankingShapeBenchmarks: { __typename?: 'RankingShapeBenchmarks', domainMeanTopGap: number, domainStdTopGap?: number | null, medianSpread: number }, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } } };
 
 export type RefreshDomainAnalysisMutationVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -3876,6 +3877,7 @@ export type DomainAnalysisConditionTranscriptsQuery = { __typename?: 'Query', do
 
 export type DomainAvailableSignaturesQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
+  scope?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -5346,14 +5348,27 @@ export function useDeleteDomainContextMutation() {
   return Urql.useMutation<DeleteDomainContextMutation, DeleteDomainContextMutationVariables>(DeleteDomainContextDocument);
 };
 export const DomainAnalysisDocument = gql`
-    query DomainAnalysis($domainId: ID!, $scoreMethod: String, $signature: String) {
+    query DomainAnalysis($domainId: ID!, $scope: String, $scoreMethod: String, $signature: String) {
   domainAnalysis(
     domainId: $domainId
+    scope: $scope
     scoreMethod: $scoreMethod
     signature: $signature
   ) {
     domainId
     domainName
+    contributionSummary {
+      domainId
+      domainName
+      rawTrialCount
+      share
+    }
+    excludedDataSummary {
+      domainId
+      domainName
+      reasonCode
+      count
+    }
     totalDefinitions
     targetedDefinitions
     coveredDefinitions
@@ -5560,8 +5575,8 @@ export function useDomainAnalysisConditionTranscriptsQuery(options: Omit<Urql.Us
   return Urql.useQuery<DomainAnalysisConditionTranscriptsQuery, DomainAnalysisConditionTranscriptsQueryVariables>({ query: DomainAnalysisConditionTranscriptsDocument, ...options });
 };
 export const DomainAvailableSignaturesDocument = gql`
-    query DomainAvailableSignatures($domainId: ID!) {
-  domainAvailableSignatures(domainId: $domainId) {
+    query DomainAvailableSignatures($domainId: ID!, $scope: String) {
+  domainAvailableSignatures(domainId: $domainId, scope: $scope) {
     signature
     label
     isVirtual

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -20,6 +20,7 @@ import {
 import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
 import { DominanceSection } from '../components/domains/DominanceSection';
 import { SimilaritySection } from '../components/domains/SimilaritySection';
+import { DomainAnalysisScopeSummary } from '../components/domains/DomainAnalysisScopeSummary';
 import { ValuePrioritiesSection } from '../components/domains/ValuePrioritiesSection';
 import {
   VALUES,
@@ -36,10 +37,15 @@ import {
   parseTemperatureFromSignature,
 } from '../utils/domainAnalysisUtils';
 
+const ALL_DOMAINS_SCOPE = 'all-domains';
+
 export function DomainAnalysis() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { domains, queryLoading: domainsLoading, error: domainsError } = useDomains();
+  const [selectedScope, setSelectedScope] = useState<'DOMAIN' | 'ALL_DOMAINS'>(
+    searchParams.get('scope') === ALL_DOMAINS_SCOPE ? 'ALL_DOMAINS' : 'DOMAIN',
+  );
   const [selectedDomainId, setSelectedDomainId] = useState<string>(searchParams.get('domainId') ?? '');
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
@@ -52,7 +58,10 @@ export function DomainAnalysis() {
     DomainAvailableSignaturesQueryResult, DomainAvailableSignaturesQueryVariables
   >({
     query: DOMAIN_AVAILABLE_SIGNATURES_QUERY,
-    variables: { domainId: selectedDomainId },
+    variables: {
+      domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
+      scope: selectedScope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined,
+    },
     pause: selectedDomainId === '',
     requestPolicy: 'cache-and-network',
   });
@@ -88,29 +97,44 @@ export function DomainAnalysis() {
   }, [selectedDomainId, selectedSignature]);
 
   useEffect(() => {
-    if (selectedDomainId === '') return;
-    if (searchParams.get('domainId') === selectedDomainId && (searchParams.get('signature') ?? '') === selectedSignature) return;
+    const currentScope = searchParams.get('scope') === ALL_DOMAINS_SCOPE ? 'ALL_DOMAINS' : 'DOMAIN';
+    const nextDomainId = selectedDomainId !== '' ? selectedDomainId : (domains[0]?.id ?? '');
+    if (nextDomainId === '' && selectedScope === 'DOMAIN') return;
+    if (
+      searchParams.get('domainId') === nextDomainId
+      && (searchParams.get('signature') ?? '') === selectedSignature
+      && currentScope === selectedScope
+    ) return;
     const next = new URLSearchParams(searchParams);
-    next.set('domainId', selectedDomainId);
+    if (nextDomainId !== '') next.set('domainId', nextDomainId);
+    else next.delete('domainId');
     next.set('scoreMethod', 'FULL_BT');
+    if (selectedScope === 'ALL_DOMAINS') next.set('scope', ALL_DOMAINS_SCOPE);
+    else next.delete('scope');
     if (selectedSignature === '') next.delete('signature');
     else next.set('signature', selectedSignature);
     setSearchParams(next, { replace: true });
-  }, [searchParams, selectedDomainId, selectedSignature, setSearchParams]);
+  }, [domains, searchParams, selectedDomainId, selectedSignature, selectedScope, setSearchParams]);
 
+  const activeUseLegacyQuery = useLegacyQuery && selectedScope !== 'ALL_DOMAINS';
   const [
     { data: scoredData, fetching: scoredFetching, error: scoredError },
     reexecuteScoredQuery,
   ] = useQuery<DomainAnalysisQueryResult, DomainAnalysisQueryVariables>({
     query: DOMAIN_ANALYSIS_QUERY,
-    variables: { domainId: selectedDomainId, scoreMethod: 'FULL_BT', signature: selectedSignature === '' ? undefined : selectedSignature },
-    pause: selectedDomainId === '' || useLegacyQuery,
+    variables: {
+      domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
+      scope: selectedScope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined,
+      scoreMethod: 'FULL_BT',
+      signature: selectedSignature === '' ? undefined : selectedSignature,
+    },
+    pause: selectedDomainId === '' || activeUseLegacyQuery,
     requestPolicy: 'cache-and-network',
   });
   const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<DomainAnalysisQueryResult, { domainId: string }>({
     query: DOMAIN_ANALYSIS_QUERY_LEGACY,
     variables: { domainId: selectedDomainId },
-    pause: selectedDomainId === '' || !useLegacyQuery,
+    pause: selectedDomainId === '' || !activeUseLegacyQuery,
     requestPolicy: 'cache-and-network',
   });
   const [{ fetching: refreshFetching }, refreshDomainAnalysis] = useMutation<
@@ -124,17 +148,18 @@ export function DomainAnalysis() {
       || message.includes('Unknown argument "signature"')
       || message.includes('Cannot query field')
       || message.includes('Unknown field');
-    if (isFieldError && !useLegacyQuery) setUseLegacyQuery(true);
-  }, [scoredError, useLegacyQuery]);
+    if (isFieldError && !useLegacyQuery && selectedScope !== 'ALL_DOMAINS') setUseLegacyQuery(true);
+  }, [scoredError, selectedScope, useLegacyQuery]);
 
-  const data = useLegacyQuery ? legacyData : scoredData;
-  const fetching = useLegacyQuery ? legacyFetching : scoredFetching;
-  const error = useLegacyQuery ? legacyError : scoredError;
+  const data = activeUseLegacyQuery ? legacyData : scoredData;
+  const fetching = activeUseLegacyQuery ? legacyFetching : scoredFetching;
+  const error = activeUseLegacyQuery ? legacyError : scoredError;
   const cacheStatusCopy = useMemo(
     () => getCacheStatusCopy(data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt),
     [data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt],
   );
   const showPageLoader = domainsLoading || (selectedDomainId !== '' && data?.domainAnalysis == null && fetching);
+  const isAllDomains = selectedScope === 'ALL_DOMAINS';
 
   const models = useMemo<ModelEntry[]>(() => {
     const sourceModels = data?.domainAnalysis.models ?? [];
@@ -173,7 +198,7 @@ export function DomainAnalysis() {
   );
 
   const handleExport = async () => {
-    if (selectedDomainId === '') return;
+    if (selectedDomainId === '' || isAllDomains) return;
     setExportLoading(true);
     setExportError(null);
     try {
@@ -186,7 +211,7 @@ export function DomainAnalysis() {
   };
 
   const handleRefreshAnalysis = async () => {
-    if (selectedDomainId === '') return;
+    if (selectedDomainId === '' || isAllDomains) return;
     setRefreshNotice(null);
     setRefreshError(null);
 
@@ -205,7 +230,7 @@ export function DomainAnalysis() {
   };
 
   const handleRunMissingVignettes = () => {
-    if (selectedDomainId === '' || allMissingDefinitionIds.length === 0) return;
+    if (selectedDomainId === '' || allMissingDefinitionIds.length === 0 || isAllDomains) return;
     const query = new URLSearchParams();
     query.set('definitionIds', allMissingDefinitionIds.join(','));
     if (selectedSignature !== '') {
@@ -230,7 +255,7 @@ export function DomainAnalysis() {
                 {cacheStatusCopy.badgeLabel}
               </span>
               <span>{cacheStatusCopy.detail}</span>
-              {!useLegacyQuery && (
+              {!activeUseLegacyQuery && !isAllDomains && (
                 <Button
                   type="button"
                   variant="secondary"
@@ -257,16 +282,28 @@ export function DomainAnalysis() {
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="text-sm font-semibold text-gray-900">Domain Selection</h2>
-            <p className="text-xs text-gray-600">Analysis is shown from the latest saved snapshot for this domain.</p>
+            <p className="text-xs text-gray-600">
+              {isAllDomains
+                ? 'Cross-domain analysis is read-only and pools every visible domain that matches the selected signature.'
+                : 'Analysis is shown from the latest saved snapshot for this domain.'}
+            </p>
           </div>
           <div className="flex flex-col gap-2 md:flex-row md:items-center">
             <select
               className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800"
-              value={selectedDomainId}
-              onChange={(e) => setSelectedDomainId(e.target.value)}
-              disabled={domainsLoading || domains.length === 0}
+              value={isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId}
+              onChange={(e) => {
+                if (e.target.value === ALL_DOMAINS_SCOPE) {
+                  setSelectedScope('ALL_DOMAINS');
+                  return;
+                }
+                setSelectedScope('DOMAIN');
+                setSelectedDomainId(e.target.value);
+              }}
+              disabled={domainsLoading || (domains.length === 0 && !isAllDomains)}
             >
-              {domains.length === 0 && <option value="">No domains available</option>}
+              <option value={ALL_DOMAINS_SCOPE}>All domains</option>
+              {domains.length === 0 && !domainsLoading && <option value="">No domains available</option>}
               {domains.map((domain) => (
                 <option key={domain.id} value={domain.id}>{domain.name}</option>
               ))}
@@ -282,42 +319,57 @@ export function DomainAnalysis() {
                 <option key={opt.signature} value={opt.signature}>{formatSignatureOptionLabel(opt)}</option>
               ))}
             </select>
-            <Button type="button" variant="secondary" size="sm" onClick={handleExport} disabled={selectedDomainId === '' || exportLoading}>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleExport}
+              disabled={selectedDomainId === '' || exportLoading || isAllDomains}
+              title={isAllDomains ? 'CSV export is unavailable in All domains mode' : undefined}
+            >
               {exportLoading ? 'Exporting\u2026' : 'Export CSV'}
             </Button>
           </div>
           {exportError !== null && <p className="mt-1 text-xs text-amber-700">{exportError}</p>}
         </div>
-        {data?.domainAnalysis != null && missingDefinitionCount > 0 && (
+        {isAllDomains && data?.domainAnalysis != null && (
+          <DomainAnalysisScopeSummary
+            contributionSummary={data.domainAnalysis.contributionSummary}
+            excludedDataSummary={data.domainAnalysis.excludedDataSummary}
+          />
+        )}
+        {data?.domainAnalysis != null && missingDefinitionCount > 0 && !isAllDomains && (
           <div className="mt-2 space-y-1 text-xs text-gray-500">
-            {missingDefinitionCount > 0 && (
-              <>
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className="text-amber-700">Analysis filter excluded {missingDefinitionCount} vignette{missingDefinitionCount === 1 ? '' : 's'}.</p>
-                  <Button type="button" variant="secondary" size="sm" onClick={handleRunMissingVignettes} disabled={allMissingDefinitionIds.length === 0}>
-                    Run Missing Vignettes
-                  </Button>
-                </div>
-                <ul className="list-disc space-y-1 pl-5 text-amber-800">
-                  {(data.domainAnalysis.missingDefinitions ?? []).map((m) => (
-                    <li key={m.definitionId}>
-                      {m.definitionName} ({m.definitionId}) - {m.reasonLabel} - AIs: {m.missingAllModels ? 'All AIs' : m.missingModelLabels.join(', ')}
-                    </li>
-                  ))}
-                </ul>
-              </>
-            )}
+            <>
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-amber-700">Analysis filter excluded {missingDefinitionCount} vignette{missingDefinitionCount === 1 ? '' : 's'}.</p>
+                <Button type="button" variant="secondary" size="sm" onClick={handleRunMissingVignettes} disabled={allMissingDefinitionIds.length === 0}>
+                  Run Missing Vignettes
+                </Button>
+              </div>
+              <ul className="list-disc space-y-1 pl-5 text-amber-800">
+                {(data.domainAnalysis.missingDefinitions ?? []).map((m) => (
+                  <li key={m.definitionId}>
+                    {m.definitionName} ({m.definitionId}) - {m.reasonLabel} - AIs: {m.missingAllModels ? 'All AIs' : m.missingModelLabels.join(', ')}
+                  </li>
+                ))}
+              </ul>
+            </>
           </div>
         )}
       </section>
-
 
       {showPageLoader ? (
         <Loading size="lg" text="Loading domain analysis..." />
       ) : (
         <>
           <ModelGroupsSection clusterAnalysis={data?.domainAnalysis.clusterAnalysis} />
-          <ValuePrioritiesSection models={models} selectedDomainId={selectedDomainId} selectedSignature={selectedSignature === '' ? null : selectedSignature} />
+          <ValuePrioritiesSection
+            models={models}
+            selectedDomainId={selectedDomainId}
+            selectedSignature={selectedSignature === '' ? null : selectedSignature}
+            isReadOnly={isAllDomains}
+          />
           <DominanceSection models={models} unavailableModels={unavailableModels} />
           <SimilaritySection models={models} clusterAnalysis={data?.domainAnalysis.clusterAnalysis} />
         </>

--- a/cloud/apps/web/tests/components/domains/ValuePrioritiesSection.test.tsx
+++ b/cloud/apps/web/tests/components/domains/ValuePrioritiesSection.test.tsx
@@ -1,0 +1,74 @@
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ValuePrioritiesSection } from '../../../src/components/domains/ValuePrioritiesSection';
+import type { ModelEntry } from '../../../src/data/domainAnalysisData';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+const models: ModelEntry[] = [
+  {
+    model: 'claude',
+    label: 'Claude',
+    values: {
+      Self_Direction_Action: 42,
+      Universalism_Nature: 12,
+      Benevolence_Dependability: 11,
+      Security_Personal: 10,
+      Power_Dominance: 9,
+      Achievement: 8,
+      Tradition: 7,
+      Stimulation: 6,
+      Hedonism: 5,
+      Conformity_Interpersonal: 4,
+    },
+    winRates: {
+      Self_Direction_Action: 42,
+      Universalism_Nature: 12,
+      Benevolence_Dependability: 11,
+      Security_Personal: 10,
+      Power_Dominance: 9,
+      Achievement: 8,
+      Tradition: 7,
+      Stimulation: 6,
+      Hedonism: 5,
+      Conformity_Interpersonal: 4,
+    },
+  },
+];
+
+describe('ValuePrioritiesSection', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+  });
+
+  it('keeps value cells read-only in all-domains mode', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ValuePrioritiesSection
+          models={models}
+          selectedDomainId="domain-a"
+          selectedSignature="vnewtd"
+          isReadOnly
+        />
+      </MemoryRouter>,
+    );
+
+    const cellButton = screen.getByRole('button', { name: /42\.0%/i });
+    expect(cellButton).toBeDisabled();
+
+    await user.click(cellButton);
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -42,6 +42,10 @@ const defaultDomainAnalysis = {
   domainAnalysis: {
     domainId: 'domain-a',
     domainName: 'Domain A',
+    contributionSummary: [
+      { domainId: 'domain-a', domainName: 'Domain A', rawTrialCount: 12, share: 1 },
+    ],
+    excludedDataSummary: [],
     totalDefinitions: 2,
     targetedDefinitions: 2,
     coveredDefinitions: 2,
@@ -237,5 +241,27 @@ describe('DomainAnalysis', () => {
         }),
       );
     });
+  });
+
+  it('preserves the all-domains scope and disables domain-only actions', async () => {
+    render(
+      <MemoryRouter initialEntries={['/domains/analysis?scope=all-domains&signature=vnewtd']}>
+        <DomainAnalysis />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(useQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: expect.objectContaining({
+            scope: 'all-domains',
+          }),
+        }),
+      );
+    });
+
+    expect(await screen.findByText(/cross-domain summary/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /run missing vignettes/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Add a read-only "All domains" scope to the Domain Analysis page.
- Aggregate analysis across every domain that matches the selected signature.
- Add a cross-domain contribution/exclusion summary and keep drill-down actions disabled in all-domains mode.

## Validation
- `cd cloud/apps/web && ../../node_modules/.bin/vitest run tests/pages/DomainAnalysis.test.tsx tests/components/domains/ValuePrioritiesSection.test.tsx`
- `cd cloud/apps/web && ../../node_modules/.bin/eslint src/pages/DomainAnalysis.tsx src/components/domains/DomainAnalysisScopeSummary.tsx src/components/domains/ValuePrioritiesSection.tsx src/api/operations/domainAnalysis.ts --ext .ts,.tsx`
- `cd cloud/apps/api && ../../node_modules/.bin/eslint src/services/analysis/domain-analysis-cache.ts src/services/analysis/domain-analysis-snapshot-builder.ts src/services/analysis/domain-analysis-scope-loader.ts src/services/analysis/domain-analysis-scope.ts src/graphql/queries/domain/analysis/domain-analysis.ts src/graphql/queries/domain/planning.ts src/graphql/mutations/domain/analysis.ts src/queue/handlers/refresh-domain-analysis-snapshot.ts src/queue/handlers/analyze-basic.ts src/graphql/queries/models-analysis.ts src/graphql/queries/domain/types.ts src/graphql/queries/domain/shared.ts src/services/analysis/domain-analysis-cache-types.ts --ext .ts,.tsx`

## Note
- `cd cloud && npx turbo build --filter=@valuerank/web` still fails on unrelated pre-existing workspace issues in `src/components/domains/coverageMatrixHelpers.ts`, `src/hooks/useAvailableSignatures.ts`, and other files outside this change.
