### PR TITLE
Weight all-domains summary equally by domain

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-scope-loader.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-scope-loader.ts
@@ -131,7 +131,6 @@ export function buildContributionAndExcludedSummary(params: {
   }
 
   const domainNameById = params.domainNameById;
-  const totalContribution = Array.from(contributionByDomain.values()).reduce((sum, value) => sum + value, 0);
   const sortedContributions = Array.from(contributionByDomain.entries())
     .map(([domainId, rawTrialCount]) => ({
       domainId,
@@ -140,23 +139,25 @@ export function buildContributionAndExcludedSummary(params: {
     }))
     .sort((left, right) => right.rawTrialCount - left.rawTrialCount || left.domainName.localeCompare(right.domainName));
 
+  const contributingDomainCount = sortedContributions.length;
   const topContributions = sortedContributions.slice(0, 5);
   const remainingContribution = sortedContributions.slice(5).reduce((sum, entry) => sum + entry.rawTrialCount, 0);
+  const remainingDomainCount = Math.max(0, contributingDomainCount - topContributions.length);
 
-  const contributionSummary: DomainAnalysisContributionSummary[] = totalContribution > 0
+  const contributionSummary: DomainAnalysisContributionSummary[] = contributingDomainCount > 0
     ? [
         ...topContributions.map((entry) => ({
           domainId: entry.domainId,
           domainName: entry.domainName,
           rawTrialCount: entry.rawTrialCount,
-          share: entry.rawTrialCount / totalContribution,
+          share: 1 / contributingDomainCount,
         })),
         ...(remainingContribution > 0
           ? [{
               domainId: 'other-domains',
               domainName: 'Other domains',
               rawTrialCount: remainingContribution,
-              share: remainingContribution / totalContribution,
+              share: remainingDomainCount / contributingDomainCount,
             }]
           : []),
       ]

--- a/cloud/apps/api/tests/services/analysis/domain-analysis-scope-loader.test.ts
+++ b/cloud/apps/api/tests/services/analysis/domain-analysis-scope-loader.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalysisOutputRow, DomainAnalysisValuePair } from '../../../src/services/analysis/domain-analysis-cache-types.js';
+import { buildContributionAndExcludedSummary } from '../../../src/services/analysis/domain-analysis-scope-loader.js';
+
+function buildAnalysisRow(runId: string, prioritized: number): AnalysisOutputRow {
+  return {
+    runId,
+    inputHash: 'hash',
+    output: {
+      perModel: {
+        claude: {
+          values: {
+            Achievement: {
+              count: {
+                prioritized,
+                deprioritized: 1,
+                neutral: 0,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe('buildContributionAndExcludedSummary', () => {
+  it('weights each contributing domain equally in all-domains mode', () => {
+    const contributionSummary = buildContributionAndExcludedSummary({
+      domainNameById: new Map([
+        ['domain-a', 'Domain A'],
+        ['domain-b', 'Domain B'],
+      ]),
+      definitionDomainIdById: new Map([
+        ['def-a', 'domain-a'],
+        ['def-b', 'domain-b'],
+      ]),
+      valuePairByDefinition: new Map<string, DomainAnalysisValuePair>([
+        ['def-a', { valueA: 'Achievement', valueB: 'Benevolence_Dependability' }],
+        ['def-b', { valueA: 'Achievement', valueB: 'Benevolence_Dependability' }],
+      ]),
+      analysisRows: [
+        buildAnalysisRow('run-a', 9),
+        buildAnalysisRow('run-b', 1),
+      ],
+      filteredSourceRunDefinitionById: new Map([
+        ['run-a', 'def-a'],
+        ['run-b', 'def-b'],
+      ]),
+    });
+
+    expect(contributionSummary.contributionSummary).toEqual([
+      expect.objectContaining({
+        domainId: 'domain-a',
+        domainName: 'Domain A',
+        rawTrialCount: 10,
+        share: 0.5,
+      }),
+      expect.objectContaining({
+        domainId: 'domain-b',
+        domainName: 'Domain B',
+        rawTrialCount: 2,
+        share: 0.5,
+      }),
+    ]);
+  });
+});

--- a/cloud/apps/web/src/components/domains/DomainAnalysisScopeSummary.tsx
+++ b/cloud/apps/web/src/components/domains/DomainAnalysisScopeSummary.tsx
@@ -19,17 +19,18 @@ export function DomainAnalysisScopeSummary({
   return (
     <div className="mt-3 rounded-lg border border-sky-100 bg-sky-50 p-3 text-xs text-sky-900">
       <p className="font-semibold">Cross-domain summary</p>
+      <p className="mt-1 text-sky-800">
+        Each domain counts equally in the all-domains aggregate.
+      </p>
       {hasContributions ? (
         <div className="mt-2 grid gap-3 md:grid-cols-2">
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-sky-800">Included raw trials</p>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-sky-800">Included domains</p>
             <ul className="mt-2 space-y-1.5">
               {contributionSummary.map((entry) => (
                 <li key={`${entry.domainId}-${entry.domainName}`} className="flex items-center justify-between gap-3 rounded border border-sky-100 bg-white px-2 py-1.5">
                   <span className="font-medium text-sky-950">{entry.domainName}</span>
-                  <span className="text-sky-800">
-                    {Math.round(entry.share * 1000) / 10}% · {entry.rawTrialCount.toFixed(1)} trials
-                  </span>
+                  <span className="text-sky-800">{Math.round(entry.share * 1000) / 10}%</span>
                 </li>
               ))}
             </ul>

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -261,6 +261,8 @@ describe('DomainAnalysis', () => {
     });
 
     expect(await screen.findByText(/cross-domain summary/i)).toBeInTheDocument();
+    expect(screen.getByText(/each domain counts equally in the all-domains aggregate/i)).toBeInTheDocument();
+    expect(screen.queryByText(/raw trials/i)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /export csv/i })).toBeDisabled();
     expect(screen.queryByRole('button', { name: /run missing vignettes/i })).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Make the all-domains cross-domain summary weight each contributing domain equally.
- Remove raw-trial wording from the summary so the UI matches the weighting rule.
- Add tests for the equal-domain summary behavior.

## Validation
- `cd cloud/apps/api && ../../node_modules/.bin/vitest run tests/services/analysis/domain-analysis-scope-loader.test.ts`
- `cd cloud/apps/web && ../../node_modules/.bin/vitest run tests/pages/DomainAnalysis.test.tsx`
- `cd cloud/apps/api && ../../node_modules/.bin/eslint src/services/analysis/domain-analysis-scope-loader.ts --ext .ts,.tsx`

## Note
- The broader all-domains feature is already merged in PR #731. This PR contains the follow-up weighting fix only.
