### PR TITLE
fix(models-confidence): follow aggregate sourceRunIds instead of scanning all runs

### DIFF
--- a/cloud/apps/api/src/graphql/queries/models-confidence.ts
+++ b/cloud/apps/api/src/graphql/queries/models-confidence.ts
@@ -44,17 +44,21 @@ builder.queryField('modelsConfidence', (t) =>
         availableOnly: false,
       });
 
-      const runs = await db.run.findMany({
+      // Aggregate runs are pooling views — they own metadata but transcripts live on
+      // source runs. Fetch aggregate runs (small set), filter by signature, then
+      // follow config.sourceRunIds to reach the actual transcript-bearing runs.
+      const aggregateRuns = await db.run.findMany({
         where: {
           status: 'COMPLETED',
           deletedAt: null,
+          tags: { some: { tag: { name: 'Aggregate' } } },
         },
         select: { id: true, config: true },
       });
 
-      const scopedRuns = signature != null
-        ? runs.filter((run) => runMatchesSignature(run.config, signature))
-        : runs;
+      const scopedAggregateRuns = signature != null
+        ? aggregateRuns.filter((run) => runMatchesSignature(run.config, signature))
+        : aggregateRuns;
 
       const emptyValues = (): ModelsConfidenceValueResultShape[] =>
         DOMAIN_ANALYSIS_VALUE_KEYS.map((k) => ({
@@ -64,7 +68,7 @@ builder.queryField('modelsConfidence', (t) =>
           leanCount: 0,
         }));
 
-      if (scopedRuns.length === 0) {
+      if (scopedAggregateRuns.length === 0) {
         return {
           models: activeModels.map((m) => ({
             modelId: m.modelId,
@@ -77,9 +81,32 @@ builder.queryField('modelsConfidence', (t) =>
         };
       }
 
-      const runIds = scopedRuns.map((r) => r.id);
+      // Collect unique source run IDs from all matching aggregate run configs.
+      const sourceRunIdSet = new Set<string>();
+      for (const run of scopedAggregateRuns) {
+        const config = run.config as { sourceRunIds?: string[] } | null;
+        if (config?.sourceRunIds != null) {
+          for (const id of config.sourceRunIds) {
+            sourceRunIdSet.add(id);
+          }
+        }
+      }
+
+      if (sourceRunIdSet.size === 0) {
+        return {
+          models: activeModels.map((m) => ({
+            modelId: m.modelId,
+            label: m.displayName,
+            overallConfidence: null,
+            overallStrongCount: 0,
+            overallLeanCount: 0,
+            values: emptyValues(),
+          })),
+        };
+      }
+
       const transcripts = await db.transcript.findMany({
-        where: { runId: { in: runIds }, deletedAt: null },
+        where: { runId: { in: Array.from(sourceRunIdSet) }, deletedAt: null },
         select: {
           modelId: true,
           decisionMetadata: true,


### PR DESCRIPTION
## Summary

- Previous fix (PR #786) caused a production timeout: dropping the Aggregate tag filter meant loading every completed run globally — no scope guard, thousands of rows
- Root cause is that Aggregate runs are pooling views; their `config.sourceRunIds` records exactly which source runs (with actual transcripts) they pool from
- Fix: fetch Aggregate-tagged runs (small set) → filter by signature → extract `config.sourceRunIds` → query transcripts from those IDs only

## Validation

- `npm run lint --workspace @valuerank/api` → 0 errors
- `npm run build --workspace @valuerank/api` → 1 pre-existing error (compression types, same as main)
- `npm run test --workspace @valuerank/web` → 137/137 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)