### PR TITLE
ff-advance: refuse to write empty head_sha to annotations[]

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_advance.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_advance.py
@@ -38,6 +38,7 @@ def _eager_validate(args: argparse.Namespace) -> str:
 
 
 def _git_head_sha() -> str:
+    """Return current HEAD sha or empty string if git could not resolve it."""
     try:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
@@ -58,6 +59,15 @@ def command_advance(args: argparse.Namespace) -> int:
     reason = _eager_validate(args)
 
     head_sha = _git_head_sha()
+    if not head_sha:
+        # An empty head_sha in annotations[] is forensically useless and would
+        # be confused with "advance ran on the empty tree." Refuse to write.
+        print(
+            "could not resolve HEAD via 'git rev-parse'; aborting before "
+            "state mutation. Re-run from a clean git checkout.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
     ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S_%fZ")
 
     def mutate(state: dict) -> None:

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_advance_subcommand.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_advance_subcommand.py
@@ -181,6 +181,70 @@ class AdvanceSubcommandTests(unittest.TestCase):
         self.assertIn("diff", stage_action.choices)
         self.assertNotIn("implementation", stage_action.choices)
 
+    def test_empty_head_sha_aborts_before_state_mutation(self) -> None:
+        """Regression: blank head_sha in annotations[] is forensically useless.
+
+        Pre-fix, _git_head_sha returned "" on any subprocess error and the
+        annotation was written with head_sha="" — confusable with "advance
+        ran on the empty tree." The fix exits 2 instead.
+        """
+        before = self._read_state()
+        args = self._parser().parse_args([
+            "advance",
+            "--slug",
+            SLUG,
+            "--stage",
+            "spec",
+            "--reason",
+            "valid reason longer than minimum",
+        ])
+        stderr = io.StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            with patch.object(
+                self.advance.subprocess,
+                "run",
+                side_effect=FileNotFoundError("git not on PATH"),
+            ), contextlib.redirect_stdout(io.StringIO()), \
+                    contextlib.redirect_stderr(stderr):
+                args.func(args)
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertIn("could not resolve HEAD", stderr.getvalue())
+        self.assertEqual(before, self._read_state())
+
+    def test_nonzero_git_returncode_aborts_before_state_mutation(self) -> None:
+        """Same as above but covers `git rev-parse HEAD` returning non-zero
+        (e.g., REPO_ROOT is not inside a git work tree).
+        """
+        before = self._read_state()
+        args = self._parser().parse_args([
+            "advance",
+            "--slug",
+            SLUG,
+            "--stage",
+            "spec",
+            "--reason",
+            "valid reason longer than minimum",
+        ])
+        stderr = io.StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            with patch.object(
+                self.advance.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(
+                    args=["git", "rev-parse", "HEAD"],
+                    returncode=128,
+                    stdout="",
+                    stderr="fatal: not a git repository\n",
+                ),
+            ), contextlib.redirect_stdout(io.StringIO()), \
+                    contextlib.redirect_stderr(stderr):
+                args.func(args)
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertIn("could not resolve HEAD", stderr.getvalue())
+        self.assertEqual(before, self._read_state())
+
     def test_whitespace_trimmed_reason_below_minimum_rejects(self) -> None:
         before = self._read_state()
         args = self._parser().parse_args([


### PR DESCRIPTION
## Summary

- Hotfix follow-up to PR #757 / #758. Adversarial Sonnet review of PR #757 surfaced one MEDIUM finding that PR #758 didn't pick up: `command_advance` writes an empty-string `head_sha` to `annotations[]` whenever `git rev-parse HEAD` fails (git missing, timeout, non-zero return).
- An empty audit field is forensically useless and confusable with "advance ran on the empty tree." This change exits 2 with a clear stderr message before any state mutation when `_git_head_sha` returns empty — preserving the eager-validate-then-mutate contract from FR-013.
- 296 FF tests pass (was 294 in #758 + 2 new boundary tests).

## Test plan

- [x] `python3 -m unittest discover docs/workflow/operations/codex-skills/feature-factory/scripts/tests` — 296 OK
- [x] Ran twice in a row, count stable at 296 (no test-pollution from the new tests)
- [x] New tests cover both failure modes:
  - `subprocess.FileNotFoundError` from `subprocess.run`
  - `git rev-parse HEAD` returning non-zero with a "fatal: not a git repository" stderr
- [x] Existing happy-path / 19-char / 20-char / unknown-stage / whitespace-strip tests still pass with no expectation changes
- [ ] Manual: invoke `advance --slug X --stage spec --reason "<≥20 chars>"` from a non-git directory — confirm exit 2 and `annotations[]` unchanged

## Related

- Fixes the one finding from the Sonnet adversarial review of PR #757 that was not addressed by #758
- Out-of-scope flag: the FF test suite has a separate test-isolation bug where some judge-panel tests write to real `docs/workflow/feature-runs/ff-judge-panel/state.json` and `ff-completeness-veto/state.json` instead of using the patched `FACTORY_RUNS_ROOT` tempdir. Spawned as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)