### PR TITLE
Fix: allow manual re-probe to bypass terminal-state guard on completed runs

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/run-anomaly.ts
+++ b/cloud/apps/api/src/graphql/mutations/run-anomaly.ts
@@ -203,6 +203,7 @@ builder.mutationField('reprobeAnomalySlot', (t) =>
             modelId: slot.modelId,
             sampleIndex: slot.sampleIndex,
             config: { maxTurns: 10 },
+            manualReprobe: true,
           },
           { ...jobOptions, singletonKey },
         );

--- a/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
@@ -75,8 +75,10 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
   );
 
   try {
-    // Check if run is in a terminal state (completed/cancelled) - skip processing
-    if (await isRunTerminal(runId)) {
+    // Check if run is in a terminal state (completed/cancelled) - skip processing.
+    // manualReprobe bypasses this guard: the reprobeAnomalySlot mutation explicitly
+    // targets completed runs whose anomalies predate the adapter guards.
+    if (job.data.manualReprobe !== true && await isRunTerminal(runId)) {
       log.info({ jobId, runId }, 'Skipping job - run is in terminal state');
       return;
     }
@@ -107,7 +109,9 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
         { jobId, runId, scenarioId, modelId, sampleIndex, transcriptId: existingProbeResult.transcriptId },
         'Skipping probe job - result already succeeded'
       );
-      await enqueueTopUpProbesSingleton(runId);
+      if (job.data.manualReprobe !== true) {
+        await enqueueTopUpProbesSingleton(runId);
+      }
       await maybeAdvanceRunStatus(runId);
       return;
     }
@@ -123,7 +127,9 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
         { jobId, runId, scenarioId, modelId, sampleIndex, currentRetryCount },
         'Skipping probe job - already terminal failed'
       );
-      await enqueueTopUpProbesSingleton(runId);
+      if (job.data.manualReprobe !== true) {
+        await enqueueTopUpProbesSingleton(runId);
+      }
       await maybeAdvanceRunStatus(runId);
       return;
     }
@@ -319,7 +325,9 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
       where: { id: runId },
       select: { status: true },
     });
-    await enqueueTopUpProbesSingleton(runId);
+    if (job.data.manualReprobe !== true) {
+      await enqueueTopUpProbesSingleton(runId);
+    }
 
     // If the run is already summarizing, queue the just-created transcript.
     // When we just entered SUMMARIZING in this call, queueSummarizeJobs already handled it.

--- a/cloud/apps/api/src/queue/types.ts
+++ b/cloud/apps/api/src/queue/types.ts
@@ -31,6 +31,9 @@ export type ProbeScenarioJobData = {
     seed?: number;
     maxTurns: number;
   };
+  // Only set by the reprobeAnomalySlot mutation. Bypasses the isRunTerminal guard
+  // so manual re-probes can execute on completed runs.
+  manualReprobe?: boolean;
 };
 
 export type TopUpProbesJobData = {

--- a/cloud/apps/api/tests/queue/handlers/probe-scenario.integration.test.ts
+++ b/cloud/apps/api/tests/queue/handlers/probe-scenario.integration.test.ts
@@ -546,6 +546,59 @@ describe('probe-scenario integration', () => {
 
       expect(spawnPython).not.toHaveBeenCalled();
     });
+
+    it('bypasses terminal guard and creates transcript when manualReprobe=true on completed run', async () => {
+      await db.run.update({
+        where: { id: TEST_IDS.run },
+        data: { status: 'COMPLETED' },
+      });
+
+      const handler = createProbeScenarioHandler();
+      await handler([createMockJob({ manualReprobe: true })]);
+
+      // Python probe worker should have been called
+      expect(spawnPython).toHaveBeenCalled();
+
+      // Transcript should be created
+      const transcript = await db.transcript.findFirst({
+        where: { runId: TEST_IDS.run },
+      });
+      expect(transcript).not.toBeNull();
+
+      // Run should still be COMPLETED — manual re-probe must not change run status
+      const run = await db.run.findUnique({ where: { id: TEST_IDS.run } });
+      expect(run?.status).toBe('COMPLETED');
+    });
+
+    it('still skips job when run is completed and manualReprobe is not set', async () => {
+      await db.run.update({
+        where: { id: TEST_IDS.run },
+        data: { status: 'COMPLETED' },
+      });
+
+      const handler = createProbeScenarioHandler();
+      await handler([createMockJob()]);
+
+      expect(spawnPython).not.toHaveBeenCalled();
+
+      const transcript = await db.transcript.findFirst({
+        where: { runId: TEST_IDS.run },
+      });
+      expect(transcript).toBeNull();
+    });
+
+    it('still defers manualReprobe job when run is paused', async () => {
+      await db.run.update({
+        where: { id: TEST_IDS.run },
+        data: { status: 'PAUSED' },
+      });
+
+      const handler = createProbeScenarioHandler();
+
+      await expect(handler([createMockJob({ manualReprobe: true })])).rejects.toThrow('RUN_PAUSED');
+
+      expect(spawnPython).not.toHaveBeenCalled();
+    });
   });
 
   describe('multi-provider support', () => {


### PR DESCRIPTION
## Summary
- Re-probing an `INVALID_RESPONSE_FAILURE` anomaly on a `COMPLETED` run silently dropped the work. The `probe_scenario` handler's `isRunTerminal` early-return exited before spawning the Python worker, leaving the slot empty (original soft-deleted, no replacement).
- Threads a `manualReprobe` flag through the `ProbeScenarioJobData` payload. The `reprobeAnomalySlot` mutation sets it; the handler's `isRunTerminal` guard skips when the flag is set.
- Guards `enqueueTopUpProbesSingleton` at all three call sites so a manual re-probe on a completed run doesn't fan out new top-up probes.
- `isRunPaused` guard is left intact — paused runs still block manual re-probes.
- `maybeAdvanceRunStatus` verified safe for `COMPLETED` runs (CAS gates exclude it; no-op).
- `summarize_transcript` handler has no `isRunTerminal` guard; no changes needed there.

## Test plan
- [x] Lint passed (0 errors, 20 pre-existing warnings)
- [x] Unit tests pass (13/13)
- [ ] Integration tests require local DB — new tests added to `probe-scenario.integration.test.ts` covering: bypass on COMPLETED, normal skip on COMPLETED, still-defers on PAUSED
- [ ] Build has pre-existing `@types/compression` error unrelated to these changes

## Validation
```
npm run lint --workspace @valuerank/api  → 0 errors
npm run test --workspace @valuerank/api (unit only) → 13 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)