### PR TITLE
Wave 3 fix-up: address Codex review findings on /status page

### DIFF
--- a/cloud/apps/web/src/components/status/AnomalyRow.tsx
+++ b/cloud/apps/web/src/components/status/AnomalyRow.tsx
@@ -86,8 +86,11 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
   const [isReprobing, setIsReprobing] = useState(false);
   const [isResolving, setIsResolving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const reprobeTimerRef = useRef<number | null>(null);
-  const resolveTimerRef = useRef<number | null>(null);
+  // Captures anomaly.reprobeCount at the moment a re-probe mutation fires. The
+  // "Re-probing…" UI clears when polling shows reprobeCount has incremented past
+  // this baseline — i.e. the backend has actually persisted the new attempt — so
+  // the row never re-enables prematurely on slow queues or throttled tabs.
+  const reprobeBaselineRef = useRef<number | null>(null);
   const isMountedRef = useRef(true);
 
   const [, reprobeAnomalySlot] = useMutation<
@@ -113,14 +116,23 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
-      if (reprobeTimerRef.current != null) {
-        window.clearTimeout(reprobeTimerRef.current);
-      }
-      if (resolveTimerRef.current != null) {
-        window.clearTimeout(resolveTimerRef.current);
-      }
     };
   }, []);
+
+  // When the next poll lands and the backend's reprobeCount has incremented past
+  // the baseline captured at mutation time, clear the "Re-probing…" state. This
+  // keeps the row disabled until the server has actually persisted the new attempt
+  // (whereas a fixed timeout would re-enable the button even on backed-up queues).
+  useEffect(() => {
+    if (
+      isReprobing
+      && reprobeBaselineRef.current != null
+      && anomaly.reprobeCount > reprobeBaselineRef.current
+    ) {
+      setIsReprobing(false);
+      reprobeBaselineRef.current = null;
+    }
+  }, [anomaly.reprobeCount, isReprobing]);
 
   const handleOpenReprobeModal = () => {
     setErrorMessage(null);
@@ -130,6 +142,9 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
   const handleConfirmReprobe = async () => {
     setIsReprobeModalOpen(false);
     setErrorMessage(null);
+    // Capture the current count BEFORE firing the mutation so the post-poll effect
+    // can detect when the backend's count has incremented past this baseline.
+    reprobeBaselineRef.current = anomaly.reprobeCount;
     setIsReprobing(true);
 
     try {
@@ -138,19 +153,14 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
         return;
       }
       if (result.error) {
+        reprobeBaselineRef.current = null;
         setIsReprobing(false);
         setErrorMessage(result.error.message);
-        return;
       }
-
-      if (reprobeTimerRef.current != null) {
-        window.clearTimeout(reprobeTimerRef.current);
-      }
-      reprobeTimerRef.current = window.setTimeout(() => {
-        setIsReprobing(false);
-        reprobeTimerRef.current = null;
-      }, 5000);
+      // On success, the row stays "Re-probing…" until the next poll updates
+      // anomaly.reprobeCount past the baseline (handled by the watch effect above).
     } catch (error) {
+      reprobeBaselineRef.current = null;
       setIsReprobing(false);
       setErrorMessage(error instanceof Error ? error.message : 'Failed to re-probe anomaly slot');
     }
@@ -170,14 +180,9 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
         setErrorMessage(result.error.message);
         return;
       }
-
-      if (resolveTimerRef.current != null) {
-        window.clearTimeout(resolveTimerRef.current);
-      }
-      resolveTimerRef.current = window.setTimeout(() => {
-        setIsResolving(false);
-        resolveTimerRef.current = null;
-      }, 5000);
+      // Successfully resolved: the row will drop out of openRunAnomalies on the
+      // next poll (filter is resolvedAt IS NULL), at which point this component
+      // unmounts and clears its own state. No timer needed.
     } catch (error) {
       setIsResolving(false);
       setErrorMessage(error instanceof Error ? error.message : 'Failed to resolve anomaly');
@@ -239,18 +244,31 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
         const title = anomaly.reprobeLimitReached
           ? 'This slot has been re-probed 3 times. Use [Resolve] to close manually; if the underlying issue persists, the next sweep will re-create the anomaly.'
           : (!anomaly.reprobeEligible ? 'This slot cannot be re-probed.' : undefined);
+        const limitReachedDescriptionId = `reprobe-limit-${anomaly.id}`;
 
         return (
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={handleOpenReprobeModal}
-            disabled={disabled}
-            title={title}
-          >
-            {isReprobing ? 'Re-probing…' : 'Re-probe'}
-          </Button>
+          <div className="flex items-center gap-2">
+            {anomaly.reprobeLimitReached && (
+              <span
+                id={limitReachedDescriptionId}
+                role="note"
+                className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900"
+              >
+                Limit reached
+              </span>
+            )}
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleOpenReprobeModal}
+              disabled={disabled}
+              title={title}
+              aria-describedby={anomaly.reprobeLimitReached ? limitReachedDescriptionId : undefined}
+            >
+              {isReprobing ? 'Re-probing…' : 'Re-probe'}
+            </Button>
+          </div>
         );
       }
       case 'PAIR_ASYMMETRY':

