### PR TITLE
Cross-domain Status page: Wave 5 — Active Evaluations + filter UI

### DIFF
--- a/cloud/apps/web/src/api/operations/active-evaluation.graphql
+++ b/cloud/apps/web/src/api/operations/active-evaluation.graphql
@@ -1,0 +1,41 @@
+query ActiveEvaluations($domainId: ID) {
+  activeEvaluations(domainId: $domainId) {
+    id
+    domainId
+    domainNameAtLaunch
+    scopeCategory
+    status
+    createdAt
+    startedAt
+    completedAt
+    startedRuns
+    failedDefinitions
+    skippedForBudget
+    projectedCostUsd
+    models
+    temperature
+    maxBudgetUsd
+    memberCount
+    launchableDefinitionIds
+    samplePercentage
+    samplesPerScenario
+    targetBatchCount
+    launchableDefinitions {
+      definitionId
+      definitionName
+      pairKey
+    }
+    members {
+      runId
+      definitionIdAtLaunch
+      definitionNameAtLaunch
+      domainIdAtLaunch
+      modelIds
+      createdAt
+      runStatus
+      runCategory
+      runStartedAt
+      runCompletedAt
+    }
+  }
+}

--- a/cloud/apps/web/src/api/operations/active-evaluation.ts
+++ b/cloud/apps/web/src/api/operations/active-evaluation.ts
@@ -1,0 +1,11 @@
+import type {
+  ActiveEvaluationsQuery as GeneratedActiveEvaluationsQuery,
+  ActiveEvaluationsQueryVariables as GeneratedActiveEvaluationsQueryVariables,
+} from '../../generated/graphql';
+
+export type ActiveEvaluation = GeneratedActiveEvaluationsQuery['activeEvaluations'][number];
+
+export { ActiveEvaluationsDocument as ACTIVE_EVALUATIONS_QUERY } from '../../generated/graphql';
+
+export type ActiveEvaluationsQueryResult = GeneratedActiveEvaluationsQuery;
+export type ActiveEvaluationsQueryVariables = GeneratedActiveEvaluationsQueryVariables;

