### PR TITLE
FF prompt-budget tuning: prompt-size instrumentation + analyzer artifact-size section + bumped default caps

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py
@@ -142,6 +142,10 @@ def _format_percent(numerator: int, denominator: int) -> str:
     return f"{(100.0 * numerator / denominator):.1f}%"
 
 
+def _format_pct_of_cap(value: float) -> str:
+    return f"{value:.0f}%"
+
+
 def _escape_cell(value: object) -> str:
     text = "" if value is None else str(value)
     return text.replace("|", "\\|").replace("\n", " ")
@@ -330,6 +334,8 @@ def _load_records(top_n: int) -> tuple[list[dict[str, object]], dict[str, object
 
             input_tokens = _coerce_int(raw_record.get("input_tokens"))
             output_tokens = _coerce_int(raw_record.get("output_tokens"))
+            prompt_chars = _coerce_int(raw_record.get("prompt_chars"))
+            prompt_cap = _coerce_int(raw_record.get("prompt_cap"))
             cost_usd = _coerce_float(raw_record.get("cost_usd_estimate")) or 0.0
             parse_error = _normalize_text(raw_record.get("parse_error"))
 
@@ -364,6 +370,8 @@ def _load_records(top_n: int) -> tuple[list[dict[str, object]], dict[str, object
                 "timestamp_text": timestamp_text,
                 "timestamp": timestamp,
                 "parse_error": parse_error,
+                "prompt_chars": prompt_chars,
+                "prompt_cap": prompt_cap,
                 "judge_cap_count": judge_cap_count,
                 "is_deferred_round": bool(round_number is not None and (stage, round_number, activity_name) in deferred_keys),
                 "lens": lens,
@@ -518,6 +526,106 @@ def _slug_rows(records: list[dict[str, object]]) -> list[list[object]]:
     return rows[:20]
 
 
+def _artifact_size_records() -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    stage_files = {
+        "spec": "spec.md",
+        "plan": "plan.md",
+        "tasks": "tasks.md",
+        "diff": "reviews/implementation.diff.patch",
+    }
+    runs_root = factory_state.FACTORY_RUNS_ROOT
+    if not runs_root.exists():
+        return records
+    for slug_dir in sorted(path for path in runs_root.iterdir() if path.is_dir()):
+        for stage, relative_path in stage_files.items():
+            artifact_path = slug_dir / relative_path
+            if not artifact_path.exists():
+                continue
+            records.append(
+                {
+                    "slug": slug_dir.name,
+                    "stage": stage,
+                    "char_count": len(artifact_path.read_text(encoding="utf-8")),
+                }
+            )
+    return records
+
+
+def _artifact_distribution_rows(artifact_records: list[dict[str, object]]) -> list[list[object]]:
+    grouped: dict[str, list[int]] = defaultdict(list)
+    for record in artifact_records:
+        grouped[str(record["stage"])].append(int(record["char_count"]))
+
+    rows: list[list[object]] = []
+    for stage in ("spec", "plan", "tasks", "diff"):
+        counts = grouped.get(stage, [])
+        if not counts:
+            continue
+        rows.append(
+            [
+                stage,
+                len(counts),
+                int(round(_percentile([float(value) for value in counts], 50))),
+                int(round(_percentile([float(value) for value in counts], 95))),
+                max(counts),
+                sum(1 for value in counts if value > 50000),
+                sum(1 for value in counts if value > 100000),
+            ]
+        )
+    return rows
+
+
+def _largest_artifact_rows(artifact_records: list[dict[str, object]]) -> list[list[object]]:
+    ordered = sorted(
+        artifact_records,
+        key=lambda item: int(item["char_count"]),
+        reverse=True,
+    )[:10]
+    return [[item["slug"], item["stage"], item["char_count"]] for item in ordered]
+
+
+def _cap_pressure_rows(records: list[dict[str, object]]) -> list[list[object]]:
+    grouped: dict[tuple[str, str], list[dict[str, object]]] = defaultdict(list)
+    for record in records:
+        prompt_chars = _coerce_int(record.get("prompt_chars"))
+        prompt_cap = _coerce_int(record.get("prompt_cap"))
+        if prompt_chars is None or prompt_cap is None or prompt_cap <= 0:
+            continue
+        normalized = dict(record)
+        normalized["prompt_chars"] = prompt_chars
+        normalized["prompt_cap"] = prompt_cap
+        grouped[(str(record["model"]), str(record["activity_type"]))].append(normalized)
+
+    rows: list[list[object]] = []
+    for (model, activity_type), items in grouped.items():
+        pct_values = [
+            (100.0 * int(item["prompt_chars"])) / int(item["prompt_cap"])
+            for item in items
+        ]
+        rows.append(
+            [
+                model,
+                activity_type,
+                len(items),
+                _format_pct_of_cap(_percentile(pct_values, 50)),
+                _format_pct_of_cap(_percentile(pct_values, 95)),
+                sum(
+                    1
+                    for item in items
+                    if int(item["prompt_chars"]) >= (0.9 * int(item["prompt_cap"]))
+                ),
+                sum(
+                    1
+                    for item in items
+                    if int(item["prompt_chars"]) > int(item["prompt_cap"])
+                ),
+            ]
+        )
+    rows.sort(key=lambda row: (str(row[0]), str(row[1])))
+    return rows
+
+
 def _lens_rows(records: list[dict[str, object]]) -> list[list[object]]:
     grouped: dict[tuple[str, str], list[dict[str, object]]] = defaultdict(list)
     for record in records:
@@ -548,6 +656,7 @@ def _render_report(records: list[dict[str, object]], data_quality: dict[str, obj
     total_duration = sum(float(record["duration_seconds"]) for record in records)
     total_cost = sum(float(record["cost_usd_estimate"]) for record in records)
     total_parse_errors = sum(1 for record in records if record.get("parse_error"))
+    artifact_records = _artifact_size_records()
     timestamps = [record["timestamp"] for record in records if isinstance(record.get("timestamp"), datetime)]
     date_range = "unknown"
     if timestamps:
@@ -690,6 +799,56 @@ def _render_report(records: list[dict[str, object]], data_quality: dict[str, obj
     else:
         lines.append("No relevant records found.")
 
+    artifact_distribution_rows = _artifact_distribution_rows(artifact_records)
+    largest_artifact_rows = _largest_artifact_rows(artifact_records)
+    lines.extend(["", "## 8. Artifact Sizes", ""])
+    if artifact_distribution_rows:
+        lines.extend(["### Table 8a — Per-stage artifact-size distribution", ""])
+        lines.extend(
+            _markdown_table(
+                [
+                    "stage",
+                    "count",
+                    "p50_chars",
+                    "p95_chars",
+                    "max_chars",
+                    "over_50k_count",
+                    "over_100k_count",
+                ],
+                artifact_distribution_rows,
+            )
+        )
+        lines.extend(["", "### Table 8b — Top 10 largest artifacts", ""])
+        lines.extend(
+            _markdown_table(
+                ["slug", "stage", "char_count"],
+                largest_artifact_rows,
+            )
+        )
+    else:
+        lines.append("No workflow artifacts found.")
+
+    cap_pressure_rows = _cap_pressure_rows(records)
+    lines.extend(["", "## 9. Prompt-Cap Pressure", ""])
+    if cap_pressure_rows:
+        lines.extend(["### Table 9a — Cap-pressure summary", ""])
+        lines.extend(
+            _markdown_table(
+                [
+                    "model",
+                    "activity_type",
+                    "count_with_size_data",
+                    "p50_pct_of_cap",
+                    "p95_pct_of_cap",
+                    "within_90pct_cap",
+                    "over_cap",
+                ],
+                cap_pressure_rows,
+            )
+        )
+    else:
+        lines.append("No prompt-size data available yet — re-run after the next 2-3 feature runs.")
+
     dropped_fields = data_quality["dropped_fields"]
     partial_fields = data_quality["partial_fields"]
     skipped_slugs = data_quality["skipped_slugs"]
@@ -702,7 +861,7 @@ def _render_report(records: list[dict[str, object]], data_quality: dict[str, obj
     lines.extend(
         [
             "",
-            "## 8. Data Quality",
+            "## 10. Data Quality",
             "",
             f"- Dropped records: {int(data_quality['dropped_records'])}",
             f"- Dropped-record field breakdown: {', '.join(f'{field}={count}' for field, count in sorted(dropped_fields.items())) or 'none'}",

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_implement.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_implement.py
@@ -120,6 +120,8 @@ def _run_serial(slug: str, tasks: list[str]) -> int:
                 ["codex", "exec", "-m", "gpt-5.4-mini", "-s", "workspace-write", prompt_text],
                 REPO_ROOT,
             ),
+            prompt_chars=len(prompt_text),
+            prompt_cap=None,
         )
         rc = result.returncode
         if rc == 124:
@@ -189,13 +191,16 @@ def _run_parallel(slug: str, group: dict, max_workers: int = 4) -> int:
                     )
                 futures[
                     executor.submit(
-                        record_ai_call,
-                        slug,
-                        "tasks",
-                        round_number,
-                        "implementation",
-                        "gpt-5.4-mini",
-                        _call,
+                        lambda _call=_call, prompt_text=prompt_text: record_ai_call(
+                            slug,
+                            "tasks",
+                            round_number,
+                            "implementation",
+                            "gpt-5.4-mini",
+                            _call,
+                            prompt_chars=len(prompt_text),
+                            prompt_cap=None,
+                        ),
                     )
                 ] = i
             except Exception as exc:

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_judge.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_judge.py
@@ -641,6 +641,8 @@ def _attempt_model_call(
         result = record_ai_call(
             slug, stage, round_number, "judge_panel", model, _call,
             lens=f"{lens}-judge",
+            prompt_chars=len(system_prompt) + len(user_prompt),
+            prompt_cap=None,
         )
     except Exception as exc:
         return None, "", str(exc)

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_stages.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_stages.py
@@ -43,7 +43,9 @@ from factory_git import _git_head_sha  # noqa: E402
 VERIFY_CHECKPOINT = REVIEW_SCRIPTS / "verify_review_checkpoint.py"
 VERIFY_RECONCILIATION = REVIEW_SCRIPTS / "verify_reconciliation.py"
 
-HARD_DIFF_ARTIFACT_MAX_CHARS = 150000
+# Raised per PR #789's analyzer report plus PR #791's perf fixes.
+# Operators can still override per-call on checkpoint commands.
+HARD_DIFF_ARTIFACT_MAX_CHARS = 300000
 LARGE_DIFF_RERUN_WARN_CHARS = 80000
 
 NEXT_ACTION_LABELS: dict[str, str] = {

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_telemetry.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_telemetry.py
@@ -263,6 +263,8 @@ def record_ai_call(
     model: str,
     callable_fn: Callable[[], subprocess.CompletedProcess],
     lens: Optional[str] = None,
+    prompt_chars: int | None = None,
+    prompt_cap: int | None = None,
 ) -> subprocess.CompletedProcess:
     """Record an AI subprocess call into state.token_usage.
 
@@ -270,6 +272,10 @@ def record_ai_call(
     added in PR #790: the analyzer (PR #789) showed 1186 of 1446 records
     had no unambiguous lens attribution. Callers SHOULD pass it; older
     callers that don't will record `lens: null` (back-compatible).
+
+    `prompt_chars` and `prompt_cap` were added next so the analyzer can
+    measure prompt-cap pressure directly from recorded calls. Callers
+    that do not pass them record `null` for both fields.
     """
     if activity_type not in VALID_ACTIVITY_TYPES:
         raise ValueError(f"Unknown activity type: {activity_type}")
@@ -300,6 +306,8 @@ def record_ai_call(
         "activity_type": activity_type,
         "model": model,
         "lens": lens,
+        "prompt_chars": prompt_chars,
+        "prompt_cap": prompt_cap,
         "input_tokens": parsed["input_tokens"] if parsed else None,
         "output_tokens": parsed["output_tokens"] if parsed else None,
         "cost_usd_estimate": cost_usd_estimate,

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_analyze_reviews.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_analyze_reviews.py
@@ -91,6 +91,11 @@ class AnalyzeReviewsTests(unittest.TestCase):
             encoding="utf-8",
         )
 
+    def _write_artifact(self, slug: str, relative_path: str, text: str) -> None:
+        artifact_path = self.runs_root / slug / relative_path
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(text, encoding="utf-8")
+
     def _record(
         self,
         *,
@@ -104,6 +109,8 @@ class AnalyzeReviewsTests(unittest.TestCase):
         parse_error: str | None = None,
         timestamp: str = "2026-04-25T12:00:00Z",
         cost_usd_estimate: float = 0.5,
+        prompt_chars: int | None = None,
+        prompt_cap: int | None = None,
     ) -> dict:
         record = {
             "stage": stage,
@@ -118,6 +125,10 @@ class AnalyzeReviewsTests(unittest.TestCase):
         }
         if parse_error is not None:
             record["parse_error"] = parse_error
+        if prompt_chars is not None:
+            record["prompt_chars"] = prompt_chars
+        if prompt_cap is not None:
+            record["prompt_cap"] = prompt_cap
         return record
 
     def _run(self, *, out: Path | None = None, top_n: int = 20) -> tuple[int, str, str, str]:
@@ -225,6 +236,82 @@ class AnalyzeReviewsTests(unittest.TestCase):
 
         _, _, _, report = self._run()
         self.assertIn("| schema violation at path very/long/path/that/keeps/going and going and still... | 3 | gpt-5.4, gpt-5.4-mini | delta |", report)
+
+    def test_artifact_size_section_reports_fixture_distribution(self) -> None:
+        self._write_state("alpha", [])
+        self._write_state("beta", [])
+        self._write_artifact("alpha", "spec.md", "a" * 10)
+        self._write_artifact("alpha", "plan.md", "b" * 20)
+        self._write_artifact("alpha", "tasks.md", "c" * 30)
+        self._write_artifact("alpha", "reviews/implementation.diff.patch", "d" * 40)
+        self._write_artifact("beta", "spec.md", "e" * 50)
+        self._write_artifact("beta", "plan.md", "f" * 60)
+        self._write_artifact("beta", "tasks.md", "g" * 70)
+        self._write_artifact("beta", "reviews/implementation.diff.patch", "h" * 80)
+
+        _, _, _, report = self._run()
+
+        self.assertIn("## 8. Artifact Sizes", report)
+        self.assertIn("| spec | 2 | 30 | 48 | 50 | 0 | 0 |", report)
+        self.assertIn("| plan | 2 | 40 | 58 | 60 | 0 | 0 |", report)
+        self.assertIn("| tasks | 2 | 50 | 68 | 70 | 0 | 0 |", report)
+        self.assertIn("| diff | 2 | 60 | 78 | 80 | 0 | 0 |", report)
+        self.assertIn("| beta | diff | 80 |", report)
+        self.assertIn("| beta | tasks | 70 |", report)
+
+    def test_prompt_cap_pressure_section_reports_rollup(self) -> None:
+        self._write_state(
+            "epsilon",
+            [
+                self._record(
+                    stage="spec",
+                    round_number=1,
+                    activity_type="adversarial_review",
+                    model="gpt-5.4-mini",
+                    duration_seconds=10.0,
+                    prompt_chars=900,
+                    prompt_cap=1000,
+                ),
+                self._record(
+                    stage="plan",
+                    round_number=1,
+                    activity_type="adversarial_review",
+                    model="gpt-5.4-mini",
+                    duration_seconds=20.0,
+                    prompt_chars=600,
+                    prompt_cap=1000,
+                ),
+                self._record(
+                    stage="tasks",
+                    round_number=1,
+                    activity_type="judge_panel",
+                    model="gpt-5.4",
+                    duration_seconds=30.0,
+                    prompt_chars=1100,
+                    prompt_cap=1000,
+                ),
+                self._record(
+                    stage="diff",
+                    round_number=1,
+                    activity_type="adversarial_review",
+                    model="gemini-2.5-pro",
+                    duration_seconds=40.0,
+                ),
+            ],
+        )
+
+        _, _, _, report = self._run()
+
+        self.assertIn("## 9. Prompt-Cap Pressure", report)
+        self.assertIn(
+            "| gpt-5.4-mini | adversarial_review | 2 | 75% | 88% | 1 | 0 |",
+            report,
+        )
+        self.assertIn(
+            "| gpt-5.4 | judge_panel | 1 | 110% | 110% | 1 | 1 |",
+            report,
+        )
+        self.assertNotIn("No prompt-size data available yet", report)
 
 
 if __name__ == "__main__":

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_telemetry.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_telemetry.py
@@ -101,6 +101,35 @@ class FactoryTelemetryTests(unittest.TestCase):
         usage = self._usage(slug)
         self.assertEqual(usage[-1]["lens"], "feasibility-adversarial")
 
+    def test_record_ai_call_records_prompt_size_fields_and_defaults(self) -> None:
+        slug = "telemetry-prompt-size"
+        completed = _completed_process(stderr='{"totalTokens": {"prompt": 100, "candidates": 50}}\n')
+
+        FACTORY_TELEMETRY.record_ai_call(
+            slug,
+            "spec",
+            1,
+            "adversarial_review",
+            "gpt-5.4-mini",
+            lambda: completed,
+            prompt_chars=1234,
+            prompt_cap=2000,
+        )
+        FACTORY_TELEMETRY.record_ai_call(
+            slug,
+            "plan",
+            2,
+            "adversarial_review",
+            "gpt-5.4-mini",
+            lambda: completed,
+        )
+
+        usage = self._usage(slug)
+        self.assertEqual(usage[0]["prompt_chars"], 1234)
+        self.assertEqual(usage[0]["prompt_cap"], 2000)
+        self.assertIsNone(usage[1]["prompt_chars"])
+        self.assertIsNone(usage[1]["prompt_cap"])
+
     def test_record_ai_call_invalid_activity_type_raises(self) -> None:
         with self.assertRaises(ValueError):
             FACTORY_TELEMETRY.record_ai_call(

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py
@@ -39,7 +39,7 @@ from review_attempts import append_review_attempt, review_attempt_record
 
 def main() -> int:
     started_at = time.monotonic()
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--artifact", required=True)
     parser.add_argument("--lens", required=True)
     parser.add_argument("--stage", required=True, choices=["spec", "plan", "tasks", "diff", "closeout"])
@@ -55,9 +55,27 @@ def main() -> int:
     # past 120s never returns a parseable verdict. Saves ~5+ hours of cumulative
     # wall clock across feature runs. Operators can still override per-call.
     parser.add_argument("--timeout-seconds", type=int, default=120)
-    parser.add_argument("--max-artifact-chars", type=int, default=50000)
-    parser.add_argument("--max-context-chars", type=int, default=10000)
-    parser.add_argument("--max-total-chars", type=int, default=70000)
+    # Raised per PR #789's analyzer report plus PR #791's perf fixes.
+    # Operators were already overriding to these values routinely; they
+    # can still override per-call when a review needs tighter limits.
+    parser.add_argument(
+        "--max-artifact-chars",
+        type=int,
+        default=100000,
+        help="Maximum artifact chars to include before narrowing.",
+    )
+    parser.add_argument(
+        "--max-context-chars",
+        type=int,
+        default=20000,
+        help="Maximum chars to include from each context file before narrowing.",
+    )
+    parser.add_argument(
+        "--max-total-chars",
+        type=int,
+        default=200000,
+        help="Maximum total prompt chars allowed after narrowing.",
+    )
     args = parser.parse_args()
 
     try:
@@ -233,6 +251,8 @@ def main() -> int:
         args.model,
         _call,
         lens=args.lens,
+        prompt_chars=len(prompt),
+        prompt_cap=args.max_total_chars,
     )
 
     stdout_path.write_text(result.stdout, encoding="utf-8")

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/run_gemini_review.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/run_gemini_review.py
@@ -549,7 +549,7 @@ def prompt_for(stage: str, lens: str, artifact_label: str, artifact_text: str, e
 
 def main() -> int:
     started_at = time.monotonic()
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--artifact", required=True)
     parser.add_argument("--lens", required=True)
     parser.add_argument("--stage", required=True, choices=["spec", "plan", "tasks", "diff", "closeout"])
@@ -560,9 +560,27 @@ def main() -> int:
     parser.add_argument("--workspace-dir")
     parser.add_argument("--git-base-ref", default=os.environ.get("REVIEW_BASE_REF"))
     parser.add_argument("--timeout-seconds", type=int, default=90)
-    parser.add_argument("--max-artifact-chars", type=int, default=50000)
-    parser.add_argument("--max-context-chars", type=int, default=10000)
-    parser.add_argument("--max-total-chars", type=int, default=70000)
+    # Raised per PR #789's analyzer report plus PR #791's perf fixes.
+    # Operators were already overriding to these values routinely; they
+    # can still override per-call when a review needs tighter limits.
+    parser.add_argument(
+        "--max-artifact-chars",
+        type=int,
+        default=100000,
+        help="Maximum artifact chars to include before narrowing.",
+    )
+    parser.add_argument(
+        "--max-context-chars",
+        type=int,
+        default=20000,
+        help="Maximum chars to include from each context file before narrowing.",
+    )
+    parser.add_argument(
+        "--max-total-chars",
+        type=int,
+        default=200000,
+        help="Maximum total prompt chars allowed after narrowing.",
+    )
     parser.add_argument("--retries", type=int, default=1)
     parser.add_argument(
         "--no-gemini-lock",
@@ -738,6 +756,8 @@ def main() -> int:
                         args.model,
                         lambda tmpdir=tmpdir: _call(tmpdir),
                         lens=args.lens,
+                        prompt_chars=len(prompt),
+                        prompt_cap=args.max_total_chars,
                     )
             else:
                 result = record_ai_call(
@@ -748,6 +768,8 @@ def main() -> int:
                     args.model,
                     lambda: _call(str(run_cwd)),
                     lens=args.lens,
+                    prompt_chars=len(prompt),
+                    prompt_cap=args.max_total_chars,
                 )
             if result.returncode == 0:
                 break

--- a/docs/workflow/orchestrator-prompts/ff-prompt-budget-tuning.md
+++ b/docs/workflow/orchestrator-prompts/ff-prompt-budget-tuning.md
@@ -1,0 +1,201 @@
+# Codex Prompt — FF Prompt-Budget Tuning
+
+You are implementing three small, independent fixes that bundle naturally into one PR. **Single-shot implementation** — no FF spec/plan/tasks adversarial cycle needed; this is mechanical instrumentation + default tuning. The motivation is data-driven: see the report at `docs/workflow/analysis/review-performance-2026-04-29.md` shipped in PR #789, plus PR #791 which fixed the token parsers.
+
+## Repo
+
+- Branch off `origin/main` to: `claude/ff-prompt-budget-tuning`
+- Working dir: the current cwd should already be the repo root or a worktree of `chrislawcodes/valuerank`.
+- Per `cloud/CLAUDE.md`: do NOT push or open the PR until the human asks — leave the branch local with the commit ready.
+
+## Read these first
+
+- `docs/workflow/analysis/review-performance-2026-04-29.md` — the analysis that motivated this PR.
+- `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_telemetry.py` — `record_ai_call` lives here; PR #791 just added the `lens` parameter, you'll add `prompt_chars` next.
+- `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py` — analyzer to extend.
+- `docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py` — has the runner-side cap defaults; you'll bump them.
+
+## What this PR does (3 changes, 1 commit)
+
+### Change A — Prompt-size instrumentation (~30 min)
+
+Goal: every `record_ai_call` invocation records the actual prompt char count and the configured cap, so future analyzer runs can answer "what % of calls are within 90% of their cap."
+
+**File**: `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_telemetry.py`
+
+Add two optional parameters to `record_ai_call`:
+- `prompt_chars: int | None = None` — total char count of the prompt actually sent to the model.
+- `prompt_cap: int | None = None` — the `--max-total-chars` value in effect for this call (or whatever cap the caller wants to record; if there's no per-call cap, pass None).
+
+Persist both into the `state.token_usage` record alongside `lens`. Defaults to None means existing call sites that don't pass these (`factory_cmd_implement.py` for example) record `null` for both — back-compatible.
+
+Update these call sites to pass values:
+- `docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py`: pass `prompt_chars=len(prompt)` and `prompt_cap=args.max_total_chars`. The exact variable name is whatever the prompt string is bound to right before `_call` is defined.
+- `docs/workflow/operations/codex-skills/review-lens/scripts/run_gemini_review.py`: same pattern. Pass for both `_call` branches (run_cwd None and run_cwd set).
+- `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_judge.py`: pass `prompt_chars=len(system_prompt) + len(user_prompt)` and `prompt_cap=None` (judges don't go through the same cap pipeline).
+- `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_implement.py`: pass `prompt_chars=len(prompt_text)` and `prompt_cap=None`.
+
+Add 1 unit test in `tests/test_factory_telemetry.py` verifying the new fields are recorded when passed and default to None when omitted.
+
+### Change B — Artifact-size section in analyzer (~45 min)
+
+Goal: extend `analyze-reviews` so the report includes a section showing actual artifact sizes per slug per stage, plus a "% of calls within 90% of their cap" rollup once Change A's data starts populating.
+
+**File**: `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py`
+
+Add two new sections to the report (insert AFTER current section 7 "Wall Clock by Slug", BEFORE current section 8 "Data Quality"):
+
+#### New section 8 — Artifact sizes (filesystem walk)
+
+Walk every `docs/workflow/feature-runs/<slug>/` and read the char count of `spec.md`, `plan.md`, `tasks.md`. Also count any matching `reviews/implementation.diff.patch` if it exists.
+
+Render two tables:
+
+**Table 8a — Per-stage artifact-size distribution** (across all slugs):
+```
+| stage | count | p50_chars | p95_chars | max_chars | over_50k_count | over_100k_count |
+| --- | --- | --- | --- | --- | --- | --- |
+| spec | 26 | 14000 | 38000 | 47000 | 5 | 0 |
+| plan | 26 | 21000 | 52000 | 89000 | 8 | 1 |
+| ...
+```
+
+**Table 8b — Top 10 largest artifacts**:
+```
+| slug | stage | char_count |
+| --- | --- | --- |
+| sensitivity-table-redesign-v2 | plan | 89234 |
+| ...
+```
+
+This section uses ZERO data from `state.token_usage` — purely filesystem-based. Always populated.
+
+#### New section 9 — Prompt-cap pressure (token_usage based)
+
+For records that have `prompt_chars` AND `prompt_cap` populated (the new fields from Change A — empty for old records, populates going forward), compute:
+
+**Table 9a — Cap-pressure summary**:
+```
+| model | activity_type | count_with_size_data | p50_pct_of_cap | p95_pct_of_cap | within_90pct_cap | over_cap |
+| --- | --- | --- | --- | --- | --- | --- |
+| gpt-5.4-mini | adversarial_review | 12 | 65% | 95% | 4 | 0 |
+| ...
+```
+
+`within_90pct_cap` = count where `prompt_chars >= 0.9 * prompt_cap`. `over_cap` should always be 0 (the runner enforces); report it anyway as a sanity check.
+
+If no records have `prompt_chars`/`prompt_cap` populated yet, emit "No prompt-size data available yet — re-run after the next 2-3 feature runs." instead of an empty table.
+
+Renumber the existing section 8 ("Data Quality") to section 10. Update the section ordering in any docstring or top-level commentary.
+
+Add 2 unit tests covering: (a) the artifact-size walk happy path with a fixture tree containing spec/plan/tasks of known sizes, (b) the cap-pressure section with mock `token_usage` records carrying the new fields.
+
+### Change C — Bump default char caps (~15 min)
+
+Goal: align the runner defaults with what operators actually pass. We've been passing `--max-total-chars 200000` on every checkpoint this session. Make the new default close to that.
+
+**File**: `docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py`
+
+Change:
+- `--max-artifact-chars`: 50000 → **100000**
+- `--max-context-chars`: 10000 → **20000**
+- `--max-total-chars`: 70000 → **200000**
+
+Same change in `docs/workflow/operations/codex-skills/review-lens/scripts/run_gemini_review.py` if those flags exist there too — verify with grep first; the Gemini script may use different names.
+
+In `docs/workflow/operations/codex-skills/feature-factory/scripts/factory_stages.py`:
+- `HARD_DIFF_ARTIFACT_MAX_CHARS`: 150000 → **300000**
+- `LARGE_DIFF_RERUN_WARN_CHARS`: keep as-is unless it's now larger than the new HARD value, in which case adjust.
+
+Add a comment at each cap site referencing PR #789's analyzer report and PR #791's perf fixes as the motivation, and noting that operators can still override per-call.
+
+DO NOT change:
+- The Codex CLI subprocess `--timeout-seconds` (already tuned to 120s in PR #791).
+- Anything else.
+
+## Testing
+
+After the three changes:
+1. Run preflight (NO PIPE — exit code check directly):
+   ```bash
+   cd /Users/chrislaw/valuerank/.claude/worktrees/friendly-aryabhata-9efbf7
+   python3 -m unittest discover docs/workflow/operations/codex-skills/feature-factory/scripts/tests
+   ```
+   All existing tests must still pass. New tests should add 3 cases (Change A: 1, Change B: 2).
+2. **Manually run the extended analyzer once** against the real repo to verify the new sections render correctly:
+   ```bash
+   python3 docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py analyze-reviews --out /tmp/analyzer-test.md
+   ```
+   Verify section 8 (artifact sizes) populates, section 9 (cap pressure) shows the "no data yet" message, and section 10 (data quality) is unchanged.
+3. **Smoke test the cap defaults** by checking `--help` of `run_codex_review.py` — should show the new defaults.
+
+## Commit
+
+Stage explicitly (NOT `git add -A` — the worktree may have unrelated dirty paths from concurrent FF runs):
+```bash
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/factory_telemetry.py
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_judge.py
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_implement.py
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/factory_stages.py
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_telemetry.py
+git add docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_analyze_reviews.py
+git add docs/workflow/operations/codex-skills/review-lens/scripts/run_codex_review.py
+git add docs/workflow/operations/codex-skills/review-lens/scripts/run_gemini_review.py
+git add docs/workflow/orchestrator-prompts/ff-prompt-budget-tuning.md
+```
+
+Commit message format:
+```
+ff-prompt-budget-tuning: prompt-size instrumentation + analyzer artifact-size section + bumped default caps
+
+Three small fixes bundled by the analysis report at PR #789. Together
+they (a) start collecting prompt-size data so future analyses can
+recommend per-cap tuning, (b) surface artifact-size distributions in
+the analyzer immediately from filesystem data, and (c) align runner
+defaults with the values operators routinely pass.
+
+Change A — prompt-size instrumentation:
+- record_ai_call() takes optional prompt_chars + prompt_cap, persists
+  both into state.token_usage. Older records keep null. 4 call sites
+  updated (run_codex_review, run_gemini_review (both branches),
+  factory_cmd_judge, factory_cmd_implement).
+
+Change B — analyzer extension:
+- New section 8: per-stage artifact-size distribution + top-10 largest.
+  Filesystem-based; available immediately, no token_usage needed.
+- New section 9: prompt-cap pressure rollup (uses Change A's data; emits
+  "no data yet" message until 2-3 new feature runs populate it).
+- Renumbered Data Quality 8 -> 10.
+
+Change C — bumped default caps:
+- run_codex_review.py + run_gemini_review.py:
+  --max-artifact-chars 50000 -> 100000
+  --max-context-chars 10000 -> 20000
+  --max-total-chars 70000 -> 200000
+- factory_stages.py: HARD_DIFF_ARTIFACT_MAX_CHARS 150000 -> 300000
+- Operators were passing these values manually on every checkpoint
+  this session; making them defaults removes ~80% of the cap-related
+  retries. Operators can still override per-call.
+
+Tests: 3 new (1 telemetry, 2 analyzer); existing FF tests pass.
+```
+
+Do NOT push. Report back with the commit SHA, the manually-tested analyzer report path (so the operator can review), and a short summary of what you observed.
+
+## Output
+
+When done, print:
+- The commit SHA
+- The path of the manually-tested analyzer output (e.g., `/tmp/analyzer-test.md`)
+- Final test count (should be ~358 = 355 + 3)
+- Any unexpected issues (e.g., a call site you couldn't update cleanly, a test that needed adjustment)
+- The exact `git push` + `gh pr create` commands the human can run to ship
+
+## Things to NOT do
+
+- **No FF spec/plan/tasks adversarial cycle.** This is small mechanical work; the analysis already happened.
+- **No new dependencies.** Stdlib only.
+- **No `git push`** per `cloud/CLAUDE.md`.
+- Do not change the Codex `--timeout-seconds` — that's already tuned in PR #791.
+- Do not touch unrelated tests, STATUS.md, or any feature run state.


### PR DESCRIPTION
## Summary
Three small bundled fixes informed by the FF performance analysis report (PR #789). Together they (a) start collecting prompt-size data so future analyses can recommend per-cap tuning, (b) surface artifact-size distributions in the analyzer immediately from filesystem data, and (c) align runner defaults with the values operators routinely pass.

## Changes

### A — Prompt-size instrumentation
`record_ai_call()` now takes optional `prompt_chars` and `prompt_cap` parameters, persisted into `state.token_usage`. Older records remain valid (null). 4 call sites updated:
- `run_codex_review.py`: `prompt_chars=len(prompt)`, `prompt_cap=args.max_total_chars`
- `run_gemini_review.py`: same pattern (both `_call` branches)
- `factory_cmd_judge.py`: `prompt_chars=len(system+user)`
- `factory_cmd_implement.py`: `prompt_chars=len(prompt_text)`

### B — Analyzer extension
`analyze-reviews` report adds:
- **Section 8** — per-stage artifact-size distribution (p50/p95/max char counts) + top-10 largest individual artifacts. Filesystem-based; available immediately.
- **Section 9** — prompt-cap pressure rollup (uses Change A's data; emits "no data yet" message until 2-3 new feature runs populate it).
- Old Section 8 (Data Quality) renumbered to 10.

### C — Bumped default caps
| File | Cap | Old | New |
|---|---|---|---|
| `run_codex_review.py` + `run_gemini_review.py` | `--max-artifact-chars` | 50,000 | **100,000** |
| same | `--max-context-chars` | 10,000 | **20,000** |
| same | `--max-total-chars` | 70,000 | **200,000** |
| `factory_stages.py` | `HARD_DIFF_ARTIFACT_MAX_CHARS` | 150,000 | **300,000** |

Operators were passing these values manually on every checkpoint this session; making them defaults removes ~80% of the cap-related retries. Operators can still override per-call.

## Tests
- 3 new test cases (1 telemetry for the new fields, 2 analyzer for the new sections)
- **358 FF tests pass** (was 355)

## Risk
- **R1 (low)** — Bumped caps could occasionally pass too much context and slow some calls. Mitigation: PR #791 already tightened Codex timeout to 120s, so a too-big prompt now fails faster. Section 9 of the analyzer will surface this on the next 2-3 runs.
- **R2 (low)** — `prompt_chars` instrumentation adds ~5 lines per call site. Counter overhead is negligible; failure modes don't propagate (record_ai_call is best-effort).

## What this enables
After this lands and 2-3 feature runs complete, re-run `analyze-reviews`. Section 9 will populate with data like "X% of gpt-5.4-mini calls within 90% of cap". Combined with Section 8's artifact-size distribution, we'll have the empirical basis for per-stage cap tuning (e.g., "spec-stage cap can drop to 80K, plan-stage stays at 200K").

## Deferred
- Investigating `sensitivity-table-redesign-v2` — single slug eating 17% of total wall clock. Human investigation, not a coded fix.
- Smarter truncation (preserve frontmatter, drop verbose middle): premature without size-distribution data this PR enables.

## Test plan
- [x] 358 FF tests pass locally
- [ ] CI green
- [ ] After 2-3 feature runs, re-run `analyze-reviews` — Section 9 populates, Section 6 (duration vs input_tokens) becomes trustworthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Codex (gpt-5.4) <noreply@openai.com>
