### PR TITLE
Fail loud on empty LLM responses; add parse_failed sentinel

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/decision-model-helpers.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model-helpers.ts
@@ -62,6 +62,7 @@ export function isCachedWinnerFirstDecision(value: unknown): value is CachedWinn
     && decision.decisionState !== 'neutral'
     && decision.decisionState !== 'unknown'
     && decision.decisionState !== 'refusal'
+    && decision.decisionState !== 'parse_failed'
   ) {
     return false;
   }
@@ -78,10 +79,11 @@ export function isCachedWinnerFirstDecision(value: unknown): value is CachedWinn
     return decision.favoredValueKey === null && decision.strength === 'neutral';
   }
 
-  // 'unknown' and 'refusal' share the same field shape: no favored value,
-  // strength reported as 'unknown'. Keeping them separate decisionStates
-  // preserves the semantic signal (parser failure vs model refusal) without
-  // requiring any other field to differ.
+  // 'unknown', 'refusal', and 'parse_failed' share the same field shape: no
+  // favored value, strength reported as 'unknown'. Keeping them separate
+  // decisionStates preserves the semantic signal (parser ambiguity vs model
+  // refusal vs explicit parse-failure sentinel) without requiring any other
+  // field to differ.
   return decision.favoredValueKey === null && decision.strength === 'unknown';
 }
 

