### PR TITLE
Pressure Sensitivity hotfix: read transcripts from sourceRunIds

### DIFF
--- a/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
@@ -104,6 +104,18 @@ function strengthFromCanonical(strength: 'strong' | 'lean' | 'neutral' | 'unknow
   return null;
 }
 
+/**
+ * Aggregate-tagged runs are pooling views over a set of source runs; transcripts live on
+ * the source runs, not the aggregate run itself. Pull the source-run IDs out of the aggregate
+ * run's config (`config.sourceRunIds`) so we can fetch transcripts from the right place.
+ */
+function extractSourceRunIds(config: unknown): string[] {
+  if (config === null || typeof config !== 'object') return [];
+  const sourceRunIds = (config as { sourceRunIds?: unknown }).sourceRunIds;
+  if (!Array.isArray(sourceRunIds)) return [];
+  return sourceRunIds.filter((id): id is string => typeof id === 'string' && id.length > 0);
+}
+
 builder.queryField('pressureSensitivity', (t) =>
   t.field({
     type: PressureSensitivityResultRef,
@@ -233,24 +245,34 @@ builder.queryField('pressureSensitivity', (t) =>
         });
       }
 
-      // 5. Stream transcripts
-      const eligibleRunIds = eligibleRuns
-        .filter((r) => definitionMeta.has(r.definition?.id ?? r.definitionId))
-        .map((r) => r.id);
+      // 5. Stream transcripts from the SOURCE runs of each Aggregate-tagged run.
+      // Aggregate runs are pooling views — they own metadata (perScenario summaries) but
+      // the raw transcripts live on the runs listed in `config.sourceRunIds`. Fetching
+      // transcripts WHERE runId IN aggregateRunIds returns 0 rows; the production smoke
+      // test on PR #770 caught this.
+      const sourceRunToDefId = new Map<string, string>();
+      for (const r of eligibleRuns) {
+        const defId = r.definition?.id ?? r.definitionId;
+        if (!definitionMeta.has(defId)) continue;
+        for (const sourceRunId of extractSourceRunIds(r.config)) {
+          sourceRunToDefId.set(sourceRunId, defId);
+        }
+      }
+      const sourceRunIds = [...sourceRunToDefId.keys()];
       const rosterModelIds = models.map((m) => m.modelId);
       let excludedScenariosCount = 0;
 
       // Defensive cap: pressure-sensitivity reads raw transcripts (no pooling per FR-022)
-      // bounded by signature-filtered Aggregate-tagged runs. At current scale (~270
-      // definitions × ~8 models × few transcripts each) the volume is comfortable, but the
-      // cap prevents an unrelated runaway dataset from OOMing the API. Adjust upward
-      // intentionally if real coverage grows past this threshold; do not silently raise.
+      // bounded by signature-filtered Aggregate-tagged runs' source runs. At current scale
+      // (~270 definitions × ~8 models × few transcripts each) the volume is comfortable,
+      // but the cap prevents an unrelated runaway dataset from OOMing the API. Adjust
+      // upward intentionally if real coverage grows past this threshold.
       const TRANSCRIPT_FETCH_LIMIT = 200_000;
-      const transcripts = eligibleRunIds.length === 0 || rosterModelIds.length === 0
+      const transcripts = sourceRunIds.length === 0 || rosterModelIds.length === 0
         ? []
         : ((await db.transcript.findMany({
           where: {
-            runId: { in: eligibleRunIds },
+            runId: { in: sourceRunIds },
             modelId: { in: rosterModelIds },
             deletedAt: null,
           },
@@ -266,15 +288,12 @@ builder.queryField('pressureSensitivity', (t) =>
           take: TRANSCRIPT_FETCH_LIMIT,
         })) as TranscriptRow[]);
 
-      // 6-8. Bucket transcripts
-      const runDefMap = new Map<string, string>();
-      for (const r of eligibleRuns) runDefMap.set(r.id, r.definition?.id ?? r.definitionId);
-
+      // 6-8. Bucket transcripts via the sourceRun → definitionId map built above.
       const perModel = new Map<string, Map<string, PairAccumulator>>();
       for (const m of models) perModel.set(m.modelId, new Map());
 
       for (const tx of transcripts) {
-        const defId = runDefMap.get(tx.runId);
+        const defId = sourceRunToDefId.get(tx.runId);
         if (defId == null) continue;
         const meta = definitionMeta.get(defId);
         if (!meta) continue;


### PR DESCRIPTION
## Summary

Hotfix for the post-deploy smoke test failure on [#770](https://github.com/chrislawcodes/valuerank/pull/770). The Pressure Sensitivity report shipped with all models in `insufficient[]` because the resolver was fetching transcripts from the wrong `runId` set.

## Root cause

Aggregate-tagged runs are *pooling views*. They own metadata (per-scenario summaries, source-run linkage) but the raw transcripts live on the runs listed in `config.sourceRunIds`, not on the aggregate run itself. The resolver was doing:

```ts
db.transcript.findMany({ where: { runId: { in: aggregateRunIds } } })
```

which returned 0 rows for every run. Every (model, value pair) ended up with empty cells → pushed to `insufficient[]` with reason `no-coverage`. `excludedDefinitions` was empty (validation passed) and `excludedScenariosCount` was 0 (no scenarios were even seen) — the diagnostic shape pointed straight at this bug.

This mirrors what `models-consistency.ts` does in production: reads the aggregate run's pre-computed `analysisResults.reliabilitySummary` for the heavy lifting and only fetches transcripts from paired source runs for the order-effect computation. My plan said "go to raw transcripts" but missed that the right join key was source runs, not aggregate runs.

## Fix

- Add `extractSourceRunIds(config)` helper that pulls `config.sourceRunIds` out of each Aggregate-tagged run's config
- Build a `sourceRunToDefId` map from those source-run IDs to their parent definition (one aggregate is per-definition, so the mapping is unambiguous)
- Fetch transcripts `WHERE runId IN sourceRunIds`
- Bucket via the `sourceRunToDefId` lookup instead of the aggregate-run-id map

## Test plan

- [x] `npx turbo build --filter=@valuerank/api` — clean
- [x] Existing 38 unit tests still pass
- [ ] Post-deploy: re-run `pressureSensitivity(domainId: "cmmqi1urq0000e4y3ot8sfm06", signature: "vnewtd")` against prod via MCP. Expected: at least one model in `models[]` with non-empty `valuePairs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)