### PR TITLE
Model Confidence Heatmap page

### DIFF
--- a/cloud/apps/api/src/graphql/queries/models-confidence.ts
+++ b/cloud/apps/api/src/graphql/queries/models-confidence.ts
@@ -1,0 +1,164 @@
+import { db } from '@valuerank/db';
+import { getModelsFromDatabase } from '../../config/models.js';
+import { runMatchesSignature } from './domain-coverage-gql-types.js';
+import { resolveTranscriptDecisionModel } from './domain/shared.js';
+import { DOMAIN_ANALYSIS_VALUE_KEYS, type DomainAnalysisValueKey } from './domain-analysis-values.js';
+import { builder } from '../builder.js';
+import {
+  ModelsConfidenceResultRef,
+  type ModelsConfidenceModelResultShape,
+  type ModelsConfidenceValueResultShape,
+} from '../types/models-confidence.js';
+
+type ConfidenceCounts = { strong: number; lean: number };
+type ModelConfidenceCounts = {
+  valueMap: Map<DomainAnalysisValueKey, ConfidenceCounts>;
+  rawStrong: number;
+  rawLean: number;
+};
+
+function computeConfidence(counts: ConfidenceCounts): number | null {
+  const total = counts.strong + counts.lean;
+  if (total === 0) return null;
+  return (counts.strong / total) * 100;
+}
+
+type TranscriptRow = {
+  modelId: string;
+  decisionMetadata: unknown;
+  definitionSnapshot: unknown;
+  scenario: { orientationFlipped: boolean } | null;
+};
+
+builder.queryField('modelsConfidence', (t) =>
+  t.field({
+    type: ModelsConfidenceResultRef,
+    args: {
+      signature: t.arg.string({ required: false }),
+    },
+    resolve: async (_root, args) => {
+      const signature = args.signature != null ? String(args.signature) : null;
+
+      const activeModels = await getModelsFromDatabase({
+        activeOnly: true,
+        availableOnly: false,
+      });
+
+      const runs = await db.run.findMany({
+        where: {
+          status: 'COMPLETED',
+          deletedAt: null,
+          tags: { some: { tag: { name: 'Aggregate' } } },
+        },
+        select: { id: true, config: true },
+      });
+
+      const scopedRuns = signature != null
+        ? runs.filter((run) => runMatchesSignature(run.config, signature))
+        : runs;
+
+      const emptyValues = (): ModelsConfidenceValueResultShape[] =>
+        DOMAIN_ANALYSIS_VALUE_KEYS.map((k) => ({
+          valueKey: k,
+          confidence: null,
+          strongCount: 0,
+          leanCount: 0,
+        }));
+
+      if (scopedRuns.length === 0) {
+        return {
+          models: activeModels.map((m) => ({
+            modelId: m.modelId,
+            label: m.displayName,
+            overallConfidence: null,
+            overallStrongCount: 0,
+            overallLeanCount: 0,
+            values: emptyValues(),
+          })),
+        };
+      }
+
+      const runIds = scopedRuns.map((r) => r.id);
+      const transcripts = await db.transcript.findMany({
+        where: { runId: { in: runIds }, deletedAt: null },
+        select: {
+          modelId: true,
+          decisionMetadata: true,
+          definitionSnapshot: true,
+          scenario: { select: { orientationFlipped: true } },
+        },
+      }) as TranscriptRow[];
+
+      // modelId -> counts
+      const countsMap = new Map<string, ModelConfidenceCounts>();
+      for (const model of activeModels) {
+        const valueMap = new Map<DomainAnalysisValueKey, ConfidenceCounts>();
+        for (const key of DOMAIN_ANALYSIS_VALUE_KEYS) {
+          valueMap.set(key, { strong: 0, lean: 0 });
+        }
+        countsMap.set(model.modelId, {
+          valueMap,
+          rawStrong: 0,
+          rawLean: 0,
+        });
+      }
+
+      for (const transcript of transcripts) {
+        const modelCounts = countsMap.get(transcript.modelId);
+        if (modelCounts == null) continue;
+
+        const { canonical } = resolveTranscriptDecisionModel({
+          decisionMetadata: transcript.decisionMetadata,
+          definitionSnapshot: transcript.definitionSnapshot,
+          orientationFlipped: transcript.scenario?.orientationFlipped ?? null,
+        });
+
+        if (canonical.direction !== 'favor_first' && canonical.direction !== 'favor_second') continue;
+        if (canonical.strength !== 'strong' && canonical.strength !== 'lean') continue;
+
+        if (canonical.strength === 'strong') modelCounts.rawStrong += 1;
+        else modelCounts.rawLean += 1;
+
+        // Both values in the pair receive the strength count — confidence is
+        // about how decisively the model engages with a value, regardless of direction.
+        const valueKeys = [canonical.favoredValueKey, canonical.opposedValueKey].filter(
+          (k): k is DomainAnalysisValueKey => k != null,
+        );
+        for (const valueKey of valueKeys) {
+          const counts = modelCounts.valueMap.get(valueKey);
+          if (counts == null) continue;
+          if (canonical.strength === 'strong') counts.strong += 1;
+          else counts.lean += 1;
+        }
+      }
+
+      const models: ModelsConfidenceModelResultShape[] = activeModels.map((model) => {
+        const modelCounts = countsMap.get(model.modelId);
+        const valueMap = modelCounts?.valueMap ?? new Map<DomainAnalysisValueKey, ConfidenceCounts>();
+        const rawStrong = modelCounts?.rawStrong ?? 0;
+        const rawLean = modelCounts?.rawLean ?? 0;
+
+        const values: ModelsConfidenceValueResultShape[] = DOMAIN_ANALYSIS_VALUE_KEYS.map((valueKey) => {
+          const counts = valueMap.get(valueKey) ?? { strong: 0, lean: 0 };
+          return {
+            valueKey,
+            confidence: computeConfidence(counts),
+            strongCount: counts.strong,
+            leanCount: counts.lean,
+          };
+        });
+
+        return {
+          modelId: model.modelId,
+          label: model.displayName,
+          overallConfidence: computeConfidence({ strong: rawStrong, lean: rawLean }),
+          overallStrongCount: rawStrong,
+          overallLeanCount: rawLean,
+          values,
+        };
+      });
+
+      return { models };
+    },
+  }),
+);

