### PR TITLE
Fix: aggregate runs were piling up as UNKNOWN_LEGACY

### DIFF
--- a/cloud/apps/api/src/services/analysis/aggregate/aggregate-run-workflow.ts
+++ b/cloud/apps/api/src/services/analysis/aggregate/aggregate-run-workflow.ts
@@ -63,6 +63,10 @@ export async function claimAggregateRun(prepared: AggregateRunPreparation): Prom
           createdByUserId: prepared.templateRun.createdByUserId,
           experimentId: prepared.templateRun.experimentId,
           status: 'RUNNING',
+          // Aggregate runs are first-class production rollups. Without this,
+          // they fall through to the schema default (UNKNOWN_LEGACY) and pile
+          // up incorrectly. See migration 20260424_backfill_aggregate_run_category.
+          runCategory: 'PRODUCTION',
           config: claimConfig as unknown as Prisma.InputJsonValue,
           tags: {
             create: {

--- a/cloud/apps/api/tests/services/analysis/aggregate.test.ts
+++ b/cloud/apps/api/tests/services/analysis/aggregate.test.ts
@@ -309,6 +309,47 @@ describe('updateAggregateRun same-signature aggregate eligibility', () => {
     });
   });
 
+  it('creates new aggregate runs with runCategory = PRODUCTION', async () => {
+    const definition = await db.definition.create({
+      data: {
+        name: `aggregate-test-runcategory-${Date.now()}`,
+        content: {
+          schema_version: 1,
+          dimensions: [{ name: 'ValueA' }, { name: 'ValueB' }],
+        },
+      },
+    });
+    definitionIds.push(definition.id);
+
+    const scenarios = await db.scenario.createManyAndReturn({
+      data: [
+        { definitionId: definition.id, name: 'Scenario 1', content: { dimensions: { stakes: 1 } } },
+        { definitionId: definition.id, name: 'Scenario 2', content: { dimensions: { stakes: 2 } } },
+      ],
+      select: { id: true },
+    });
+    const scenarioIds = scenarios.map((scenario) => scenario.id);
+
+    await createSourceRun({
+      definitionId: definition.id,
+      scenarioIds,
+      modelScenarioMap: { 'gpt-4': scenarioIds },
+    });
+
+    const prepared = await prepareAggregateRunSnapshot(definition.id, 'pre-1', 1, 0.7);
+    expect(prepared).not.toBeNull();
+
+    const claim = await claimAggregateRun(prepared!);
+    const aggregateRun = await db.run.findUniqueOrThrow({
+      where: { id: claim.aggregateRunId },
+      select: { runCategory: true },
+    });
+
+    expect(aggregateRun.runCategory).toBe('PRODUCTION');
+
+    await releaseAggregateClaim(prepared!, claim);
+  });
+
   it('rejects stale aggregate claims before the final persist step', async () => {
     const definition = await db.definition.create({
       data: {

--- a/cloud/packages/db/prisma/migrations/20260424120000_backfill_aggregate_run_category/migration.sql
+++ b/cloud/packages/db/prisma/migrations/20260424120000_backfill_aggregate_run_category/migration.sql
@@ -1,0 +1,13 @@
+-- Backfill run_category for aggregate rollup runs that were created with the
+-- schema default (UNKNOWN_LEGACY). The aggregate-run workflow at
+-- apps/api/src/services/analysis/aggregate/aggregate-run-workflow.ts now sets
+-- runCategory = PRODUCTION at create time; this fixes existing rows.
+--
+-- These rows are first-class production rollups: each has isAggregate = true
+-- and a sourceRunIds list pointing at the runs it summarizes. They never had
+-- transcripts of their own (by design) so progress stays NULL.
+UPDATE "runs"
+SET "run_category" = 'PRODUCTION'
+WHERE "deleted_at" IS NULL
+  AND "run_category" = 'UNKNOWN_LEGACY'
+  AND ("config"->>'isAggregate')::boolean = TRUE;


### PR DESCRIPTION
## Summary

- Aggregate rollup runs (`config.isAggregate = true`) were being created without `runCategory`, falling through to the Prisma schema default `UNKNOWN_LEGACY`.
- The one-time migration on 2026-03-20 fixed historical rows, but the code path was never updated. **372 aggregate runs** have piled up as `UNKNOWN_LEGACY` since then.
- This PR fixes the create path and adds a migration that flips the existing 372 rows to `PRODUCTION`.

## Distribution of the 372 stragglers

| Domain | Count |
|---|---|
| Job Choice | 102 |
| National Priorities | 90 |
| Neighborhood Choice | 90 |
| Software Approach Choice | 90 |

All 372 have `config.isAggregate = true`, valid `sourceRunIds`, `methodologySafe = true`, and `jobChoiceLaunchMode = PAIRED_BATCH`. They're production rollups; just mislabeled.

## Changes

- `cloud/apps/api/src/services/analysis/aggregate/aggregate-run-workflow.ts` — set `runCategory: 'PRODUCTION'` in `tx.run.create(...)` so new aggregates don't repeat the bug.
- `cloud/packages/db/prisma/migrations/20260424120000_backfill_aggregate_run_category/migration.sql` — one-line UPDATE for existing rows. Scoped narrowly: `run_category = 'UNKNOWN_LEGACY'` AND `(config->>'isAggregate')::boolean = TRUE` AND `deleted_at IS NULL`.
- `cloud/apps/api/tests/services/analysis/aggregate.test.ts` — integration test asserting new aggregate runs land with `runCategory = 'PRODUCTION'`.

## Why progress stays NULL on these rows

Aggregate runs don't execute trials — they reference `sourceRunIds`. They never had transcripts of their own, so the `progress = {total, completed, failed}` shape doesn't apply.

## Test plan

- [ ] CI passes lint, unit tests, integration tests
- [ ] Migration applies cleanly on Railway deploy
- [ ] After deploy, verify on prod: `SELECT count(*) FROM runs WHERE run_category = 'UNKNOWN_LEGACY' AND status = 'COMPLETED' AND deleted_at IS NULL` returns `0`
- [ ] Spot-check that one flipped row now reads `run_category = 'PRODUCTION'`

## Validation

| Command | Result |
|---|---|
| `npx turbo lint --filter=@valuerank/api` | ✅ 0 errors (20 pre-existing warnings) |
| `npx turbo build --filter=@valuerank/api` | ✅ |
| New integration test | ⚠️ Skipped locally (Docker not running); will run in CI |

🤖 Generated with [Claude Code](https://claude.com/claude-code)