### PR TITLE
Cross-domain Status page: Wave 2 — GraphQL queries + mutations + augmented RunAnomaly type

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/run-anomaly.ts
+++ b/cloud/apps/api/src/graphql/mutations/run-anomaly.ts
@@ -1,0 +1,220 @@
+import { db, type Prisma } from '@valuerank/db';
+import { AppError, AuthenticationError, NotFoundError } from '@valuerank/shared';
+import { builder } from '../builder.js';
+import { RunAnomalyRef } from '../types/refs.js';
+import { parseSlotSubject } from '../types/run-anomaly.js';
+import { getBoss } from '../../queue/boss.js';
+import { DEFAULT_JOB_OPTIONS } from '../../queue/types.js';
+import { getQueueNameForModel } from '../../services/parallelism/index.js';
+
+const REPROBE_LIMIT = 3;
+
+class ReprobeError extends AppError {
+  constructor(message: string, code: string) {
+    super(message, code, 400);
+    this.name = 'ReprobeError';
+  }
+}
+
+function readReprobeAttempts(details: unknown): number {
+  if (details == null || typeof details !== 'object' || Array.isArray(details)) return 0;
+  const value = (details as Record<string, unknown>).reprobeAttempts;
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+}
+
+function buildIncrementedDetails(details: unknown, currentAttempts: number): Prisma.InputJsonValue {
+  const base: Record<string, unknown> = (details != null && typeof details === 'object' && !Array.isArray(details))
+    ? { ...(details as Record<string, unknown>) }
+    : {};
+  base.reprobeAttempts = currentAttempts + 1;
+  return base as Prisma.InputJsonValue;
+}
+
+builder.mutationField('resolveRunAnomaly', (t) =>
+  t.field({
+    type: RunAnomalyRef,
+    description: 'Manually mark an open run anomaly as resolved. Idempotent: resolving an already-resolved anomaly is a no-op success and returns the row unchanged. If the underlying condition is still detected on the next reconciliation pass, a fresh anomaly will be created (the unique constraint allows recreation because resolvedAt is non-null on the prior row).',
+    args: {
+      id: t.arg.id({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      if (ctx.user == null) {
+        throw new AuthenticationError('Authentication required');
+      }
+
+      const id = String(args.id);
+      const existing = await db.runAnomaly.findUnique({ where: { id } });
+      if (existing === null) {
+        throw new NotFoundError('RunAnomaly', id);
+      }
+
+      if (existing.resolvedAt !== null) {
+        return existing;
+      }
+
+      const updated = await db.runAnomaly.update({
+        where: { id },
+        data: { resolvedAt: new Date() },
+      });
+
+      return updated;
+    },
+  }),
+);
+
+builder.mutationField('reprobeAnomalySlot', (t) =>
+  t.field({
+    type: RunAnomalyRef,
+    description: 'Re-probe the slot associated with an INVALID_RESPONSE_FAILURE anomaly. Soft-deletes any existing transcript at the slot, hard-deletes the corresponding probe_results row, increments the anomaly\'s reprobeAttempts counter inside a transaction, then enqueues a new probe_scenario job (post-commit) with a slot-tuple singletonKey for queue-layer deduplication. Returns the updated anomaly. Errors: NOT_FOUND, ANOMALY_NOT_OPEN, ANOMALY_NOT_REPROBABLE, RUN_NOT_REPROBABLE, REPROBE_LIMIT_EXCEEDED, REPROBE_ALREADY_IN_FLIGHT, REPROBE_SCENARIO_REQUIRED.',
+    args: {
+      anomalyId: t.arg.id({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      if (ctx.user == null) {
+        throw new AuthenticationError('Authentication required');
+      }
+
+      const anomalyId = String(args.anomalyId);
+
+      const anomaly = await db.runAnomaly.findUnique({ where: { id: anomalyId } });
+      if (anomaly === null) {
+        throw new NotFoundError('RunAnomaly', anomalyId);
+      }
+      if (anomaly.resolvedAt !== null) {
+        throw new ReprobeError('Anomaly is already resolved; cannot re-probe', 'ANOMALY_NOT_OPEN');
+      }
+      if (anomaly.type !== 'INVALID_RESPONSE_FAILURE') {
+        throw new ReprobeError(`Anomaly type ${anomaly.type} is not reprobable in v1`, 'ANOMALY_NOT_REPROBABLE');
+      }
+
+      const run = await db.run.findUnique({
+        where: { id: anomaly.runId },
+        select: { id: true, status: true },
+      });
+      if (run === null) {
+        throw new NotFoundError('Run', anomaly.runId);
+      }
+      if (run.status === 'FAILED' || run.status === 'CANCELLED') {
+        throw new ReprobeError(`Run is in terminal state ${run.status}; cannot re-probe`, 'RUN_NOT_REPROBABLE');
+      }
+
+      const currentAttempts = readReprobeAttempts(anomaly.details);
+      if (currentAttempts >= REPROBE_LIMIT) {
+        throw new ReprobeError(`Re-probe limit of ${REPROBE_LIMIT} reached for this slot`, 'REPROBE_LIMIT_EXCEEDED');
+      }
+
+      const slot = parseSlotSubject(anomaly.subject);
+      if (slot === null) {
+        throw new ReprobeError(`Anomaly subject ${anomaly.subject} is not a valid slot tuple`, 'ANOMALY_NOT_REPROBABLE');
+      }
+      if (slot.scenarioId === null) {
+        // probe_scenario job payload requires scenarioId; we cannot re-enqueue without it.
+        throw new ReprobeError('Cannot re-probe a slot whose scenario has been deleted', 'REPROBE_SCENARIO_REQUIRED');
+      }
+      const scenarioId: string = slot.scenarioId;
+
+      // Pre-flight check: refuse if a probe_scenario job is already pending for this slot.
+      // The post-commit boss.send also uses singletonKey for queue-layer dedup as a backstop.
+      const queueName = await getQueueNameForModel(slot.modelId);
+      const pendingProbe = await db.$queryRaw<Array<{ exists: boolean }>>`
+        SELECT 1 AS exists FROM pgboss.job
+        WHERE name = ${queueName}
+          AND state IN ('created', 'retry', 'active')
+          AND data->>'runId' = ${slot.runId}
+          AND data->>'scenarioId' = ${scenarioId}
+          AND data->>'modelId' = ${slot.modelId}
+          AND (data->>'sampleIndex')::int = ${slot.sampleIndex}
+        LIMIT 1
+      `;
+      if (pendingProbe.length > 0) {
+        throw new ReprobeError('A probe job for this slot is already pending', 'REPROBE_ALREADY_IN_FLIGHT');
+      }
+
+      const updated = await db.$transaction(async (tx) => {
+        // Lock the anomaly row for the duration of the transaction. Concurrent
+        // re-probe clicks for the same anomaly serialize at this point.
+        await tx.$executeRaw`SELECT id FROM run_anomalies WHERE id = ${anomalyId} FOR UPDATE`;
+
+        // Re-read inside the transaction to defend against TOCTOU on resolvedAt
+        // and reprobeAttempts.
+        const locked = await tx.runAnomaly.findUnique({ where: { id: anomalyId } });
+        if (locked === null) {
+          throw new NotFoundError('RunAnomaly', anomalyId);
+        }
+        if (locked.resolvedAt !== null) {
+          throw new ReprobeError('Anomaly was resolved by another process during re-probe', 'ANOMALY_NOT_OPEN');
+        }
+        const lockedAttempts = readReprobeAttempts(locked.details);
+        if (lockedAttempts >= REPROBE_LIMIT) {
+          throw new ReprobeError(`Re-probe limit of ${REPROBE_LIMIT} reached for this slot`, 'REPROBE_LIMIT_EXCEEDED');
+        }
+
+        // Soft-delete any non-deleted transcript at the slot. Historical-path
+        // anomalies have one; forward-path anomalies do not.
+        await tx.transcript.updateMany({
+          where: {
+            runId: slot.runId,
+            scenarioId,
+            modelId: slot.modelId,
+            sampleIndex: slot.sampleIndex,
+            deletedAt: null,
+          },
+          data: { deletedAt: new Date() },
+        });
+
+        // Hard-delete any probe_results row at the slot. Both forward and
+        // historical paths have one (FAILED for forward, SUCCESS for historical).
+        // The probe_scenario handler's idempotency guard at handler.ts:82-92
+        // requires the row to be gone before a fresh probe job will run.
+        await tx.probeResult.deleteMany({
+          where: {
+            runId: slot.runId,
+            scenarioId,
+            modelId: slot.modelId,
+            sampleIndex: slot.sampleIndex,
+          },
+        });
+
+        const persisted = await tx.runAnomaly.update({
+          where: { id: anomalyId },
+          data: {
+            details: buildIncrementedDetails(locked.details, lockedAttempts),
+            lastSeenAt: new Date(),
+          },
+        });
+
+        return persisted;
+      });
+
+      // Enqueue post-commit. boss.send is not transactional, so a failure here
+      // leaves the slot in a soft-deleted state with the anomaly still open and
+      // reprobeAttempts incremented. The user sees an error chip in the UI
+      // (Wave 3) and can retry. We do NOT roll back the transaction — that
+      // would leave the singletonKey conflict unresolved for the next attempt.
+      const singletonKey = `${slot.runId}:${scenarioId}:${slot.modelId}:${slot.sampleIndex}`;
+      const jobOptions = DEFAULT_JOB_OPTIONS['probe_scenario'];
+      const boss = getBoss();
+      try {
+        await boss.send(
+          queueName,
+          {
+            runId: slot.runId,
+            scenarioId,
+            modelId: slot.modelId,
+            sampleIndex: slot.sampleIndex,
+            config: { maxTurns: 10 },
+          },
+          { ...jobOptions, singletonKey },
+        );
+      } catch (error) {
+        // The DB writes have committed; surface the failure to the caller.
+        throw new ReprobeError(
+          `Re-probe job enqueue failed after DB commit: ${(error as Error).message}`,
+          'REPROBE_ENQUEUE_FAILED',
+        );
+      }
+
+      return updated;
+    },
+  }),
+);

--- a/cloud/apps/api/src/graphql/queries/active-evaluations.ts
+++ b/cloud/apps/api/src/graphql/queries/active-evaluations.ts
@@ -1,0 +1,44 @@
+import { db, type Prisma } from '@valuerank/db';
+import { AuthenticationError } from '@valuerank/shared';
+import { builder } from '../builder.js';
+import { DomainEvaluationRef } from './domain/evaluation/types.js';
+import { evaluationInclude, toShape } from './domain/evaluation/helpers.js';
+
+builder.queryField('activeEvaluations', (t) =>
+  t.field({
+    type: [DomainEvaluationRef],
+    description: 'List DomainEvaluations that have at least one member run currently in RUNNING or SUMMARIZING status. Optional domainId filter scopes to one domain. Used by the cross-domain /status page.',
+    args: {
+      domainId: t.arg.id({ required: false }),
+    },
+    resolve: async (_root, args, ctx) => {
+      if (ctx.user == null) {
+        throw new AuthenticationError('Authentication required');
+      }
+
+      const where: Prisma.DomainEvaluationWhereInput = {
+        deletedAt: null,
+        members: {
+          some: {
+            run: {
+              status: { in: ['RUNNING', 'SUMMARIZING'] },
+              deletedAt: null,
+            },
+          },
+        },
+      };
+
+      if (args.domainId != null) {
+        where.domainId = String(args.domainId);
+      }
+
+      const evaluations = await db.domainEvaluation.findMany({
+        where,
+        include: evaluationInclude,
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      });
+
+      return evaluations.map(toShape);
+    },
+  }),
+);

--- a/cloud/apps/api/src/graphql/queries/run-anomaly.ts
+++ b/cloud/apps/api/src/graphql/queries/run-anomaly.ts
@@ -1,0 +1,44 @@
+import { db, type Prisma } from '@valuerank/db';
+import { AuthenticationError } from '@valuerank/shared';
+import { builder } from '../builder.js';
+import { RunAnomalyRef } from '../types/refs.js';
+import { RunAnomalyTypeEnum } from '../types/run-anomaly.js';
+
+builder.queryField('openRunAnomalies', (t) =>
+  t.field({
+    type: [RunAnomalyRef],
+    description: 'List anomalies that are currently open (resolvedAt IS NULL) across all runs. Optional filters: domainId scopes to anomalies whose run belongs to a definition in that domain; type scopes to a single RunAnomalyType.',
+    args: {
+      domainId: t.arg.id({ required: false }),
+      type: t.arg({ type: RunAnomalyTypeEnum, required: false }),
+    },
+    resolve: async (_root, args, ctx) => {
+      if (ctx.user == null) {
+        throw new AuthenticationError('Authentication required');
+      }
+
+      const where: Prisma.RunAnomalyWhereInput = {
+        resolvedAt: null,
+      };
+
+      if (args.type != null) {
+        where.type = args.type;
+      }
+
+      if (args.domainId != null) {
+        where.run = {
+          definition: {
+            domainId: String(args.domainId),
+          },
+        };
+      }
+
+      const anomalies = await db.runAnomaly.findMany({
+        where,
+        orderBy: { firstSeenAt: 'desc' },
+      });
+
+      return anomalies;
+    },
+  }),
+);

--- a/cloud/apps/api/src/graphql/types/run-anomaly.ts
+++ b/cloud/apps/api/src/graphql/types/run-anomaly.ts
@@ -1,5 +1,6 @@
+import { db } from '@valuerank/db';
 import { builder } from '../builder.js';
-import { RunAnomalyRef } from './refs.js';
+import { DomainRef, RunAnomalyRef, RunRef } from './refs.js';
 
 export const RunAnomalyTypeEnum: ReturnType<typeof builder.enumType<'RunAnomalyType', readonly ['STRANDED_TRANSCRIPT', 'ORPHAN_TRANSCRIPT', 'PAIR_ASYMMETRY', 'SUMMARIZING_STALL', 'MODEL_TRANSCRIPT_SHORTFALL', 'SCHEDULED_COUNT_MISMATCH', 'INVALID_RESPONSE_FAILURE']>> = builder.enumType('RunAnomalyType', {
   values: [
@@ -21,6 +22,83 @@ const RunAnomalySourceEnum = builder.enumType('RunAnomalySource', {
   },
   description: 'Source of a run anomaly record',
 });
+
+const REPROBE_LIMIT = 3;
+const RECENT_COST_SAMPLE_SIZE = 10;
+
+const DISPLAY_LABEL_BY_TYPE: Record<string, string> = {
+  STRANDED_TRANSCRIPT: 'Stranded Transcript',
+  ORPHAN_TRANSCRIPT: 'Orphan Transcript',
+  PAIR_ASYMMETRY: 'Pair Asymmetry',
+  SUMMARIZING_STALL: 'Summarizing Stall',
+  MODEL_TRANSCRIPT_SHORTFALL: 'Model Transcript Shortfall',
+  SCHEDULED_COUNT_MISMATCH: 'Scheduled Count Mismatch',
+  INVALID_RESPONSE_FAILURE: 'Invalid Response',
+};
+
+const SLOT_KEYED_TYPES = new Set(['INVALID_RESPONSE_FAILURE']);
+const REPROBABLE_TYPES = new Set(['INVALID_RESPONSE_FAILURE']);
+const TRANSCRIPT_KEYED_TYPES = new Set(['STRANDED_TRANSCRIPT', 'ORPHAN_TRANSCRIPT']);
+
+function readReprobeAttempts(details: unknown): number {
+  if (details == null || typeof details !== 'object' || Array.isArray(details)) {
+    return 0;
+  }
+  const value = (details as Record<string, unknown>).reprobeAttempts;
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+}
+
+function readModelIdFromDetails(details: unknown): string | null {
+  if (details == null || typeof details !== 'object' || Array.isArray(details)) {
+    return null;
+  }
+  const value = (details as Record<string, unknown>).modelId;
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+type SlotTuple = {
+  runId: string;
+  scenarioId: string | null;
+  modelId: string;
+  sampleIndex: number;
+};
+
+/**
+ * Parse a slot-keyed subject `<runId>:<scenarioId>:<modelId>:<sampleIndex>`.
+ * Returns null if the format doesn't match. Empty scenarioId segment is mapped
+ * back to null (matches the empty-string fallback in
+ * anomaly-invalid-response-detection.ts).
+ */
+export function parseSlotSubject(subject: string): SlotTuple | null {
+  const parts = subject.split(':');
+  if (parts.length !== 4) return null;
+  const [runId, scenarioRaw, modelId, sampleRaw] = parts;
+  if (!runId || !modelId || !sampleRaw) return null;
+  const sampleIndex = Number.parseInt(sampleRaw, 10);
+  if (!Number.isInteger(sampleIndex) || sampleIndex < 0) return null;
+  return {
+    runId,
+    scenarioId: scenarioRaw && scenarioRaw.length > 0 ? scenarioRaw : null,
+    modelId,
+    sampleIndex,
+  };
+}
+
+function buildDisplaySubject(type: string, subject: string): string {
+  if (SLOT_KEYED_TYPES.has(type)) {
+    const slot = parseSlotSubject(subject);
+    if (slot !== null) {
+      return `model ${slot.modelId} · sample ${slot.sampleIndex}`;
+    }
+    return subject;
+  }
+  if (TRANSCRIPT_KEYED_TYPES.has(type)) {
+    if (subject.length === 0) return subject;
+    const shortId = subject.slice(0, 8);
+    return `transcript ${shortId}`;
+  }
+  return subject;
+}
 
 builder.objectType(RunAnomalyRef, {
   description: 'Structured anomaly record for a run',
@@ -44,5 +122,87 @@ builder.objectType(RunAnomalyRef, {
     lastSeenAt: t.expose('lastSeenAt', { type: 'DateTime' }),
     resolvedAt: t.expose('resolvedAt', { type: 'DateTime', nullable: true }),
     acknowledgedByUserId: t.exposeString('acknowledgedByUserId', { nullable: true }),
+
+    run: t.field({
+      type: RunRef,
+      description: 'The run this anomaly belongs to',
+      resolve: async (anomaly) => {
+        const run = await db.run.findUniqueOrThrow({ where: { id: anomaly.runId } });
+        return run;
+      },
+    }),
+
+    domain: t.field({
+      type: DomainRef,
+      nullable: true,
+      description: 'The domain this anomaly belongs to (via run.definition.domain). Null if the definition is not associated with a domain.',
+      resolve: async (anomaly) => {
+        const run = await db.run.findUnique({
+          where: { id: anomaly.runId },
+          select: { definition: { select: { domain: true } } },
+        });
+        return run?.definition.domain ?? null;
+      },
+    }),
+
+    displayLabel: t.string({
+      description: 'Human-friendly anomaly type label. For unknown future enum values, returns the raw enum string.',
+      resolve: (anomaly) => DISPLAY_LABEL_BY_TYPE[anomaly.type] ?? anomaly.type,
+    }),
+
+    displaySubject: t.string({
+      description: 'Human-friendly subject label. Type-aware: slot-keyed types render as "model X · sample N", transcript-keyed types render as "transcript <short>", others return the raw subject.',
+      resolve: (anomaly) => buildDisplaySubject(anomaly.type, anomaly.subject),
+    }),
+
+    reprobeEligible: t.boolean({
+      description: 'Whether the [Re-probe] action is offered for this anomaly type. v1: only INVALID_RESPONSE_FAILURE is reprobable; other slot-keyed types may be added later.',
+      resolve: (anomaly) => REPROBABLE_TYPES.has(anomaly.type),
+    }),
+
+    reprobeCount: t.int({
+      description: 'Number of re-probe attempts already made for this anomaly. Reads details.reprobeAttempts; 0 for non-slot-keyed types.',
+      resolve: (anomaly) => REPROBABLE_TYPES.has(anomaly.type) ? readReprobeAttempts(anomaly.details) : 0,
+    }),
+
+    reprobeLimitReached: t.boolean({
+      description: 'True when reprobeCount has reached the circuit-breaker limit (3). UI should disable the [Re-probe] button.',
+      resolve: (anomaly) => REPROBABLE_TYPES.has(anomaly.type) && readReprobeAttempts(anomaly.details) >= REPROBE_LIMIT,
+    }),
+
+    estimatedCost: t.float({
+      nullable: true,
+      description: 'Best-effort cost estimate for the next re-probe attempt, computed as the average estimatedCost of the last 10 successful (non-deleted, summarized) transcripts for the same modelId across all runs. Returns null when the anomaly is not reprobable, no modelId is available, or no recent transcripts have cost data.',
+      resolve: async (anomaly) => {
+        if (!REPROBABLE_TYPES.has(anomaly.type)) return null;
+        const modelId = readModelIdFromDetails(anomaly.details);
+        if (modelId === null) return null;
+
+        const recent = await db.transcript.findMany({
+          where: {
+            modelId,
+            deletedAt: null,
+            summarizedAt: { not: null },
+            estimatedCost: { not: null },
+          },
+          select: { estimatedCost: true },
+          orderBy: { createdAt: 'desc' },
+          take: RECENT_COST_SAMPLE_SIZE,
+        });
+
+        if (recent.length === 0) return null;
+
+        let total = 0;
+        let counted = 0;
+        for (const row of recent) {
+          if (row.estimatedCost !== null && Number.isFinite(row.estimatedCost)) {
+            total += row.estimatedCost;
+            counted += 1;
+          }
+        }
+
+        return counted > 0 ? total / counted : null;
+      },
+    }),
   }),
 });


### PR DESCRIPTION
## Summary

Wave 2 of the cross-domain `/status` page feature. Builds on Wave 1 (PR #767 — `INVALID_RESPONSE_FAILURE` anomaly detector + audit/reconcile wiring) by adding the GraphQL surface that the new `/status` page (Wave 3+) will consume.

Design doc lives in [`docs/workflow/feature-runs/cross-domain-status-page/`](docs/workflow/feature-runs/cross-domain-status-page/) (shipped in Wave 1).

## What's in this PR

**New GraphQL queries:**
- `openRunAnomalies(domainId, type)` — list anomalies with `resolvedAt IS NULL`, optionally filtered by domain (joins via `run.definition.domain`) or by `RunAnomalyType`. Ordered by `firstSeenAt DESC`. Auth: any authenticated user.
- `activeEvaluations(domainId)` — list `DomainEvaluation`s whose member runs include any in `RUNNING` or `SUMMARIZING`. Optional `domainId` filter. Reuses the existing `evaluationInclude` + `toShape` helpers so results conform to the shape `DomainEvaluationStatusPanel` already consumes.

**New GraphQL mutations:**
- `resolveRunAnomaly(id)` — sets `resolvedAt = NOW()`. Idempotent. Manual resolve is "close this instance," not "won't fix" — the unique constraint allows recreation if the underlying condition is detected again.
- `reprobeAnomalySlot(anomalyId)` — `INVALID_RESPONSE_FAILURE` only in v1. Validates: open + reprobable + run-not-terminal + not-already-pending + under reprobe limit (3). Inside Prisma `$transaction`: `SELECT ... FOR UPDATE` on the anomaly row, soft-delete any non-deleted transcript at the slot, hard-delete the `probe_results` row, increment `details.reprobeAttempts`. Post-commit: enqueues `probe_scenario` with `singletonKey = slot tuple` for queue-layer dedup.

**Augmented `RunAnomaly` type — 8 new fields:**
- `run: Run!` — Prisma relation
- `domain: Domain` (nullable) — via `run.definition.domain`
- `displayLabel: String!` — type-aware human label, defensive default for unknown future enum values
- `displaySubject: String!` — type-aware subject formatter (slot-keyed → `"model X · sample N"`, transcript-keyed → `"transcript <short>"`, others → raw)
- `reprobeEligible: Boolean!` — true only for `INVALID_RESPONSE_FAILURE`
- `reprobeCount: Int!` — reads `details.reprobeAttempts`
- `reprobeLimitReached: Boolean!` — `reprobeCount >= 3`
- `estimatedCost: Float` (nullable) — avg `estimatedCost` of last 10 successful transcripts for the same `modelId`

## Auth

Matches existing `/status` access — authenticated user only. No admin role required, no per-domain access check (ValueRank's user model is flat per spec.md Decision 3).

## What's NOT in this PR

- Tests for queries/mutations/augmented type — **deferred to a follow-up commit.** The existing mutations under `cloud/apps/api/src/graphql/mutations/` generally rely on integration tests rather than per-resolver unit tests; that pattern will be matched when the feature stabilizes.
- UI components, pages, routes — Wave 3+
- Filters UI — Wave 5
- Hard removal of `/domains/status/:domainId` — Wave 6

## Reviewer notes — `reprobeAnomalySlot` is the most complex piece

Worth focused attention on:
- Transactional integrity: pre-flight check + `SELECT FOR UPDATE` re-read inside the transaction defends against TOCTOU on `resolvedAt` and `reprobeAttempts`. PgBoss `singletonKey` on the slot tuple provides queue-layer dedup as backstop.
- Post-commit enqueue intentionally outside the transaction: `boss.send` is not transactional, and rolling back the DB on a failed enqueue would leave the singletonKey conflict unresolved for the next attempt.
- Slot subject parsing (`<runId>:<scenarioId>:<modelId>:<sampleIndex>`) is brittle to colons in IDs but CUIDs and current model IDs don't contain colons. Documented constraint.

## Test plan

- [x] Gemini quality+correctness review on the diff: 1 MEDIUM (estimatedCost potential bias), 1 LOW (slot subject brittleness), all other checklist items PASS
- [ ] CI typecheck + tests
- [ ] Manual smoke: open an anomaly via SQL, query `openRunAnomalies` via GraphiQL, verify all 8 augmented fields resolve
- [ ] Manual smoke: invoke `reprobeAnomalySlot` for an `INVALID_RESPONSE_FAILURE` anomaly with a probe job in the queue and verify the soft-delete + hard-delete + new probe enqueue happens transactionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)