--- a/cloud/apps/api/src/graphql/types/index.ts
+++ b/cloud/apps/api/src/graphql/types/index.ts
@@ -28,6 +28,7 @@ import './probe-result.js';
 // Model types
 import './available-model.js';
 import './models-analysis.js';
+import './models-confidence.js';
 import './models-consistency.js';
 import './pressure-sensitivity.js';
 import './circumplex.js';

--- a/cloud/apps/api/src/graphql/types/models-confidence.ts
+++ b/cloud/apps/api/src/graphql/types/models-confidence.ts
@@ -1,0 +1,71 @@
+import { builder } from '../builder.js';
+
+export type ModelsConfidenceValueResultShape = {
+  valueKey: string;
+  confidence: number | null;
+  strongCount: number;
+  leanCount: number;
+};
+
+export type ModelsConfidenceModelResultShape = {
+  modelId: string;
+  label: string;
+  overallConfidence: number | null;
+  overallStrongCount: number;
+  overallLeanCount: number;
+  values: ModelsConfidenceValueResultShape[];
+};
+
+export type ModelsConfidenceResultShape = {
+  models: ModelsConfidenceModelResultShape[];
+};
+
+const ModelsConfidenceValueResultRef =
+  builder.objectRef<ModelsConfidenceValueResultShape>('ModelsConfidenceValueResult');
+
+const ModelsConfidenceModelResultRef =
+  builder.objectRef<ModelsConfidenceModelResultShape>('ModelsConfidenceModelResult');
+
+export const ModelsConfidenceResultRef =
+  builder.objectRef<ModelsConfidenceResultShape>('ModelsConfidenceResult');
+
+builder.objectType(ModelsConfidenceValueResultRef, {
+  description: 'Confidence stats for a model/value pair',
+  fields: (t) => ({
+    valueKey: t.exposeString('valueKey'),
+    confidence: t.field({
+      type: 'Float',
+      nullable: true,
+      resolve: (v) => v.confidence,
+    }),
+    strongCount: t.exposeInt('strongCount'),
+    leanCount: t.exposeInt('leanCount'),
+  }),
+});
+
+builder.objectType(ModelsConfidenceModelResultRef, {
+  description: 'Confidence stats for a model across all values',
+  fields: (t) => ({
+    modelId: t.exposeString('modelId'),
+    label: t.exposeString('label'),
+    overallConfidence: t.field({
+      type: 'Float',
+      nullable: true,
+      resolve: (m) => m.overallConfidence,
+    }),
+    overallStrongCount: t.exposeInt('overallStrongCount'),
+    overallLeanCount: t.exposeInt('overallLeanCount'),
+    values: t.expose('values', {
+      type: [ModelsConfidenceValueResultRef],
+    }),
+  }),
+});
+
+builder.objectType(ModelsConfidenceResultRef, {
+  description: 'Cross-model confidence heatmap: strong% per model per value',
+  fields: (t) => ({
+    models: t.expose('models', {
+      type: [ModelsConfidenceModelResultRef],
+    }),
+  }),
+});

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1648,6 +1648,29 @@ type ModelsAnalysisValueResult {
   valueKey: String!
 }
 
