### PR TITLE
FF analyze-reviews: aggregate token_usage into a markdown performance report

### DIFF
--- a/docs/workflow/analysis/review-performance-2026-04-29.md
+++ b/docs/workflow/analysis/review-performance-2026-04-29.md
@@ -1,0 +1,142 @@
+# FF Review Performance Analysis
+
+Generated: 2026-04-29T21:07:03.480668Z
+
+## 1. Headline Numbers
+
+- Total reviewer + judge calls measured: 1446
+- Total wall-clock seconds: 64380.1
+- Total estimated USD cost: $0.02
+- Calls with token parse errors: 1437 (99.4%)
+- Date range covered: 2026-04-19T13:52:00.107591Z to 2026-04-29T21:05:16.047845Z
+- Distinct slugs: 26
+
+## 2. Per (model x activity_type) Summary
+
+| model | activity_type | count | total_duration_s | p50_s | p95_s | p99_s | max_s | parse_error_count | parse_error_rate |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gpt-5.4-mini | adversarial_review | 392 | 35782.1 | 85.6 | 180.0 | 180.0 | 190.5 | 383 | 97.7% |
+| gemini-2.5-pro | adversarial_review | 204 | 14896.5 | 51.0 | 236.1 | 289.8 | 600.0 | 204 | 100.0% |
+| claude-sonnet-4-6 | judge_panel | 286 | 8447.4 | 0.0 | 157.9 | 180.0 | 180.0 | 286 | 100.0% |
+| gpt-5.4-mini | judge_panel | 277 | 2934.2 | 0.0 | 63.8 | 108.1 | 159.2 | 277 | 100.0% |
+| gpt-5.4 | judge_panel | 287 | 2320.0 | 0.0 | 39.8 | 53.8 | 73.3 | 287 | 100.0% |
+
+## 3. Per (model x stage) Summary
+
+| model | stage | count | total_duration_s | p50_s | p95_s | p99_s | max_s | parse_error_count | parse_error_rate |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gpt-5.4-mini | spec | 209 | 19694.4 | 91.7 | 179.9 | 180.0 | 186.2 | 202 | 96.7% |
+| gpt-5.4-mini | plan | 332 | 9996.4 | 0.0 | 148.3 | 180.0 | 190.5 | 330 | 99.4% |
+| gemini-2.5-pro | spec | 88 | 7660.7 | 53.4 | 246.2 | 398.9 | 600.0 | 88 | 100.0% |
+| claude-sonnet-4-6 | spec | 50 | 5123.2 | 92.2 | 177.7 | 180.0 | 180.0 | 50 | 100.0% |
+| gpt-5.4-mini | diff | 62 | 4977.9 | 74.0 | 180.0 | 180.0 | 180.0 | 62 | 100.0% |
+| gpt-5.4-mini | tasks | 64 | 4008.6 | 50.6 | 144.3 | 173.4 | 180.0 | 64 | 100.0% |
+| gemini-2.5-pro | plan | 52 | 3409.1 | 48.6 | 169.6 | 266.3 | 289.8 | 52 | 100.0% |
+| gemini-2.5-pro | diff | 34 | 2325.3 | 51.6 | 220.9 | 223.8 | 224.5 | 34 | 100.0% |
+| claude-sonnet-4-6 | plan | 226 | 2082.4 | 0.0 | 110.8 | 166.2 | 180.0 | 226 | 100.0% |
+| gpt-5.4 | spec | 50 | 1479.9 | 29.2 | 46.6 | 61.0 | 73.3 | 50 | 100.0% |
+| gemini-2.5-pro | tasks | 28 | 1354.7 | 42.5 | 94.9 | 97.7 | 97.9 | 28 | 100.0% |
+| claude-sonnet-4-6 | tasks | 8 | 1086.0 | 123.7 | 176.1 | 179.2 | 180.0 | 8 | 100.0% |
+| gpt-5.4 | plan | 227 | 427.7 | 0.0 | 16.4 | 42.2 | 57.5 | 227 | 100.0% |
+| gpt-5.4 | tasks | 8 | 351.0 | 44.3 | 58.2 | 60.3 | 60.8 | 8 | 100.0% |
+| claude-sonnet-4-6 | diff | 2 | 155.8 | 77.9 | 126.8 | 131.2 | 132.3 | 2 | 100.0% |
+| gemini-2.5-pro | closeout | 2 | 146.7 | 73.4 | 115.3 | 119.1 | 120.0 | 2 | 100.0% |
+| gpt-5.4 | diff | 2 | 61.5 | 30.7 | 30.8 | 30.8 | 30.8 | 2 | 100.0% |
+| gpt-5.4-mini | closeout | 2 | 39.1 | 19.6 | 23.1 | 23.4 | 23.5 | 2 | 100.0% |
+
+## 3a. Best-Effort Lens Summary
+
+| lens | model | count | total_duration_s | p50_s | max_s | parse_error_count |
+| --- | --- | --- | --- | --- | --- | --- |
+| requirements-adversarial | gemini-2.5-pro | 86 | 7420.7 | 53.1 | 600.0 | 86 |
+| testability-adversarial | gemini-2.5-pro | 52 | 3409.1 | 48.6 | 289.8 | 52 |
+| quality-adversarial | gemini-2.5-pro | 34 | 2325.3 | 51.6 | 224.5 | 34 |
+| implementation-risk-judge | claude-sonnet-4-6 | 16 | 1709.6 | 91.0 | 180.0 | 16 |
+| coverage-adversarial | gemini-2.5-pro | 28 | 1354.7 | 42.5 | 97.9 | 28 |
+| completeness-judge | gpt-5.4 | 20 | 456.7 | 22.4 | 37.6 | 20 |
+| execution-adversarial | gpt-5.4-mini | 4 | 339.6 | 81.8 | 145.8 | 4 |
+| completeness-judge | gpt-5.4-mini | 12 | 269.8 | 12.5 | 57.8 | 12 |
+| residual-risk-adversarial | gemini-2.5-pro | 2 | 146.7 | 73.4 | 120.0 | 2 |
+| restatement-judge | gpt-5.4 | 6 | 94.7 | 4.9 | 44.7 | 6 |
+
+## 4. Top 20 Slowest Individual Calls
+
+| slug | stage | round | activity_type | model | duration_s | input_tokens | output_tokens | parse_error | timestamp |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| sensitivity-table-redesign-v2 | spec | 1 | adversarial_review | gemini-2.5-pro | 600.0 |  |  | no Gemini token stats found in stdout | 2026-04-29T15:56:18.195923Z |
+| sensitivity-table-redesign-v2 | spec | 0 | adversarial_review | gemini-2.5-pro | 368.8 |  |  | no Gemini token stats found in stdout | 2026-04-29T15:35:16.533061Z |
+| sensitivity-table-redesign-v2 | plan | 1 | adversarial_review | gemini-2.5-pro | 289.8 |  |  | no Gemini token stats found in stdout | 2026-04-29T17:28:18.451240Z |
+| sensitivity-table-redesign-v2 | spec | 1 | adversarial_review | gemini-2.5-pro | 288.7 |  |  | no Gemini token stats found in stdout | 2026-04-29T15:42:11.969889Z |
+| sensitivity-table-redesign-v2 | spec | 1 | adversarial_review | gemini-2.5-pro | 261.6 |  |  | no Gemini token stats found in stdout | 2026-04-29T16:03:08.523439Z |
+| sensitivity-table-redesign-v2 | spec | 1 | adversarial_review | gemini-2.5-pro | 247.8 |  |  | no Gemini token stats found in stdout | 2026-04-29T16:18:47.229107Z |
+| sensitivity-table-redesign-v2 | plan | 1 | adversarial_review | gemini-2.5-pro | 243.8 |  |  | no Gemini token stats found in stdout | 2026-04-29T16:49:30.638288Z |
+| sensitivity-table-redesign-v2 | spec | 0 | adversarial_review | gemini-2.5-pro | 243.1 |  |  | no Gemini token stats found in stdout | 2026-04-29T15:20:34.246092Z |
+| sensitivity-table-redesign-v2 | spec | 1 | adversarial_review | gemini-2.5-pro | 242.9 |  |  | no Gemini token stats found in stdout | 2026-04-29T16:07:11.438231Z |
+| sensitivity-table-redesign-v2 | spec | 0 | adversarial_review | gemini-2.5-pro | 238.0 |  |  | no Gemini token stats found in stdout | 2026-04-29T15:27:59.424519Z |
+| sensitivity-table-redesign-v2 | spec | 1 | adversarial_review | gemini-2.5-pro | 237.1 |  |  | no Gemini token stats found in stdout | 2026-04-29T15:11:31.236925Z |
+| sensitivity-table-redesign-v2 | plan | 1 | adversarial_review | gemini-2.5-pro | 230.2 |  |  | no Gemini token stats found in stdout | 2026-04-29T16:53:20.803270Z |
+| sensitivity-table-redesign-v2 | diff | 1 | adversarial_review | gemini-2.5-pro | 224.5 |  |  | no Gemini token stats found in stdout | 2026-04-29T18:01:47.545687Z |
+| sensitivity-table-redesign-v2 | spec | 1 | adversarial_review | gemini-2.5-pro | 224.4 |  |  | no Gemini token stats found in stdout | 2026-04-29T16:14:39.414512Z |
+| sensitivity-table-redesign-v2 | spec | 1 | adversarial_review | gemini-2.5-pro | 223.6 |  |  | no Gemini token stats found in stdout | 2026-04-29T16:10:55.006492Z |
+| sensitivity-table-redesign-v2 | diff | 1 | adversarial_review | gemini-2.5-pro | 222.5 |  |  | no Gemini token stats found in stdout | 2026-04-29T18:05:30.007085Z |
+| sensitivity-table-redesign-v2 | diff | 1 | adversarial_review | gemini-2.5-pro | 220.1 |  |  | no Gemini token stats found in stdout | 2026-04-29T17:52:12.224115Z |
+| sensitivity-table-redesign-v2 | spec | 0 | adversarial_review | gemini-2.5-pro | 207.1 |  |  | no Gemini token stats found in stdout | 2026-04-29T15:24:01.372048Z |
+| sensitivity-table-redesign-v2 | plan | 0 | adversarial_review | gpt-5.4-mini | 190.5 |  |  | no Codex token block found in stderr | 2026-04-29T17:11:19.081636Z |
+| sensitivity-table-redesign-v2 | spec | 0 | adversarial_review | gpt-5.4-mini | 186.2 |  |  | no Codex token block found in stderr | 2026-04-29T15:32:13.870719Z |
+
+## 5. Parse Error Patterns
+
+| error pattern | count | models affected | example slug |
+| --- | --- | --- | --- |
+| no Codex token block found in stderr | 947 | gpt-5.4, gpt-5.4-mini | 033-run-state-reconciliation |
+| no Claude token counts found in stdout or stderr | 286 | claude-sonnet-4-6 | 033-run-state-reconciliation |
+| no Gemini token stats found in stdout | 204 | gemini-2.5-pro | 033-run-state-reconciliation |
+
+## 6. Duration vs Input Tokens Correlation
+
+| model | input_token_bin | count | p50_duration_s | p95_duration_s |
+| --- | --- | --- | --- | --- |
+| gpt-5.4-mini | q1 [40-40] | 1 | 145.5 | 145.5 |
+| gpt-5.4-mini | q2 [41-41] | 2 | 158.4 | 161.5 |
+| gpt-5.4-mini | q3 [1500-1500] | 2 | 158.1 | 177.8 |
+| gpt-5.4-mini | q4 [1500-1500] | 2 | 152.6 | 177.3 |
+| gpt-5.4-mini | q5 [1500-1500] | 2 | 180.0 | 180.0 |
+
+## 7. Wall Clock by Slug (Top 20)
+
+| slug | total_review_duration_s | total_judge_duration_s | total_deferred_round_duration_s | rounds | stages_reaching_judge_cap |
+| --- | --- | --- | --- | --- | --- |
+| sensitivity-table-redesign-v2 | 10938.8 | 0.0 | 0.0 | 7 | 0 |
+| match-pair-counts | 4160.8 | 2400.4 | 237.5 | 9 | 2 |
+| ff-runner-fixes | 3624.1 | 2251.2 | 0.0 | 10 | 1 |
+| ff-codex-reintegration | 1649.8 | 2441.6 | 0.0 | 11 | 1 |
+| sensitivity-table-redesign | 3628.0 | 0.0 | 0.0 | 10 | 0 |
+| remove-decision-code | 3188.8 | 412.0 | 0.0 | 6 | 0 |
+| 033-run-state-reconciliation | 2523.6 | 992.3 | 0.0 | 7 | 1 |
+| ff-token-reliability | 2566.5 | 444.8 | 1044.6 | 7 | 0 |
+| paired-batch-count-min-of-two | 2613.2 | 0.0 | 0.0 | 6 | 0 |
+| ff-safety-net | 1292.0 | 1118.5 | 0.0 | 8 | 0 |
+| coverage-cell-batch-display | 1324.1 | 899.4 | 0.0 | 8 | 0 |
+| circumplex-report | 1981.1 | 239.1 | 0.0 | 6 | 0 |
+| visitor-role-access-control | 1370.7 | 835.3 | 0.0 | 6 | 1 |
+| decision-cache-single-source | 715.7 | 1359.4 | 0.0 | 3 | 1 |
+| pressure-sensitivity-report | 1903.0 | 0.0 | 0.0 | 4 | 2 |
+| decision-cache-v2-tolerance | 1503.7 | 0.0 | 0.0 | 2 | 0 |
+| ff-reconciliation-hardening | 1417.7 | 0.0 | 61.7 | 12 | 4 |
+| ff-quality-of-life | 1229.5 | 0.0 | 379.2 | 5 | 0 |
+| aggregate-consistency-data | 849.7 | 0.0 | 0.0 | 3 | 0 |
+| ff-housekeeping | 787.7 | 0.0 | 0.0 | 5 | 0 |
+
+## 8. Data Quality
+
+- Dropped records: 0
+- Dropped-record field breakdown: none
+- Partial-but-kept field breakdown: input_tokens=1437, output_tokens=1437
+- Slugs with malformed state.json: 035-audit-sweep
+- Slugs with missing or non-list token_usage: 030-remove-legacy-decision-code, 031-settings-nav-restructure, 032-queue-depth-governor, analysis-condition-detail-canonical-v2, analysis-report-v2-guard, analysis-reports-decision-score-phase1, analysis-scenarios-canonical-ui, balance-ui-merge, byvalue-two-step-winrate, ci-test-quality, domain-analysis-freshness-cache, domain-analysis-value-detail-v2, domain-coverage-completeness-guard, domain-evaluation-model-backfill, domain-evaluation-setup-state, feature-workflow-discovery-shaping, feature-workflow-repair, i7-structured-discovery, i7-wave2-runner-extension, models-consistency-report, models-tab, native-body-scroll, parallel-implement-command, reasoning-token-costs, remove-final-trial-sampler, replace, split-status-start-pages, stall-watchdog, summarization-cache, summarizer-fallback-removal, transcript-decision-model-winner-first, transcript-summarization-speedup, unified-net-weighted-condition-score, vignette-analysis-decision-model, vignette-analysis-domain-overview-ui, vignette-analysis-group1-ui, workflow-runner-hardening
+- Records with timestamps outside reasonable range: 0
+- Malformed review files skipped during deferred-round scan: 0
+- Deferred-round inference failures: 8
+- Records without unambiguous lens attribution: 1186
+- Estimated USD cost is a lower bound because 1437 calls had parse errors and null costs were treated as $0.
+- Lens attribution is best-effort only. Current token_usage records do not reliably carry a per-call lens id across repeated rounds.

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py
@@ -1,0 +1,733 @@
+#!/usr/bin/env python3
+"""Read-only telemetry analyzer for Feature Factory review and judge calls."""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+import factory_state
+from factory_mutating import readonly_command
+
+
+_RELEVANT_ACTIVITY_TYPES = frozenset({"judge_panel", "review", "adversarial_review", "implementation_review"})
+_REASONABLE_TIMESTAMP_MIN = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
+def _warn(message: str) -> None:
+    print(f"warning: {message}", file=sys.stderr)
+
+
+def _utc_today() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _default_output_path() -> Path:
+    return (
+        factory_state.REPO_ROOT
+        / "docs"
+        / "workflow"
+        / "analysis"
+        / f"review-performance-{_utc_today()}.md"
+    )
+
+
+def _resolve_output_path(raw: str | None) -> Path:
+    if not raw:
+        return _default_output_path()
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        return candidate
+    return (factory_state.REPO_ROOT / candidate).resolve()
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return int(stripped)
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        return number if math.isfinite(number) else None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            number = float(stripped)
+        except ValueError:
+            return None
+        return number if math.isfinite(number) else None
+    return None
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        if stripped.endswith("Z"):
+            return datetime.fromisoformat(stripped.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(stripped)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except ValueError:
+        return None
+
+
+def _normalize_text(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.split())
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return f"{text[: max(limit - 3, 0)].rstrip()}..."
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (percentile / 100.0) * (len(ordered) - 1)
+    lower = int(math.floor(rank))
+    upper = int(math.ceil(rank))
+    if lower == upper:
+        return ordered[lower]
+    fraction = rank - lower
+    return ordered[lower] + ((ordered[upper] - ordered[lower]) * fraction)
+
+
+def _format_duration(value: float) -> str:
+    return f"{value:.1f}"
+
+
+def _format_cost(value: float) -> str:
+    return f"${value:,.2f}"
+
+
+def _format_percent(numerator: int, denominator: int) -> str:
+    if denominator <= 0:
+        return "0.0%"
+    return f"{(100.0 * numerator / denominator):.1f}%"
+
+
+def _escape_cell(value: object) -> str:
+    text = "" if value is None else str(value)
+    return text.replace("|", "\\|").replace("\n", " ")
+
+
+def _markdown_table(headers: list[str], rows: Iterable[Iterable[object]]) -> list[str]:
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(_escape_cell(cell) for cell in row) + " |")
+    return lines
+
+
+def _is_relevant_activity(activity_type: object) -> bool:
+    if not isinstance(activity_type, str):
+        return False
+    normalized = activity_type.strip()
+    return normalized in _RELEVANT_ACTIVITY_TYPES or "review" in normalized
+
+
+def _provider_key_from_model(model: str) -> str:
+    lowered = model.lower()
+    if lowered.startswith("gemini-"):
+        return "gemini"
+    if lowered.startswith("claude-"):
+        return "claude"
+    if lowered.startswith("gpt-") or lowered.startswith("gpt"):
+        return "codex"
+    return lowered
+
+
+def _scan_review_metadata(
+    slug_dir: Path,
+    state_blob: dict[str, object],
+    data_quality: dict[str, object],
+) -> tuple[set[tuple[str, int, str]], dict[tuple[str, str, str], list[str]], int]:
+    deferred_keys: set[tuple[str, int, str]] = set()
+    lens_candidates: dict[tuple[str, str, str], list[str]] = defaultdict(list)
+    judge_cap_count = 0
+
+    stages = state_blob.get("stages", {})
+    if isinstance(stages, dict):
+        for stage_name, stage_state in stages.items():
+            if not isinstance(stage_state, dict):
+                continue
+            judge_rounds = _coerce_int(stage_state.get("judge_rounds")) or 0
+            if judge_rounds >= 3:
+                judge_cap_count += 1
+
+    reviews_dir = slug_dir / "reviews"
+    if not reviews_dir.exists():
+        return deferred_keys, lens_candidates, judge_cap_count
+
+    deferred_inference_failures = _coerce_int(data_quality.get("deferred_inference_failures")) or 0
+    malformed_review_files = _coerce_int(data_quality.get("malformed_review_files")) or 0
+
+    for review_path in sorted(reviews_dir.glob("*.review.md")):
+        try:
+            metadata, _ = factory_state.parse_review_frontmatter(review_path)
+        except Exception:
+            malformed_review_files += 1
+            continue
+
+        stage = str(metadata.get("stage", "") or "").strip()
+        reviewer = str(metadata.get("reviewer", "") or "").strip().lower()
+        lens = str(metadata.get("lens", "") or "").strip()
+        if not stage or not reviewer or not lens:
+            continue
+
+        activity_type = "judge_panel" if lens.endswith("-judge") or review_path.name.startswith("judge.") else "adversarial_review"
+        if activity_type == "judge_panel":
+            provider_key = reviewer
+        else:
+            provider_key = reviewer
+            if reviewer.startswith("gpt-") or reviewer.startswith("gpt"):
+                provider_key = "codex"
+            elif reviewer.startswith("claude-"):
+                provider_key = "claude"
+            elif reviewer.startswith("gemini-"):
+                provider_key = "gemini"
+
+        key = (stage, activity_type, provider_key)
+        if lens not in lens_candidates[key]:
+            lens_candidates[key].append(lens)
+
+        if str(metadata.get("resolution_status", "") or "").strip() != "deferred":
+            continue
+
+        stage_state = stages.get(stage, {}) if isinstance(stages, dict) else {}
+        if not isinstance(stage_state, dict):
+            deferred_inference_failures += 1
+            continue
+        round_field = "judge_rounds" if activity_type == "judge_panel" else "adversarial_rounds"
+        inferred_round = _coerce_int(stage_state.get(round_field))
+        if inferred_round is None or inferred_round <= 0:
+            deferred_inference_failures += 1
+            continue
+        deferred_keys.add((stage, inferred_round, activity_type))
+
+    data_quality["deferred_inference_failures"] = deferred_inference_failures
+    data_quality["malformed_review_files"] = malformed_review_files
+    return deferred_keys, lens_candidates, judge_cap_count
+
+
+def _load_records(top_n: int) -> tuple[list[dict[str, object]], dict[str, object]]:
+    del top_n  # caller owns output shaping; keep signature stable for tests
+    records: list[dict[str, object]] = []
+    data_quality: dict[str, object] = {
+        "dropped_fields": Counter(),
+        "partial_fields": Counter(),
+        "skipped_slugs": [],
+        "token_usage_missing": [],
+        "bad_timestamps": 0,
+        "records_seen": 0,
+        "dropped_records": 0,
+        "deferred_inference_failures": 0,
+        "malformed_review_files": 0,
+        "unattributed_lens_records": 0,
+    }
+
+    runs_root = factory_state.FACTORY_RUNS_ROOT
+    for state_path in sorted(runs_root.glob("*/state.json")):
+        slug = state_path.parent.name
+        try:
+            raw_state = json.loads(state_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            _warn(f"skipping malformed state.json for {slug}: {exc}")
+            cast_skipped = data_quality["skipped_slugs"]
+            assert isinstance(cast_skipped, list)
+            cast_skipped.append(slug)
+            continue
+
+        token_usage = raw_state.get("token_usage")
+        if not isinstance(token_usage, list):
+            _warn(f"skipping {slug}: token_usage missing or not a list")
+            cast_missing = data_quality["token_usage_missing"]
+            assert isinstance(cast_missing, list)
+            cast_missing.append(slug)
+            continue
+
+        deferred_keys, lens_candidates, judge_cap_count = _scan_review_metadata(state_path.parent, raw_state, data_quality)
+
+        for raw_record in token_usage:
+            data_quality["records_seen"] = int(data_quality["records_seen"]) + 1
+            if not isinstance(raw_record, dict):
+                cast_dropped = data_quality["dropped_fields"]
+                assert isinstance(cast_dropped, Counter)
+                cast_dropped["record_not_object"] += 1
+                data_quality["dropped_records"] = int(data_quality["dropped_records"]) + 1
+                continue
+
+            activity_type = raw_record.get("activity_type")
+            if not _is_relevant_activity(activity_type):
+                continue
+
+            model = raw_record.get("model")
+            duration_seconds = _coerce_float(raw_record.get("duration_seconds"))
+            if not isinstance(model, str) or not model.strip():
+                cast_dropped = data_quality["dropped_fields"]
+                assert isinstance(cast_dropped, Counter)
+                cast_dropped["model"] += 1
+                data_quality["dropped_records"] = int(data_quality["dropped_records"]) + 1
+                continue
+            if duration_seconds is None:
+                cast_dropped = data_quality["dropped_fields"]
+                assert isinstance(cast_dropped, Counter)
+                cast_dropped["duration_seconds"] += 1
+                data_quality["dropped_records"] = int(data_quality["dropped_records"]) + 1
+                continue
+
+            stage = str(raw_record.get("stage", "") or "").strip() or "unknown"
+            round_number = _coerce_int(raw_record.get("round"))
+            timestamp_text = str(raw_record.get("timestamp", "") or "").strip()
+            timestamp = _parse_timestamp(timestamp_text)
+            if timestamp is None and timestamp_text:
+                cast_partial = data_quality["partial_fields"]
+                assert isinstance(cast_partial, Counter)
+                cast_partial["timestamp_unparseable"] += 1
+            if timestamp is not None and (
+                timestamp < _REASONABLE_TIMESTAMP_MIN
+                or timestamp > datetime.now(timezone.utc) + timedelta(days=1)
+            ):
+                data_quality["bad_timestamps"] = int(data_quality["bad_timestamps"]) + 1
+
+            input_tokens = _coerce_int(raw_record.get("input_tokens"))
+            output_tokens = _coerce_int(raw_record.get("output_tokens"))
+            cost_usd = _coerce_float(raw_record.get("cost_usd_estimate")) or 0.0
+            parse_error = _normalize_text(raw_record.get("parse_error"))
+
+            for optional_field, value in (
+                ("round", round_number),
+                ("timestamp", timestamp_text or None),
+                ("input_tokens", input_tokens),
+                ("output_tokens", output_tokens),
+            ):
+                if value is None:
+                    cast_partial = data_quality["partial_fields"]
+                    assert isinstance(cast_partial, Counter)
+                    cast_partial[optional_field] += 1
+
+            activity_name = str(activity_type).strip()
+            provider_key = model.strip().lower() if activity_name == "judge_panel" else _provider_key_from_model(model.strip())
+            candidate_lenses = lens_candidates.get((stage, activity_name, provider_key), [])
+            lens = candidate_lenses[0] if len(candidate_lenses) == 1 else ""
+            if not lens:
+                data_quality["unattributed_lens_records"] = int(data_quality["unattributed_lens_records"]) + 1
+
+            record = {
+                "slug": slug,
+                "stage": stage,
+                "round": round_number,
+                "activity_type": activity_name,
+                "model": model.strip(),
+                "duration_seconds": duration_seconds,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cost_usd_estimate": cost_usd,
+                "timestamp_text": timestamp_text,
+                "timestamp": timestamp,
+                "parse_error": parse_error,
+                "judge_cap_count": judge_cap_count,
+                "is_deferred_round": bool(round_number is not None and (stage, round_number, activity_name) in deferred_keys),
+                "lens": lens,
+            }
+            records.append(record)
+
+    return records, data_quality
+
+
+def _summarize_grouped(records: list[dict[str, object]], group_keys: tuple[str, ...]) -> list[list[object]]:
+    grouped: dict[tuple[object, ...], list[dict[str, object]]] = defaultdict(list)
+    for record in records:
+        grouped[tuple(record.get(key) for key in group_keys)].append(record)
+
+    rows: list[list[object]] = []
+    for key, items in grouped.items():
+        durations = [float(item["duration_seconds"]) for item in items]
+        parse_error_count = sum(1 for item in items if item.get("parse_error"))
+        row = list(key)
+        row.extend(
+            [
+                len(items),
+                _format_duration(sum(durations)),
+                _format_duration(_percentile(durations, 50)),
+                _format_duration(_percentile(durations, 95)),
+                _format_duration(_percentile(durations, 99)),
+                _format_duration(max(durations)),
+                parse_error_count,
+                _format_percent(parse_error_count, len(items)),
+            ]
+        )
+        rows.append(row)
+
+    rows.sort(key=lambda row: float(str(row[len(group_keys) + 1])), reverse=True)
+    return rows
+
+
+def _top_slowest_rows(records: list[dict[str, object]], top_n: int) -> list[list[object]]:
+    ordered = sorted(records, key=lambda item: float(item["duration_seconds"]), reverse=True)[:top_n]
+    rows: list[list[object]] = []
+    for record in ordered:
+        rows.append(
+            [
+                record["slug"],
+                record["stage"],
+                record.get("round", ""),
+                record["activity_type"],
+                record["model"],
+                _format_duration(float(record["duration_seconds"])),
+                record.get("input_tokens", ""),
+                record.get("output_tokens", ""),
+                _truncate(str(record.get("parse_error", "") or ""), 80),
+                record.get("timestamp_text", ""),
+            ]
+        )
+    return rows
+
+
+def _parse_error_rows(records: list[dict[str, object]]) -> list[list[object]]:
+    grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for record in records:
+        normalized = _truncate(_normalize_text(record.get("parse_error")), 80)
+        if normalized:
+            grouped[normalized].append(record)
+
+    rows: list[list[object]] = []
+    for pattern, items in grouped.items():
+        models = sorted({str(item["model"]) for item in items})
+        model_list = ", ".join(models[:4])
+        if len(models) > 4:
+            model_list = f"{model_list}, +{len(models) - 4} more"
+        rows.append([pattern, len(items), model_list, items[0]["slug"]])
+    rows.sort(key=lambda row: int(row[1]), reverse=True)
+    return rows
+
+
+def _correlation_rows(records: list[dict[str, object]]) -> list[list[object]]:
+    by_model: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for record in records:
+        if record.get("input_tokens") is None:
+            continue
+        by_model[str(record["model"])].append(record)
+
+    rows: list[list[object]] = []
+    for model in sorted(by_model):
+        ordered = sorted(by_model[model], key=lambda item: int(item["input_tokens"]))  # type: ignore[arg-type]
+        if not ordered:
+            continue
+        count = len(ordered)
+        emitted_index = 0
+        for index in range(5):
+            start = (index * count) // 5
+            end = ((index + 1) * count) // 5
+            if end <= start:
+                continue
+            emitted_index += 1
+            bucket = ordered[start:end]
+            durations = [float(item["duration_seconds"]) for item in bucket]
+            min_tokens = int(bucket[0]["input_tokens"])  # type: ignore[arg-type]
+            max_tokens = int(bucket[-1]["input_tokens"])  # type: ignore[arg-type]
+            rows.append(
+                [
+                    model,
+                    f"q{emitted_index} [{min_tokens}-{max_tokens}]",
+                    len(bucket),
+                    _format_duration(_percentile(durations, 50)),
+                    _format_duration(_percentile(durations, 95)),
+                ]
+            )
+    return rows
+
+
+def _slug_rows(records: list[dict[str, object]]) -> list[list[object]]:
+    grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for record in records:
+        grouped[str(record["slug"])].append(record)
+
+    rows: list[list[object]] = []
+    for slug, items in grouped.items():
+        review_duration = sum(
+            float(item["duration_seconds"])
+            for item in items
+            if str(item["activity_type"]) != "judge_panel"
+        )
+        judge_duration = sum(
+            float(item["duration_seconds"])
+            for item in items
+            if str(item["activity_type"]) == "judge_panel"
+        )
+        deferred_duration = sum(
+            float(item["duration_seconds"])
+            for item in items
+            if bool(item.get("is_deferred_round"))
+        )
+        rounds = {
+            (str(item["stage"]), int(item["round"]))
+            for item in items
+            if item.get("round") is not None
+        }
+        judge_caps = max(int(item.get("judge_cap_count", 0) or 0) for item in items)
+        rows.append(
+            [
+                slug,
+                _format_duration(review_duration),
+                _format_duration(judge_duration),
+                _format_duration(deferred_duration),
+                len(rounds),
+                judge_caps,
+            ]
+        )
+    rows.sort(key=lambda row: float(str(row[1])) + float(str(row[2])), reverse=True)
+    return rows[:20]
+
+
+def _lens_rows(records: list[dict[str, object]]) -> list[list[object]]:
+    grouped: dict[tuple[str, str], list[dict[str, object]]] = defaultdict(list)
+    for record in records:
+        lens = str(record.get("lens", "") or "").strip()
+        if not lens:
+            continue
+        grouped[(lens, str(record["model"]))].append(record)
+
+    rows: list[list[object]] = []
+    for (lens, model), items in grouped.items():
+        durations = [float(item["duration_seconds"]) for item in items]
+        rows.append(
+            [
+                lens,
+                model,
+                len(items),
+                _format_duration(sum(durations)),
+                _format_duration(_percentile(durations, 50)),
+                _format_duration(max(durations)),
+                sum(1 for item in items if item.get("parse_error")),
+            ]
+        )
+    rows.sort(key=lambda row: float(str(row[3])), reverse=True)
+    return rows[:20]
+
+
+def _render_report(records: list[dict[str, object]], data_quality: dict[str, object], top_n: int) -> str:
+    total_duration = sum(float(record["duration_seconds"]) for record in records)
+    total_cost = sum(float(record["cost_usd_estimate"]) for record in records)
+    total_parse_errors = sum(1 for record in records if record.get("parse_error"))
+    timestamps = [record["timestamp"] for record in records if isinstance(record.get("timestamp"), datetime)]
+    date_range = "unknown"
+    if timestamps:
+        ordered = sorted(timestamps)
+        date_range = f"{ordered[0].isoformat().replace('+00:00', 'Z')} to {ordered[-1].isoformat().replace('+00:00', 'Z')}"
+
+    lines: list[str] = [
+        "# FF Review Performance Analysis",
+        "",
+        f"Generated: {datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')}",
+        "",
+        "## 1. Headline Numbers",
+        "",
+        f"- Total reviewer + judge calls measured: {len(records)}",
+        f"- Total wall-clock seconds: {_format_duration(total_duration)}",
+        f"- Total estimated USD cost: {_format_cost(total_cost)}",
+        f"- Calls with token parse errors: {total_parse_errors} ({_format_percent(total_parse_errors, len(records))})",
+        f"- Date range covered: {date_range}",
+        f"- Distinct slugs: {len({str(record['slug']) for record in records})}",
+        "",
+        "## 2. Per (model x activity_type) Summary",
+        "",
+    ]
+
+    section_2_rows = _summarize_grouped(records, ("model", "activity_type"))
+    if section_2_rows:
+        lines.extend(
+            _markdown_table(
+                [
+                    "model",
+                    "activity_type",
+                    "count",
+                    "total_duration_s",
+                    "p50_s",
+                    "p95_s",
+                    "p99_s",
+                    "max_s",
+                    "parse_error_count",
+                    "parse_error_rate",
+                ],
+                section_2_rows,
+            )
+        )
+    else:
+        lines.append("No relevant records found.")
+    lines.extend(["", "## 3. Per (model x stage) Summary", ""])
+
+    section_3_rows = _summarize_grouped(records, ("model", "stage"))
+    if section_3_rows:
+        lines.extend(
+            _markdown_table(
+                [
+                    "model",
+                    "stage",
+                    "count",
+                    "total_duration_s",
+                    "p50_s",
+                    "p95_s",
+                    "p99_s",
+                    "max_s",
+                    "parse_error_count",
+                    "parse_error_rate",
+                ],
+                section_3_rows,
+            )
+        )
+    else:
+        lines.append("No relevant records found.")
+
+    lens_rows = _lens_rows(records)
+    lines.extend(["", "## 3a. Best-Effort Lens Summary", ""])
+    if lens_rows:
+        lines.extend(
+            _markdown_table(
+                ["lens", "model", "count", "total_duration_s", "p50_s", "max_s", "parse_error_count"],
+                lens_rows,
+            )
+        )
+    else:
+        lines.append("No unambiguous lens attributions found.")
+
+    lines.extend(["", f"## 4. Top {top_n} Slowest Individual Calls", ""])
+    slowest_rows = _top_slowest_rows(records, top_n)
+    if slowest_rows:
+        lines.extend(
+            _markdown_table(
+                [
+                    "slug",
+                    "stage",
+                    "round",
+                    "activity_type",
+                    "model",
+                    "duration_s",
+                    "input_tokens",
+                    "output_tokens",
+                    "parse_error",
+                    "timestamp",
+                ],
+                slowest_rows,
+            )
+        )
+    else:
+        lines.append("No relevant records found.")
+
+    lines.extend(["", "## 5. Parse Error Patterns", ""])
+    error_rows = _parse_error_rows(records)
+    if error_rows:
+        lines.extend(_markdown_table(["error pattern", "count", "models affected", "example slug"], error_rows))
+    else:
+        lines.append("No parse errors found.")
+
+    lines.extend(["", "## 6. Duration vs Input Tokens Correlation", ""])
+    correlation_rows = _correlation_rows(records)
+    if correlation_rows:
+        lines.extend(
+            _markdown_table(
+                ["model", "input_token_bin", "count", "p50_duration_s", "p95_duration_s"],
+                correlation_rows,
+            )
+        )
+    else:
+        lines.append("No records with input token counts found.")
+
+    lines.extend(["", "## 7. Wall Clock by Slug (Top 20)", ""])
+    slug_rows = _slug_rows(records)
+    if slug_rows:
+        lines.extend(
+            _markdown_table(
+                [
+                    "slug",
+                    "total_review_duration_s",
+                    "total_judge_duration_s",
+                    "total_deferred_round_duration_s",
+                    "rounds",
+                    "stages_reaching_judge_cap",
+                ],
+                slug_rows,
+            )
+        )
+    else:
+        lines.append("No relevant records found.")
+
+    dropped_fields = data_quality["dropped_fields"]
+    partial_fields = data_quality["partial_fields"]
+    skipped_slugs = data_quality["skipped_slugs"]
+    token_usage_missing = data_quality["token_usage_missing"]
+    assert isinstance(dropped_fields, Counter)
+    assert isinstance(partial_fields, Counter)
+    assert isinstance(skipped_slugs, list)
+    assert isinstance(token_usage_missing, list)
+
+    lines.extend(
+        [
+            "",
+            "## 8. Data Quality",
+            "",
+            f"- Dropped records: {int(data_quality['dropped_records'])}",
+            f"- Dropped-record field breakdown: {', '.join(f'{field}={count}' for field, count in sorted(dropped_fields.items())) or 'none'}",
+            f"- Partial-but-kept field breakdown: {', '.join(f'{field}={count}' for field, count in sorted(partial_fields.items())) or 'none'}",
+            f"- Slugs with malformed state.json: {', '.join(skipped_slugs) or 'none'}",
+            f"- Slugs with missing or non-list token_usage: {', '.join(token_usage_missing) or 'none'}",
+            f"- Records with timestamps outside reasonable range: {int(data_quality['bad_timestamps'])}",
+            f"- Malformed review files skipped during deferred-round scan: {int(data_quality['malformed_review_files'])}",
+            f"- Deferred-round inference failures: {int(data_quality['deferred_inference_failures'])}",
+            f"- Records without unambiguous lens attribution: {int(data_quality['unattributed_lens_records'])}",
+            f"- Estimated USD cost is a lower bound because {total_parse_errors} calls had parse errors and null costs were treated as $0.",
+            "- Lens attribution is best-effort only. Current token_usage records do not reliably carry a per-call lens id across repeated rounds.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+@readonly_command("analyze-reviews")
+def command_analyze_reviews(args: argparse.Namespace) -> int:
+    top_n = int(getattr(args, "top_n", 20) or 20)
+    output_path = _resolve_output_path(getattr(args, "out", None))
+
+    records, data_quality = _load_records(top_n)
+    report = _render_report(records, data_quality, top_n)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report, encoding="utf-8")
+    print(str(output_path))
+    return 0

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py
@@ -105,6 +105,7 @@ from factory_mutating import (  # noqa: E402
     enumerate_subparser_handlers,
     mutates_state,
 )
+from factory_cmd_analyze_reviews import command_analyze_reviews  # noqa: E402
 from factory_stages import stage_manifest_state  # noqa: E402  (re-imported for invariant check)
 from workflow_utils import resolve_stored_path  # noqa: E402
 
@@ -503,6 +504,14 @@ def build_parser() -> argparse.ArgumentParser:
     isolation_group.add_argument("--check", action="store_true")
     check_isolation_parser.add_argument("--baseline", type=Path)
     check_isolation_parser.set_defaults(func=command_check_workflow_isolation)
+
+    analyze_reviews_parser = subparsers.add_parser(
+        "analyze-reviews",
+        help="Aggregate FF review and judge telemetry into a markdown report",
+    )
+    analyze_reviews_parser.add_argument("--out")
+    analyze_reviews_parser.add_argument("--top-n", type=int, default=20)
+    analyze_reviews_parser.set_defaults(func=command_analyze_reviews)
 
     return parser
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_analyze_reviews.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_analyze_reviews.py
@@ -1,0 +1,231 @@
+import argparse
+import contextlib
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import sys
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_DIR / f"{name}.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+FACTORY_STATE = _load("factory_state")
+ANALYZER = _load("factory_cmd_analyze_reviews")
+
+
+class AnalyzeReviewsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.repo_root = Path(self._tmpdir.name)
+        self.runs_root = self.repo_root / "docs" / "workflow" / "feature-runs"
+        self.analysis_root = self.repo_root / "docs" / "workflow" / "analysis"
+        self.runs_root.mkdir(parents=True, exist_ok=True)
+
+        self._repo_patch = mock.patch.object(FACTORY_STATE, "REPO_ROOT", self.repo_root)
+        self._runs_patch = mock.patch.object(FACTORY_STATE, "FACTORY_RUNS_ROOT", self.runs_root)
+        self._analyzer_repo_patch = mock.patch.object(ANALYZER.factory_state, "REPO_ROOT", self.repo_root)
+        self._analyzer_runs_patch = mock.patch.object(ANALYZER.factory_state, "FACTORY_RUNS_ROOT", self.runs_root)
+        self._repo_patch.start()
+        self._runs_patch.start()
+        self._analyzer_repo_patch.start()
+        self._analyzer_runs_patch.start()
+        self.addCleanup(self._repo_patch.stop)
+        self.addCleanup(self._runs_patch.stop)
+        self.addCleanup(self._analyzer_repo_patch.stop)
+        self.addCleanup(self._analyzer_runs_patch.stop)
+
+    def _write_state(
+        self,
+        slug: str,
+        token_usage: object,
+        *,
+        stages: dict | None = None,
+        raw_text: str | None = None,
+    ) -> None:
+        slug_dir = self.runs_root / slug
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        path = slug_dir / "state.json"
+        if raw_text is not None:
+            path.write_text(raw_text, encoding="utf-8")
+            return
+        payload = {"token_usage": token_usage}
+        if stages is not None:
+            payload["stages"] = stages
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def _write_review(
+        self,
+        slug: str,
+        name: str,
+        *,
+        reviewer: str,
+        lens: str,
+        stage: str,
+        status: str,
+    ) -> None:
+        reviews_dir = self.runs_root / slug / "reviews"
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        (reviews_dir / name).write_text(
+            "---\n"
+            f'reviewer: "{reviewer}"\n'
+            f'lens: "{lens}"\n'
+            f'stage: "{stage}"\n'
+            f'resolution_status: "{status}"\n'
+            "---\n"
+            "# Review\n",
+            encoding="utf-8",
+        )
+
+    def _record(
+        self,
+        *,
+        stage: str,
+        round_number: int,
+        activity_type: str,
+        model: str,
+        duration_seconds: float,
+        input_tokens: int = 100,
+        output_tokens: int = 10,
+        parse_error: str | None = None,
+        timestamp: str = "2026-04-25T12:00:00Z",
+        cost_usd_estimate: float = 0.5,
+    ) -> dict:
+        record = {
+            "stage": stage,
+            "round": round_number,
+            "activity_type": activity_type,
+            "model": model,
+            "duration_seconds": duration_seconds,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "timestamp": timestamp,
+            "cost_usd_estimate": cost_usd_estimate,
+        }
+        if parse_error is not None:
+            record["parse_error"] = parse_error
+        return record
+
+    def _run(self, *, out: Path | None = None, top_n: int = 20) -> tuple[int, str, str, str]:
+        output = out or (self.analysis_root / "report.md")
+        args = argparse.Namespace(out=str(output), top_n=top_n)
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            rc = ANALYZER.command_analyze_reviews(args)
+        report = output.read_text(encoding="utf-8")
+        return rc, stdout.getvalue(), stderr.getvalue(), report
+
+    def test_happy_path_summarizes_model_activity_counts_and_percentiles(self) -> None:
+        self._write_state(
+            "alpha",
+            [
+                self._record(stage="spec", round_number=1, activity_type="adversarial_review", model="gpt-5.4-mini", duration_seconds=10.0),
+                self._record(stage="spec", round_number=1, activity_type="adversarial_review", model="gpt-5.4-mini", duration_seconds=20.0),
+                self._record(stage="plan", round_number=1, activity_type="judge_panel", model="gpt-5.4", duration_seconds=30.0),
+                self._record(stage="plan", round_number=1, activity_type="judge_panel", model="gpt-5.4", duration_seconds=40.0),
+                self._record(stage="diff", round_number=2, activity_type="adversarial_review", model="gemini-2.5-pro", duration_seconds=50.0),
+            ],
+            stages={"spec": {"adversarial_rounds": 1, "judge_rounds": 0}, "plan": {"adversarial_rounds": 1, "judge_rounds": 1}},
+        )
+        self._write_state(
+            "beta",
+            [
+                self._record(stage="spec", round_number=2, activity_type="adversarial_review", model="gpt-5.4-mini", duration_seconds=30.0),
+                self._record(stage="tasks", round_number=1, activity_type="judge_panel", model="gpt-5.4", duration_seconds=50.0),
+                self._record(stage="tasks", round_number=1, activity_type="judge_panel", model="gpt-5.4", duration_seconds=60.0),
+                self._record(stage="diff", round_number=2, activity_type="adversarial_review", model="gemini-2.5-pro", duration_seconds=70.0),
+                self._record(stage="diff", round_number=2, activity_type="implementation", model="gpt-5.4-mini", duration_seconds=999.0),
+            ],
+            stages={"tasks": {"adversarial_rounds": 1, "judge_rounds": 3}},
+        )
+
+        rc, _, stderr, report = self._run()
+        self.assertEqual(rc, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("| gpt-5.4-mini | adversarial_review | 3 | 60.0 | 20.0 | 29.0 | 29.8 | 30.0 | 0 | 0.0% |", report)
+        self.assertIn("| gpt-5.4 | judge_panel | 4 | 180.0 | 45.0 | 58.5 | 59.7 | 60.0 | 0 | 0.0% |", report)
+        self.assertIn("- Total reviewer + judge calls measured: 9", report)
+        self.assertIn("| beta | 100.0 | 110.0 | 0.0 | 3 | 1 |", report)
+
+    def test_missing_fields_are_dropped_and_reported(self) -> None:
+        self._write_state(
+            "gamma",
+            [
+                self._record(stage="spec", round_number=1, activity_type="adversarial_review", model="gpt-5.4-mini", duration_seconds=10.0),
+                {"stage": "spec", "round": 1, "activity_type": "adversarial_review", "duration_seconds": 20.0},
+                {"stage": "spec", "round": 1, "activity_type": "adversarial_review", "model": "gpt-5.4-mini"},
+            ],
+        )
+
+        _, _, _, report = self._run()
+        self.assertIn("- Dropped records: 2", report)
+        self.assertIn("duration_seconds=1, model=1", report)
+        self.assertIn("- Total reviewer + judge calls measured: 1", report)
+
+    def test_empty_state_does_not_crash(self) -> None:
+        self._write_state("empty", [])
+        rc, _, stderr, report = self._run()
+        self.assertEqual(rc, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("- Total reviewer + judge calls measured: 0", report)
+
+    def test_malformed_state_json_is_skipped_and_warns(self) -> None:
+        self._write_state("broken", [], raw_text="{not-json")
+        rc, _, stderr, report = self._run()
+        self.assertEqual(rc, 0)
+        self.assertIn("warning: skipping malformed state.json for broken", stderr)
+        self.assertIn("- Slugs with malformed state.json: broken", report)
+
+    def test_parse_error_grouping_truncates_to_shared_pattern(self) -> None:
+        shared = "schema violation at path very/long/path/that/keeps/going and going and still has unique suffix "
+        self._write_state(
+            "delta",
+            [
+                self._record(
+                    stage="spec",
+                    round_number=1,
+                    activity_type="judge_panel",
+                    model="gpt-5.4",
+                    duration_seconds=11.0,
+                    parse_error=shared + "AAA",
+                ),
+                self._record(
+                    stage="spec",
+                    round_number=1,
+                    activity_type="judge_panel",
+                    model="gpt-5.4",
+                    duration_seconds=12.0,
+                    parse_error=shared + "BBB",
+                ),
+                self._record(
+                    stage="spec",
+                    round_number=1,
+                    activity_type="judge_panel",
+                    model="gpt-5.4-mini",
+                    duration_seconds=13.0,
+                    parse_error=shared + "CCC",
+                ),
+            ],
+        )
+
+        _, _, _, report = self._run()
+        self.assertIn("| schema violation at path very/long/path/that/keeps/going and going and still... | 3 | gpt-5.4, gpt-5.4-mini | delta |", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_mutating_registry.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_mutating_registry.py
@@ -51,6 +51,7 @@ EXPECTED_SUBCOMMANDS = {
     "closeout",
     "review-extract",
     "check-isolation",
+    "analyze-reviews",
 }
 
 EXPECTED_MUTATING = {
@@ -70,7 +71,7 @@ EXPECTED_MUTATING = {
     "parallel",
 }
 
-EXPECTED_READONLY = {"status", "doctor", "review-extract", "check-isolation"}
+EXPECTED_READONLY = {"status", "doctor", "review-extract", "check-isolation", "analyze-reviews"}
 
 
 def _assert_registry_is_classified(parser: argparse.ArgumentParser) -> None:
@@ -114,6 +115,7 @@ class MutatingRegistryTests(unittest.TestCase):
         self.assertEqual(getattr(RUN_FACTORY.command_doctor, "__ff_readonly_command__"), "doctor")
         self.assertEqual(getattr(RUN_FACTORY.command_review_extract, "__ff_readonly_command__"), "review-extract")
         self.assertEqual(getattr(RUN_FACTORY.command_check_workflow_isolation, "__ff_readonly_command__"), "check-isolation")
+        self.assertEqual(getattr(RUN_FACTORY.command_analyze_reviews, "__ff_readonly_command__"), "analyze-reviews")
 
     def test_fake_undecorated_handler_fails_with_subcommand_name(self) -> None:
         parser = argparse.ArgumentParser()

--- a/docs/workflow/orchestrator-prompts/ff-reconciliation-hardening.md
+++ b/docs/workflow/orchestrator-prompts/ff-reconciliation-hardening.md
@@ -1,0 +1,279 @@
+# Codex Orchestrator Prompt — FF Reconciliation Hardening
+
+You are running the **Feature Factory workflow** as the orchestrator. You author spec.md, plan.md, tasks.md, run checkpoints, reconcile reviewer findings, dispatch the implementation (do it inline — you ARE Codex), and deliver the PR.
+
+## Repo
+
+- Working directory: the current `cwd` should already be the repo root or a worktree of `chrislawcodes/valuerank`.
+- Branch you'll create: `claude/ff-reconciliation-hardening`.
+- Slug: `ff-reconciliation-hardening`.
+
+## Read these first
+
+Required context (read in this order, take 2-3 minutes):
+- `docs/workflow/operations/codex-skills/feature-factory/SKILL.md` — workflow overview.
+- `docs/workflow/operations/codex-skills/feature-factory/CODEX-ORCHESTRATOR.md` — Codex-specific orchestrator guide.
+- `docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py --help` — runner CLI surface.
+- `AGENTS.md` and `cloud/CLAUDE.md` — project conventions.
+- One prior shipped FF run for reference, e.g. `docs/workflow/feature-runs/ff-token-reliability/spec.md` and `plan.md` and `tasks.md` (PR #765, just shipped).
+
+## What this PR fixes
+
+Four issues from a real FF session that locked the operator out of plan-stage iteration. Source: PR #765's adversarial-review feedback batch.
+
+### Fix 1 — Auto-reconciler false-positives on CRITICAL severity (HIGH priority)
+
+**File**: `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review_specs.py`
+
+**Today**: the auto-reconcile path:
+- (a) pre-populates `resolution_status: "accepted"` and `resolution_note: "No actionable findings detected — auto-accepted"` in the review's YAML frontmatter BEFORE parsing the body for severity tags, AND
+- (b) the severity regex set covers HIGH/MEDIUM/LOW only — **CRITICAL is missing entirely**.
+
+**Real session result**: 3 reviews with HIGH and CRITICAL findings in the body got auto-accepted with the boilerplate note. Operators who trust auto-accept skip real findings.
+
+**Fix**:
+1. Add CRITICAL to every severity regex in the set. Each pattern needs the alternation extended:
+   - `^\s*-\s*\*\*(HIGH|MEDIUM|LOW|CRITICAL)\*\*[\s:\[]`
+   - `^\s*-\s*(HIGH|MEDIUM|LOW|CRITICAL)\s*:`
+   - `^\s*\d+\.\s*\*\*(HIGH|MEDIUM|LOW|CRITICAL)\*\*`
+   - `^#+\s*(HIGH|MEDIUM|LOW|CRITICAL)(\s*:|\s*$)` (require `:` or EOL — NOT `\b` — so "Low-level" doesn't match)
+   - `^\s*\*\*(HIGH|MEDIUM|LOW|CRITICAL)[\s:\[]`
+   - `^\s*Severity:\s*(HIGH|MEDIUM|LOW|CRITICAL)`
+   - `^\s*\|\s*\*\*(HIGH|MEDIUM|LOW|CRITICAL)\*\*\s*\|`
+2. Reverse the auto-reconcile default: set `resolution_status: "open"` in the boilerplate. Only flip to `"accepted"` AFTER body parse confirms zero matches of any severity. Update boilerplate note to reflect what was checked: `"No HIGH/MEDIUM/LOW/CRITICAL findings detected — auto-accepted"`.
+3. Add tests covering: a review with `**CRITICAL**:` bullet → not auto-accepted; a review with `## CRITICAL: foo` heading → not auto-accepted; pure-prose review with no severity tags → auto-accepted with the new boilerplate note.
+
+### Fix 2 — Canonical comparison for reconciliation notes (HIGH priority)
+
+**File**: `docs/workflow/operations/codex-skills/review-lens/scripts/verify_reconciliation.py`
+
+**Today**: validation compares plan.md note text against YAML frontmatter `resolution_note` text byte-for-byte. YAML escaping (`\"flapping\"` vs `"flapping"` after parse) and inner double quotes trip the comparator even when content is semantically identical. Operator gets a "note mismatch" loop.
+
+**Fix**:
+1. Parse the YAML frontmatter using `yaml.safe_load`. Get the parsed `resolution_note` string (this gives semantic content, with escapes resolved).
+2. Compare to the plan.md note text canonically:
+   - both strings stripped of leading/trailing whitespace
+   - both with internal whitespace runs collapsed to single space (`re.sub(r"\s+", " ", text).strip()`)
+   - case-sensitive content match
+3. If `pyyaml` isn't importable, fall back to current behavior with a printed warning to stderr ("yaml not available; falling back to byte comparison; YAML escaping mismatches may surface as note mismatches").
+4. Tests must cover: escaped vs raw quotes pair → match; trailing whitespace difference → match; case difference → mismatch (intentional).
+
+### Fix 3 — Repair preserves checkpoint flags + content-aware staleness (MEDIUM-HIGH priority)
+
+**Files**:
+- `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_state.py` (schema + helper)
+- `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_checkpoint.py` (persist on success)
+- the repair command handler (search via `grep -rn "command_repair" docs/workflow/operations/codex-skills/feature-factory/scripts/`)
+
+**Today**: when an operator edits plan.md to address a review finding, all reviews go stale; repair regenerates them from scratch and FORGETS the operator's previous successful flags (e.g. `--no-auto-context`, `--max-artifact-chars 200000`). The regen then hits char limits, fails, and the operator is stuck in a loop.
+
+**Fix part A** — persist flags:
+1. Add a new field `state.last_successful_checkpoint_flags: dict` (top-level), shape:
+   ```
+   {
+     "spec":  {"max_artifact_chars": 50000, "max_total_chars": 200000, "no_auto_context": false, ...},
+     "plan":  {...},
+     "tasks": {...},
+     "diff":  {...},
+     "closeout": {...}
+   }
+   ```
+2. On every successful checkpoint, persist the flag set actually used to that stage's slot. Capture flags at the top of `command_checkpoint` after argparse, and write them to state on the success path.
+3. Don't break the existing `command_telemetry` and `token_usage` schemas — this is a NEW top-level field. Add `setdefault("last_successful_checkpoint_flags", {})` to the load path.
+
+**Fix part B** — repair re-uses flags:
+1. When `command_repair` triggers a regen of a stage's reviews, read `state.last_successful_checkpoint_flags[stage]` and apply those flags to the regen invocation transparently.
+2. Operator sees a log line: `[repair] re-using flags from last successful checkpoint: --no-auto-context --max-artifact-chars 200000`.
+3. Operator can override by passing flags explicitly to the repair command — explicit flags WIN over persisted flags.
+
+**Fix part C** — content-aware staleness:
+1. Today, ANY edit to plan.md bumps the artifact's sha256, marking all reviews stale. Including reconciliation-section appends.
+2. Add a helper `factory_state.compute_narrowed_artifact_sha(path: Path) -> str` that strips the `## Review Reconciliation` section from plan.md before hashing. (For spec.md, tasks.md, etc., narrowed sha == full sha — no special section to strip.)
+3. Reviews compare against the narrowed sha. Operator's plan.md edits that ONLY touch the reconciliation section don't mark reviews stale. Edits that touch any other section DO mark reviews stale.
+4. Add tests: edit just `## Review Reconciliation` content → reviews stay healthy; edit any other plan section → reviews go stale; compute_narrowed_artifact_sha produces consistent output regardless of trailing whitespace in the reconciliation block.
+
+### Fix 4 — Default `--no-auto-context` at plan + diff stages (XS effort, high impact)
+
+**File**: `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_checkpoint.py`
+
+**Today**: auto-context is on by default at every stage. At plan/diff stages, the artifact IS the source of truth; auto-context just adds noise that pushes char counts over the limit.
+
+**Fix**:
+1. At plan and diff stages, default `--no-auto-context` to True (was False).
+2. Add `--auto-context` flag (boolean, default False at plan/diff, True at spec/tasks) so operators can force-enable auto-context if they actually want it.
+3. Spec and tasks stages keep auto-context on by default.
+4. Update help text.
+5. Update `docs/workflow/operations/codex-skills/feature-factory/SKILL.md` to mention the new default.
+
+## Workflow you will execute
+
+Drive the FF runner end-to-end. Sequence:
+
+### 1. Branch + init
+
+```bash
+git fetch origin main
+git checkout -b claude/ff-reconciliation-hardening origin/main
+python3 docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py init \
+  --slug ff-reconciliation-hardening \
+  --path docs/workflow/feature-runs/ff-reconciliation-hardening
+```
+
+### 2. Discover
+
+```bash
+python3 docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py discover \
+  --slug ff-reconciliation-hardening \
+  --summary "<2-3 sentence summary>" \
+  --non-goal "..." (5-6 of these) \
+  --acceptance-criteria "..." (8-10 of these, each user-facing) \
+  --complete
+```
+
+### 3. Author spec.md
+
+Write a comprehensive spec covering the 4 fixes. Use FR numbering (FR-001, FR-002, ...). Document residual risks. Reference PRs #744 (severity regex), #751 (3-way reconcile), #765 (token reliability) as prior art. Target ~250-400 lines. Include user stories with Given/When/Then acceptance scenarios.
+
+### 4. Spec checkpoint loop
+
+```bash
+python3 .../run_factory.py checkpoint --slug ff-reconciliation-hardening --stage spec --repair-timeout-seconds 900 --no-auto-context
+```
+
+(Note: `--no-auto-context` is part of what we're fixing. For this PR, pass it explicitly until Fix 4 lands.)
+
+Then:
+```bash
+python3 .../run_factory.py auto-reconcile --slug ff-reconciliation-hardening --stage spec
+```
+
+For each "needs-review" output, READ the review's `## Findings` section. For each finding, decide:
+- **FIXED** — update spec.md to address, then `reconcile --status accepted --note "<short note explaining the fix>"`.
+- **ACCEPTED AS RESIDUAL** — document the trade-off in spec.md Risks section (R1, R2, ...), then `reconcile --status accepted --note "documented as residual R<N>"`.
+- **DEFERRED** — out of scope, defer to follow-up. `reconcile --status deferred --note "<reason>"`.
+- **REJECTED** — reviewer is wrong. `reconcile --status accepted --note "<rebuttal>"`. Be honest about WHY.
+
+Re-checkpoint. Iterate until either:
+- (a) all reviewers pass on a clean round (auto-reconcile shows zero needs-review), OR
+- (b) you hit the 3-round adversarial cap.
+
+On cap, run `judge --slug ff-reconciliation-hardening --stage spec`. If judge says advance, proceed. If judge says block with unresolved concerns, address them before retrying.
+
+### 5. Author plan.md → plan checkpoint loop (same process)
+
+### 6. Author tasks.md → record parallel analysis → tasks checkpoint loop
+
+```bash
+python3 .../run_factory.py parallel --slug ff-reconciliation-hardening --note "<reasoning about parallel opportunities>"
+python3 .../run_factory.py checkpoint --slug ff-reconciliation-hardening --stage tasks --repair-timeout-seconds 900 --no-auto-context
+```
+
+### 7. Implement
+
+You ARE the implementer. Do the edits inline. Each fix maps to ~50-200 lines of code + tests:
+
+- **Fix 1**: `factory_review_specs.py` + `tests/test_factory_review_specs.py`
+- **Fix 2**: `verify_reconciliation.py` (review-lens) + new tests for canonical comparison
+- **Fix 3**: `factory_state.py` + `factory_cmd_checkpoint.py` + `factory_cmd_repair.py` (or wherever repair lives) + tests
+- **Fix 4**: `factory_cmd_checkpoint.py` defaults + tests + SKILL.md update
+
+After each logical chunk, run preflight:
+```bash
+python3 -m unittest discover docs/workflow/operations/codex-skills/feature-factory/scripts/tests
+```
+Check exit code DIRECTLY — do NOT pipe to tail/grep. Pipe loses the runner's exit status. To see a summary AFTER the gate passes, run a second time piping to `tail -3` for human display.
+
+### 8. Commit
+
+Stage modified files explicitly (NOT `git add -A` — the worktree has unrelated dirty paths from concurrent FF runs):
+```bash
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review_specs.py
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/factory_state.py
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_checkpoint.py
+# ... etc, list each file you actually modified
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/tests/
+git add docs/workflow/operations/codex-skills/review-lens/scripts/verify_reconciliation.py
+git add docs/workflow/feature-runs/ff-reconciliation-hardening/
+git commit -m "ff-reconciliation-hardening: <one-line summary>
+
+<multi-line body covering each fix>
+
+Co-Authored-By: Codex (gpt-5.4) <noreply@openai.com>"
+```
+
+### 9. Run diff checkpoint + reconcile (same process)
+
+### 10. Deliver
+
+```bash
+git push -u origin claude/ff-reconciliation-hardening
+gh pr create --repo chrislawcodes/valuerank \
+  --base main \
+  --head claude/ff-reconciliation-hardening \
+  --draft \
+  --title "FF Reconciliation Hardening: CRITICAL severity, canonical note compare, flag persistence, plan no-auto-context default" \
+  --body "$(cat <<'EOF'
+## Summary
+<...>
+
+## What changed
+<table of fixes>
+
+## Tests
+<count: was 327; should be ~340>
+
+## Adversarial review fixes
+<the HIGHs that were caught and addressed>
+
+## Test plan
+- [x] All FF tests pass locally
+- [ ] CI green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 11. Ship
+
+```bash
+gh pr checks <pr-number> --repo chrislawcodes/valuerank --watch
+gh pr ready <pr-number> --repo chrislawcodes/valuerank
+gh pr merge <pr-number> --repo chrislawcodes/valuerank --squash --delete-branch
+git fetch origin main && git log origin/main --oneline -2
+```
+
+## Escape hatches you may need
+
+- **Codex review timeout**: if a Codex reviewer subprocess times out during checkpoint, reconcile that one review as `--status deferred --note "Codex timed out; round-N findings already addressed."` and proceed.
+- **Char overflow** at any stage: pass `--no-auto-context` AND `--max-artifact-chars 200000 --max-total-chars 400000`. (Once Fix 4 lands, plan/diff won't need `--no-auto-context` — but until commit, keep passing it.)
+- **Diff artifact > 150KB hard cap**: pass `--allow-large-diff-rerun` AND raise `--max-artifact-chars` to ~300000.
+- **Dirty path outside scope**: pass `--allow-dirty-path docs/workflow/feature-runs/ff-reconciliation-hardening/`.
+- **PR refuses to merge ("not up to date")**: rebase on origin/main, force-push (`--force-with-lease`), wait for CI, retry merge.
+- **`docs/workflow/operations/review-attempts.jsonl` is dirty after each checkpoint**: it's an audit log; `git checkout --` it before any path-sensitive command. Do NOT commit it.
+- **Workflow state files for OTHER feature runs get dirtied during test runs**: `git checkout --` them; this is the test-isolation issue PR #765's gate caught; fixing those tests is out of scope here.
+- **Codex sandbox can't commit (`.git/worktrees/<name>/index.lock` not writable)**: NOT applicable when YOU are running as orchestrator (you have full git access). Just commit normally.
+- **Out of Codex quota mid-run**: stop, write a postmortem at `docs/workflow/feature-runs/ff-reconciliation-hardening/postmortem.md` explaining where you stopped, commit progress, push, leave the PR draft. Do NOT mark ready.
+
+## DO NOT TOUCH
+
+- `CLAUDE.md`, `AGENTS.md`, `MEMORY.md`, `.gitignore`, `cloud/CLAUDE.md`
+- Any file outside `docs/workflow/` and `docs/workflow/operations/codex-skills/feature-factory/scripts/` and `docs/workflow/operations/codex-skills/review-lens/scripts/`
+- The `repair`, `block`, `discover`, `parallel`, `init` CLI subcommand HANDLER NAMES (you can change behavior, not names)
+- Other feature runs' state.json or scope.json files
+- `factory_telemetry.py` (existing reviewer-LLM telemetry — separate concern; PR #765 added `factory_telemetry_commands.py` for orchestrator telemetry)
+
+## Output
+
+When the PR is merged, print:
+- The PR URL
+- The merge commit SHA on main
+- The final test count
+- Any issues you encountered and how you resolved them
+- Any items deferred to follow-up
+
+## When you're stuck
+
+If you've made 3+ attempts to resolve a single reviewer finding without progress: write a brief note to stderr explaining the impasse, mark that review as `--status deferred`, and continue. Don't loop.
+
+If a checkpoint blocks on something you can't unblock with a documented escape hatch: stop, write a postmortem, leave the PR draft, exit. The operator (the user who launched you) will pick up from there.

--- a/docs/workflow/orchestrator-prompts/ff-review-performance-analyzer.md
+++ b/docs/workflow/orchestrator-prompts/ff-review-performance-analyzer.md
@@ -1,0 +1,171 @@
+# Codex Prompt — FF Review-Performance Analyzer
+
+You are implementing a small read-only analysis tool. **Single-shot implementation** — no FF spec/plan/tasks adversarial cycle needed; this is mechanical data aggregation with no behavior change to the runner.
+
+## Goal
+
+Aggregate every reviewer/judge LLM call recorded across all FF feature runs and emit a markdown report that surfaces:
+- which lenses + models are slow,
+- which time out,
+- which fail to parse,
+- and how much wall clock we burn on rounds that ultimately get deferred.
+
+This unblocks an empirical decision about whether to drop a lens, switch a model, tighten timeouts, truncate prompts more aggressively, or fix a different bug entirely. We've been guessing — this PR makes us measure.
+
+## Repo
+
+- Branch off `origin/main` to: `claude/ff-review-performance-analyzer`
+- Working dir: the repo root or any worktree of `chrislawcodes/valuerank`
+- Per `cloud/CLAUDE.md`: do NOT push or open the PR until the human asks — leave the branch local with the commit ready.
+
+## Files to create
+
+1. **`docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py`** — the analyzer
+2. **`docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_analyze_reviews.py`** — unit tests on a fixture
+3. **`docs/workflow/orchestrator-prompts/ff-review-performance-analyzer.md`** — this file (already written; commit as part of the PR)
+
+## Files to modify
+
+1. **`docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py`** — register the new `analyze-reviews` subcommand
+
+## Data source
+
+Each FF feature run has a `state.json` at `docs/workflow/feature-runs/<slug>/state.json`. Inside, `state.token_usage` is a list of records with this shape (verified by reading `factory_telemetry.py:191-250`):
+
+```json
+{
+  "stage": "spec",
+  "round": 1,
+  "activity_type": "review" | "judge_panel" | ...,
+  "model": "gpt-5.4-mini" | "gemini-2.5-pro" | ...,
+  "input_tokens": 12345,
+  "output_tokens": 678,
+  "cost_usd_estimate": 0.0123,
+  "timestamp": "2026-04-25T16:42:18.506364Z",
+  "started_at": "2026-04-25T16:41:50Z",
+  "ended_at": "2026-04-25T16:42:18.506364Z",
+  "duration_seconds": 28.5,
+  "agent_id": "...",
+  "artifact_sha_at_time": "abc123",
+  "parse_error": "<reason>" | null,
+  "activity_subtype": "micro" | null
+}
+```
+
+Some records will be missing fields (older state.json files). Read defensively with `.get(...)`.
+
+There may also be lens information embedded in the parent context — but if not directly in the record, you can infer the lens from the `stage` + `model` + `activity_type` triple, or extract it from accompanying review file names if needed. **Best-effort: report what we can; flag what we can't.** Don't error out on missing fields; emit a "data quality" section at the end of the report listing how many records were dropped or had partial data.
+
+## What the analyzer does
+
+### Argparse surface
+
+```
+python3 run_factory.py analyze-reviews [--out <path>] [--top-n <int>]
+```
+
+- `--out`: output markdown path. Default: `docs/workflow/analysis/review-performance-<UTC-date>.md` (create the `analysis/` dir if missing).
+- `--top-n`: how many rows in "top slowest" sections. Default: 20.
+
+### Walk
+
+1. Glob `docs/workflow/feature-runs/*/state.json`. Skip non-existent or unreadable files (warn to stderr, don't fail).
+2. For each, load the JSON, extract `state.token_usage` (list). If absent or non-list, skip with a warning.
+3. Annotate each record with the source slug (parent dir name).
+4. Concatenate into one big list.
+
+### Aggregations
+
+Compute and emit, in order:
+
+#### Section 1 — Headline numbers
+- Total reviewer + judge calls measured
+- Total wall-clock seconds across all calls
+- Total estimated USD cost (sum `cost_usd_estimate`, treat null as 0)
+- Date range covered (min/max `timestamp`)
+- Number of distinct slugs
+
+#### Section 2 — Per (model × activity_type) summary table
+Columns: model, activity_type, count, total_duration_s, p50_s, p95_s, p99_s, max_s, parse_error_count, parse_error_rate.
+Sort by total_duration_s descending.
+
+This is the load-bearing table — it tells us which model+activity combo eats the most wall clock.
+
+#### Section 3 — Per (model × stage) summary
+Same columns as section 2, grouped by model + stage instead. Tells us if certain stages have outlier costs.
+
+#### Section 4 — Top N slowest individual calls
+Columns: slug, stage, round, activity_type, model, duration_s, input_tokens, output_tokens, parse_error, timestamp.
+Sort by duration_s descending. Take top N (default 20).
+
+#### Section 5 — Parse error patterns
+Group by `parse_error` text (after light normalization — e.g., truncate at 80 chars). Columns: error pattern, count, models affected, example slug.
+Sort by count descending.
+
+This is where we'll find the recursion bug, the schema_violation patterns, and quota-hit patterns.
+
+#### Section 6 — Duration vs input_tokens correlation
+For each model, bin `input_tokens` into 5 quantiles. For each bin, report count, p50_duration_s, p95_duration_s.
+This tells us whether prompt size predicts duration (and where the inflection is).
+
+#### Section 7 — Wall clock by slug (top 20)
+Columns: slug, total review duration, total judge duration, total deferred-round duration, # rounds, # stages reaching judge cap.
+Sort by total review + judge duration descending.
+"deferred-round duration" = sum of duration_seconds for calls in rounds whose review file has `resolution_status: "deferred"`. (To get this you need to also walk `reviews/*.review.md` files and parse the YAML frontmatter — best effort; if too complex, drop this column and note it in data quality.)
+This tells us which slugs were the worst offenders.
+
+#### Section 8 — Data quality
+- Records dropped because of missing fields (with breakdown per field)
+- Slugs whose state.json couldn't be parsed
+- Records with timestamps outside reasonable range
+
+### Markdown formatting
+
+Use real markdown tables. Round durations to 1 decimal place; tokens as integers. Cost as `$X.XX`.
+
+The output should be **scan-readable**: someone reading top-to-bottom in 60 seconds should be able to identify the worst offenders without having to interpret raw JSON.
+
+## Tests
+
+`tests/test_analyze_reviews.py`. Use `tempfile.TemporaryDirectory` to create a fake `feature-runs/` tree with a few state.json fixtures. Cases:
+
+1. **Happy path**: 2 slugs, each with 5 token_usage records. Verify the section 2 table has the right counts and percentiles.
+2. **Missing fields**: a state.json with token_usage records missing `duration_seconds` or `model`. Verify they're dropped + appear in section 8.
+3. **Empty state**: a slug with no token_usage at all. Verify the analyzer doesn't crash.
+4. **Malformed state.json**: a slug with invalid JSON. Verify it's skipped + a warning prints to stderr.
+5. **Parse error grouping**: 3 records with parse_error containing similar text. Verify they group together in section 5.
+
+The tests should patch `factory_state.FACTORY_RUNS_ROOT` to the temp dir so the analyzer reads from the fixture, not from the real repo. PR #758 + #765 lessons: also patch `factory_state.REPO_ROOT` if the analyzer uses it for output path resolution.
+
+## Things to NOT do
+
+- **No model calls.** This is pure data aggregation.
+- **No mutation of state.json files.** Read-only.
+- **No `git add` / `git push`.** Per `cloud/CLAUDE.md`, leave the work local; the human will push.
+- **No new dependencies.** Use stdlib only (`statistics` for percentiles, `json`, `pathlib`, `argparse`, `datetime`, `sys`, `os`, `collections`).
+
+## Workflow
+
+1. Create the branch: `git checkout -b claude/ff-review-performance-analyzer origin/main`
+2. Implement the 3 files above.
+3. Run preflight (NO PIPE): `python3 -m unittest discover docs/workflow/operations/codex-skills/feature-factory/scripts/tests` — check exit code directly. All existing tests must still pass.
+4. **Manually run the analyzer once against the real repo** (`python3 docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py analyze-reviews`). Verify the output markdown looks reasonable. Include the resulting report in the commit at `docs/workflow/analysis/review-performance-<UTC-date>.md` so the operator can read it immediately.
+5. Stage explicit files (NOT `git add -A` — there are unrelated dirty paths from concurrent FF runs):
+   ```
+   git add docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py
+   git add docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_analyze_reviews.py
+   git add docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py
+   git add docs/workflow/orchestrator-prompts/ff-review-performance-analyzer.md
+   git add docs/workflow/analysis/
+   ```
+6. Commit with a clear message body covering: motivation (we've been guessing), what's measured, where the report lives, top-3 takeaways from the report itself.
+7. Do NOT push. Report back with the commit SHA, the report path, and a short summary of what you observed in the data.
+
+## Output to the human
+
+When done, print:
+- The commit SHA
+- The report path
+- A 5-bullet summary of the most striking findings from the report
+- Any FF runs that had data-quality issues
+- The exact `git push` + `gh pr create` commands the human can run to ship


### PR DESCRIPTION
## Summary
Read-only `analyze-reviews` subcommand that walks every `docs/workflow/feature-runs/*/state.json` and aggregates `state.token_usage` records into a markdown report. Surfaces which lenses + models are slow, where time is wasted on timeouts, and which slugs are outliers.

Motivation: we've been raising timeouts and char caps reactively without measuring. This PR replaces the guessing with data.

## What's measured
8 sections in the generated report:
1. Headline numbers (total calls, wall clock, cost, slugs, date range)
2. Per (model × activity_type) summary with p50/p95/p99 durations
3. Per (model × stage) summary
4. Best-effort per-lens summary
5. Top N slowest individual calls
6. Parse-error pattern grouping
7. Duration vs input_tokens correlation (binned)
8. Wall-clock-by-slug ranking
9. Data quality (dropped records, malformed state.json, etc)

## First-run findings
Committed report at `docs/workflow/analysis/review-performance-2026-04-29.md` covers 1446 calls across 26 slugs over 10 days (17.9 hours total wall clock).

Top 5 takeaways:
- **`gpt-5.4-mini` adversarial review is the #1 cost** — 9.9 hours wall clock; p95 + p99 + max all hit 180s, meaning every slow call gets killed at the timeout.
- **One slug accounts for ~17% of total wall clock** — `sensitivity-table-redesign-v2` ate 3 hours of Gemini time alone (18 of top-20 slowest calls).
- **Judge `claude-sonnet-4-6` hits its 180s timeout regularly** — p95 = 158s. Switching to `gpt-5.4` (p95 = 40s) would save ~2 hours.
- **99.4% of calls have parse errors** — but they're TELEMETRY parsing failures (token-count extraction), not review failures. Reviews completed; we just can't measure tokens.
- **Lens attribution missing on 1186 of 1446 records** — telemetry doesn't reliably carry lens id.

## Tests
- 5 new test cases on tempfile fixtures (happy path, missing fields, empty state, malformed JSON, parse-error grouping)
- 349 FF tests pass (was 344)

## Risk
None. Read-only subcommand, no behavior change to runner.

## Test plan
- [x] 349 FF tests pass locally
- [ ] CI green
- [ ] Manual review of report findings → drives next round of fixes (timeout tightening, judge model switch, telemetry repair)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Codex (gpt-5.4) <noreply@openai.com>
