### PR TITLE
Group non-default models in domain shifts

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -27,7 +27,7 @@
 |---------|--------|--------|--------------|
 | **domain-coverage-completeness-guard** | `030-remove-legacy-decision-code` | 🟡 In progress | Plan/tasks are green. Shared completeness plumbing, coverage-query helpers, UI helper splits, and the read-only audit script are in place; diff checkpoint and rebase are next. |
 | **domain-analysis-definition-snapshot-crash** | — | 🟡 Ready | Default-temperature domain analysis can crash in Prisma when transcripts contain unreadable `definitionSnapshot` data. Local API fix is ready: domain analysis now uses the pre-resolved value pair instead of reading transcript snapshots. Prod data cleanup still needs direct SQL access to find and null the bad snapshots. |
-| **domain-shifts-snapshot-selection** | `codex/domain-shift-na-fix` | 🟡 Local fix | Domain Shifts can show `n/a` for Job Choice when the models report picks the newest snapshot across signatures instead of the default-temperature domain snapshot. Production confirms Job Choice `vnewt0` has only 6 Claude Sonnet 4.5 value entries while `vnewtd` has all 10. Local fix adds a signature dropdown defaulting to `vnewtd` and excludes the synthetic all-domains snapshot from report columns. |
+| **domain-shifts-snapshot-selection** | `codex/domain-shift-na-fix` | 🟡 Local fix | Domain Shifts can show `n/a` for Job Choice when the models report picks the newest snapshot across signatures instead of the default-temperature domain snapshot. Production confirms Job Choice `vnewt0` has only 6 Claude Sonnet 4.5 value entries while `vnewtd` has all 10. Local fix adds a signature dropdown defaulting to `vnewtd` and excludes the synthetic all-domains snapshot from report columns. Follow-up prod finding on 2026-04-22: `National Priorities` has a CURRENT `vnewtd` snapshot, but it is empty and marks all 90 vignettes as `NO_COMPLETED_RUNS` despite 180 completed default-temperature runs, so that domain still will not appear in Domain Shifts until the snapshot data is rebuilt or the resolver bug is fixed. |
 | **transcript-resummarization-backfill** | — | 🟡 Ready | Script written (`cloud/scripts/backfill-resummarize-existing-transcripts.ts`) but no PR yet — needs review and merge |
 | **provider-budget migration** | — | 🟡 Pending prod apply | PR #483 merged. Migration SQL not yet applied to prod. Run: `psql $DIRECT_URL -f cloud/packages/db/prisma/migrations/20260331000000_add_provider_budget_tracking/migration.sql` then `npx prisma@5 migrate resolve --applied 20260331000000_add_provider_budget_tracking` |
 | **domain-evaluation-model-backfill** | `codex/domain-evaluation-backfill-attach` | 🟡 In review | Adds a supported way to backfill missing model coverage into existing Domain Level Batches so reruns stay attached to the original evaluation instead of becoming orphan batches |
@@ -79,6 +79,7 @@ Once the above are resolved:
 ### Analysis Reports
 - [x] Domain Shifts by Value heatmap implemented at `/models/domain-shifts`; focused tests and web preflight pass.
 - [x] Domain Shifts readability controls added locally: cells can toggle between shift and raw win rate, and table columns are sortable.
+- [x] Domain Shifts model picker now groups default models first and separates non-default models with `---` before alphabetical non-default options.
 
 ---
 