+"""Confidence stats for a model across all values"""
+type ModelsConfidenceModelResult {
+  label: String!
+  modelId: String!
+  overallConfidence: Float
+  overallLeanCount: Int!
+  overallStrongCount: Int!
+  values: [ModelsConfidenceValueResult!]!
+}
+
+"""Cross-model confidence heatmap: strong% per model per value"""
+type ModelsConfidenceResult {
+  models: [ModelsConfidenceModelResult!]!
+}
+
+"""Confidence stats for a model/value pair"""
+type ModelsConfidenceValueResult {
+  confidence: Float
+  leanCount: Int!
+  strongCount: Int!
+  valueKey: String!
+}
+
 type ModelsConsistencyResult {
   insufficient: [InsufficientModel!]!
   models: [ModelConsistency!]!
@@ -2534,6 +2557,7 @@ type Query {
     """Optional batch signature to filter snapshots (e.g. vnewtd, vnewt0)"""
     signature: String
   ): ModelsAnalysisResult!
+  modelsConfidence(signature: String): ModelsConfidenceResult!
   modelsConsistency(domainId: ID, minScenarios: Int, providerId: ID, signature: String!): ModelsConsistencyResult!
 
   """

--- a/cloud/apps/web/src/App.tsx
+++ b/cloud/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ import { DomainValueShiftHeatmap } from './pages/DomainValueShiftHeatmap';
 import { ModelsConsistency } from './pages/ModelsConsistency';
 import { PressureSensitivity } from './pages/PressureSensitivity';
 import { ModelsCircumplex } from './pages/ModelsCircumplex';
+import { ModelsConfidence } from './pages/ModelsConfidence';
 import { DefinitionDetail } from './pages/DefinitionDetail';
 import { StartPairedBatchPage } from './pages/DefinitionDetail/StartPairedBatchPage';
 import { Runs } from './pages/Runs';
@@ -213,6 +214,14 @@ function App() {
               element={
                 <ProtectedLayout>
                   <ModelsCircumplex />
+                </ProtectedLayout>
+              }
+            />
+            <Route
+              path="/models/confidence"
+              element={
+                <ProtectedLayout>
+                  <ModelsConfidence />
                 </ProtectedLayout>
               }
             />

--- a/cloud/apps/web/src/api/operations/modelsConfidence.graphql
+++ b/cloud/apps/web/src/api/operations/modelsConfidence.graphql
@@ -1,0 +1,17 @@
+query ModelsConfidence($signature: String) {
+  modelsConfidence(signature: $signature) {
+    models {
+      modelId
+      label
+      overallConfidence
+      overallStrongCount
+      overallLeanCount
+      values {
+        valueKey
+        confidence
+        strongCount
+        leanCount
+      }
+    }
+  }
+}

--- a/cloud/apps/web/src/api/operations/modelsConfidence.ts
+++ b/cloud/apps/web/src/api/operations/modelsConfidence.ts
@@ -1,47 +1,12 @@
-import { gql } from 'urql';
+import type {
+  ModelsConfidenceQuery as GeneratedModelsConfidenceQuery,
+  ModelsConfidenceQueryVariables as GeneratedModelsConfidenceQueryVariables,
+} from '../../generated/graphql';
 
-export type ModelsConfidenceValueResult = {
-  valueKey: string;
-  confidence: number | null;
-  strongCount: number;
-  leanCount: number;
-};
+export { ModelsConfidenceDocument as MODELS_CONFIDENCE_QUERY } from '../../generated/graphql';
 
-export type ModelsConfidenceModelResult = {
-  modelId: string;
-  label: string;
-  overallConfidence: number | null;
-  overallStrongCount: number;
-  overallLeanCount: number;
-  values: ModelsConfidenceValueResult[];
-};
+export type ModelsConfidenceQueryResult = GeneratedModelsConfidenceQuery;
+export type ModelsConfidenceQueryVariables = GeneratedModelsConfidenceQueryVariables;
 
-export type ModelsConfidenceQueryResult = {
-  modelsConfidence: {
-    models: ModelsConfidenceModelResult[];
-  };
-};
-
-export type ModelsConfidenceQueryVariables = {
-  signature?: string | null;
-};
-
-export const MODELS_CONFIDENCE_QUERY = gql`
-  query ModelsConfidence($signature: String) {
-    modelsConfidence(signature: $signature) {
-      models {
-        modelId
-        label
-        overallConfidence
-        overallStrongCount
-        overallLeanCount
-        values {
-          valueKey
-          confidence
-          strongCount
-          leanCount
-        }
-      }
-    }
-  }
-`;
+export type ModelsConfidenceModelResult = GeneratedModelsConfidenceQuery['modelsConfidence']['models'][number];
+export type ModelsConfidenceValueResult = ModelsConfidenceModelResult['values'][number];

--- a/cloud/apps/web/src/api/operations/modelsConfidence.ts
+++ b/cloud/apps/web/src/api/operations/modelsConfidence.ts
@@ -1,0 +1,47 @@
+import { gql } from 'urql';
+
+export type ModelsConfidenceValueResult = {
+  valueKey: string;
+  confidence: number | null;
+  strongCount: number;
+  leanCount: number;
+};
+
+export type ModelsConfidenceModelResult = {
+  modelId: string;
+  label: string;
+  overallConfidence: number | null;
+  overallStrongCount: number;
+  overallLeanCount: number;
+  values: ModelsConfidenceValueResult[];
+};
+
+export type ModelsConfidenceQueryResult = {
+  modelsConfidence: {
+    models: ModelsConfidenceModelResult[];
+  };
+};
+
+export type ModelsConfidenceQueryVariables = {
+  signature?: string | null;
+};
+
+export const MODELS_CONFIDENCE_QUERY = gql`
+  query ModelsConfidence($signature: String) {
+    modelsConfidence(signature: $signature) {
+      models {
+        modelId
+        label
+        overallConfidence
+        overallStrongCount
+        overallLeanCount
+        values {
+          valueKey
+          confidence
+          strongCount
+          leanCount
+        }
+      }
+    }
+  }
+`;

--- a/cloud/apps/web/src/components/layout/NavTabs.tsx
+++ b/cloud/apps/web/src/components/layout/NavTabs.tsx
@@ -41,6 +41,7 @@ const modelsMenuItems: MenuItem[] = [
   { name: 'Consistency', path: '/models/consistency' },
   { name: 'Pressure Sensitivity', path: '/models/pressure-sensitivity' },
   { name: 'Circumplex', path: '/models/circumplex' },
+  { name: 'Confidence', path: '/models/confidence' },
 ];
 
 const archiveMenuItems: MenuItem[] = [

--- a/cloud/apps/web/src/components/models/ConfidenceHeatmap.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceHeatmap.tsx
@@ -79,13 +79,13 @@ export function ConfidenceHeatmap({ models }: { models: ModelsConfidenceModelRes
                   );
                 })}
                 <td
-                  title={`Avg: ${formatConfidence(model.overallConfidence)} · Strong: ${model.overallStrongCount} · Lean: ${model.overallLeanCount}`}
+                  title={`Avg: ${formatConfidence(model.overallConfidence ?? null)} · Strong: ${model.overallStrongCount} · Lean: ${model.overallLeanCount}`}
                   className={cn(
                     'px-2 py-2 text-center font-semibold border-l border-l-gray-200 border-b border-b-gray-100 tabular-nums',
-                    getConfidenceTone(model.overallConfidence),
+                    getConfidenceTone(model.overallConfidence ?? null),
                   )}
                 >
-                  {formatConfidence(model.overallConfidence)}
+                  {formatConfidence(model.overallConfidence ?? null)}
                 </td>
               </tr>
             );

--- a/cloud/apps/web/src/components/models/ConfidenceHeatmap.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceHeatmap.tsx
@@ -1,0 +1,97 @@
+import { VALUES, VALUE_LABELS } from '../../data/domainAnalysisData';
+import { formatFullSchwartzValueName } from '../../utils/schwartz';
+import type { ModelsConfidenceModelResult } from '../../api/operations/modelsConfidence';
+import { cn } from '../../lib/utils';
+
+function getConfidenceTone(confidence: number | null): string {
+  if (confidence == null) return 'bg-gray-50 text-gray-400 border-gray-100';
+  if (confidence >= 75) return 'bg-violet-100 text-violet-900 border-violet-200';
+  if (confidence >= 60) return 'bg-violet-50 text-violet-800 border-violet-100';
+  if (confidence >= 45) return 'bg-gray-50 text-gray-700 border-gray-100';
+  return 'bg-slate-50 text-slate-500 border-slate-100';
+}
+
+function formatConfidence(confidence: number | null): string {
+  if (confidence == null) return '—';
+  return `${Math.round(confidence)}%`;
+}
+
+function buildTooltip(valueKey: string, result: ModelsConfidenceModelResult['values'][number] | undefined): string {
+  if (result == null || result.strongCount + result.leanCount === 0) return 'No data';
+  const total = result.strongCount + result.leanCount;
+  return `${formatFullSchwartzValueName(valueKey as Parameters<typeof formatFullSchwartzValueName>[0])}\nStrong: ${result.strongCount} · Lean: ${result.leanCount} · Total: ${total}`;
+}
+
+export function ConfidenceHeatmap({ models }: { models: ModelsConfidenceModelResult[] }) {
+  const sorted = [...models].sort((a, b) => {
+    const aConf = a.overallConfidence ?? -1;
+    const bConf = b.overallConfidence ?? -1;
+    return bConf - aConf;
+  });
+
+  if (models.length === 0) {
+    return <p className="text-sm text-gray-500">No data</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm border-collapse">
+        <thead>
+          <tr>
+            <th className="sticky left-0 z-10 bg-white pr-4 pl-1 py-2 text-left font-medium text-gray-500 border-b border-gray-200 min-w-[160px] whitespace-nowrap">
+              Model
+            </th>
+            {VALUES.map((key) => (
+              <th
+                key={key}
+                title={formatFullSchwartzValueName(key)}
+                className="px-2 py-2 text-center font-medium text-gray-500 border-b border-gray-200 min-w-[74px] whitespace-nowrap"
+              >
+                {VALUE_LABELS[key]}
+              </th>
+            ))}
+            <th className="px-2 py-2 text-center font-semibold text-gray-700 border-b border-l border-gray-200 min-w-[64px]">
+              Avg
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((model) => {
+            const byKey = new Map(model.values.map((v) => [v.valueKey, v]));
+            return (
+              <tr key={model.modelId} className="hover:bg-gray-50/40">
+                <td className="sticky left-0 z-10 bg-white pr-4 pl-1 py-2 font-medium text-gray-800 border-b border-gray-100 whitespace-nowrap">
+                  {model.label}
+                </td>
+                {VALUES.map((key) => {
+                  const v = byKey.get(key);
+                  return (
+                    <td
+                      key={key}
+                      title={buildTooltip(key, v)}
+                      className={cn(
+                        'px-2 py-2 text-center border border-gray-100 tabular-nums',
+                        getConfidenceTone(v?.confidence ?? null),
+                      )}
+                    >
+                      {formatConfidence(v?.confidence ?? null)}
+                    </td>
+                  );
+                })}
+                <td
+                  title={`Avg: ${formatConfidence(model.overallConfidence)} · Strong: ${model.overallStrongCount} · Lean: ${model.overallLeanCount}`}
+                  className={cn(
+                    'px-2 py-2 text-center font-semibold border-l border-l-gray-200 border-b border-b-gray-100 tabular-nums',
+                    getConfidenceTone(model.overallConfidence),
+                  )}
+                >
+                  {formatConfidence(model.overallConfidence)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1532,6 +1532,32 @@ export type ModelsAnalysisValueResult = {
   valueKey: Scalars['String']['output'];
 };
 
+/** Confidence stats for a model across all values */
+export type ModelsConfidenceModelResult = {
+  __typename?: 'ModelsConfidenceModelResult';
+  label: Scalars['String']['output'];
+  modelId: Scalars['String']['output'];
+  overallConfidence?: Maybe<Scalars['Float']['output']>;
+  overallLeanCount: Scalars['Int']['output'];
+  overallStrongCount: Scalars['Int']['output'];
+  values: Array<ModelsConfidenceValueResult>;
+};
+
+/** Cross-model confidence heatmap: strong% per model per value */
+export type ModelsConfidenceResult = {
+  __typename?: 'ModelsConfidenceResult';
+  models: Array<ModelsConfidenceModelResult>;
+};
+
+/** Confidence stats for a model/value pair */
+export type ModelsConfidenceValueResult = {
+  __typename?: 'ModelsConfidenceValueResult';
+  confidence?: Maybe<Scalars['Float']['output']>;
+  leanCount: Scalars['Int']['output'];
+  strongCount: Scalars['Int']['output'];
+  valueKey: Scalars['String']['output'];
+};
+
 export type ModelsConsistencyResult = {
   __typename?: 'ModelsConsistencyResult';
   insufficient: Array<InsufficientModel>;
@@ -2576,6 +2602,7 @@ export type Query = {
   /** Get token statistics for specific models. Useful for understanding prediction quality. */
   modelTokenStats: Array<ModelTokenStats>;
   modelsAnalysis: ModelsAnalysisResult;
+  modelsConfidence: ModelsConfidenceResult;
   modelsConsistency: ModelsConsistencyResult;
   /** List anomalies that are currently open (resolvedAt IS NULL) across all runs. Optional filters: domainId scopes to anomalies whose run belongs to a definition in that domain; type scopes to a single RunAnomalyType. */
   openRunAnomalies: Array<RunAnomaly>;
@@ -2981,6 +3008,11 @@ export type QueryModelTokenStatsArgs = {
 
 export type QueryModelsAnalysisArgs = {
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  signature?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryModelsConfidenceArgs = {
   signature?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -4503,6 +4535,13 @@ export type ModelsAnalysisQueryVariables = Exact<{
 
 
 export type ModelsAnalysisQuery = { __typename?: 'Query', modelsAnalysis: { __typename?: 'ModelsAnalysisResult', models: Array<{ __typename?: 'ModelsAnalysisModelResult', modelId: string, label: string, values: Array<{ __typename?: 'ModelsAnalysisValueResult', valueKey: string, pooledWinRate?: number | null, stabilityScore?: number | null, eligibleDomainCount: number, domains: Array<{ __typename?: 'ModelsAnalysisDomainBreakdown', domainId: string, domainName: string, winRate: number, evidenceWeight?: number | null }> }> }> } };
+
+export type ModelsConfidenceQueryVariables = Exact<{
+  signature?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type ModelsConfidenceQuery = { __typename?: 'Query', modelsConfidence: { __typename?: 'ModelsConfidenceResult', models: Array<{ __typename?: 'ModelsConfidenceModelResult', modelId: string, label: string, overallConfidence?: number | null, overallStrongCount: number, overallLeanCount: number, values: Array<{ __typename?: 'ModelsConfidenceValueResult', valueKey: string, confidence?: number | null, strongCount: number, leanCount: number }> }> } };
 
 export type ModelsConsistencyQueryVariables = Exact<{
   domainId?: InputMaybe<Scalars['ID']['input']>;
@@ -6830,6 +6869,29 @@ export const ModelsAnalysisDocument = gql`
 
 export function useModelsAnalysisQuery(options?: Omit<Urql.UseQueryArgs<ModelsAnalysisQueryVariables>, 'query'>) {
   return Urql.useQuery<ModelsAnalysisQuery, ModelsAnalysisQueryVariables>({ query: ModelsAnalysisDocument, ...options });
+};
+export const ModelsConfidenceDocument = gql`
+    query ModelsConfidence($signature: String) {
+  modelsConfidence(signature: $signature) {
+    models {
+      modelId
+      label
+      overallConfidence
+      overallStrongCount
+      overallLeanCount
+      values {
+        valueKey
+        confidence
+        strongCount
+        leanCount
+      }
+    }
+  }
+}
+    `;
+
+export function useModelsConfidenceQuery(options?: Omit<Urql.UseQueryArgs<ModelsConfidenceQueryVariables>, 'query'>) {
+  return Urql.useQuery<ModelsConfidenceQuery, ModelsConfidenceQueryVariables>({ query: ModelsConfidenceDocument, ...options });
 };
 export const ModelsConsistencyDocument = gql`
     query ModelsConsistency($domainId: ID, $providerId: ID, $minScenarios: Int, $signature: String!) {

--- a/cloud/apps/web/src/pages/ModelsConfidence.tsx
+++ b/cloud/apps/web/src/pages/ModelsConfidence.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from 'urql';
+import { useSearchParams } from 'react-router-dom';
+import { ErrorMessage } from '../components/ui/ErrorMessage';
+import { Loading } from '../components/ui/Loading';
+import { Select } from '../components/ui/Select';
+import {
+  AVAILABLE_SIGNATURES_QUERY,
+  type AvailableSignaturesQueryResult,
+} from '../api/operations/available-signatures';
+import {
+  MODELS_CONFIDENCE_QUERY,
+  type ModelsConfidenceQueryResult,
+  type ModelsConfidenceQueryVariables,
+} from '../api/operations/modelsConfidence';
+import { ConfidenceHeatmap } from '../components/models/ConfidenceHeatmap';
+import {
+  buildDomainShiftSignatureOptions,
+  getDefaultDomainShiftSignature,
+} from './domainValueShiftHeatmapUtils';
+
+export function ModelsConfidence() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const signatureParam = searchParams.get('signature');
+
+  const [{ data: signatureData }] = useQuery<AvailableSignaturesQueryResult>({
+    query: AVAILABLE_SIGNATURES_QUERY,
+    variables: {},
+    requestPolicy: 'cache-and-network',
+  });
+
+  const availableSignatures = useMemo(
+    () => signatureData?.availableSignatures.map((entry) => entry.signature) ?? [],
+    [signatureData],
+  );
+
+  const signatureOptions = useMemo(
+    () => buildDomainShiftSignatureOptions(availableSignatures),
+    [availableSignatures],
+  );
+
+  const [selectedSignature, setSelectedSignature] = useState<string>(
+    signatureParam ?? 'vnewtd',
+  );
+
+  useEffect(() => {
+    const resolved = getDefaultDomainShiftSignature(availableSignatures, selectedSignature);
+    if (resolved !== selectedSignature) {
+      setSelectedSignature(resolved);
+    }
+  }, [availableSignatures, selectedSignature]);
+
+  useEffect(() => {
+    if (signatureParam == null && availableSignatures.length > 0) {
+      setSearchParams({ signature: selectedSignature }, { replace: true });
+    }
+  }, [selectedSignature, signatureParam, availableSignatures.length, setSearchParams]);
+
+  const [{ data, fetching, error }] = useQuery<ModelsConfidenceQueryResult, ModelsConfidenceQueryVariables>({
+    query: MODELS_CONFIDENCE_QUERY,
+    variables: { signature: selectedSignature },
+    requestPolicy: 'cache-and-network',
+  });
+
+  const models = useMemo(() => data?.modelsConfidence.models ?? [], [data]);
+  const loading = fetching && data == null;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
+        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Confidence Heatmap</h1>
+        <p className="max-w-3xl text-sm text-gray-600">
+          How often each model responds with strong conviction vs. a lean.
+          Strong% = strongly support / (strongly support + somewhat support).
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <label className="text-sm text-gray-600">Signature</label>
+        <Select
+          value={selectedSignature}
+          onChange={(value) => {
+            setSelectedSignature(value);
+            setSearchParams({ signature: value });
+          }}
+          options={signatureOptions}
+        />
+      </div>
+
+      {error != null && <ErrorMessage message={error.message} />}
+      {loading ? <Loading /> : <ConfidenceHeatmap models={models} />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **New page** at `/models/confidence` under the Models nav dropdown showing which AI models respond with strong conviction vs. a lean, across all values
- **Heatmap**: models as rows, 10 `DOMAIN_ANALYSIS_VALUE_KEYS` as columns, Average column on right; cells color-coded by Strong% (violet = high confidence, slate = low)
- **Signature filter** with URL persistence (`?signature=...`) following the DomainValueShiftHeatmap pattern
- **Confidence definition**: Strong% = strongly_support / (strongly_support + somewhat_support), counting only decisive transcripts (`direction ∈ {favor_first, favor_second}`, `strength ∈ {strong, lean}`)

## Changes

**API** (`cloud/apps/api/`)
- `graphql/types/models-confidence.ts`: Added `overallStrongCount` and `overallLeanCount` fields
- `graphql/queries/models-confidence.ts`: Fixed double-count bug — `overallConfidence` was previously computed by summing per-value counts (each transcript counted twice, once per value key). Now uses separate `rawStrong`/`rawLean` counters incremented once per transcript before the per-value doubling loop. Removed non-goal `domainId` arg.

**Web** (`cloud/apps/web/`)
- `api/operations/modelsConfidence.graphql` + `modelsConfidence.ts`: Operation file using codegen-derived types
- `components/models/ConfidenceHeatmap.tsx`: Average column tooltip uses API-supplied `overallStrongCount`/`overallLeanCount`; empty state for `models.length === 0`
- `pages/ModelsConfidence.tsx`: New page with signature Select filter and URL persistence
- `App.tsx` + `components/layout/NavTabs.tsx`: Route and nav wiring
- `schema.graphql` + `generated/graphql.ts`: Regenerated to include `modelsConfidence` query

## Validation

| Command | Result |
|---|---|
| `npm run lint --workspace @valuerank/web` | ✅ 0 errors |
| `npm run build --workspace @valuerank/web` | ✅ built in 2.80s |
| `npm run build --workspace @valuerank/api` | ✅ one pre-existing `compression` type error (exists on `origin/main`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)