--- a/cloud/apps/web/src/components/status/ActiveEvaluationsSection.tsx
+++ b/cloud/apps/web/src/components/status/ActiveEvaluationsSection.tsx
@@ -1,0 +1,338 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useQuery } from 'urql';
+import { RefreshCw } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Badge } from '../ui/Badge';
+import { ErrorMessage } from '../ui/ErrorMessage';
+import {
+  DomainEvaluationStatusDrawer,
+} from '../domains/domainTrials/DomainEvaluationStatusDrawer';
+import {
+  DomainEvaluationStatusPanel,
+} from '../domains/domainTrials/DomainEvaluationStatusPanel';
+import {
+  formatTimestamp,
+} from '../domains/domainTrials/DomainEvaluationStatusPanel.helpers';
+import {
+  ACTIVE_EVALUATIONS_QUERY,
+  type ActiveEvaluation,
+  type ActiveEvaluationsQueryResult,
+  type ActiveEvaluationsQueryVariables,
+} from '../../api/operations/active-evaluation';
+import {
+  DOMAIN_TRIAL_RUNS_STATUS_QUERY,
+  type DomainTrialRunsStatusQueryResult,
+  type DomainTrialRunsStatusQueryVariables,
+} from '../../api/operations/domains';
+
+type ActiveEvaluationsSectionProps = {
+  domainId?: string | null;
+  pollIntervalMs?: number;
+};
+
+type DomainEvaluationGroup = {
+  domainId: string;
+  domainName: string;
+  evaluations: ActiveEvaluation[];
+};
+
+type RunStatusRow = DomainTrialRunsStatusQueryResult['domainTrialRunsStatus'][number];
+
+function formatSectionError(message: string): string {
+  return `Failed to load active evaluations: ${message}`;
+}
+
+function groupEvaluationsByDomain(evaluations: ActiveEvaluation[]): DomainEvaluationGroup[] {
+  const groups = new Map<string, DomainEvaluationGroup>();
+  const orderedGroups: DomainEvaluationGroup[] = [];
+
+  for (const evaluation of evaluations) {
+    const existing = groups.get(evaluation.domainId);
+    if (existing != null) {
+      existing.evaluations.push(evaluation);
+      continue;
+    }
+
+    const group = {
+      domainId: evaluation.domainId,
+      domainName: evaluation.domainNameAtLaunch,
+      evaluations: [evaluation],
+    };
+    groups.set(evaluation.domainId, group);
+    orderedGroups.push(group);
+  }
+
+  return orderedGroups;
+}
+
+function formatEvaluationSummary(evaluation: ActiveEvaluation): string {
+  const parts = [
+    evaluation.scopeCategory,
+    `${evaluation.memberCount} run${evaluation.memberCount === 1 ? '' : 's'}`,
+  ];
+
+  if (evaluation.startedAt != null) {
+    parts.push(`started ${formatTimestamp(evaluation.startedAt)}`);
+  }
+
+  if (evaluation.completedAt != null) {
+    parts.push(`completed ${formatTimestamp(evaluation.completedAt)}`);
+  }
+
+  return parts.join(' · ');
+}
+
+export function ActiveEvaluationsSection({
+  domainId,
+  pollIntervalMs = 5000,
+}: ActiveEvaluationsSectionProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const normalizedDomainId = domainId != null && domainId.trim() !== '' ? domainId : null;
+  const rawSelectedRunId = searchParams.get('runId');
+  const selectedRunId = rawSelectedRunId != null && rawSelectedRunId.trim() !== '' ? rawSelectedRunId : null;
+
+  const [evaluationsResult, reexecuteEvaluations] = useQuery<
+    ActiveEvaluationsQueryResult,
+    ActiveEvaluationsQueryVariables
+  >({
+    query: ACTIVE_EVALUATIONS_QUERY,
+    variables: { domainId: normalizedDomainId },
+    requestPolicy: 'network-only',
+  });
+
+  const activeEvaluations = useMemo(
+    () => evaluationsResult.data?.activeEvaluations ?? [],
+    [evaluationsResult.data?.activeEvaluations],
+  );
+
+  const activeRunIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const evaluation of activeEvaluations) {
+      for (const member of evaluation.members) {
+        ids.add(member.runId);
+      }
+    }
+    return Array.from(ids).sort();
+  }, [activeEvaluations]);
+
+  const [statusResult, reexecuteStatuses] = useQuery<
+    DomainTrialRunsStatusQueryResult,
+    DomainTrialRunsStatusQueryVariables
+  >({
+    query: DOMAIN_TRIAL_RUNS_STATUS_QUERY,
+    variables: { runIds: activeRunIds },
+    pause: activeRunIds.length === 0,
+    requestPolicy: 'network-only',
+  });
+
+  const queryError = evaluationsResult.error ?? statusResult.error ?? null;
+  const isInitialLoading = evaluationsResult.fetching && evaluationsResult.data == null;
+  const isRefreshing = (evaluationsResult.fetching || statusResult.fetching) && evaluationsResult.data != null;
+
+  const isFetchingRef = useRef(false);
+  useEffect(() => {
+    isFetchingRef.current = evaluationsResult.fetching || statusResult.fetching;
+  }, [evaluationsResult.fetching, statusResult.fetching]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      if (isFetchingRef.current) {
+        return;
+      }
+
+      reexecuteEvaluations({ requestPolicy: 'network-only' });
+      if (activeRunIds.length > 0) {
+        reexecuteStatuses({ requestPolicy: 'network-only' });
+      }
+    }, pollIntervalMs);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [activeRunIds, pollIntervalMs, reexecuteEvaluations, reexecuteStatuses]);
+
+  const evaluationStatuses = useMemo(
+    () => statusResult.data?.domainTrialRunsStatus ?? [],
+    [statusResult.data?.domainTrialRunsStatus],
+  );
+
+  const evaluationStatusesByRunId = useMemo(() => {
+    return new Map<string, RunStatusRow>(evaluationStatuses.map((status) => [status.runId, status]));
+  }, [evaluationStatuses]);
+
+  const groupedEvaluations = useMemo(
+    () => groupEvaluationsByDomain(activeEvaluations),
+    [activeEvaluations],
+  );
+
+  const handleRunSelect = (runId: string) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('runId', runId);
+    setSearchParams(next, { replace: true });
+  };
+
+  const handleDrawerClose = () => {
+    const next = new URLSearchParams(searchParams);
+    next.delete('runId');
+    setSearchParams(next, { replace: true });
+  };
+
+  if (isInitialLoading) {
+    return (
+      <section className="rounded-lg border border-gray-200 bg-white">
+        <div className="px-6 py-5 space-y-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <div className="h-5 w-44 rounded bg-gray-200 animate-pulse" />
+              <div className="h-4 w-64 rounded bg-gray-100 animate-pulse" />
+            </div>
+            <div className="h-9 w-24 rounded-md bg-gray-100 animate-pulse" />
+          </div>
+          <div className="space-y-3">
+            <div className="rounded-lg border border-gray-200 bg-white p-4 animate-pulse">
+              <div className="h-4 w-56 rounded bg-gray-200" />
+              <div className="mt-3 grid gap-2">
+                <div className="h-4 rounded bg-gray-100" />
+                <div className="h-4 rounded bg-gray-100" />
+                <div className="h-4 rounded bg-gray-100" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const showEmptyState = queryError == null && groupedEvaluations.length === 0;
+
+  return (
+    <>
+      <section className="rounded-lg border border-gray-200 bg-white">
+        <div className="px-6 py-5 space-y-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <h2 className="text-lg font-medium text-gray-900">
+                  Active Evaluations
+                </h2>
+                <Badge variant="neutral" size="count">
+                  {activeEvaluations.length}
+                </Badge>
+              </div>
+              <p className="text-sm text-gray-500">
+                Live evaluation launches currently running or summarizing.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {isRefreshing && (
+                <span className="text-xs font-medium text-gray-500">Refreshing…</span>
+              )}
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  reexecuteEvaluations({ requestPolicy: 'network-only' });
+                  if (activeRunIds.length > 0) {
+                    reexecuteStatuses({ requestPolicy: 'network-only' });
+                  }
+                }}
+              >
+                <RefreshCw className="mr-1.5 h-4 w-4" />
+                Refresh
+              </Button>
+            </div>
+          </div>
+
+          {queryError != null && (
+            <ErrorMessage
+              message={formatSectionError(queryError.message)}
+              onRetry={() => {
+                reexecuteEvaluations({ requestPolicy: 'network-only' });
+                if (activeRunIds.length > 0) {
+                  reexecuteStatuses({ requestPolicy: 'network-only' });
+                }
+              }}
+            />
+          )}
+
+          {showEmptyState ? (
+            <div className="rounded-lg border border-gray-200 bg-white px-6 py-10 text-center">
+              <p className="text-sm font-medium text-gray-900">No active evaluations.</p>
+              <p className="mt-1 text-sm text-gray-500">
+                Nothing is currently running or summarizing.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {groupedEvaluations.map((group) => (
+                <section key={group.domainId} className="space-y-4 rounded-xl border border-gray-200 bg-gray-50/60 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="space-y-1">
+                      <h3 className="text-base font-semibold text-gray-900">
+                        {group.domainName}
+                      </h3>
+                      <p className="text-sm text-gray-600">
+                        {group.evaluations.length} active evaluation{group.evaluations.length === 1 ? '' : 's'}
+                      </p>
+                    </div>
+                    <Badge variant="neutral" size="count">
+                      {group.domainId.slice(-8)}
+                    </Badge>
+                  </div>
+
+                  <div className="space-y-4">
+                    {group.evaluations.map((evaluation) => {
+                      const runStatuses = evaluation.members
+                        .map((member) => evaluationStatusesByRunId.get(member.runId))
+                        .filter((status): status is RunStatusRow => status != null);
+
+                      return (
+                        <div key={evaluation.id} className="space-y-3">
+                          <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div className="space-y-1">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h4 className="text-sm font-semibold text-gray-900">
+                                  Launch {evaluation.id.slice(-8)}
+                                </h4>
+                                <Badge variant="info" size="count">
+                                  {evaluation.status.toLowerCase()}
+                                </Badge>
+                              </div>
+                              <p className="text-xs text-gray-600">
+                                {formatEvaluationSummary(evaluation)}
+                              </p>
+                            </div>
+                          </div>
+
+                          <DomainEvaluationStatusPanel
+                            domainName={group.domainName}
+                            evaluation={evaluation}
+                            evaluationStatus={null}
+                            runStatuses={runStatuses}
+                            fetching={evaluationsResult.fetching || statusResult.fetching}
+                            lastUpdatedAt={null}
+                            selectedRunId={selectedRunId}
+                            onSelectRun={handleRunSelect}
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <DomainEvaluationStatusDrawer
+        runId={selectedRunId}
+        open={selectedRunId != null}
+        onClose={handleDrawerClose}
+      />
+    </>
+  );
+}

--- a/cloud/apps/web/src/components/status/StatusFilters.tsx
+++ b/cloud/apps/web/src/components/status/StatusFilters.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useQuery } from 'urql';
+import { DOMAINS_QUERY, type DomainsQueryResult, type DomainsQueryVariables } from '../../api/operations/domains';
+import { type RunAnomalyType } from '../../api/operations/run-anomaly';
+
+type AnomalyTypeOption = {
+  value: RunAnomalyType;
+  label: string;
+};
+
+const ANOMALY_TYPE_OPTIONS: AnomalyTypeOption[] = [
+  { value: 'INVALID_RESPONSE_FAILURE', label: 'Invalid response failure' },
+  { value: 'MODEL_TRANSCRIPT_SHORTFALL', label: 'Model transcript shortfall' },
+  { value: 'ORPHAN_TRANSCRIPT', label: 'Orphan transcript' },
+  { value: 'PAIR_ASYMMETRY', label: 'Pair asymmetry' },
+  { value: 'SCHEDULED_COUNT_MISMATCH', label: 'Scheduled count mismatch' },
+  { value: 'STRANDED_TRANSCRIPT', label: 'Stranded transcript' },
+  { value: 'SUMMARIZING_STALL', label: 'Summarizing stall' },
+];
+
+function isRunAnomalyType(value: string | null): value is RunAnomalyType {
+  if (value == null) {
+    return false;
+  }
+  return ANOMALY_TYPE_OPTIONS.some((option) => option.value === value);
+}
+
+export function StatusFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [domainsResult] = useQuery<DomainsQueryResult, DomainsQueryVariables>({
+    query: DOMAINS_QUERY,
+    variables: { limit: 500, offset: 0 },
+    requestPolicy: 'cache-and-network',
+  });
+
+  const domains = useMemo(
+    () => [...(domainsResult.data?.domains ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
+    [domainsResult.data?.domains],
+  );
+
+  const domainIdParam = searchParams.get('domain');
+  const typeParam = searchParams.get('type');
+  const domainIdSet = useMemo(() => new Set(domains.map((domain) => domain.id)), [domains]);
+  const selectedDomainId = domainIdParam != null && domainIdSet.has(domainIdParam) ? domainIdParam : '';
+  const selectedType = isRunAnomalyType(typeParam) ? typeParam : '';
+
+  const updateSearchParams = (key: string, value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value.trim() === '') {
+      next.delete(key);
+    } else {
+      next.set(key, value);
+    }
+    setSearchParams(next, { replace: true });
+  };
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="space-y-2">
+          <span className="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+            Domain
+          </span>
+          <select
+            value={selectedDomainId}
+            onChange={(event) => updateSearchParams('domain', event.target.value)}
+            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+          >
+            <option value="">All Domains</option>
+            {domains.map((domain) => (
+              <option key={domain.id} value={domain.id}>
+                {domain.name}
+              </option>
+            ))}
+          </select>
+          <span className="block text-xs text-gray-500">
+            Applies to both status sections.
+          </span>
+        </label>
+
+        <label className="space-y-2">
+          <span className="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+            Anomaly type
+          </span>
+          <select
+            value={selectedType}
+            onChange={(event) => updateSearchParams('type', event.target.value)}
+            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500"
+          >
+            <option value="">All Types</option>
+            {ANOMALY_TYPE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <span className="block text-xs text-gray-500">
+            Open Anomalies only.
+          </span>
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -4269,6 +4269,13 @@ export type DomainEvaluationsQueryVariables = Exact<{
 
 export type DomainEvaluationsQuery = { __typename?: 'Query', domainEvaluations: Array<{ __typename?: 'DomainEvaluation', id: string, domainId: string, domainNameAtLaunch: string, scopeCategory: string, status: string, createdAt: string, startedAt?: string | null, completedAt?: string | null, startedRuns: number, failedDefinitions: number, skippedForBudget: number, projectedCostUsd: number, models: Array<string>, temperature?: number | null, maxBudgetUsd?: number | null, memberCount: number, launchableDefinitionIds: Array<string>, samplePercentage?: number | null, samplesPerScenario?: number | null, targetBatchCount?: number | null }> };
 
+export type ActiveEvaluationsQueryVariables = Exact<{
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+}>;
+
+
+export type ActiveEvaluationsQuery = { __typename?: 'Query', activeEvaluations: Array<{ __typename?: 'DomainEvaluation', id: string, domainId: string, domainNameAtLaunch: string, scopeCategory: string, status: string, createdAt: string, startedAt?: string | null, completedAt?: string | null, startedRuns: number, failedDefinitions: number, skippedForBudget: number, projectedCostUsd: number, models: Array<string>, temperature?: number | null, maxBudgetUsd?: number | null, memberCount: number, launchableDefinitionIds: Array<string>, samplePercentage?: number | null, samplesPerScenario?: number | null, targetBatchCount?: number | null, launchableDefinitions: Array<{ __typename?: 'DomainEvaluationLaunchableDefinition', definitionId: string, definitionName: string, pairKey?: string | null }>, members: Array<{ __typename?: 'DomainEvaluationMember', runId: string, definitionIdAtLaunch: string, definitionNameAtLaunch: string, domainIdAtLaunch: string, modelIds: Array<string>, createdAt: string, runStatus: string, runCategory: string, runStartedAt?: string | null, runCompletedAt?: string | null }> }> };
+
 export type DomainEvaluationQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
@@ -6212,6 +6219,54 @@ export const DomainEvaluationsDocument = gql`
   }
 }
     `;
+
+export const ActiveEvaluationsDocument = gql`
+    query ActiveEvaluations($domainId: ID) {
+  activeEvaluations(domainId: $domainId) {
+    id
+    domainId
+    domainNameAtLaunch
+    scopeCategory
+    status
+    createdAt
+    startedAt
+    completedAt
+    startedRuns
+    failedDefinitions
+    skippedForBudget
+    projectedCostUsd
+    models
+    temperature
+    maxBudgetUsd
+    memberCount
+    launchableDefinitionIds
+    samplePercentage
+    samplesPerScenario
+    targetBatchCount
+    launchableDefinitions {
+      definitionId
+      definitionName
+      pairKey
+    }
+    members {
+      runId
+      definitionIdAtLaunch
+      definitionNameAtLaunch
+      domainIdAtLaunch
+      modelIds
+      createdAt
+      runStatus
+      runCategory
+      runStartedAt
+      runCompletedAt
+    }
+  }
+}
+    `;
+
+export function useActiveEvaluationsQuery(options?: Omit<Urql.UseQueryArgs<ActiveEvaluationsQueryVariables>, 'query'>) {
+  return Urql.useQuery<ActiveEvaluationsQuery, ActiveEvaluationsQueryVariables>({ query: ActiveEvaluationsDocument, ...options });
+};
 
 export function useDomainEvaluationsQuery(options: Omit<Urql.UseQueryArgs<DomainEvaluationsQueryVariables>, 'query'>) {
   return Urql.useQuery<DomainEvaluationsQuery, DomainEvaluationsQueryVariables>({ query: DomainEvaluationsDocument, ...options });

--- a/cloud/apps/web/src/pages/Status.tsx
+++ b/cloud/apps/web/src/pages/Status.tsx
@@ -1,5 +1,7 @@
 import { useSearchParams } from 'react-router-dom';
+import { ActiveEvaluationsSection } from '../components/status/ActiveEvaluationsSection';
 import { OpenAnomaliesSection } from '../components/status/OpenAnomaliesSection';
+import { StatusFilters } from '../components/status/StatusFilters';
 
 const POLL_MS = 5000;
 
@@ -7,23 +9,14 @@ export function Status() {
   const [searchParams] = useSearchParams();
   const domainId = searchParams.get('domain');
   const typeFilter = searchParams.get('type');
+  const normalizedDomainId = domainId != null && domainId.trim() !== '' ? domainId : null;
 
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Status</h1>
-
-      <OpenAnomaliesSection
-        domainId={domainId}
-        type={typeFilter}
-        pollIntervalMs={POLL_MS}
-      />
-
-      <section className="rounded-lg border border-gray-200 bg-white p-6">
-        <h2 className="text-lg font-medium text-gray-900">Active Evaluations</h2>
-        <p className="mt-2 text-sm text-gray-500">
-          Wave 5 will surface live evaluation status here.
-        </p>
-      </section>
+      <StatusFilters />
+      <OpenAnomaliesSection domainId={normalizedDomainId} type={typeFilter} pollIntervalMs={POLL_MS} />
+      <ActiveEvaluationsSection domainId={normalizedDomainId} pollIntervalMs={POLL_MS} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Wave 5 of the cross-domain `/status` page. Replaces the placeholder under Open Anomalies with a working Active Evaluations section, and adds the domain + type filter dropdowns the spec called for.

After this lands, `/status` is feature-complete:
- Open Anomalies (Wave 3)
- Active Evaluations grouped by domain (this PR)
- Domain + type filters with URL state (this PR)

The old `/domains/status/:domainId` route is intentionally still wired (Wave 6 cleanup). Researchers retain their existing per-domain monitor while the cross-domain view rolls out.

## What's in this PR

**New components:**
- `ActiveEvaluationsSection` — calls `activeEvaluations` query (Wave 2 backend), groups results by domain name, renders `DomainEvaluationStatusPanel` for each. Includes the existing `DomainEvaluationStatusDrawer` for run drill-down via `?runId=`.
- `StatusFilters` — single-select domain dropdown + single-select type dropdown. Both write to URL query params (`?domain=`, `?type=`); no localStorage. Type filter scopes only the Open Anomalies section (per plan Decision 4); Active Evaluations honors the domain filter only.

**New GraphQL operations file:**
- `cloud/apps/web/src/api/operations/active-evaluation.graphql` + `.ts`
- `OpenRunAnomalies` and the existing operations are unchanged.

**Modified:**
- `Status.tsx` — replaces the Wave 3 placeholder with `<ActiveEvaluationsSection>` and adds the `<StatusFilters>` block.
- `cloud/apps/web/src/generated/graphql.ts` — manually synced to include the new operation types (codegen wasn't runnable in the dispatch env; CI codegen check should validate freshness).

## Test plan

- [ ] CI: Lint & Build, Web Tests (with codegen freshness check), API & DB Tests
- [ ] Manual: open `/status`, verify the Active Evaluations section renders the in-progress run grouped under its domain
- [ ] Manual: select a domain in the filter — both sections narrow to that domain
- [ ] Manual: select a type in the filter — only Open Anomalies narrows; Active Evaluations is unaffected
- [ ] Manual: click into a run from Active Evaluations — drawer opens, `?runId=` reflected in URL

## What's NOT in this PR

- Wave 4 (enhanced per-model panel with ETA / throughput / cost) — deferred. The Active Evaluations section reuses the existing `DomainEvaluationStatusPanel` as-is.
- Wave 6 (hard removal of `/domains/status/:domainId`) — deferred. The old route stays live for back-compat until users have migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)