--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -1,13 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'urql';
-import {
-  MODELS_ANALYSIS_QUERY,
-  type ModelsAnalysisQueryResult,
-} from '../api/operations/modelsAnalysis';
-import {
-  AVAILABLE_SIGNATURES_QUERY,
-  type AvailableSignaturesQueryResult,
-} from '../api/operations/available-signatures';
+import { MODELS_ANALYSIS_QUERY, type ModelsAnalysisQueryResult } from '../api/operations/modelsAnalysis';
+import { AVAILABLE_SIGNATURES_QUERY, type AvailableSignaturesQueryResult } from '../api/operations/available-signatures';
+import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { Button } from '../components/ui/Button';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { Loading } from '../components/ui/Loading';
@@ -17,6 +12,7 @@ import {
   DEFAULT_DOMAIN_SHIFT_SORT,
   DEFAULT_DOMAIN_SHIFT_SIGNATURE,
   buildDomainShiftHeatmap,
+  buildDomainShiftModelOptions,
   buildDomainShiftSignatureOptions,
   formatEvidenceWeight,
   formatPercent,
@@ -33,15 +29,7 @@ import {
 
 const MAX_COLOR_SHIFT = 25;
 
-export {
-  buildDomainShiftHeatmap,
-  formatEvidenceWeight,
-  formatPercent,
-  formatPointShift,
-  getDefaultDomainShiftSignature,
-  getDefaultModelId,
-  sortHeatmapRows,
-} from './domainValueShiftHeatmapUtils';
+export { buildDomainShiftHeatmap, formatEvidenceWeight, formatPercent, formatPointShift, getDefaultDomainShiftSignature, getDefaultModelId, sortHeatmapRows } from './domainValueShiftHeatmapUtils';
 
 function getCellTone(shift: number): string {
   const clamped = Math.max(-MAX_COLOR_SHIFT, Math.min(MAX_COLOR_SHIFT, shift));
@@ -203,6 +191,11 @@ export function DomainValueShiftHeatmap() {
     requestPolicy: 'cache-and-network',
   });
   const [selectedSignature, setSelectedSignature] = useState<string>(DEFAULT_DOMAIN_SHIFT_SIGNATURE);
+  const [{ data: llmModelsData }] = useQuery<LlmModelsQueryResult>({
+    query: LLM_MODELS_QUERY,
+    variables: { status: 'ACTIVE' },
+    requestPolicy: 'cache-and-network',
+  });
   const [{ data, fetching, error }] = useQuery<ModelsAnalysisQueryResult>({
     query: MODELS_ANALYSIS_QUERY,
     variables: { signature: selectedSignature },
@@ -216,9 +209,10 @@ export function DomainValueShiftHeatmap() {
     () => buildDomainShiftSignatureOptions(availableSignatures),
     [availableSignatures],
   );
-  const models = useMemo(
-    () => [...(data?.modelsAnalysis.models ?? [])].sort((left, right) => left.label.localeCompare(right.label)),
-    [data],
+  const models = useMemo(() => data?.modelsAnalysis.models ?? [], [data]);
+  const defaultModelIds = useMemo(
+    () => new Set((llmModelsData?.llmModels ?? []).filter((model) => model.isDefault).map((model) => model.modelId)),
+    [llmModelsData],
   );
   const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
   const [displayMode, setDisplayMode] = useState<DomainShiftDisplayMode>('shift');
@@ -232,11 +226,11 @@ export function DomainValueShiftHeatmap() {
   }, [availableSignatures, selectedSignature]);
 
   useEffect(() => {
-    const nextModelId = getDefaultModelId(models, selectedModelId);
+    const nextModelId = getDefaultModelId(models, selectedModelId, defaultModelIds);
     if (nextModelId !== selectedModelId) {
       setSelectedModelId(nextModelId);
     }
-  }, [models, selectedModelId]);
+  }, [defaultModelIds, models, selectedModelId]);
 
   const selectedModel = selectedModelId == null
     ? null
@@ -246,7 +240,10 @@ export function DomainValueShiftHeatmap() {
     () => sortHeatmapRows(heatmap.rows, sort, displayMode),
     [heatmap.rows, sort, displayMode],
   );
-  const modelOptions = models.map((model) => ({ value: model.modelId, label: model.label }));
+  const modelOptions = useMemo(
+    () => buildDomainShiftModelOptions(models, defaultModelIds),
+    [defaultModelIds, models],
+  );
   const loading = fetching && data == null;
 
   return (

--- a/cloud/apps/web/src/pages/domainValueShiftHeatmapUtils.ts
+++ b/cloud/apps/web/src/pages/domainValueShiftHeatmapUtils.ts
@@ -58,6 +58,14 @@ export type DomainShiftSignatureOption = {
   label: string;
 };
 
+export type DomainShiftModelOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+const NON_DEFAULT_MODELS_DIVIDER_VALUE = '__non-default-models__';
+
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
@@ -110,12 +118,36 @@ export function getDefaultDomainShiftSignature(signatures: string[], currentSign
   return DEFAULT_DOMAIN_SHIFT_SIGNATURE;
 }
 
-export function getDefaultModelId(models: ModelsAnalysisModelResult[], currentModelId: string | null): string | null {
-  const sorted = [...models].sort((left, right) => left.label.localeCompare(right.label));
+function sortModels(models: ModelsAnalysisModelResult[]): ModelsAnalysisModelResult[] {
+  return [...models].sort((left, right) => left.label.localeCompare(right.label));
+}
+
+export function buildDomainShiftModelOptions(
+  models: ModelsAnalysisModelResult[],
+  defaultModelIds: ReadonlySet<string>,
+): DomainShiftModelOption[] {
+  const sorted = sortModels(models);
+  const defaults = sorted.filter((model) => defaultModelIds.has(model.modelId));
+  const nonDefaults = sorted.filter((model) => !defaultModelIds.has(model.modelId));
+  return [
+    ...defaults.map((model) => ({ value: model.modelId, label: model.label })),
+    ...(defaults.length > 0 && nonDefaults.length > 0
+      ? [{ value: NON_DEFAULT_MODELS_DIVIDER_VALUE, label: '---', disabled: true }]
+      : []),
+    ...nonDefaults.map((model) => ({ value: model.modelId, label: model.label })),
+  ];
+}
+
+export function getDefaultModelId(
+  models: ModelsAnalysisModelResult[],
+  currentModelId: string | null,
+  defaultModelIds: ReadonlySet<string> = new Set<string>(),
+): string | null {
+  const sorted = sortModels(models);
   if (currentModelId != null && sorted.some((model) => model.modelId === currentModelId)) {
     return currentModelId;
   }
-  return sorted[0]?.modelId ?? null;
+  return sorted.find((model) => defaultModelIds.has(model.modelId))?.modelId ?? sorted[0]?.modelId ?? null;
 }
 
 function sortValueKeys(valueKeys: Set<string>): string[] {

--- a/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../src/pages/DomainValueShiftHeatmap';
 import { MODELS_ANALYSIS_QUERY, type ModelsAnalysisModelResult } from '../../src/api/operations/modelsAnalysis';
 import { AVAILABLE_SIGNATURES_QUERY } from '../../src/api/operations/available-signatures';
+import { LLM_MODELS_QUERY } from '../../src/api/operations/llm';
 
 const useQueryMock = vi.fn();
 
@@ -62,7 +63,11 @@ function makeModel(overrides: Partial<ModelsAnalysisModelResult> = {}): ModelsAn
   };
 }
 
-function installModels(models: ModelsAnalysisModelResult[], signatures: string[] = ['vnewtd', 'vnewt0']) {
+function installModels(
+  models: ModelsAnalysisModelResult[],
+  signatures: string[] = ['vnewtd', 'vnewt0'],
+  defaultModelIds: string[] = models.map((model) => model.modelId),
+) {
   useQueryMock.mockImplementation((args: { query: unknown }) => {
     if (args.query === AVAILABLE_SIGNATURES_QUERY) {
       return [{
@@ -70,6 +75,28 @@ function installModels(models: ModelsAnalysisModelResult[], signatures: string[]
           availableSignatures: signatures.map((signature) => ({
             signature,
             mostRecentRunAt: '2026-04-17T03:06:20.919Z',
+          })),
+        },
+        fetching: false,
+        error: undefined,
+      }];
+    }
+    if (args.query === LLM_MODELS_QUERY) {
+      return [{
+        data: {
+          llmModels: models.map((model) => ({
+            id: model.modelId,
+            providerId: 'provider',
+            modelId: model.modelId,
+            displayName: model.label,
+            costInputPerMillion: 0,
+            costOutputPerMillion: 0,
+            status: 'ACTIVE',
+            isDefault: defaultModelIds.includes(model.modelId),
+            isAvailable: true,
+            apiConfig: null,
+            createdAt: '2026-04-17T03:06:20.919Z',
+            updatedAt: '2026-04-17T03:06:20.919Z',
           })),
         },
         fetching: false,
@@ -197,6 +224,7 @@ describe('DomainValueShiftHeatmap helpers', () => {
     ];
 
     expect(getDefaultModelId(models, null)).toBe('model-a');
+    expect(getDefaultModelId(models, null, new Set(['model-b']))).toBe('model-b');
     expect(getDefaultModelId(models, 'model-b')).toBe('model-b');
     expect(getDefaultModelId(models, 'missing')).toBe('model-a');
     expect(getDefaultModelId([], 'missing')).toBeNull();
@@ -294,6 +322,23 @@ describe('DomainValueShiftHeatmap page', () => {
     await user.click(screen.getByRole('option', { name: 'Zulu' }));
 
     expect(screen.getByRole('heading', { name: 'Zulu' })).toBeInTheDocument();
+  });
+
+  it('groups default models ahead of non-default models with a divider', async () => {
+    const user = userEvent.setup({ delay: null });
+    installModels([
+      makeModel({ modelId: 'model-c', label: 'Charlie' }),
+      makeModel({ modelId: 'model-a', label: 'Alpha' }),
+      makeModel({ modelId: 'model-b', label: 'Bravo' }),
+    ], ['vnewtd', 'vnewt0'], ['model-c', 'model-a']);
+
+    renderPage();
+
+    await screen.findByRole('button', { name: /alpha/i });
+    await user.click(screen.getByRole('button', { name: /alpha/i }));
+
+    const options = screen.getAllByRole('option').map((option) => option.textContent?.trim());
+    expect(options).toEqual(['Alpha', 'Charlie', '---', 'Bravo']);
   });
 
   it('shows an empty state when fewer than two domains are eligible', async () => {


### PR DESCRIPTION
## Summary
- group default models first in the Domain Shifts model picker, insert `---`, then sort non-default models alphabetically
- prefer the first available default model as the initial selection and add focused test coverage for the grouped dropdown order
- note the production `National Priorities` finding in status: the current `vnewtd` snapshot exists but is empty even though completed default-temperature runs exist

## Validation
- [x] `npm run test --workspace @valuerank/web -- DomainValueShiftHeatmap`
- [x] `./node_modules/.bin/eslint apps/web/src/pages/DomainValueShiftHeatmap.tsx apps/web/src/pages/domainValueShiftHeatmapUtils.ts`
- [x] `npx turbo build --filter=@valuerank/web`

## Notes
- Production investigation on 2026-04-22 showed `National Priorities` is missing from Domain Shifts because its CURRENT `vnewtd` snapshot is empty (`model_count = 0`, `coveredDefinitions = 0`), not because of the dropdown ordering.