### PR TITLE
fix(models-confidence): query source runs not aggregate pooling views

### DIFF
--- a/cloud/apps/api/src/graphql/queries/models-confidence.ts
+++ b/cloud/apps/api/src/graphql/queries/models-confidence.ts
@@ -48,7 +48,6 @@ builder.queryField('modelsConfidence', (t) =>
         where: {
           status: 'COMPLETED',
           deletedAt: null,
-          tags: { some: { tag: { name: 'Aggregate' } } },
         },
         select: { id: true, config: true },
       });


### PR DESCRIPTION
## Summary

- Aggregate runs are pooling views — they own metadata but transcripts live on source runs
- The original resolver filtered to Aggregate-tagged runs, so `db.transcript.findMany({ where: { runId: { in: aggregateRunIds } } })` always returned zero rows
- This caused the heatmap to show `—` for every model/value cell
- Fix: drop the Aggregate tag filter; query all completed runs and let `runMatchesSignature` scope to the right signature (same pattern as `domain-coverage.ts`)

## Validation

- `npm run lint --workspace @valuerank/web` → 0 errors
- `npm run lint --workspace @valuerank/api` → 0 errors
- `npm run test --workspace @valuerank/web` → 137/137 pass
- `npm run build --workspace @valuerank/web` → clean
- `npm run build --workspace @valuerank/api` → 1 pre-existing error (compression types, same as main)
- `npm run test --workspace @valuerank/api` → 320 failures (all pre-existing; main has 344)

🤖 Generated with [Claude Code](https://claude.com/claude-code)