--- a/cloud/apps/web/src/components/status/OpenAnomaliesSection.tsx
+++ b/cloud/apps/web/src/components/status/OpenAnomaliesSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'urql';
 import { CheckCircle, RefreshCw } from 'lucide-react';
 import { Button } from '../ui/Button';
@@ -49,12 +49,6 @@ function formatRunAnomalyCount(count: number): string {
   return count === 1 ? 'Open Anomalies (1)' : `Open Anomalies (${count})`;
 }
 
-function sortOpenAnomalies(anomalies: OpenRunAnomaly[]): OpenRunAnomaly[] {
-  return [...anomalies].sort(
-    (left, right) => new Date(right.lastSeenAt).getTime() - new Date(left.lastSeenAt).getTime()
-  );
-}
-
 function formatQueryError(message: string): string {
   return `Failed to load open anomalies: ${message}`;
 }
@@ -85,8 +79,11 @@ export function OpenAnomaliesSection({
     requestPolicy: 'cache-and-network',
   });
 
-  const openAnomalies = useMemo(
-    () => sortOpenAnomalies(result.data?.openRunAnomalies ?? []),
+  // The backend returns openRunAnomalies ordered by firstSeenAt DESC. Preserve that
+  // order — re-sorting client-side (e.g. by lastSeenAt) makes rows jump around as
+  // the detector refreshes lastSeenAt on every reconciliation tick.
+  const openAnomalies: OpenRunAnomaly[] = useMemo(
+    () => result.data?.openRunAnomalies ?? [],
     [result.data?.openRunAnomalies]
   );
 
@@ -102,8 +99,21 @@ export function OpenAnomaliesSection({
   const isInitialLoading = result.fetching && result.data == null;
   const isRefreshing = result.fetching && result.data != null;
 
+  // Track in-flight state via a ref so the interval callback always sees the latest
+  // value without restarting on every render. This prevents overlapping fetches if
+  // the network is slow enough that one request hasn't returned by the next tick.
+  const isFetchingRef = useRef(result.fetching);
+  useEffect(() => {
+    isFetchingRef.current = result.fetching;
+  }, [result.fetching]);
+
   useEffect(() => {
     const interval = window.setInterval(() => {
+      if (isFetchingRef.current) {
+        // Skip this tick — a previous request is still in flight. The next interval
+        // will retry once it returns. Keeps requests from piling up under load.
+        return;
+      }
       reexecuteQuery({ requestPolicy: 'network-only' });
     }, pollIntervalMs);
 


### PR DESCRIPTION
## Summary

Follow-up to #773 (Wave 3 of cross-domain status page). Addresses 4 review findings from Codex on the merged Wave 3 diff. The PR was already squash-merged when this fix-up was ready, so this lands as a separate small PR rather than a fix-up commit on the original.

## Findings addressed

| severity | finding | fix |
|---|---|---|
| **MEDIUM** | `OpenAnomaliesSection.tsx` re-sorted by `lastSeenAt` client-side, overriding backend's `firstSeenAt DESC`. Rows jumped around as `lastSeenAt` ticked on every reconciliation. | Removed the re-sort. Backend ordering is preserved. |
| **MEDIUM** | Polling had no in-flight guard. A slow request could overlap the next 5s tick and pile up under load. | Track `result.fetching` via a ref; skip the interval tick if a request is still pending. |
| **LOW** | Disabled `[Re-probe]` button used `title` attribute only — hover-only, not keyboard-accessible. Spec's visible "Limit reached" chip was missing. | Added a visible amber "Limit reached" chip with `role="note"` and wired `aria-describedby` from the button to the chip. |
| **LOW** | "Re-probing…" state cleared on a fixed 5s `setTimeout`. Could re-enable the button early on slow queues / throttled tabs and invite duplicate clicks. | Replaced the timer with a poll-driven approach: capture `anomaly.reprobeCount` as a baseline when the mutation fires; an effect watches the field and clears the state only after the next poll confirms the count has incremented past the baseline. Resolve simplified to just unmount-driven clearing (the row drops out of `openRunAnomalies` when `resolvedAt` becomes non-null). |

The 1 finding I did NOT address is the missing filter UI (`Status.tsx` reads `?domain` and `?type` from the URL but no dropdowns are rendered) — that's deferred to Wave 5 per the plan, alongside `StatusFilters.tsx` and `ActiveEvaluationsSection.tsx`.

## Test plan

- [x] TS check: 0 errors in changed files
- [ ] CI Lint & Build + Web Tests
- [ ] Manual: open `/status` and observe an anomaly with `reprobeCount >= 3` — confirm the visible "Limit reached" chip + button is disabled with descriptive aria-describedby
- [ ] Manual: click `[Re-probe]` on an eligible anomaly; confirm the "Re-probing…" state persists until the next poll updates `reprobeCount`, not until 5 seconds elapse

## Diff

| file | lines |
|---|---|
| `components/status/AnomalyRow.tsx` | +52 / -36 |
| `components/status/OpenAnomaliesSection.tsx` | +20 / -8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)