### PR TITLE
Wake recovery scheduler on stale default-source anomalies

### DIFF
--- a/cloud/apps/api/src/services/run/scheduler.ts
+++ b/cloud/apps/api/src/services/run/scheduler.ts
@@ -172,7 +172,31 @@ async function hasRecoveryActivity(): Promise<boolean> {
     LIMIT 1
   `;
 
-  return orphanBacklog.length > 0;
+  if (orphanBacklog.length > 0) {
+    return true;
+  }
+
+  // Wake on lingering open anomalies even when transcript state is clean.
+  // The reconciler clears stale default-source anomalies via
+  // syncAnomalies(..., [], 'default'), but only when it actually runs. Without
+  // this check, an idle system can't auto-resolve anomalies that have already
+  // self-cleared underneath, leaving rows in run_anomalies forever.
+  const staleAnomaly = await db.runAnomaly.findFirst({
+    where: {
+      resolvedAt: null,
+      source: 'default',
+      run: {
+        deletedAt: null,
+        status: 'COMPLETED',
+        updatedAt: {
+          gt: new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000),
+        },
+      },
+    },
+    select: { id: true },
+  });
+
+  return staleAnomaly !== null;
 }
 
 export async function enqueueRunStateReconcileJobs(): Promise<number> {

--- a/cloud/apps/api/tests/services/run/scheduler.test.ts
+++ b/cloud/apps/api/tests/services/run/scheduler.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockDbRunFindFirst = vi.hoisted(() => vi.fn());
 const mockDbRunFindMany = vi.hoisted(() => vi.fn());
 const mockDbTranscriptFindFirst = vi.hoisted(() => vi.fn());
+const mockDbRunAnomalyFindFirst = vi.hoisted(() => vi.fn());
 const mockDbQueryRaw = vi.hoisted(() => vi.fn());
 const mockBossSchedule = vi.hoisted(() => vi.fn());
 const mockBossUnschedule = vi.hoisted(() => vi.fn());
@@ -19,6 +20,9 @@ vi.mock('@valuerank/db', () => ({
     },
     transcript: {
       findFirst: mockDbTranscriptFindFirst,
+    },
+    runAnomaly: {
+      findFirst: mockDbRunAnomalyFindFirst,
     },
     $queryRaw: mockDbQueryRaw,
   },
@@ -172,6 +176,43 @@ describe('getReconcileWindowDays', () => {
         fallbackDays: 30,
       }),
       'Invalid RUN_RECONCILE_WINDOW_DAYS, falling back to default'
+    );
+  });
+});
+
+describe('hasRecoveryActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.RUN_RECONCILE_WINDOW_DAYS;
+    mockDbRunFindFirst.mockResolvedValue(null);
+    mockDbRunFindMany.mockResolvedValue([]);
+    mockDbTranscriptFindFirst.mockResolvedValue(null);
+    mockDbRunAnomalyFindFirst.mockResolvedValue(null);
+    mockDbQueryRaw.mockResolvedValue([]);
+  });
+
+  it('starts the scheduler when there are open default-source anomalies, even with no active runs', async () => {
+    // No active runs, no stranded transcripts, no orphan backlog -- but one
+    // open default-source anomaly. Without this wake-up condition, the
+    // scheduler would stay dormant forever and the stale anomaly would never
+    // get re-checked.
+    mockDbRunAnomalyFindFirst.mockResolvedValue({ id: 'anomaly-1' });
+
+    const { startRecoveryScheduler } = await loadScheduler();
+    await startRecoveryScheduler();
+
+    expect(mockLogInfo).toHaveBeenCalledWith('Recovery scheduler started (active runs detected)');
+    expect(mockLogInfo).not.toHaveBeenCalledWith(
+      'Recovery scheduler initialized but not running (no active runs)',
+    );
+  });
+
+  it('stays dormant when nothing -- no active runs, no transcripts, no anomalies', async () => {
+    const { startRecoveryScheduler } = await loadScheduler();
+    await startRecoveryScheduler();
+
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      'Recovery scheduler initialized but not running (no active runs)',
     );
   });
 });


### PR DESCRIPTION
## Summary

Companion to #753. PR #753 fixed the *enqueue* SQL so that runs with stale anomalies get a reconcile job — but only when the scheduler ticks. The scheduler is gated on `hasRecoveryActivity()`, which only returns true when there are active runs, stranded transcripts, or orphan backlog. **On an idle system, the scheduler never ticks**, so PR #753's enqueue logic never fires.

This PR adds a 4th wake-up condition: any open `default`-source anomaly on a recent run.

## The full chain after this lands

1. `hasRecoveryActivity()` returns `true` because there's an open `default`-source anomaly
2. Recovery scheduler starts ticking (every 5 min)
3. Each tick calls `enqueueRunStateReconcileJobs` (PR #753's SQL)
4. Reconciler runs on each affected run → finds no current issues → calls `syncAnomalies(runId, type, [], 'default')` → marks stale rows resolved

## Why two PRs instead of one

PR #753 was complete on its own merits — it fixed the enqueue SQL. The scheduler-wake gap was a separate liveness bug that only surfaced after #753 deployed and we observed *"Recovery scheduler initialized but not running (no active runs)"* in Railway logs while 8 anomalies sat untouched.

## Test plan

- [x] New unit tests:
  - Scheduler starts when there's only a stale anomaly (no active runs / transcripts / orphans)
  - Scheduler stays dormant when there's truly nothing
- [x] All 8 scheduler tests pass locally
- [ ] Post-deploy: verify on prod that the 8 `STRANDED_TRANSCRIPT` / `default` anomalies drop to 0 within ~5 min of deploy

## Validation

| Command | Result |
|---|---|
| `npx turbo lint --filter=@valuerank/api` | ✅ |
| `npx turbo build --filter=@valuerank/api` | ✅ |
| `npx vitest run tests/services/run/scheduler.test.ts` | ✅ 8/8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)