### PR TITLE
Add domain shift heatmap report

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -75,6 +75,9 @@ Once the above are resolved:
 - [ ] Build deck
 - [ ] Review with Ari
 
+### Analysis Reports
+- [x] Domain Shifts by Value heatmap implemented at `/models/domain-shifts`; focused tests and web preflight pass.
+
 ---
 
 ## Goal: Feature Factory

--- a/cloud/apps/web/src/App.tsx
+++ b/cloud/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import { DomainAnalysis } from './pages/DomainAnalysis';
 import { DomainCoverage } from './pages/DomainCoverage';
 import { DomainAnalysisValueDetail } from './pages/DomainAnalysisValueDetail';
 import { Models } from './pages/Models';
+import { DomainValueShiftHeatmap } from './pages/DomainValueShiftHeatmap';
 import { ModelsConsistency } from './pages/ModelsConsistency';
 import { ModelsCircumplex } from './pages/ModelsCircumplex';
 import { DefinitionDetail } from './pages/DefinitionDetail';
@@ -168,6 +169,14 @@ function App() {
               element={
                 <ProtectedLayout>
                   <Models />
+                </ProtectedLayout>
+              }
+            />
+            <Route
+              path="/models/domain-shifts"
+              element={
+                <ProtectedLayout>
+                  <DomainValueShiftHeatmap />
                 </ProtectedLayout>
               }
             />

--- a/cloud/apps/web/src/components/layout/MobileNav.tsx
+++ b/cloud/apps/web/src/components/layout/MobileNav.tsx
@@ -9,12 +9,25 @@ type NavItem = {
   icon: LucideIcon;
   path?: string;
   aliases?: string[];
+  match?: 'exact' | 'prefix';
+  activateWithChildren?: boolean;
   children?: NavItem[];
 };
 
 const navItems: NavItem[] = [
   { name: 'Home', path: '/', icon: Home },
-  { name: 'Models', path: '/models', icon: Cpu },
+  {
+    name: 'Models',
+    path: '/models',
+    icon: Cpu,
+    activateWithChildren: true,
+    children: [
+      { name: 'Matrix', path: '/models', icon: Cpu, match: 'exact' },
+      { name: 'Domain Shifts', path: '/models/domain-shifts', icon: BarChart2 },
+      { name: 'Consistency', path: '/models/consistency', icon: BarChart2 },
+      { name: 'Circumplex', path: '/models/circumplex', icon: BarChart2 },
+    ],
+  },
   {
     name: 'Domains',
     path: '/domains',
@@ -72,7 +85,7 @@ function matchesNavPath(pathname: string, item: NavItem) {
 
   return (
     pathname === item.path
-    || pathname.startsWith(`${item.path}/`)
+    || (item.match !== 'exact' && pathname.startsWith(`${item.path}/`))
     || (item.aliases ?? []).some((alias) => pathname === alias || pathname.startsWith(`${alias}/`))
   );
 }
@@ -125,7 +138,8 @@ export function MobileNav({ className }: MobileNavProps) {
   }, [isOpen]);
 
   const isNavActive = (item: NavItem, includeChildren = true): boolean => {
-    const itemMatches = (!includeChildren && item.children && item.path)
+    const shouldIncludeChildren = includeChildren || item.activateWithChildren === true;
+    const itemMatches = (!shouldIncludeChildren && item.children && item.path)
       ? (
         item.path === '/'
           ? location.pathname === '/'
@@ -133,7 +147,7 @@ export function MobileNav({ className }: MobileNavProps) {
       )
       : matchesNavPath(location.pathname, item);
 
-    if (includeChildren && item.children) {
+    if (shouldIncludeChildren && item.children) {
       return item.children.some((child) => isNavActive(child, true)) || itemMatches;
     }
 

--- a/cloud/apps/web/src/components/layout/NavTabs.tsx
+++ b/cloud/apps/web/src/components/layout/NavTabs.tsx
@@ -12,6 +12,7 @@ type MenuLinkItem = {
   name: string;
   path: string;
   aliases?: string[];
+  match?: 'exact' | 'prefix';
 };
 
 type MenuGroupItem = {
@@ -34,7 +35,8 @@ const domainMenuItems: MenuItem[] = [
 ];
 
 const modelsMenuItems: MenuItem[] = [
-  { name: 'Matrix', path: '/models' },
+  { name: 'Matrix', path: '/models', match: 'exact' },
+  { name: 'Domain Shifts', path: '/models/domain-shifts' },
   { name: 'Consistency', path: '/models/consistency' },
   { name: 'Circumplex', path: '/models/circumplex' },
 ];
@@ -77,18 +79,18 @@ export function NavTabs() {
   const archiveMenuRef = useRef<HTMLDivElement>(null);
   const settingsMenuRef = useRef<HTMLDivElement>(null);
 
-  const isPathActive = useCallback((path: string) => (
-    location.pathname === path || location.pathname.startsWith(`${path}/`)
+  const isPathActive = useCallback((path: string, match: 'exact' | 'prefix' = 'prefix') => (
+    location.pathname === path || (match === 'prefix' && location.pathname.startsWith(`${path}/`))
   ), [location.pathname]);
 
-  const isTabActive = useCallback((tabPath: string, aliases: string[] = []) => (
-    isPathActive(tabPath) || aliases.some((alias) => isPathActive(alias))
+  const isTabActive = useCallback((tabPath: string, aliases: string[] = [], match: 'exact' | 'prefix' = 'prefix') => (
+    isPathActive(tabPath, match) || aliases.some((alias) => isPathActive(alias, match))
   ), [isPathActive]);
 
   const isMenuItemActive = useCallback((item: MenuItem) => (
     isMenuGroupItem(item)
-      ? item.children.some((child) => isTabActive(child.path, child.aliases ?? []))
-      : isTabActive(item.path, item.aliases ?? [])
+      ? item.children.some((child) => isTabActive(child.path, child.aliases ?? [], child.match ?? 'prefix'))
+      : isTabActive(item.path, item.aliases ?? [], item.match ?? 'prefix')
   ), [isTabActive]);
 
   const isVignettesActive = vignettesMenuItems.some((item) => isMenuItemActive(item));
@@ -193,7 +195,7 @@ export function NavTabs() {
                     <div className="absolute left-full top-0 z-50 min-w-[180px] pl-1 opacity-0 invisible pointer-events-none group-hover/submenu:opacity-100 group-hover/submenu:visible group-hover/submenu:pointer-events-auto transition-all duration-150">
                       <div className="rounded-md border border-gray-700 bg-[#1A1A1A] shadow-lg py-1">
                         {item.children.map((child) => {
-                          const childActive = isTabActive(child.path, child.aliases ?? []);
+                          const childActive = isTabActive(child.path, child.aliases ?? [], child.match ?? 'prefix');
                           return (
                             <NavLink
                               key={child.path}
@@ -210,7 +212,7 @@ export function NavTabs() {
                 );
               }
 
-              const itemActive = isTabActive(item.path, item.aliases ?? []);
+              const itemActive = isTabActive(item.path, item.aliases ?? [], item.match ?? 'prefix');
               return (
                 <NavLink
                   key={item.path}

--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -1,0 +1,342 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from 'urql';
+import {
+  MODELS_ANALYSIS_QUERY,
+  type ModelsAnalysisDomainBreakdown,
+  type ModelsAnalysisModelResult,
+  type ModelsAnalysisQueryResult,
+  type ModelsAnalysisValueResult,
+} from '../api/operations/modelsAnalysis';
+import { ErrorMessage } from '../components/ui/ErrorMessage';
+import { Loading } from '../components/ui/Loading';
+import { Select } from '../components/ui/Select';
+import { VALUE_LABELS, VALUES, type ValueKey } from '../data/domainAnalysisData';
+
+const AVERAGE_PARITY_TOLERANCE = 0.05;
+const MAX_COLOR_SHIFT = 25;
+
+export type DomainShiftColumn = {
+  domainId: string;
+  domainName: string;
+};
+
+export type DomainShiftCell = {
+  domainId: string;
+  domainName: string;
+  winRate: number;
+  averageWinRate: number;
+  shift: number;
+  evidenceWeight: number | null;
+};
+
+export type DomainShiftRow = {
+  valueKey: string;
+  valueLabel: string;
+  pooledWinRate: number | null;
+  averageWinRate: number | null;
+  averageMatchesPooled: boolean | null;
+  comparableDomainCount: number;
+  cells: Map<string, DomainShiftCell>;
+};
+
+export type DomainShiftHeatmap = {
+  columns: DomainShiftColumn[];
+  rows: DomainShiftRow[];
+  eligibleDomainCount: number;
+};
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isValueKey(value: string): value is ValueKey {
+  return (VALUES as string[]).includes(value);
+}
+
+function formatValueLabel(valueKey: string): string {
+  return isValueKey(valueKey) ? VALUE_LABELS[valueKey] : valueKey;
+}
+
+export function formatPointShift(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return 'n/a';
+  const rounded = Math.round(value);
+  if (rounded === 0) return '0 pts';
+  return `${rounded > 0 ? '+' : ''}${rounded} pts`;
+}
+
+export function formatPercent(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return 'n/a';
+  return `${Math.round(value)}%`;
+}
+
+export function formatEvidenceWeight(value: number | null): string {
+  if (value == null || !Number.isFinite(value) || value <= 0) return '—';
+  return `${Math.round(value)}`;
+}
+
+export function getDefaultModelId(models: ModelsAnalysisModelResult[], currentModelId: string | null): string | null {
+  const sorted = [...models].sort((left, right) => left.label.localeCompare(right.label));
+  if (currentModelId != null && sorted.some((model) => model.modelId === currentModelId)) {
+    return currentModelId;
+  }
+  return sorted[0]?.modelId ?? null;
+}
+
+function sortValueKeys(valueKeys: Set<string>): string[] {
+  const canonical = VALUES.filter((valueKey) => valueKeys.has(valueKey));
+  const unknown = [...valueKeys]
+    .filter((valueKey) => !isValueKey(valueKey))
+    .sort((left, right) => left.localeCompare(right));
+  return [...canonical, ...unknown];
+}
+
+function eligibleDomainsForValue(value: ModelsAnalysisValueResult): ModelsAnalysisDomainBreakdown[] {
+  return value.domains.filter((domain) => isFiniteNumber(domain.winRate));
+}
+
+function computeAverage(domains: ModelsAnalysisDomainBreakdown[]): number | null {
+  if (domains.length === 0) return null;
+  const total = domains.reduce((sum, domain) => sum + domain.winRate, 0);
+  return total / domains.length;
+}
+
+export function buildDomainShiftHeatmap(model: ModelsAnalysisModelResult | null): DomainShiftHeatmap {
+  if (model == null) {
+    return { columns: [], rows: [], eligibleDomainCount: 0 };
+  }
+
+  const valueKeys = new Set<string>(VALUES);
+
+  for (const value of model.values) {
+    valueKeys.add(value.valueKey);
+  }
+
+  const rowsByValue = new Map(model.values.map((value) => [value.valueKey, value]));
+  const domainById = new Map<string, DomainShiftColumn>();
+  const rows = sortValueKeys(valueKeys).map((valueKey) => {
+    const value = rowsByValue.get(valueKey);
+    const eligibleDomains = value == null ? [] : eligibleDomainsForValue(value);
+    const comparableDomainCount = eligibleDomains.length;
+    const averageWinRate = comparableDomainCount >= 2 ? computeAverage(eligibleDomains) : null;
+    const cells = new Map<string, DomainShiftCell>();
+
+    if (value != null && averageWinRate != null) {
+      for (const domain of eligibleDomains) {
+        domainById.set(domain.domainId, {
+          domainId: domain.domainId,
+          domainName: domain.domainName,
+        });
+        cells.set(domain.domainId, {
+          domainId: domain.domainId,
+          domainName: domain.domainName,
+          winRate: domain.winRate,
+          averageWinRate,
+          shift: domain.winRate - averageWinRate,
+          evidenceWeight: isFiniteNumber(domain.evidenceWeight) ? domain.evidenceWeight : null,
+        });
+      }
+    }
+
+    return {
+      valueKey,
+      valueLabel: formatValueLabel(valueKey),
+      pooledWinRate: value?.pooledWinRate ?? null,
+      averageWinRate,
+      averageMatchesPooled: averageWinRate == null || value?.pooledWinRate == null
+        ? null
+        : Math.abs(averageWinRate - value.pooledWinRate) <= AVERAGE_PARITY_TOLERANCE,
+      comparableDomainCount,
+      cells,
+    };
+  });
+  const columns = [...domainById.values()].sort((left, right) => left.domainName.localeCompare(right.domainName));
+
+  return {
+    columns,
+    rows,
+    eligibleDomainCount: columns.length,
+  };
+}
+
+function getCellTone(shift: number): string {
+  const clamped = Math.max(-MAX_COLOR_SHIFT, Math.min(MAX_COLOR_SHIFT, shift));
+  const intensity = Math.abs(clamped) / MAX_COLOR_SHIFT;
+  if (Math.abs(shift) < 0.5) {
+    return 'border-gray-200 bg-gray-50 text-gray-700';
+  }
+  if (shift > 0) {
+    return intensity > 0.66
+      ? 'border-emerald-300 bg-emerald-100 text-emerald-900'
+      : intensity > 0.33
+        ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+        : 'border-emerald-100 bg-emerald-50/60 text-emerald-700';
+  }
+  return intensity > 0.66
+    ? 'border-rose-300 bg-rose-100 text-rose-900'
+    : intensity > 0.33
+      ? 'border-rose-200 bg-rose-50 text-rose-800'
+      : 'border-rose-100 bg-rose-50/60 text-rose-700';
+}
+
+function Cell({ cell, valueLabel }: { cell: DomainShiftCell | null; valueLabel: string }) {
+  if (cell == null) {
+    return (
+      <span className="inline-flex min-w-[82px] justify-center rounded-md border border-gray-100 bg-gray-50 px-2 py-1 text-sm text-gray-400">
+        n/a
+      </span>
+    );
+  }
+
+  const detail = `${valueLabel} in ${cell.domainName}: ${formatPointShift(cell.shift)} versus this value's equal-domain average. Domain win rate ${formatPercent(cell.winRate)}; average ${formatPercent(cell.averageWinRate)}; evidence vignettes ${formatEvidenceWeight(cell.evidenceWeight)}.`;
+
+  return (
+    <span
+      className={`inline-flex min-w-[82px] justify-center rounded-md border px-2 py-1 text-sm font-semibold ${getCellTone(cell.shift)}`}
+      title={detail}
+      aria-label={detail}
+    >
+      {formatPointShift(cell.shift)}
+    </span>
+  );
+}
+
+export function DomainValueShiftHeatmap() {
+  const [{ data, fetching, error }] = useQuery<ModelsAnalysisQueryResult>({
+    query: MODELS_ANALYSIS_QUERY,
+    variables: {},
+    requestPolicy: 'cache-and-network',
+  });
+  const models = useMemo(
+    () => [...(data?.modelsAnalysis.models ?? [])].sort((left, right) => left.label.localeCompare(right.label)),
+    [data],
+  );
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const nextModelId = getDefaultModelId(models, selectedModelId);
+    if (nextModelId !== selectedModelId) {
+      setSelectedModelId(nextModelId);
+    }
+  }, [models, selectedModelId]);
+
+  const selectedModel = selectedModelId == null
+    ? null
+    : models.find((model) => model.modelId === selectedModelId) ?? null;
+  const heatmap = useMemo(() => buildDomainShiftHeatmap(selectedModel), [selectedModel]);
+  const modelOptions = models.map((model) => ({ value: model.modelId, label: model.label }));
+  const loading = fetching && data == null;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
+        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Domain Shifts by Value</h1>
+        <p className="max-w-3xl text-sm text-gray-600">
+          Exploratory heatmap for domain-associated value shifts. Each cell shows a percentage-point shift
+          versus the selected model&apos;s equal-domain average for that value.
+        </p>
+      </div>
+
+      {error != null && (
+        <ErrorMessage message={`Failed to load domain shifts: ${error.message}`} />
+      )}
+
+      <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+        <div className="max-w-sm">
+          <Select
+            label="Model"
+            options={modelOptions}
+            value={selectedModelId ?? undefined}
+            onChange={setSelectedModelId}
+            placeholder={loading ? 'Loading models...' : 'Select a model'}
+            disabled={loading || modelOptions.length === 0}
+          />
+        </div>
+      </section>
+
+      {loading && <Loading size="lg" text="Loading domain shifts..." />}
+
+      {!loading && models.length === 0 && (
+        <section className="rounded-xl border border-gray-200 bg-white p-6">
+          <p className="text-sm text-gray-600">No models with analysis data are available yet.</p>
+        </section>
+      )}
+
+      {!loading && models.length > 0 && selectedModel != null && heatmap.eligibleDomainCount < 2 && (
+        <section className="rounded-xl border border-amber-200 bg-amber-50 p-6">
+          <h2 className="text-base font-semibold text-amber-950">More domain coverage needed</h2>
+          <p className="mt-2 text-sm text-amber-900">
+            Domain-shift analysis needs at least one value with eligible win-rate data in two or more domains for
+            the selected model. With only one domain for a value, the shift would be 0 pts by definition and would
+            not be meaningful.
+          </p>
+        </section>
+      )}
+
+      {!loading && selectedModel != null && heatmap.eligibleDomainCount >= 2 && (
+        <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+          <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">{selectedModel.label}</h2>
+              <p className="text-sm text-gray-600">
+                Values are rows. Domains are columns. Green means above this model&apos;s usual win rate for that value;
+                red means below. Evidence counts are shown in each cell detail.
+              </p>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+              <span className="font-semibold text-gray-800">Metric:</span> percentage-point shift, not percent change
+            </div>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-[900px] border-separate border-spacing-0 text-sm">
+              <thead>
+                <tr>
+                  <th className="sticky left-0 z-20 border-b border-gray-200 bg-white px-3 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Value
+                  </th>
+                  {heatmap.columns.map((domain) => (
+                    <th
+                      key={domain.domainId}
+                      className="border-b border-gray-200 bg-white px-3 py-3 text-center text-xs font-semibold uppercase tracking-wide text-gray-500"
+                    >
+                      {domain.domainName}
+                    </th>
+                  ))}
+                  <th className="border-b border-gray-200 bg-white px-3 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Avg
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {heatmap.rows.map((row) => (
+                  <tr key={row.valueKey}>
+                    <th className="sticky left-0 z-10 border-b border-gray-100 bg-white px-3 py-3 text-left font-medium text-gray-900">
+                      {row.valueLabel}
+                    </th>
+                    {heatmap.columns.map((domain) => (
+                      <td key={domain.domainId} className="border-b border-gray-100 px-2 py-2 text-center">
+                        <Cell cell={row.cells.get(domain.domainId) ?? null} valueLabel={row.valueLabel} />
+                      </td>
+                    ))}
+                    <td className="border-b border-gray-100 px-3 py-3 text-right font-mono text-gray-700">
+                      {formatPercent(row.averageWinRate)}
+                      {row.averageMatchesPooled === false && (
+                        <span
+                          className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-xs font-sans text-amber-800"
+                          title="Computed average differs from the API pooled win rate by more than the allowed tolerance."
+                        >
+                          check
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/cloud/apps/web/tests/App.test.tsx
+++ b/cloud/apps/web/tests/App.test.tsx
@@ -11,10 +11,15 @@ vi.mock('../src/api/client', () => ({
   },
 }));
 
+vi.mock('../src/pages/DomainValueShiftHeatmap', () => ({
+  DomainValueShiftHeatmap: () => <div>Domain shifts route smoke</div>,
+}));
+
 // Mock localStorage
 beforeEach(() => {
   localStorage.clear();
   window.history.pushState({}, '', '/');
+  vi.stubGlobal('fetch', vi.fn());
   vi.resetAllMocks();
 });
 
@@ -49,4 +54,18 @@ describe('App Routing', () => {
     });
   });
 
+  it('should render the protected domain shifts route when authenticated', async () => {
+    localStorage.setItem('valuerank_token', 'test-token');
+    window.history.pushState({}, '', '/models/domain-shifts');
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'user-1', email: 'researcher@example.com', name: 'Researcher' }),
+    } as Response);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Domain shifts route smoke')).toBeInTheDocument();
+    });
+  });
 });

--- a/cloud/apps/web/tests/components/layout/MobileNav.test.tsx
+++ b/cloud/apps/web/tests/components/layout/MobileNav.test.tsx
@@ -24,8 +24,22 @@ describe('MobileNav Component', () => {
     expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
     expect(screen.getByRole('link', { name: 'Domains' })).toHaveAttribute('href', '/domains');
     expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/models');
+    expect(screen.getByRole('link', { name: 'Matrix' })).toHaveAttribute('href', '/models');
+    expect(screen.getByRole('link', { name: 'Domain Shifts' })).toHaveAttribute('href', '/models/domain-shifts');
+    expect(screen.getByRole('link', { name: 'Consistency' })).toHaveAttribute('href', '/models/consistency');
+    expect(screen.getByRole('link', { name: 'Circumplex' })).toHaveAttribute('href', '/models/circumplex');
     expect(screen.getByRole('link', { name: 'Archive' })).toHaveAttribute('href', '/archive');
     expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings/account');
+  });
+
+  it('highlights Models and Domain Shifts on the domain shifts route', async () => {
+    await renderMobileNav('/models/domain-shifts');
+
+    expect(screen.getByRole('link', { name: 'Models' }).className).toContain('border-teal-500');
+    expect(screen.getByRole('link', { name: 'Matrix' }).className).not.toContain('border-teal-500');
+    expect(screen.getByRole('link', { name: 'Domain Shifts' }).className).toContain('border-teal-500');
+    expect(screen.getByRole('link', { name: 'Consistency' }).className).not.toContain('border-teal-500');
+    expect(screen.getByRole('link', { name: 'Circumplex' }).className).not.toContain('border-teal-500');
   });
 
   it('keeps the domain compatibility links nested under Domains', async () => {
@@ -60,5 +74,13 @@ describe('MobileNav Component', () => {
 
     expect(screen.getByRole('link', { name: 'Settings' }).className).not.toContain('border-teal-500');
     expect(screen.getByRole('link', { name: 'LLM Models' }).className).toContain('border-teal-500');
+  });
+
+  it('keeps the mobile menu escape behavior after Models gains children', async () => {
+    await renderMobileNav('/models/domain-shifts');
+
+    expect(screen.getByRole('link', { name: 'Domain Shifts' })).toBeInTheDocument();
+    await user.keyboard('{Escape}');
+    expect(screen.getByRole('button', { name: /open navigation menu/i })).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/cloud/apps/web/tests/components/layout/NavTabs.test.tsx
+++ b/cloud/apps/web/tests/components/layout/NavTabs.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { NavTabs } from '../../../src/components/layout/NavTabs';
@@ -23,6 +23,7 @@ describe('NavTabs Component', () => {
     renderNavTabs();
 
     expect(screen.queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Domains' })).toHaveAttribute('href', '/domains');
     expect(screen.getByRole('link', { name: 'Vignettes' })).toHaveAttribute('href', '/definitions');
     expect(screen.getByRole('link', { name: 'Archive' })).toHaveAttribute('href', '/archive');
@@ -32,6 +33,37 @@ describe('NavTabs Component', () => {
     expect(screen.queryByRole('button', { name: 'Toggle Validation menu' })).not.toBeInTheDocument();
     // Compare was removed
     expect(screen.queryByRole('link', { name: 'Compare' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the model report links available from the models menu', async () => {
+    renderNavTabs('/models/domain-shifts');
+    const toggle = screen.getByRole('button', { name: 'Toggle Models menu' });
+    const menuRoot = toggle.closest('.relative');
+    if (menuRoot === null) {
+      throw new Error('Missing Models menu root');
+    }
+    fireEvent.mouseEnter(menuRoot);
+
+    expect(toggle).toHaveAttribute('aria-haspopup', 'menu');
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    });
+    expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/models');
+    expect(screen.getByRole('link', { name: 'Matrix' })).toHaveAttribute('href', '/models');
+    expect(screen.getByRole('link', { name: 'Domain Shifts' })).toHaveAttribute('href', '/models/domain-shifts');
+    expect(screen.getByRole('link', { name: 'Consistency' })).toHaveAttribute('href', '/models/consistency');
+    expect(screen.getByRole('link', { name: 'Circumplex' })).toHaveAttribute('href', '/models/circumplex');
+  });
+
+  it('highlights only Domain Shifts inside the models menu on the domain shifts route', async () => {
+    renderNavTabs('/models/domain-shifts');
+    await openMenu('Models');
+
+    expect(screen.getByRole('link', { name: 'Models' }).parentElement?.className).toContain('border-teal-500');
+    expect(screen.getByRole('link', { name: 'Matrix' }).className).not.toContain('bg-teal-600/20');
+    expect(screen.getByRole('link', { name: 'Domain Shifts' }).className).toContain('bg-teal-600/20');
+    expect(screen.getByRole('link', { name: 'Consistency' }).className).not.toContain('bg-teal-600/20');
+    expect(screen.getByRole('link', { name: 'Circumplex' }).className).not.toContain('bg-teal-600/20');
   });
 
   it('keeps the vignettes menu links available from the vignettes menu', async () => {

--- a/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  DomainValueShiftHeatmap,
+  buildDomainShiftHeatmap,
+  formatEvidenceWeight,
+  formatPointShift,
+  getDefaultModelId,
+} from '../../src/pages/DomainValueShiftHeatmap';
+import { MODELS_ANALYSIS_QUERY, type ModelsAnalysisModelResult } from '../../src/api/operations/modelsAnalysis';
+
+const useQueryMock = vi.fn();
+
+vi.mock('urql', async () => {
+  const actual = await vi.importActual<typeof import('urql')>('urql');
+  return {
+    ...actual,
+    useQuery: (args: unknown) => useQueryMock(args),
+  };
+});
+
+function makeModel(overrides: Partial<ModelsAnalysisModelResult> = {}): ModelsAnalysisModelResult {
+  return {
+    modelId: 'model-a',
+    label: 'Model A',
+    values: [
+      {
+        valueKey: 'Achievement',
+        pooledWinRate: 60,
+        stabilityScore: null,
+        eligibleDomainCount: 3,
+        domains: [
+          { domainId: 'jobs', domainName: 'Jobs', winRate: 40, evidenceWeight: 2 },
+          { domainId: 'city', domainName: 'City Planning', winRate: 80, evidenceWeight: null },
+          { domainId: 'bad', domainName: 'Bad Data', winRate: Number.NaN, evidenceWeight: 3 },
+        ],
+      },
+      {
+        valueKey: 'Security_Personal',
+        pooledWinRate: null,
+        stabilityScore: null,
+        eligibleDomainCount: 0,
+        domains: [],
+      },
+      {
+        valueKey: 'Novel_Value',
+        pooledWinRate: 50,
+        stabilityScore: null,
+        eligibleDomainCount: 2,
+        domains: [
+          { domainId: 'jobs', domainName: 'Jobs', winRate: 55, evidenceWeight: 0 },
+          { domainId: 'city', domainName: 'City Planning', winRate: 45, evidenceWeight: -1 },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function installModels(models: ModelsAnalysisModelResult[]) {
+  useQueryMock.mockImplementation((args: { query: unknown }) => {
+    if (args.query === MODELS_ANALYSIS_QUERY) {
+      return [{
+        data: { modelsAnalysis: { models } },
+        fetching: false,
+        error: undefined,
+      }];
+    }
+    return [{ data: undefined, fetching: false, error: undefined }];
+  });
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <DomainValueShiftHeatmap />
+    </MemoryRouter>,
+  );
+}
+
+describe('DomainValueShiftHeatmap helpers', () => {
+  it('computes equal-domain averages and point shifts from eligible finite win rates', () => {
+    const heatmap = buildDomainShiftHeatmap(makeModel());
+    const achievement = heatmap.rows.find((row) => row.valueKey === 'Achievement');
+
+    expect(heatmap.columns.map((column) => column.domainName)).toEqual(['City Planning', 'Jobs']);
+    expect(achievement?.averageWinRate).toBe(60);
+    expect(achievement?.averageMatchesPooled).toBe(true);
+    expect(achievement?.cells.get('city')?.shift).toBe(20);
+    expect(achievement?.cells.get('jobs')?.shift).toBe(-20);
+    expect(achievement?.cells.has('bad')).toBe(false);
+  });
+
+  it('keeps canonical values with no eligible domains as n/a rows and appends unknown values stably', () => {
+    const heatmap = buildDomainShiftHeatmap(makeModel());
+    const security = heatmap.rows.find((row) => row.valueKey === 'Security_Personal');
+
+    expect(security?.cells.size).toBe(0);
+    expect(heatmap.rows.at(-1)?.valueKey).toBe('Novel_Value');
+  });
+
+  it('treats one-domain value rows as not comparable instead of fake zero shifts', () => {
+    const heatmap = buildDomainShiftHeatmap(makeModel({
+      values: [
+        {
+          valueKey: 'Achievement',
+          pooledWinRate: 40,
+          stabilityScore: null,
+          eligibleDomainCount: 1,
+          domains: [{ domainId: 'jobs', domainName: 'Jobs', winRate: 40, evidenceWeight: 1 }],
+        },
+        {
+          valueKey: 'Tradition',
+          pooledWinRate: 70,
+          stabilityScore: null,
+          eligibleDomainCount: 2,
+          domains: [
+            { domainId: 'city', domainName: 'City Planning', winRate: 80, evidenceWeight: 2 },
+            { domainId: 'parks', domainName: 'Parks', winRate: 60, evidenceWeight: 2 },
+          ],
+        },
+      ],
+    }));
+    const achievement = heatmap.rows.find((row) => row.valueKey === 'Achievement');
+    const tradition = heatmap.rows.find((row) => row.valueKey === 'Tradition');
+
+    expect(heatmap.columns.map((column) => column.domainName)).toEqual(['City Planning', 'Parks']);
+    expect(achievement?.comparableDomainCount).toBe(1);
+    expect(achievement?.averageWinRate).toBeNull();
+    expect(achievement?.cells.size).toBe(0);
+    expect(tradition?.cells.get('city')?.shift).toBe(10);
+    expect(tradition?.cells.get('parks')?.shift).toBe(-10);
+  });
+
+  it('formats point shifts and unknown evidence without percent-change language', () => {
+    expect(formatPointShift(12.4)).toBe('+12 pts');
+    expect(formatPointShift(-8.6)).toBe('-9 pts');
+    expect(formatPointShift(0.2)).toBe('0 pts');
+    expect(formatEvidenceWeight(null)).toBe('—');
+    expect(formatEvidenceWeight(0)).toBe('—');
+    expect(formatEvidenceWeight(-1)).toBe('—');
+    expect(formatEvidenceWeight(3)).toBe('3');
+  });
+
+  it('defaults to the sorted first available model and preserves a valid current selection', () => {
+    const models = [
+      makeModel({ modelId: 'model-b', label: 'Zulu' }),
+      makeModel({ modelId: 'model-a', label: 'Alpha' }),
+    ];
+
+    expect(getDefaultModelId(models, null)).toBe('model-a');
+    expect(getDefaultModelId(models, 'model-b')).toBe('model-b');
+    expect(getDefaultModelId(models, 'missing')).toBe('model-a');
+    expect(getDefaultModelId([], 'missing')).toBeNull();
+  });
+});
+
+describe('DomainValueShiftHeatmap page', () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+  });
+
+  it('renders the selected model heatmap with raw detail in accessible text', async () => {
+    installModels([makeModel()]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Domain Shifts by Value' })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /model a/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Achievement in City Planning: \+20 pts/i)).toHaveAccessibleName(
+      /Domain win rate 80%; average 60%; evidence vignettes —/i,
+    );
+    expect(screen.getByText('Metric:')).toBeInTheDocument();
+    expect(screen.getByText(/percentage-point shift, not percent change/i)).toBeInTheDocument();
+  });
+
+  it('lets the user select a different model', async () => {
+    const user = userEvent.setup({ delay: null });
+    installModels([
+      makeModel({ modelId: 'model-b', label: 'Zulu' }),
+      makeModel({ modelId: 'model-a', label: 'Alpha' }),
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByRole('button', { name: /alpha/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /alpha/i }));
+    await user.click(screen.getByRole('option', { name: 'Zulu' }));
+
+    expect(screen.getByRole('heading', { name: 'Zulu' })).toBeInTheDocument();
+  });
+
+  it('shows an empty state when fewer than two domains are eligible', async () => {
+    installModels([
+      makeModel({
+        values: [
+          {
+            valueKey: 'Achievement',
+            pooledWinRate: 40,
+            stabilityScore: null,
+            eligibleDomainCount: 1,
+            domains: [{ domainId: 'jobs', domainName: 'Jobs', winRate: 40, evidenceWeight: 1 }],
+          },
+        ],
+      }),
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText('More domain coverage needed')).toBeInTheDocument();
+    expect(screen.getByText(/two or more domains/i)).toBeInTheDocument();
+  });
+
+  it('shows the no-models empty state', async () => {
+    installModels([]);
+
+    renderPage();
+
+    expect(await screen.findByText(/No models with analysis data/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a new `/models/domain-shifts` report page for single-model value shifts across domains.
- Compute percentage-point shifts against each value's equal-domain average and show sparse rows as `n/a` instead of fake `0 pts`.
- Add Domain Shifts to desktop and mobile Models navigation with route/nav/page tests.

## Validation
- [x] `npm ci`
- [x] `npm run build --workspace @valuerank/shared`
- [x] `npx eslint src/pages/DomainValueShiftHeatmap.tsx src/App.tsx src/components/layout/NavTabs.tsx src/components/layout/MobileNav.tsx`
- [x] `npm run test --workspace @valuerank/web -- DomainValueShiftHeatmap NavTabs MobileNav App`
- [x] `npx turbo lint --filter=@valuerank/web && npx turbo test --filter=@valuerank/web && npx turbo build --filter=@valuerank/web`

## Notes
- Full web lint passes with existing warnings.
- Web tests pass with existing React `act(...)` warnings in interactive component tests.