--- a/cloud/apps/api/src/graphql/queries/domain/decision-model-types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model-types.ts
@@ -124,10 +124,15 @@ export type ParsedDecisionPath = {
  * - `"unknown"`: parser could not resolve.
  * - `"refusal"`: model explicitly refused to answer. Signalled by the Python
  *   worker setting `decisionMetadata.refusal = true`.
+ * - `"parse_failed"`: explicit sentinel for "no decision recoverable" — emitted
+ *   when buildWinnerFirstSummaryCache would otherwise have returned null
+ *   (e.g. empty model response, unparseable output). Shape and downstream
+ *   handling match `"unknown"`; the distinct label makes parser failures
+ *   visible in queries instead of silently null in the JSONB.
  */
 export type CachedWinnerFirstDecision = {
   cacheVersion: 2;
-  decisionState: 'resolved' | 'neutral' | 'unknown' | 'refusal';
+  decisionState: 'resolved' | 'neutral' | 'unknown' | 'refusal' | 'parse_failed';
   favoredValueKey: DomainAnalysisValueKey | null;
   strength: DecisionStrength;
 };

--- a/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/decision-model.ts
@@ -154,11 +154,16 @@ export function resolveCanonicalDecision(input: DecisionModelInput): CanonicalDe
 
   const parsedPath = parseDecisionPath(input.raw.parsePath);
   const cachedDecision = input.cachedDecision ?? null;
-  if (cachedDecision && cachedDecision.decisionState !== 'unknown') {
-    // When cachedDecision.decisionState is 'unknown', skip the cache and
-    // fall through to re-resolve from raw evidence. This handles cases where
-    // the cache was built with incorrect config (e.g. wrong value statements
-    // or label prefix for the domain family).
+  if (
+    cachedDecision
+    && cachedDecision.decisionState !== 'unknown'
+    && cachedDecision.decisionState !== 'parse_failed'
+  ) {
+    // When cachedDecision.decisionState is 'unknown' or 'parse_failed', skip
+    // the cache and fall through to re-resolve from raw evidence. Both states
+    // signal "no decision recovered" — re-resolving may succeed if the cache
+    // was built with incorrect config (wrong value statements or label prefix)
+    // or if the parser was upgraded after the empty-response was recorded.
 
     if (cachedDecision.decisionState === 'neutral') {
       return buildCanonicalDecisionFromPair(

--- a/cloud/apps/api/src/graphql/queries/domain/scale-code-from-canonical.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/scale-code-from-canonical.ts
@@ -34,6 +34,7 @@ export type ScaleCode = '1' | '2' | '3' | '4' | '5' | 'refusal' | 'unknown';
  *
  *   decisionState === 'refusal'                 → 'refusal'
  *   decisionState === 'unknown'                 → 'unknown'
+ *   decisionState === 'parse_failed'            → 'unknown'
  *   decisionState === 'neutral'                 → '3'
  *   favoredValueKey = valueA, strong, !flipped  → '5'
  *   favoredValueKey = valueA, strong, flipped   → '1'
@@ -52,6 +53,7 @@ export function scaleCodeFromCanonical(
 ): ScaleCode {
   if (canonical.decisionState === 'refusal') return 'refusal';
   if (canonical.decisionState === 'unknown') return 'unknown';
+  if (canonical.decisionState === 'parse_failed') return 'unknown';
   if (canonical.decisionState === 'neutral') return '3';
 
   // decisionState === 'resolved' — need favored key + strength

--- a/cloud/apps/api/src/queue/handlers/summarize-transcript.ts
+++ b/cloud/apps/api/src/queue/handlers/summarize-transcript.ts
@@ -115,7 +115,7 @@ function getProviderNameFromModelId(modelId: string, fallbackProvider: string): 
 async function buildWinnerFirstSummaryCache(
   transcript: TranscriptRecord,
   summary: SuccessfulSummarizeWorkerSummary,
-): Promise<WinnerFirstSummaryCache | null> {
+): Promise<WinnerFirstSummaryCache> {
   const scenarioId = transcript.scenarioId;
   const scenario = scenarioId == null
     ? null
@@ -160,7 +160,17 @@ async function buildWinnerFirstSummaryCache(
   }
 
   if (canonical.favoredValueKey == null) {
-    return null;
+    // Explicit sentinel instead of returning null — makes parser failures
+    // visible in JSONB queries as decisionState='parse_failed' rather than
+    // a missing canonicalDecision key. Structurally identical to 'unknown';
+    // the distinct label flags that the resolver could not pin a value even
+    // though direction/strength were not themselves marked unknown.
+    return {
+      cacheVersion: 2,
+      decisionState: 'parse_failed',
+      favoredValueKey: null,
+      strength: 'unknown',
+    };
   }
 
   return {

--- a/cloud/apps/api/src/queue/handlers/summarize-types.ts
+++ b/cloud/apps/api/src/queue/handlers/summarize-types.ts
@@ -83,6 +83,7 @@ export function isWinnerFirstSummaryCache(value: unknown): value is WinnerFirstS
     && value.decisionState !== 'neutral'
     && value.decisionState !== 'unknown'
     && value.decisionState !== 'refusal'
+    && value.decisionState !== 'parse_failed'
   ) {
     return false;
   }
@@ -99,7 +100,9 @@ export function isWinnerFirstSummaryCache(value: unknown): value is WinnerFirstS
     return value.favoredValueKey === null && value.strength === 'neutral';
   }
 
-  // "unknown" and "refusal" — both have null favored key and strength 'unknown'.
+  // "unknown", "refusal", and "parse_failed" — all carry null favored key and
+  // strength 'unknown'. Distinct labels preserve the semantic signal (parser
+  // ambiguity vs model refusal vs explicit parse-failure sentinel).
   return value.favoredValueKey === null && value.strength === 'unknown';
 }
 

--- a/cloud/apps/api/tests/graphql/queries/decision-model-helpers.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/decision-model-helpers.test.ts
@@ -178,6 +178,26 @@ describe('isCachedWinnerFirstDecision — cacheVersion 2 only', () => {
     expect(result).toBe(true);
   });
 
+  it('accepts cacheVersion 2 + parse_failed (sentinel for un-recoverable parses)', () => {
+    const result = isCachedWinnerFirstDecision({
+      cacheVersion: 2,
+      decisionState: 'parse_failed',
+      strength: 'unknown',
+      favoredValueKey: null,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('rejects parse_failed with non-null favoredValueKey (must share unknown shape)', () => {
+    const result = isCachedWinnerFirstDecision({
+      cacheVersion: 2,
+      decisionState: 'parse_failed',
+      strength: 'unknown',
+      favoredValueKey: 'Self_Direction_Action',
+    });
+    expect(result).toBe(false);
+  });
+
   it('rejects cacheVersion 1 + refusal (legacy shape no longer accepted)', () => {
     const result = isCachedWinnerFirstDecision({
       cacheVersion: 1,

--- a/cloud/apps/api/tests/graphql/queries/scale-code-from-canonical.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/scale-code-from-canonical.test.ts
@@ -129,6 +129,16 @@ describe('scaleCodeFromCanonical — orientation-invariant cases', () => {
     expect(scaleCodeFromCanonical(c, PAIR, false)).toBe('unknown');
     expect(scaleCodeFromCanonical(c, PAIR, true)).toBe('unknown');
   });
+
+  it('parse_failed → "unknown" (sentinel maps to same scale code as unknown)', () => {
+    const c = makeCanonical({
+      decisionState: 'parse_failed',
+      strength: 'unknown',
+      favoredValueKey: null,
+    });
+    expect(scaleCodeFromCanonical(c, PAIR, false)).toBe('unknown');
+    expect(scaleCodeFromCanonical(c, PAIR, true)).toBe('unknown');
+  });
 });
 
 describe('scaleCodeFromCanonical — malformed canonicals fall to unknown', () => {

--- a/cloud/apps/api/tests/queue/handlers/summarize-transcript.test.ts
+++ b/cloud/apps/api/tests/queue/handlers/summarize-transcript.test.ts
@@ -341,6 +341,69 @@ describe('summarize-transcript handler', () => {
       });
     });
 
+    it('emits the parse_failed sentinel instead of null when no value can be pinned', async () => {
+      // Reproduces the path where the resolver leaves favoredValueKey null while
+      // direction/strength are not themselves marked unknown — previously this
+      // returned null, which the persistence layer omitted from the JSONB,
+      // yielding silent missing-canonicalDecision rows in prod.
+      const transcript = makeTranscript({
+        scenarioId: 'scenario-2',
+        definitionSnapshot: {
+          dimensions: [{ name: 'Achievement' }, { name: 'Tradition' }],
+        },
+      });
+      mockFindUnique.mockResolvedValueOnce(transcript as never);
+      mockScenarioFindUnique.mockResolvedValueOnce({ orientationFlipped: false } as never);
+      mockResolveTranscriptDecisionModel.mockReturnValueOnce({
+        canonical: {
+          direction: 'favor_first',
+          strength: 'strong',
+          favoredValueKey: null,
+        },
+      } as ReturnType<typeof resolveTranscriptDecisionModel>);
+
+      mockSpawnPython.mockResolvedValueOnce({
+        success: true,
+        data: {
+          success: true,
+          summary: buildSuccessfulWorkerSummary(
+            { turns: [{ probePrompt: 'p', targetResponse: 'r' }] },
+            {
+              decisionText: null,
+              decisionMetadata: {
+                matchedText: null,
+                matchedLabel: null,
+                parseClass: 'ambiguous',
+                parsePath: 'text_label_ambiguous',
+                parserVersion: 'parser-1',
+                responseExcerpt: null,
+              },
+            },
+          ),
+        },
+      } as never);
+
+      const handler = createSummarizeTranscriptHandler();
+      const job: MockJob<{ runId: string; transcriptId: string }> = {
+        id: 'test-job-id',
+        data: { runId: transcript.runId, transcriptId: transcript.id },
+      };
+
+      await handler([job] as Parameters<typeof handler>[0]);
+
+      expect(mockPersistSuccess).toHaveBeenCalledTimes(1);
+      const call = mockPersistSuccess.mock.calls[0];
+      if (!call) throw new Error('expected persistSuccessfulSummary call');
+      // Sentinel keeps a parser failure visible in JSONB instead of silently
+      // dropping the canonicalDecision key.
+      expect(call[5]).toEqual({
+        cacheVersion: 2,
+        decisionState: 'parse_failed',
+        favoredValueKey: null,
+        strength: 'unknown',
+      });
+    });
+
     it('batches multiple transcripts into one Python spawn', async () => {
       const first = makeTranscript({ id: 'transcript-1', runId: 'run-a' });
       const second = makeTranscript({ id: 'transcript-2', runId: 'run-b' });

--- a/cloud/packages/db/src/types.ts
+++ b/cloud/packages/db/src/types.ts
@@ -180,7 +180,14 @@ export type SummaryCacheSummary = {
   decisionMetadata: Record<string, unknown> | null;
   canonicalDecision?: {
     cacheVersion: 2;
-    decisionState: 'resolved' | 'neutral' | 'unknown' | 'refusal';
+    /**
+     * `parse_failed` is an explicit sentinel emitted by the summarizer when the
+     * parser cannot extract any decision (e.g. empty `targetResponse`,
+     * unparseable output). It is structurally equivalent to `unknown` in every
+     * downstream consumer, but distinguishes parser failure from a model that
+     * gave a confused-but-real answer. See PR adding fail-on-empty guards.
+     */
+    decisionState: 'resolved' | 'neutral' | 'unknown' | 'refusal' | 'parse_failed';
     favoredValueKey: string | null;
     strength: 'strong' | 'lean' | 'neutral' | 'unknown';
   };

--- a/cloud/workers/common/llm_adapters/base.py
+++ b/cloud/workers/common/llm_adapters/base.py
@@ -254,6 +254,48 @@ def is_billing_exhaustion_response(status_code: int, response_text: str) -> bool
     return any(pattern in text_lower for pattern in BILLING_EXHAUSTION_PATTERNS)
 
 
+def raise_if_empty_content(
+    *,
+    provider: str,
+    content: Optional[str],
+    output_tokens: Optional[int],
+    finish_reason: Optional[str],
+) -> None:
+    """Fail loudly when the adapter parsed a response into empty content.
+
+    Two failure modes are caught here:
+    - Provider billed for output tokens but the visible content field is empty
+      (e.g. deepseek-reasoner emitting all output as ``reasoning_content`` while
+      ``message.content`` comes back blank, which the adapter would silently
+      coerce to ``""``).
+    - Provider returned no output tokens and no content (a silent provider-side
+      drop, observed on xAI ``finish_reason=""`` responses).
+
+    Without this guard the probe worker writes an empty transcript and marks the
+    probe_results row SUCCESS, which downstream parsers cannot resolve to a
+    canonical decision.
+    """
+    if content is not None and content.strip():
+        return
+    out_tokens = output_tokens or 0
+    if out_tokens > 0:
+        message = (
+            f"{provider} returned empty content despite output_tokens={out_tokens} "
+            f"(finish_reason={finish_reason!r}); reasoning-only response or adapter "
+            f"discarded the visible answer"
+        )
+    else:
+        message = (
+            f"{provider} returned no content and output_tokens={out_tokens} "
+            f"(finish_reason={finish_reason!r}); empty provider response"
+        )
+    raise LLMError(
+        message=message,
+        code=ErrorCode.INVALID_RESPONSE,
+        details=message,
+    )
+
+
 def post_json(
     url: str,
     headers: dict[str, str],

--- a/cloud/workers/common/llm_adapters/providers/anthropic.py
+++ b/cloud/workers/common/llm_adapters/providers/anthropic.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json
+from ..base import BaseLLMAdapter, post_json, raise_if_empty_content
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse
@@ -123,8 +123,16 @@ class AnthropicAdapter(BaseLLMAdapter):
                 },
             }
 
+            joined_content = "\n".join(text_parts).strip()
+            raise_if_empty_content(
+                provider="anthropic",
+                content=joined_content,
+                output_tokens=usage.get("output_tokens"),
+                finish_reason=raw_stop_reason,
+            )
+
             return LLMResponse(
-                content="\n".join(text_parts).strip(),
+                content=joined_content,
                 input_tokens=usage.get("input_tokens"),
                 output_tokens=usage.get("output_tokens"),
                 model_version=model_version,

--- a/cloud/workers/common/llm_adapters/providers/deepseek.py
+++ b/cloud/workers/common/llm_adapters/providers/deepseek.py
@@ -11,7 +11,7 @@ import requests
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json
+from ..base import BaseLLMAdapter, post_json, raise_if_empty_content
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse, StreamChunk
@@ -131,6 +131,13 @@ class DeepSeekAdapter(BaseLLMAdapter):
                     model=model,
                     finish_reason=raw_finish_reason,
                 )
+
+            raise_if_empty_content(
+                provider="deepseek",
+                content=content,
+                output_tokens=usage.get("completion_tokens"),
+                finish_reason=raw_finish_reason,
+            )
 
             return LLMResponse(
                 content=content.strip() if content else "",

--- a/cloud/workers/common/llm_adapters/providers/mistral.py
+++ b/cloud/workers/common/llm_adapters/providers/mistral.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json
+from ..base import BaseLLMAdapter, post_json, raise_if_empty_content
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse
@@ -98,6 +98,13 @@ class MistralAdapter(BaseLLMAdapter):
                     "finish_reason": raw_finish_reason,
                 },
             }
+
+            raise_if_empty_content(
+                provider="mistral",
+                content=content,
+                output_tokens=usage.get("completion_tokens"),
+                finish_reason=raw_finish_reason,
+            )
 
             return LLMResponse(
                 content=content.strip() if content else "",

--- a/cloud/workers/common/llm_adapters/providers/openai.py
+++ b/cloud/workers/common/llm_adapters/providers/openai.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json
+from ..base import BaseLLMAdapter, post_json, raise_if_empty_content
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse
@@ -132,6 +132,13 @@ class OpenAIAdapter(BaseLLMAdapter):
                     model=model,
                     finish_reason=raw_finish_reason,
                 )
+
+            raise_if_empty_content(
+                provider="openai",
+                content=content,
+                output_tokens=usage.get("completion_tokens"),
+                finish_reason=raw_finish_reason,
+            )
 
             return LLMResponse(
                 content=content.strip() if content else "",

--- a/cloud/workers/common/llm_adapters/providers/xai.py
+++ b/cloud/workers/common/llm_adapters/providers/xai.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json
+from ..base import BaseLLMAdapter, post_json, raise_if_empty_content
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse
@@ -108,6 +108,13 @@ class XAIAdapter(BaseLLMAdapter):
                     "system_fingerprint": data.get("system_fingerprint"),
                 },
             }
+
+            raise_if_empty_content(
+                provider="xai",
+                content=content,
+                output_tokens=usage.get("completion_tokens"),
+                finish_reason=raw_finish_reason,
+            )
 
             return LLMResponse(
                 content=content.strip() if content else "",

--- a/cloud/workers/probe.py
+++ b/cloud/workers/probe.py
@@ -108,6 +108,31 @@ def build_provider_metadata(response: LLMResponse) -> Optional[dict[str, Any]]:
     return metadata or None
 
 
+def _ensure_non_empty_response(response: LLMResponse, *, model_id: str, turn_label: str) -> None:
+    """Defense-in-depth check: refuse to write a transcript turn with no content.
+
+    Adapter-level guards in the OpenAI-compatible providers raise
+    INVALID_RESPONSE before we get here, but the Google adapter intentionally
+    returns empty content with a "blocked" finish_reason as a deliberate signal,
+    and any future adapter could regress. Catching empty content here ensures we
+    never persist a probe_results row marked SUCCESS with no usable answer.
+    """
+    if response.content is not None and response.content.strip():
+        return
+    finish_reason = None
+    if response.provider_metadata:
+        finish_reason = response.provider_metadata.get("finishReason")
+    out_tokens = response.output_tokens or 0
+    raise LLMError(
+        message=(
+            f"Empty response from {model_id} on turn {turn_label!r} "
+            f"(output_tokens={out_tokens}, finish_reason={finish_reason!r}); "
+            f"refusing to write empty transcript"
+        ),
+        code=ErrorCode.INVALID_RESPONSE,
+    )
+
+
 @dataclass
 class Turn:
     """A single turn in the conversation."""
@@ -289,6 +314,7 @@ def run_probe(data: dict[str, Any]) -> dict[str, Any]:
             messages,
             **generate_kwargs,
         )
+        _ensure_non_empty_response(response, model_id=model_id, turn_label="scenario_prompt")
 
         turn = Turn(
             turn_number=1,
@@ -325,6 +351,7 @@ def run_probe(data: dict[str, Any]) -> dict[str, Any]:
                 messages,
                 **generate_kwargs,
             )
+            _ensure_non_empty_response(response, model_id=model_id, turn_label=followup_label)
 
             turn = Turn(
                 turn_number=turn_num,

--- a/cloud/workers/tests/test_llm_adapters.py
+++ b/cloud/workers/tests/test_llm_adapters.py
@@ -529,3 +529,185 @@ class TestMaxTokensConfig:
             payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
             # Anthropic requires max_tokens, so we use 8192 as the default for "unlimited"
             assert payload["max_tokens"] == 8192
+
+
+# Mirrors the production failure shape from PR #N (data-quality scan 2026-04-25):
+# deepseek-reasoner billed 513 completion tokens but message.content was empty
+# because the model emitted everything as reasoning_content. The previous adapter
+# silently coerced the empty value to "" and probe_results was marked SUCCESS
+# with an unparseable transcript. After the fix the adapter raises INVALID_RESPONSE.
+def _openai_compat_response(content, completion_tokens, *, reasoning_tokens=None, finish_reason="stop"):
+    """Build a minimal OpenAI-compatible response body for testing empty-content paths."""
+    body = {
+        "id": "chatcmpl-empty",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "test-model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": finish_reason,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": completion_tokens,
+            "total_tokens": 100 + completion_tokens,
+        },
+    }
+    if reasoning_tokens is not None:
+        body["usage"]["completion_tokens_details"] = {"reasoning_tokens": reasoning_tokens}
+    return body
+
+
+class TestEmptyContentRaises:
+    """Adapters must raise LLMError(INVALID_RESPONSE) when the visible content is empty."""
+
+    def test_deepseek_reasoner_only_response_raises(self) -> None:
+        """Reproduces the production bug: completion_tokens=513, reasoning_tokens=510, content=''."""
+        adapter = DeepSeekAdapter(api_key="test-key")
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(
+                _openai_compat_response("", completion_tokens=513, reasoning_tokens=510),
+                200,
+            )
+
+            with pytest.raises(LLMError) as exc_info:
+                adapter.generate("deepseek-reasoner", [{"role": "user", "content": "Hi"}])
+
+        assert exc_info.value.code == ErrorCode.INVALID_RESPONSE
+        assert "output_tokens=513" in exc_info.value.message
+        assert "deepseek" in exc_info.value.message
+
+    def test_deepseek_null_content_raises(self) -> None:
+        """null content (vs empty string) should also raise."""
+        adapter = DeepSeekAdapter(api_key="test-key")
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(
+                _openai_compat_response(None, completion_tokens=400),
+                200,
+            )
+
+            with pytest.raises(LLMError) as exc_info:
+                adapter.generate("deepseek-reasoner", [{"role": "user", "content": "Hi"}])
+
+        assert exc_info.value.code == ErrorCode.INVALID_RESPONSE
+
+    def test_deepseek_whitespace_only_content_raises(self) -> None:
+        """Whitespace-only content cannot drive a canonical decision; should raise."""
+        adapter = DeepSeekAdapter(api_key="test-key")
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(
+                _openai_compat_response("   \n\t  ", completion_tokens=200),
+                200,
+            )
+
+            with pytest.raises(LLMError) as exc_info:
+                adapter.generate("deepseek-chat", [{"role": "user", "content": "Hi"}])
+
+        assert exc_info.value.code == ErrorCode.INVALID_RESPONSE
+
+    def test_xai_zero_token_empty_response_raises(self) -> None:
+        """Reproduces the grok-4-0709 failure: completion_tokens=0, finish_reason=''."""
+        adapter = XAIAdapter(api_key="test-key")
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(
+                _openai_compat_response("", completion_tokens=0, finish_reason=""),
+                200,
+            )
+
+            with pytest.raises(LLMError) as exc_info:
+                adapter.generate("grok-4-0709", [{"role": "user", "content": "Hi"}])
+
+        assert exc_info.value.code == ErrorCode.INVALID_RESPONSE
+        assert "output_tokens=0" in exc_info.value.message
+        assert "xai" in exc_info.value.message
+
+    def test_openai_empty_content_raises(self) -> None:
+        adapter = OpenAIAdapter(api_key="test-key")
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(
+                _openai_compat_response("", completion_tokens=42),
+                200,
+            )
+
+            with pytest.raises(LLMError) as exc_info:
+                adapter.generate("gpt-4", [{"role": "user", "content": "Hi"}])
+
+        assert exc_info.value.code == ErrorCode.INVALID_RESPONSE
+
+    def test_mistral_empty_content_raises(self) -> None:
+        adapter = MistralAdapter(api_key="test-key")
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(
+                _openai_compat_response("", completion_tokens=42),
+                200,
+            )
+
+            with pytest.raises(LLMError) as exc_info:
+                adapter.generate("mistral-large", [{"role": "user", "content": "Hi"}])
+
+        assert exc_info.value.code == ErrorCode.INVALID_RESPONSE
+
+    def test_anthropic_empty_content_raises(self) -> None:
+        """Anthropic returns a content array — empty text parts must also raise."""
+        adapter = AnthropicAdapter(api_key="test-key")
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(
+                {
+                    "id": "msg-empty",
+                    "model": "claude-3-sonnet",
+                    "content": [{"type": "text", "text": ""}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 10, "output_tokens": 50},
+                },
+                200,
+            )
+
+            with pytest.raises(LLMError) as exc_info:
+                adapter.generate("claude-3-sonnet", [{"role": "user", "content": "Hi"}])
+
+        assert exc_info.value.code == ErrorCode.INVALID_RESPONSE
+
+    def test_anthropic_no_text_parts_raises(self) -> None:
+        """Anthropic content array with no text-type parts must raise."""
+        adapter = AnthropicAdapter(api_key="test-key")
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(
+                {
+                    "id": "msg-empty",
+                    "model": "claude-3-sonnet",
+                    "content": [],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 10, "output_tokens": 0},
+                },
+                200,
+            )
+
+            with pytest.raises(LLMError) as exc_info:
+                adapter.generate("claude-3-sonnet", [{"role": "user", "content": "Hi"}])
+
+        assert exc_info.value.code == ErrorCode.INVALID_RESPONSE
+
+    def test_non_empty_content_does_not_raise(self) -> None:
+        """Sanity: a normal response still succeeds."""
+        adapter = DeepSeekAdapter(api_key="test-key")
+
+        with patch("requests.post") as mock_post:
+            mock_post.return_value = MockResponse(
+                _openai_compat_response("Strongly support taking the job", completion_tokens=42),
+                200,
+            )
+
+            result = adapter.generate("deepseek-chat", [{"role": "user", "content": "Hi"}])
+
+        assert result.content == "Strongly support taking the job"

--- a/cloud/workers/tests/test_probe.py
+++ b/cloud/workers/tests/test_probe.py
@@ -432,3 +432,80 @@ class TestErrorClassification:
         assert result["success"] is False
         assert result["error"]["code"] == "SERVER_ERROR"
         assert result["error"]["retryable"] is True
+
+
+class TestEmptyResponseRefused:
+    """Probe must refuse to write a transcript when the model returns empty content.
+
+    The adapter-level guard catches OpenAI-compatible empty-content paths, but
+    the Google adapter intentionally returns empty content with a "blocked"
+    finishReason as a deliberate signal. This probe-level check ensures we never
+    persist a probe_results row marked SUCCESS with no usable answer.
+    """
+
+    @pytest.fixture
+    def valid_input(self) -> dict[str, Any]:
+        return {
+            "runId": "run-123",
+            "scenarioId": "scenario-456",
+            "modelId": "gemini-2.5-pro",
+            "scenario": {"prompt": "Pick A or B.", "followups": []},
+            "config": {"maxTokens": 1024, "maxTurns": 10},
+        }
+
+    def test_empty_string_content_returns_invalid_response(
+        self, valid_input: dict[str, Any]
+    ) -> None:
+        from probe import run_probe
+
+        with patch("probe.generate") as mock_generate:
+            mock_generate.return_value = LLMResponse(
+                content="",
+                input_tokens=100,
+                output_tokens=0,
+                provider_metadata={"provider": "google", "finishReason": "blocked"},
+            )
+
+            result = run_probe(valid_input)
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "INVALID_RESPONSE"
+        assert "Empty response" in result["error"]["message"]
+        assert "scenario_prompt" in result["error"]["message"]
+        # The transcript was never written
+        assert "transcript" not in result
+
+    def test_whitespace_only_content_returns_invalid_response(
+        self, valid_input: dict[str, Any]
+    ) -> None:
+        from probe import run_probe
+
+        with patch("probe.generate") as mock_generate:
+            mock_generate.return_value = LLMResponse(content="  \n\t  ")
+
+            result = run_probe(valid_input)
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "INVALID_RESPONSE"
+
+    def test_empty_followup_response_returns_invalid_response(
+        self, valid_input: dict[str, Any]
+    ) -> None:
+        """First turn succeeds, second turn comes back empty — probe still refuses."""
+        from probe import run_probe
+
+        valid_input["scenario"]["followups"] = [
+            {"label": "followup_1", "prompt": "Are you sure?"},
+        ]
+
+        with patch("probe.generate") as mock_generate:
+            mock_generate.side_effect = [
+                LLMResponse(content="Yes, A.", output_tokens=5),
+                LLMResponse(content="", output_tokens=0),
+            ]
+
+            result = run_probe(valid_input)
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "INVALID_RESPONSE"
+        assert "followup_1" in result["error"]["message"]


### PR DESCRIPTION
## Summary

A 2026-04-25 prod data-quality scan found 1,272 transcripts with no `canonicalDecision`. 1,250 were one re-summarizable run; the other 22 were silent adapter/worker failures where `targetResponse=""` was written to the DB and the probe was marked `SUCCESS`. Root cause: the deepseek adapter only reads `message.content` and silently coerces null/empty to `""` when `deepseek-reasoner` emits all output as `message.reasoning_content`.

This PR closes the silent-failure path and adds an explicit sentinel so any future no-decision case is visible in JSONB queries instead of silently null.

- **Adapter guard**: new `raise_if_empty_content()` helper in `llm_adapters/base.py`. Each OpenAI-compatible adapter (`deepseek`, `openai`, `mistral`, `xai`) and `anthropic` calls it before constructing `LLMResponse` — raises `LLMError(INVALID_RESPONSE)` with `output_tokens` and `finish_reason` in the message.
- **Probe guard**: `_ensure_non_empty_response()` runs after each `generate()` call. Catches the Google-blocked path (which intentionally returns empty content) and any future adapter that forgets the helper.
- **Sentinel**: new `decisionState: 'parse_failed'` added to the canonicalDecision union. `buildWinnerFirstSummaryCache` emits it instead of returning `null` — this was the path that produced the silent missing-canonicalDecision rows. Manual override mutation does NOT accept it (parser-internal sentinel).

## Behavior change to call out

Empty-response failures use `ErrorCode.INVALID_RESPONSE`, which is **non-retryable** in the current `RETRYABLE_CODES` set. Probe rows surface as `FAILED` with a descriptive `error_message` instead of silently empty `SUCCESS`. If automatic retry is desired, just add `INVALID_RESPONSE` to `RETRYABLE_CODES` in `cloud/workers/common/errors.py:34` — no other code changes required.

## Test plan

- [x] `npx turbo build --filter=@valuerank/db --filter=@valuerank/shared --filter=@valuerank/api` → 7/7 pass, 0 errors (warnings pre-existing).
- [x] `pytest tests/test_llm_adapters.py::TestEmptyContentRaises tests/test_probe.py::TestEmptyResponseRefused tests/test_probe.py::TestRunProbe tests/test_probe.py::TestErrorClassification` → 19/19 pass.
- [x] `vitest run summarize-transcript decision-model-helpers scale-code-from-canonical` → 60/60 pass.
- [ ] Reviewer: spot-check that the `parse_failed` sentinel appears in JSONB for any production transcript that fails parsing post-merge.
- [ ] Reviewer: confirm no automatic-retry behavior is desired for empty responses, or flip `INVALID_RESPONSE` to retryable in a follow-up.

## Notes

- The 23 historical transcripts with empty `targetResponse` (`cmmzas9xi…` plus the 22 Cluster B from the scan) cannot be recovered from this codepath — their reasoning content was never persisted. They would need a re-run via the probe pipeline to populate. Out of scope for this PR.
- Existing transcripts with `summaryCache.summary.canonicalDecision: null` (the 1,272 historical) are unaffected. Going forward, no new rows will land in that state — re-summarization or fresh probes will write either a real decision or the `parse_failed` sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)