### PR TITLE
[codex] Models overview all domains

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -90,7 +90,7 @@ Once the above are resolved:
 - [x] Domain Shifts by Value heatmap implemented at `/models/domain-shifts`; focused tests and web preflight pass.
 - [x] Domain Shifts readability controls added locally: cells can toggle between shift and raw win rate, and table columns are sortable.
 - [x] Domain Shifts model picker now groups default models first and separates non-default models with `---` before alphabetical non-default options.
-- [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, and model rows no longer repeat the model ID line.
+- [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, the all-domains value priorities table now includes stability circles, and the comparison table stays below it.
 
 ---
 

--- a/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../data/domainAnalysisData';
 import { getPriorityColor } from './domainAnalysisColors';
 import { ValuePrioritiesHelpPanel } from './ValuePrioritiesHelpPanel';
+import { StabilityDots } from '../models/StabilityDotsView';
 
 type SortState = {
   key: 'model' | ValueKey;
@@ -52,6 +53,7 @@ type ValuePrioritiesSectionProps = {
   selectedDomainId: string;
   selectedSignature: string | null;
   isReadOnly?: boolean;
+  showStabilityDots?: boolean;
 };
 
 export function ValuePrioritiesSection({
@@ -59,6 +61,7 @@ export function ValuePrioritiesSection({
   selectedDomainId,
   selectedSignature,
   isReadOnly = false,
+  showStabilityDots = false,
 }: ValuePrioritiesSectionProps) {
   const navigate = useNavigate();
   const detailedTableRef = useRef<HTMLDivElement>(null);
@@ -320,6 +323,7 @@ export function ValuePrioritiesSection({
                   </td>
                   {COLUMN_VALUES.map((value) => {
                     const cellValue = getCellValue(model, value);
+                    const stabilityScore = model.stabilityScores?.[value] ?? null;
                     const background = cellValue === null
                       ? '#F9FAFB'
                       : getPriorityColor(cellValue, valueRange.min, valueRange.max);
@@ -350,6 +354,17 @@ export function ValuePrioritiesSection({
                               return `${cellValue > 0 ? '+' : ''}${cellValue.toFixed(2)}`;
                             })()}
                           </span>
+                          {showStabilityDots && (
+                            <StabilityDots
+                              score={stabilityScore}
+                              className="mt-1 text-current"
+                              title={
+                                stabilityScore != null
+                                  ? `Stability ${Math.round(stabilityScore)}/100`
+                                  : 'Stability unavailable'
+                              }
+                            />
+                          )}
                         </Button>
                       </td>
                     );

--- a/cloud/apps/web/src/components/models/ModelsMatrixCell.tsx
+++ b/cloud/apps/web/src/components/models/ModelsMatrixCell.tsx
@@ -1,7 +1,8 @@
 import { type KeyboardEvent } from 'react';
 import { Button } from '../ui/Button';
 import { type ModelsAnalysisDomainBreakdown } from '../../api/operations/modelsAnalysis';
-import { computeDots, computeSimpleMad, formatStabilityTooltip } from './stabilityDots';
+import { computeSimpleMad, formatStabilityTooltip } from './stabilityDots';
+import { StabilityDots } from './StabilityDotsView';
 
 type ModelsMatrixCellProps = {
   modelLabel: string;
@@ -18,36 +19,6 @@ type ModelsMatrixCellProps = {
 
 function formatPercent(value: number): string {
   return `${Math.round(value)}%`;
-}
-
-type DotsProps = { score: number | null; muted: boolean; className?: string };
-
-function Dots({ score, muted, className }: DotsProps) {
-  const states = computeDots(muted ? null : score);
-  return (
-    <span className={`inline-flex items-center gap-0.5 ${className ?? ''}`} aria-hidden="true">
-      {states.map((state, i) => {
-        if (state === 'full') {
-          return <span key={i} className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 bg-current" />;
-        }
-        if (state === 'half') {
-          return (
-            <span
-              key={i}
-              className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
-              style={{
-                background: 'linear-gradient(to right, currentColor 50%, transparent 50%)',
-              }}
-            />
-          );
-        }
-        if (state === 'muted') {
-          return <span key={i} className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 border border-current opacity-30" />;
-        }
-        return <span key={i} className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 border border-current" />;
-      })}
-    </span>
-  );
 }
 
 export function ModelsMatrixCell({
@@ -98,7 +69,10 @@ export function ModelsMatrixCell({
       <span className={`text-sm font-semibold ${hiddenByFilter || pooledWinRate == null ? 'text-gray-400' : 'text-gray-900'}`}>
         {primaryLabel}
       </span>
-      <Dots score={stabilityScore} muted={mutedDots} className={`mt-1 ${mutedDots ? 'text-gray-400' : 'text-gray-700'}`} />
+      <StabilityDots
+        score={mutedDots ? null : stabilityScore}
+        className={`mt-1 ${mutedDots ? 'text-gray-400' : 'text-gray-700'}`}
+      />
       <span className="sr-only">{tooltip}</span>
     </Button>
   );

--- a/cloud/apps/web/src/components/models/StabilityDotsView.tsx
+++ b/cloud/apps/web/src/components/models/StabilityDotsView.tsx
@@ -1,0 +1,39 @@
+import { computeDots, type DotState } from './stabilityDots';
+
+type StabilityDotsProps = {
+  score: number | null | undefined;
+  className?: string;
+  title?: string;
+};
+
+function Dot({ state }: { state: DotState }) {
+  if (state === 'full') {
+    return <span data-state="full" className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-current" />;
+  }
+
+  if (state === 'half') {
+    return (
+      <span data-state="half" className="relative inline-block h-1.5 w-1.5 shrink-0 overflow-hidden rounded-full border border-current">
+        <span className="absolute inset-y-0 left-0 w-1/2 bg-current" />
+      </span>
+    );
+  }
+
+  if (state === 'muted') {
+    return <span data-state="muted" className="inline-block h-1.5 w-1.5 shrink-0 rounded-full border border-current opacity-30" />;
+  }
+
+  return <span data-state="empty" className="inline-block h-1.5 w-1.5 shrink-0 rounded-full border border-current" />;
+}
+
+export function StabilityDots({ score, className, title }: StabilityDotsProps) {
+  const states = computeDots(score);
+
+  return (
+    <span className={`inline-flex items-center gap-0.5 ${className ?? ''}`} aria-hidden="true" title={title}>
+      {states.map((state, index) => (
+        <Dot key={`${state}-${index}`} state={state} />
+      ))}
+    </span>
+  );
+}

--- a/cloud/apps/web/src/data/domainAnalysisData.ts
+++ b/cloud/apps/web/src/data/domainAnalysisData.ts
@@ -15,6 +15,7 @@ export type ModelEntry = {
   label: string;
   values: Record<ValueKey, number>;
   winRates?: Record<ValueKey, number | null>;
+  stabilityScores?: Record<ValueKey, number | null>;
 };
 
 export type DomainAnalysisModelAvailability = {

--- a/cloud/apps/web/src/pages/Models.tsx
+++ b/cloud/apps/web/src/pages/Models.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'urql';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
-import { Loading } from '../components/ui/Loading';
 import { Button } from '../components/ui/Button';
 import { Select } from '../components/ui/Select';
 import { ScreenshotButton } from '../components/ui/ScreenshotButton';
 import { useDomains } from '../hooks/useDomains';
+import {
+  DOMAIN_ANALYSIS_QUERY,
+  type DomainAnalysisQueryResult,
+  type DomainAnalysisQueryVariables,
+  DOMAIN_AVAILABLE_SIGNATURES_QUERY,
+  type DomainAvailableSignaturesQueryResult,
+} from '../api/operations/domainAnalysis';
 import {
   MODELS_ANALYSIS_QUERY,
   type ModelsAnalysisQueryResult,
@@ -14,14 +20,13 @@ import {
 } from '../api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { ModelValueDetailDrawer } from '../components/models/ModelValueDetailDrawer';
+import { ValuePrioritiesSection } from '../components/domains/ValuePrioritiesSection';
 import { ModelsMatrix } from '../components/models/ModelsMatrix';
-import {
-  DOMAIN_AVAILABLE_SIGNATURES_QUERY,
-  type DomainAvailableSignaturesQueryResult,
-} from '../api/operations/domainAnalysis';
+import { VALUES, type ModelEntry, type ValueKey } from '../data/domainAnalysisData';
 import { formatSignatureOptionLabel } from '../utils/domainAnalysisUtils';
 
 const DEFAULT_SIGNATURE = 'vnewtd';
+const ALL_DOMAINS_SCOPE = 'all-domains';
 
 export function Models() {
   const { domains, queryLoading: domainsLoading, error: domainsError } = useDomains();
@@ -42,6 +47,23 @@ export function Models() {
     [signatureData],
   );
 
+  const allDomainsDomainId = domains[0]?.id ?? '';
+
+  const [{ data: allDomainsData, fetching: allDomainsFetching, error: allDomainsError }] = useQuery<
+    DomainAnalysisQueryResult,
+    DomainAnalysisQueryVariables
+  >({
+    query: DOMAIN_ANALYSIS_QUERY,
+    variables: {
+      domainId: allDomainsDomainId,
+      scope: ALL_DOMAINS_SCOPE,
+      scoreMethod: 'FULL_BT',
+      signature: selectedSignature,
+    },
+    pause: allDomainsDomainId === '',
+    requestPolicy: 'cache-and-network',
+  });
+
   // Reset to default when domain changes; keep valid selection if it exists in new options.
   useEffect(() => {
     setSelectedSignature(DEFAULT_SIGNATURE);
@@ -56,7 +78,7 @@ export function Models() {
     }),
     [selectedDomainId, selectedSignature],
   );
-  const [{ data, fetching, error }] = useQuery<ModelsAnalysisQueryResult, ModelsAnalysisQueryVariables>({
+  const [{ data: modelsAnalysisData, fetching, error }] = useQuery<ModelsAnalysisQueryResult, ModelsAnalysisQueryVariables>({
     query: MODELS_ANALYSIS_QUERY,
     variables: queryVariables,
     requestPolicy: 'cache-and-network',
@@ -70,7 +92,7 @@ export function Models() {
   const [selectedCell, setSelectedCell] = useState<{ modelId: string; valueKey: string } | null>(null);
   const initializedModelSelection = useRef(false);
 
-  const models = useMemo(() => data?.modelsAnalysis.models ?? [], [data]);
+  const comparisonModels = useMemo(() => modelsAnalysisData?.modelsAnalysis.models ?? [], [modelsAnalysisData]);
   const defaultModelIds = useMemo(
     () => new Set((llmModelsData?.llmModels ?? []).filter((m) => m.isDefault).map((m) => m.modelId)),
     [llmModelsData],
@@ -86,24 +108,24 @@ export function Models() {
 
   useEffect(() => {
     if (initializedModelSelection.current) return;
-    if (models.length === 0) return;
+    if (comparisonModels.length === 0) return;
     if (llmModelsData == null) return;
-    const availableIds = models.map((model) => model.modelId);
+    const availableIds = comparisonModels.map((model) => model.modelId);
     const defaultSelection = availableIds.filter((id) => defaultModelIds.has(id));
     // Fall back to all models if no defaults are configured or none match the current result set
     setSelectedModelIds(defaultSelection.length > 0 ? defaultSelection : availableIds);
     initializedModelSelection.current = true;
-  }, [models, llmModelsData, defaultModelIds]);
+  }, [comparisonModels, llmModelsData, defaultModelIds]);
 
   useEffect(() => {
     if (!initializedModelSelection.current) return;
     setSelectedModelIds((current) => {
       if (current.length === 0) return current;
-      const validIds = new Set(models.map((model) => model.modelId));
+      const validIds = new Set(comparisonModels.map((model) => model.modelId));
       const next = current.filter((modelId) => validIds.has(modelId));
       return next.length === current.length ? current : next;
     });
-  }, [models]);
+  }, [comparisonModels]);
 
   // Close the drawer when its model is no longer visible (filtered out or cleared)
   useEffect(() => {
@@ -113,10 +135,10 @@ export function Models() {
     }
   }, [selectedModelIds, selectedCell]);
 
-  const modelOptions = useMemo(() => models.map((model) => ({
+  const modelOptions = useMemo(() => comparisonModels.map((model) => ({
     value: model.modelId,
     label: model.label,
-  })), [models]);
+  })), [comparisonModels]);
 
   const domainOptions = useMemo(() => [
     { value: 'all', label: 'All domains' },
@@ -127,18 +149,61 @@ export function Models() {
   ], [domains]);
 
   const selectedModel = selectedCell != null
-    ? models.find((model) => model.modelId === selectedCell.modelId) ?? null
+    ? comparisonModels.find((model) => model.modelId === selectedCell.modelId) ?? null
     : null;
   const selectedValue: ModelsAnalysisValueResult | null = useMemo(() => {
     if (selectedCell == null || selectedModel == null) return null;
     return selectedModel.values.find((value) => value.valueKey === selectedCell.valueKey) ?? null;
   }, [selectedCell, selectedModel]);
 
+  const comparisonModelMap = useMemo(
+    () => new Map(comparisonModels.map((model) => [model.modelId, model] as const)),
+    [comparisonModels],
+  );
+
+  const allDomainsModels = useMemo<ModelEntry[]>(() => {
+    const sourceModels = allDomainsData?.domainAnalysis.models ?? [];
+    return sourceModels.map((model) => {
+      const comparisonModel = comparisonModelMap.get(model.model);
+      const comparisonValueMap = new Map(comparisonModel?.values.map((value) => [value.valueKey, value.stabilityScore] as const) ?? []);
+
+      const values = VALUES.reduce<Record<ValueKey, number>>((acc, valueKey) => {
+        const score = model.values.find((value) => value.valueKey === valueKey)?.score ?? 0;
+        acc[valueKey] = score;
+        return acc;
+      }, {} as Record<ValueKey, number>);
+
+      const winRates = VALUES.reduce<Record<ValueKey, number | null>>((acc, valueKey) => {
+        const value = model.values.find((entry) => entry.valueKey === valueKey) ?? null;
+        if (value == null) {
+          acc[valueKey] = null;
+          return acc;
+        }
+        const total = value.prioritized + value.deprioritized + value.neutral;
+        acc[valueKey] = total > 0 ? (value.prioritized / total) * 100 : null;
+        return acc;
+      }, {} as Record<ValueKey, number | null>);
+
+      const stabilityScores = VALUES.reduce<Record<ValueKey, number | null>>((acc, valueKey) => {
+        acc[valueKey] = comparisonValueMap.get(valueKey) ?? null;
+        return acc;
+      }, {} as Record<ValueKey, number | null>);
+
+      return {
+        model: model.model,
+        label: model.label,
+        values,
+        winRates,
+        stabilityScores,
+      };
+    });
+  }, [allDomainsData, comparisonModelMap]);
+
   const defaultSelection = useMemo(() => {
-    const availableIds = models.map((model) => model.modelId);
+    const availableIds = comparisonModels.map((model) => model.modelId);
     const defaults = availableIds.filter((id) => defaultModelIds.has(id));
     return defaults.length > 0 ? defaults : availableIds;
-  }, [models, defaultModelIds]);
+  }, [comparisonModels, defaultModelIds]);
 
   const isDefaultSelection = useMemo(() => {
     if (selectedModelIds.length !== defaultSelection.length) return false;
@@ -146,7 +211,9 @@ export function Models() {
     return selectedModelIds.every((id) => defaultSet.has(id));
   }, [selectedModelIds, defaultSelection]);
 
-  const loading = (domainsLoading && domains.length === 0) || (fetching && data == null);
+  const loading = (domainsLoading && domains.length === 0)
+    || (allDomainsFetching && allDomainsData == null)
+    || (fetching && modelsAnalysisData == null);
   const selectedModelCount = selectedModelIds.length;
 
   const toggleModelId = (modelId: string) => {
@@ -158,7 +225,7 @@ export function Models() {
   };
 
   const selectAllModels = () => {
-    setSelectedModelIds(models.map((model) => model.modelId));
+    setSelectedModelIds(comparisonModels.map((model) => model.modelId));
   };
 
   const clearModels = () => {
@@ -193,105 +260,135 @@ export function Models() {
         </div>
       </div>
 
-      {(domainsError != null || error != null) && (
-        <ErrorMessage message={`Failed to load models analysis: ${(domainsError ?? error)?.message ?? 'Unknown error'}`} />
+      {(domainsError != null || allDomainsError != null || error != null) && (
+        <ErrorMessage
+          message={`Failed to load models analysis: ${(domainsError ?? allDomainsError ?? error)?.message ?? 'Unknown error'}`}
+        />
       )}
 
-      <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
-        <div className="flex flex-wrap items-start gap-4">
-          <div className="w-48 flex-shrink-0">
-            <Select
-              label="Domain scope"
-              options={domainOptions}
-              value={selectedDomainId ?? 'all'}
-              onChange={(value) => setSelectedDomainId(value === 'all' ? null : value)}
-              placeholder="All domains"
+      {!loading && (
+        <div className="space-y-6">
+          <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+            <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">All domains value priorities</h2>
+                <p className="text-sm text-gray-600">
+                  This is the domain analysis table for all domains, with stability circles added to each cell.
+                </p>
+              </div>
+            </div>
+            <ValuePrioritiesSection
+              models={allDomainsModels}
+              selectedDomainId=""
+              selectedSignature={null}
+              isReadOnly
+              showStabilityDots
             />
-          </div>
-          {selectedDomainId != null && signatureOptions.length > 0 && (
-            <div className="w-48 flex-shrink-0">
-              <Select
-                label="Batch"
-                options={signatureOptions.map((o) => ({ value: o.signature, label: formatSignatureOptionLabel(o) }))}
-                value={selectedSignature}
-                onChange={(value) => setSelectedSignature(value)}
+          </section>
+
+          <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+            <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">Model preference table</h2>
+                <p className="text-sm text-gray-600">
+                  Keep this table underneath for comparison with the current model analysis view.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-start gap-4">
+              <div className="w-48 flex-shrink-0">
+                <Select
+                  label="Domain scope"
+                  options={domainOptions}
+                  value={selectedDomainId ?? 'all'}
+                  onChange={(value) => setSelectedDomainId(value === 'all' ? null : value)}
+                  placeholder="All domains"
+                />
+              </div>
+              {selectedDomainId != null && signatureOptions.length > 0 && (
+                <div className="w-48 flex-shrink-0">
+                  <Select
+                    label="Batch"
+                    options={signatureOptions.map((o) => ({ value: o.signature, label: formatSignatureOptionLabel(o) }))}
+                    value={selectedSignature}
+                    onChange={(value) => setSelectedSignature(value)}
+                  />
+                </div>
+              )}
+              <details className="flex-1 min-w-[220px]">
+                <summary className="cursor-pointer list-none">
+                  <p className="mb-1 text-sm font-medium text-gray-700">Model set</p>
+                  <div className="inline-flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm min-h-[44px] hover:border-gray-400 sm:min-h-0">
+                    <span className={modelOptions.length === 0 && !loading ? 'text-gray-400' : ''}>
+                      {modelSetSummary}
+                    </span>
+                    <span className="ml-2 text-gray-400">▾</span>
+                  </div>
+                </summary>
+                <div className="mt-2 space-y-3 rounded-lg border border-gray-200 bg-white p-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-xs text-gray-600">All visible models are selected by default.</p>
+                    <div className="flex items-center gap-2">
+                      <Button type="button" variant="secondary" size="sm" onClick={selectAllModels} disabled={loading}>
+                        Select all
+                      </Button>
+                      <Button type="button" variant="secondary" size="sm" onClick={clearModels} disabled={loading}>
+                        Clear
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {modelOptions.map((model) => {
+                      const isSelected = selectedModelIds.includes(model.value);
+                      return (
+                        <Button
+                          key={model.value}
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => toggleModelId(model.value)}
+                          className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
+                            isSelected
+                              ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
+                              : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
+                          }`}
+                          title={model.label}
+                        >
+                          {model.label}
+                        </Button>
+                      );
+                    })}
+                    {modelOptions.length === 0 && !loading && (
+                      <span className="text-sm text-gray-500">No active models are available.</span>
+                    )}
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    {loading
+                      ? 'Loading models and domains...'
+                      : modelOptions.length === 0
+                        ? 'No active models are available.'
+                        : selectedModelCount === modelOptions.length
+                          ? 'All visible models selected.'
+                          : `${selectedModelCount} of ${modelOptions.length} visible models selected.`}
+                    {singleDomainActive && selectedDomain != null && (
+                      <span className="ml-2">Viewing {selectedDomain.name} only.</span>
+                    )}
+                  </div>
+                </div>
+              </details>
+            </div>
+
+            <div className="mt-5">
+              <ModelsMatrix
+                models={comparisonModels}
+                selectedModelIds={selectedModelIds}
+                singleDomainActive={singleDomainActive}
+                selectedCellKey={selectedCell == null ? null : `${selectedCell.modelId}:${selectedCell.valueKey}`}
+                onCellClick={handleCellClick}
               />
             </div>
-          )}
-          <details className="flex-1 min-w-[220px]">
-            <summary className="cursor-pointer list-none">
-              <p className="mb-1 text-sm font-medium text-gray-700">Model set</p>
-              <div className="inline-flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm min-h-[44px] hover:border-gray-400 sm:min-h-0">
-                <span className={modelOptions.length === 0 && !loading ? 'text-gray-400' : ''}>
-                  {modelSetSummary}
-                </span>
-                <span className="ml-2 text-gray-400">▾</span>
-              </div>
-            </summary>
-            <div className="mt-2 space-y-3 rounded-lg border border-gray-200 bg-white p-3">
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <p className="text-xs text-gray-600">All visible models are selected by default.</p>
-                <div className="flex items-center gap-2">
-                  <Button type="button" variant="secondary" size="sm" onClick={selectAllModels} disabled={loading}>
-                    Select all
-                  </Button>
-                  <Button type="button" variant="secondary" size="sm" onClick={clearModels} disabled={loading}>
-                    Clear
-                  </Button>
-                </div>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {modelOptions.map((model) => {
-                  const isSelected = selectedModelIds.includes(model.value);
-                  return (
-                    <Button
-                      key={model.value}
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => toggleModelId(model.value)}
-                      className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
-                        isSelected
-                          ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
-                          : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
-                      }`}
-                      title={model.label}
-                    >
-                      {model.label}
-                    </Button>
-                  );
-                })}
-                {modelOptions.length === 0 && !loading && (
-                  <span className="text-sm text-gray-500">No active models are available.</span>
-                )}
-              </div>
-              <div className="text-xs text-gray-500">
-                {loading
-                  ? 'Loading models and domains...'
-                  : modelOptions.length === 0
-                    ? 'No active models are available.'
-                    : selectedModelCount === modelOptions.length
-                      ? 'All visible models selected.'
-                      : `${selectedModelCount} of ${modelOptions.length} visible models selected.`}
-                {singleDomainActive && selectedDomain != null && (
-                  <span className="ml-2">Viewing {selectedDomain.name} only.</span>
-                )}
-              </div>
-            </div>
-          </details>
+          </section>
         </div>
-      </section>
-
-      {loading && <Loading size="lg" text="Loading models analysis..." />}
-
-      {!loading && (
-        <ModelsMatrix
-          models={models}
-          selectedModelIds={selectedModelIds}
-          singleDomainActive={singleDomainActive}
-          selectedCellKey={selectedCell == null ? null : `${selectedCell.modelId}:${selectedCell.valueKey}`}
-          onCellClick={handleCellClick}
-        />
       )}
 
       <ModelValueDetailDrawer

--- a/cloud/apps/web/tests/components/models/StabilityDots.test.tsx
+++ b/cloud/apps/web/tests/components/models/StabilityDots.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { StabilityDots } from '../../../src/components/models/StabilityDotsView.tsx';
+
+describe('StabilityDots', () => {
+  it('renders a full-size half-filled circle for half states', () => {
+    const { container } = render(<StabilityDots score={55} title="Stability 55/100" />);
+
+    const dots = container.querySelectorAll('[data-state]');
+    const halfDot = container.querySelector('[data-state="half"]');
+
+    expect(dots).toHaveLength(5);
+    expect(halfDot).not.toBeNull();
+    const halfCircle = halfDot as HTMLElement;
+    expect(halfCircle).toHaveClass('inline-block', 'h-1.5', 'w-1.5', 'overflow-hidden', 'rounded-full', 'border', 'border-current');
+
+    const fill = halfCircle.firstElementChild as HTMLElement;
+    expect(fill).toHaveClass('absolute', 'inset-y-0', 'left-0', 'w-1/2', 'bg-current');
+  });
+});

--- a/cloud/apps/web/tests/pages/Models.test.tsx
+++ b/cloud/apps/web/tests/pages/Models.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Models } from '../../src/pages/Models';
+import { DOMAIN_ANALYSIS_QUERY, type DomainAnalysisQueryResult } from '../../src/api/operations/domainAnalysis';
 import { MODELS_ANALYSIS_QUERY } from '../../src/api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY } from '../../src/api/operations/llm';
 
@@ -26,6 +27,10 @@ vi.mock('../../src/hooks/useDomains', () => ({
   }),
 }));
 
+vi.mock('../../src/utils/domainAnalysisUtils', () => ({
+  formatSignatureOptionLabel: (option: { label: string }) => option.label,
+}));
+
 function renderModelsPage() {
   return render(
     <MemoryRouter>
@@ -39,6 +44,47 @@ describe('Models page', () => {
     useQueryMock.mockReset();
     useQueryMock.mockImplementation((args: { query: { definitions: Array<{ kind: string; name?: { value: string } }> } }) => {
       const operationName = args.query.definitions.find((definition) => definition.kind === 'OperationDefinition')?.name?.value;
+
+      if (operationName === 'DomainAnalysis') {
+        return [{
+          data: {
+            domainAnalysis: {
+              domainId: 'domain-a',
+              domainName: 'All domains',
+              contributionSummary: [],
+              excludedDataSummary: [],
+              totalDefinitions: 1,
+              targetedDefinitions: 1,
+              coveredDefinitions: 1,
+              missingDefinitionIds: [],
+              missingDefinitions: [],
+              definitionsWithAnalysis: 1,
+              cacheStatus: 'FRESH',
+              generatedAt: '2026-04-17T03:06:20.919Z',
+              models: [
+                {
+                  model: 'model-a',
+                  label: 'Model A',
+                  values: [
+                    {
+                      valueKey: 'Achievement',
+                      score: 0.42,
+                      prioritized: 4,
+                      deprioritized: 3,
+                      neutral: 1,
+                      totalComparisons: 8,
+                    },
+                  ],
+                  unavailableModels: [],
+                },
+              ],
+              unavailableModels: [],
+            },
+          } as DomainAnalysisQueryResult,
+          fetching: false,
+          error: undefined,
+        }];
+      }
 
       if (operationName === 'DomainAvailableSignatures') {
         return [{
@@ -112,7 +158,9 @@ describe('Models page', () => {
 
     expect(screen.getByRole('heading', { name: /model value preference overview/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /screenshot report/i })).toBeInTheDocument();
-    expect(screen.getAllByText('Model A')).toHaveLength(2);
+    expect(screen.getByRole('heading', { name: /all domains value priorities/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /model preference table/i })).toBeInTheDocument();
+    expect(screen.getAllByText('Model A').length).toBeGreaterThan(1);
     expect(screen.queryByText('model-a')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What changed
- Added an all-domains value priorities table at `/models` using the domain analysis table layout.
- Added stability circles to each cell in that new table.
- Kept the old model comparison matrix underneath for side-by-side comparison.
- Fixed the half-state stability marker so it renders as a full-size circle that is half filled in.

## Why
The page is easier to scan when the domain-analysis table comes first, and the stability signal is clearer when the half-filled state uses the same circle size as the other dots.

## Impact
- The report now matches the requested "Model Value Preference overview" presentation.
- Readers can compare the all-domains analysis against the existing matrix without losing the old view.
- Stability indicators are consistent across both tables.

## Validation
- `npx vitest run --config vitest.config.ts tests/pages/Models.test.tsx tests/components/models/StabilityDots.test.tsx tests/components/domains/ValuePrioritiesSection.test.tsx`
- `npm run lint`
- `npm run typecheck` still reports an unrelated pre-existing workspace import issue in `src/utils/domainAnalysisUtils.ts`