### PR TITLE
Hotfix: pressure-sensitivity tooltips + drop redundant heads-up banner

### DIFF
--- a/cloud/apps/web/src/components/models/PressureSensitivitySummary.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivitySummary.tsx
@@ -96,10 +96,6 @@ export function PressureSensitivitySummary({ models, selectedModelId, onSelectMo
         </div>
       </div>
 
-      <div className="mb-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
-        <strong>Heads up:</strong> pressure levels are not calibrated across vignettes. Compare with caution; see the Limitations section below.
-      </div>
-
       <Table variant="bordered">
         <TableHeader variant="bordered">
           <TableRow>

--- a/cloud/apps/web/src/components/ui/HeaderTooltip.tsx
+++ b/cloud/apps/web/src/components/ui/HeaderTooltip.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
 import { Info } from 'lucide-react';
-import { Button } from './Button';
 import { Tooltip } from './Tooltip';
 
 type Props = {
@@ -20,16 +19,15 @@ export function HeaderTooltip({ label, content }: Props) {
         variant="light"
         className="max-w-[280px] whitespace-normal"
       >
-        <Button
+        {/* eslint-disable-next-line react/forbid-elements -- Lightweight tooltip trigger requires an inline button */}
+        <button
           type="button"
-          variant="ghost"
-          size="icon"
-          className="h-auto min-h-0 w-auto min-w-0 rounded-sm p-0 text-gray-400 transition-colors hover:bg-transparent hover:text-gray-600 focus:ring-blue-500 focus:ring-offset-1"
+          className="inline-flex cursor-help rounded-sm text-gray-400 transition-colors hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
           aria-label={`Show ${labelText} help`}
           onClick={(event) => event.stopPropagation()}
         >
           <Info className="h-3.5 w-3.5" aria-hidden="true" />
-        </Button>
+        </button>
       </Tooltip>
     </span>
   );


### PR DESCRIPTION
## Summary
- Fix HeaderTooltip ⓘ icons not showing tooltips on hover. Rewrote to match the proven `SortHeaderButton` pattern (raw `<button>` directly inside `<Tooltip>`) instead of nesting through the `<Button>` component, which combined with `cloneElement` wasn't propagating hover events to the wrapping div correctly.
- Remove the "Heads up: pressure levels are not calibrated across vignettes" banner above the cross-model summary. Same warning lives in the Limitations section below; the banner was redundant.

## Test plan
- [x] `npx turbo build --filter=@valuerank/web` clean
- [x] `npm run test --workspace @valuerank/web -- --run pressure` all 22 pass
- [ ] Post-deploy: hover an ⓘ icon on `/models/pressure-sensitivity` cross-model summary → tooltip appears next to the icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)