### PR TITLE
FF judge: handle deeply-nested JSON in model output (recursion-limit retry)

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_judge.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_judge.py
@@ -505,6 +505,53 @@ def _validate_verdict(verdict: dict) -> str | None:
     return None
 
 
+_JSON_RECURSION_RETRY_LIMIT = 5000
+
+
+def _parse_json_with_recursion_retry(text: str) -> tuple[object, str | None]:
+    """Parse JSON, retrying once with an elevated recursion limit.
+
+    Python's `json` module is implemented recursively; deeply-nested model
+    output (e.g., a judge that echoes the schema wrapped in many layers)
+    can trip the default recursion limit (~1000) and produce
+    "maximum recursion depth exceeded" errors that prevent the judge
+    panel from making any progress across rounds.
+
+    Strategy:
+      1. Parse at the operator's current recursion limit.
+      2. On `RecursionError`, temporarily raise the limit to
+         `_JSON_RECURSION_RETRY_LIMIT` (5000) and retry exactly once.
+      3. Always restore the original limit in `finally`.
+      4. On any other exception, return the error string for the caller
+         to surface (existing behavior).
+
+    The 5000 cap is bounded so a truly pathological response still fails
+    cleanly rather than risking a C-level stack overflow.
+
+    Returns (parsed_value_or_None, error_string_or_None).
+    """
+    try:
+        return json.loads(text), None
+    except RecursionError:
+        original_limit = sys.getrecursionlimit()
+        try:
+            sys.setrecursionlimit(_JSON_RECURSION_RETRY_LIMIT)
+            return json.loads(text), None
+        except RecursionError as exc:
+            return None, (
+                f"maximum recursion depth exceeded even at "
+                f"{_JSON_RECURSION_RETRY_LIMIT} (judge response is "
+                f"pathologically nested; consider switching judge model "
+                f"or shortening the prompt): {exc}"
+            )
+        except Exception as exc:
+            return None, str(exc)
+        finally:
+            sys.setrecursionlimit(original_limit)
+    except Exception as exc:
+        return None, str(exc)
+
+
 def _strip_markdown_json_fences(raw: str) -> str:
     """Strip a leading ```json / ``` code fence + trailing ``` if present.
 
@@ -596,10 +643,9 @@ def _attempt_model_call(
     if result.returncode != 0:
         return None, stdout, stderr or f"non-zero exit status {result.returncode}"
     cleaned = _strip_markdown_json_fences(stdout)
-    try:
-        verdict = json.loads(cleaned)
-    except Exception as exc:
-        return None, stdout, str(exc)
+    verdict, parse_error = _parse_json_with_recursion_retry(cleaned)
+    if parse_error is not None:
+        return None, stdout, parse_error
     if not isinstance(verdict, dict):
         return None, stdout, "response was not a JSON object"
     validation_error = _validate_verdict(verdict)

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_judge.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_judge.py
@@ -747,5 +747,79 @@ class StripMarkdownJsonFencesTests(unittest.TestCase):
         self.assertEqual(stripped, '{"verdict":"proceed"}')
 
 
+class ParseJsonRecursionRetryTests(unittest.TestCase):
+    """Regression tests for _parse_json_with_recursion_retry.
+
+    Codex hit `schema_violation: maximum recursion depth exceeded` repeatedly
+    on the ff-reconciliation-hardening run because Python's `json.loads`
+    is implemented recursively. A judge model that emits deeply-nested
+    JSON (e.g., echoes the schema wrapped in many layers) trips the
+    default ~1000 recursion limit and the FF runner cannot make progress.
+    """
+
+    def test_normal_json_parses(self) -> None:
+        text = '{"verdict": "proceed", "confidence": 3}'
+        parsed, error = JUDGE._parse_json_with_recursion_retry(text)
+        self.assertIsNone(error)
+        self.assertEqual(parsed["verdict"], "proceed")
+
+    def test_invalid_json_returns_error_string(self) -> None:
+        parsed, error = JUDGE._parse_json_with_recursion_retry("{not json}")
+        self.assertIsNone(parsed)
+        self.assertIsNotNone(error)
+        # Existing behavior: non-recursion errors flow through unchanged.
+        self.assertNotIn("maximum recursion depth", error)
+
+    def test_deeply_nested_json_parses_after_retry(self) -> None:
+        # Build JSON nested ~1500 levels — well past Python's default
+        # recursion limit (~1000) but within the elevated retry cap (5000).
+        depth = 1500
+        nested = "[" * depth + "1" + "]" * depth
+        parsed, error = JUDGE._parse_json_with_recursion_retry(nested)
+        self.assertIsNone(error)
+        # Verify the structure parsed correctly.
+        cursor = parsed
+        for _ in range(depth - 1):
+            self.assertIsInstance(cursor, list)
+            cursor = cursor[0]
+        self.assertEqual(cursor, [1])
+
+    def test_pathological_nesting_fails_cleanly(self) -> None:
+        # If json.loads raises RecursionError EVEN at the elevated retry
+        # limit, the helper must return a clear error message that names
+        # the cap — NOT crash the process.
+        with patch("json.loads", side_effect=RecursionError("test forced")):
+            parsed, error = JUDGE._parse_json_with_recursion_retry("[]")
+        self.assertIsNone(parsed)
+        self.assertIsNotNone(error)
+        self.assertIn("5000", error)
+        self.assertIn("pathologically nested", error)
+
+    def test_recursion_limit_restored_after_retry(self) -> None:
+        # Whether the parse succeeds or not, sys.getrecursionlimit must
+        # be the same after the call as before. Critical because elevated
+        # limits leaking risk a real stack overflow on later code paths.
+        limit_before = sys.getrecursionlimit()
+        # Force the success-after-retry path.
+        call_count = {"n": 0}
+        original_loads = json.loads
+
+        def first_recurse_then_succeed(text):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RecursionError("test forced first call")
+            return original_loads(text)
+
+        with patch("json.loads", side_effect=first_recurse_then_succeed):
+            parsed, error = JUDGE._parse_json_with_recursion_retry('{"x": 1}')
+        self.assertIsNone(error)
+        self.assertEqual(parsed, {"x": 1})
+        self.assertEqual(sys.getrecursionlimit(), limit_before)
+        # Also verify restore on the persistent-failure path.
+        with patch("json.loads", side_effect=RecursionError("test forced")):
+            JUDGE._parse_json_with_recursion_retry("[]")
+        self.assertEqual(sys.getrecursionlimit(), limit_before)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Fixes the `schema_violation: maximum recursion depth exceeded` error Codex hit repeatedly during the ff-reconciliation-hardening run (PR #768), which exhausted the judge panel and prevented forward progress across all 3 rounds.

## Root cause
Python's `json.loads` is implemented recursively. When a judge model emits deeply-nested JSON (e.g., echoes the embedded `judge_schema.json` wrapped in many layers in its response), it trips the default ~1000 recursion limit. The exception was caught at `factory_cmd_judge.py:600` and stringified into the verdict's `reasoning` field as `schema_violation: maximum recursion depth exceeded`. Every retry hit the same wall — the FF panel had no escape.

## Fix
New helper `_parse_json_with_recursion_retry(text)`:
1. Parse at the operator's current recursion limit.
2. On `RecursionError`, temporarily elevate `sys.setrecursionlimit` to 5000 and retry exactly once.
3. Always restore the original limit in `finally` (no leak into later code paths).
4. Non-recursion exceptions: return error string — existing behavior preserved.
5. RecursionError persisting at elevated limit: clear error message naming the cap so the operator knows the model output is pathologically nested.

`_attempt_model_call` now routes through the helper. No other call sites changed.

## Tests
5 new regression tests in `ParseJsonRecursionRetryTests`:
- Normal JSON parses unchanged.
- Invalid (non-recursion) JSON returns the original error.
- Deeply-nested JSON (1500 levels) succeeds after retry.
- Pathological case (mocked persistent `RecursionError`) fails cleanly with the named cap (`5000`) and `pathologically nested` in the error.
- Recursion limit restored on both success-after-retry and persistent-failure paths.

**344 FF tests pass** (was 339; +5 new).

## Risk
- **R1 (low)** — Elevated recursion limit could enable a real C-stack overflow on truly pathological input. Mitigation: bounded at 5000 (well below the ~10000 where most platforms segfault); retry runs only on the `RecursionError` path; original limit always restored in `finally`.
- **R2 (low)** — Models that legitimately produce 5000+ deeply-nested JSON would still fail. Acceptable: this is a safety net for the "schema echoed back wrapped many times" pattern, not unbounded depth.

## Test plan
- [x] 344 FF tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
