### PR TITLE
reprobe-pipeline: full probe→summarize→analyze→aggregate chain with stage UI

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/run-anomaly.ts
+++ b/cloud/apps/api/src/graphql/mutations/run-anomaly.ts
@@ -27,6 +27,7 @@ function buildIncrementedDetails(details: unknown, currentAttempts: number): Pri
     ? { ...(details as Record<string, unknown>) }
     : {};
   base.reprobeAttempts = currentAttempts + 1;
+  base.reprobeStage = 'probing';
   return base as Prisma.InputJsonValue;
 }
 
@@ -204,6 +205,7 @@ builder.mutationField('reprobeAnomalySlot', (t) =>
             sampleIndex: slot.sampleIndex,
             config: { maxTurns: 10 },
             manualReprobe: true,
+            anomalyId,
           },
           { ...jobOptions, singletonKey },
         );

--- a/cloud/apps/api/src/graphql/types/run-anomaly.ts
+++ b/cloud/apps/api/src/graphql/types/run-anomaly.ts
@@ -170,6 +170,17 @@ builder.objectType(RunAnomalyRef, {
       resolve: (anomaly) => REPROBABLE_TYPES.has(anomaly.type) && readReprobeAttempts(anomaly.details) >= REPROBE_LIMIT,
     }),
 
+    reprobeStage: t.string({
+      nullable: true,
+      description: 'Current pipeline stage for an in-progress manual re-probe: probing | summarizing | analyzing | aggregating | fixed. Null when no re-probe is in flight.',
+      resolve: (anomaly) => {
+        if (!REPROBABLE_TYPES.has(anomaly.type)) return null;
+        const details = anomaly.details as Record<string, unknown> | null;
+        const stage = details?.reprobeStage;
+        return typeof stage === 'string' && stage.length > 0 ? stage : null;
+      },
+    }),
+
     estimatedCost: t.float({
       nullable: true,
       description: 'Best-effort cost estimate for the next re-probe attempt, computed as the average estimatedCost of the last 10 successful (non-deleted, summarized) transcripts for the same modelId across all runs. Returns null when the anomaly is not reprobable, no modelId is available, or no recent transcripts have cost data.',

--- a/cloud/apps/api/src/queue/handlers/aggregate-analysis.ts
+++ b/cloud/apps/api/src/queue/handlers/aggregate-analysis.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import type { AggregateAnalysisJobData } from '../types.js';
 import { updateAggregateRun } from '../../services/analysis/aggregate.js';
 import { parseTemperature } from '../../utils/temperature.js';
+import { setReprobeStage } from '../../services/run/anomaly-persistence.js';
 
 const log = createLogger('queue:aggregate-analysis');
 
@@ -117,11 +118,11 @@ export function createAggregateAnalysisHandler(): PgBoss.WorkHandler<AggregateAn
                             { jobId, definitionId, preambleVersionId },
                             'No definition versions found for legacy aggregate job; skipping'
                         );
-                        continue;
-                    }
-
-                    for (const target of derivedTargets) {
-                        await updateAggregateRun(definitionId, preambleVersionId, target.definitionVersion, target.temperature);
+                        // Fall through to reprobe stage check even on no-op.
+                    } else {
+                        for (const target of derivedTargets) {
+                            await updateAggregateRun(definitionId, preambleVersionId, target.definitionVersion, target.temperature);
+                        }
                     }
                 }
 
@@ -129,6 +130,29 @@ export function createAggregateAnalysisHandler(): PgBoss.WorkHandler<AggregateAn
                     { jobId, definitionId },
                     'Aggregate analysis completed successfully'
                 );
+
+                // Reprobe pipeline: advance anomalies from 'aggregating' → 'fixed' for runs
+                // belonging to this definition.
+                try {
+                    const defRuns = await db.run.findMany({
+                        where: { definitionId, status: 'COMPLETED', deletedAt: null },
+                        select: { id: true },
+                    });
+                    const runIds = defRuns.map((r) => r.id);
+                    const pipelineAnomalies = await db.runAnomaly.findMany({
+                        where: { runId: { in: runIds }, resolvedAt: null },
+                        select: { id: true, details: true },
+                    });
+                    for (const anomaly of pipelineAnomalies) {
+                        const stage = (anomaly.details as Record<string, unknown> | null)?.reprobeStage;
+                        if (stage === 'aggregating') {
+                            await setReprobeStage(anomaly.id, 'fixed');
+                            log.info({ jobId, definitionId, anomalyId: anomaly.id }, 'Advanced reprobe stage to fixed');
+                        }
+                    }
+                } catch (err) {
+                    log.error({ jobId, definitionId, err }, 'Failed to advance reprobe stage after aggregation');
+                }
             } catch (error) {
                 log.error(
                     { jobId, definitionId, err: error },

--- a/cloud/apps/api/src/queue/handlers/analyze-basic.ts
+++ b/cloud/apps/api/src/queue/handlers/analyze-basic.ts
@@ -24,6 +24,7 @@ import {
   type AnalyzeWorkerInput,
   type AnalyzeWorkerOutput,
 } from './analyze-basic-data.js';
+import { setReprobeStage } from '../../services/run/anomaly-persistence.js';
 
 const log = createLogger('queue:analyze-basic');
 
@@ -74,6 +75,22 @@ export function createAnalyzeBasicHandler(): PgBoss.WorkHandler<AnalyzeBasicJobD
 
           if (cached) {
             log.info({ jobId, runId, analysisId: cached.id }, 'Using cached analysis result');
+            // Still advance reprobe stage on cache hit — the analysis exists.
+            try {
+              const runAnomalies = await db.runAnomaly.findMany({
+                where: { runId, resolvedAt: null },
+                select: { id: true, details: true },
+              });
+              for (const anomaly of runAnomalies) {
+                const stage = (anomaly.details as Record<string, unknown> | null)?.reprobeStage;
+                if (stage === 'analyzing') {
+                  await setReprobeStage(anomaly.id, 'aggregating');
+                  log.info({ jobId, runId, anomalyId: anomaly.id }, 'Advanced reprobe stage to aggregating (cache hit)');
+                }
+              }
+            } catch (err) {
+              log.error({ jobId, runId, err }, 'Failed to advance reprobe stage on cache hit');
+            }
             return;
           }
         }
@@ -177,6 +194,23 @@ export function createAnalyzeBasicHandler(): PgBoss.WorkHandler<AnalyzeBasicJobD
           { jobId, runId, durationMs: output.analysis.durationMs },
           'Analyze:basic job completed'
         );
+
+        // Reprobe pipeline: advance any anomalies for this run from 'analyzing' → 'aggregating'.
+        try {
+          const runAnomalies = await db.runAnomaly.findMany({
+            where: { runId, resolvedAt: null },
+            select: { id: true, details: true },
+          });
+          for (const anomaly of runAnomalies) {
+            const stage = (anomaly.details as Record<string, unknown> | null)?.reprobeStage;
+            if (stage === 'analyzing') {
+              await setReprobeStage(anomaly.id, 'aggregating');
+              log.info({ jobId, runId, anomalyId: anomaly.id }, 'Advanced reprobe stage to aggregating');
+            }
+          }
+        } catch (err) {
+          log.error({ jobId, runId, err }, 'Failed to advance reprobe stage after analysis');
+        }
 
         // --- Trigger Aggregate Update ---
         try {

--- a/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
@@ -27,6 +27,7 @@ import { enqueueTopUpProbesSingleton } from '../top-up-probes.js';
 import { formatWorkerErrorMessage, extractStoredTranscriptTokenUsage, handleJobError } from './retry.js';
 import { PROBE_WORKER_PATH, fetchScenario, buildWorkerInput } from './worker-input.js';
 import type { ProbeWorkerInput, ProbeWorkerOutput } from './worker-input.js';
+import { setReprobeStage } from '../../../services/run/anomaly-persistence.js';
 
 const log = createLogger('queue:probe-scenario');
 
@@ -333,6 +334,23 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
     // When we just entered SUMMARIZING in this call, queueSummarizeJobs already handled it.
     if (!advanceResult.enteredSummarizing && currentRun?.status === 'SUMMARIZING') {
       await enqueueSummarizeTranscriptSingleton(runId, transcriptRecord.id);
+    }
+
+    // Reprobe pipeline: kick off summarization and advance stage.
+    // Enqueue first so a boss.send failure leaves the stage at 'probing' (safe to retry).
+    // Normal runs handle summarize via SUMMARIZING status; COMPLETED runs need explicit enqueue.
+    if (job.data.manualReprobe === true && typeof job.data.anomalyId === 'string' && job.data.anomalyId !== '') {
+      const anomalyId = job.data.anomalyId;
+      const { getBoss } = await import('../../boss.js');
+      const { DEFAULT_JOB_OPTIONS: jobOptions } = await import('../../types.js');
+      const boss = getBoss();
+      await boss.send(
+        'summarize_transcript',
+        { runId, transcriptId: transcriptRecord.id, anomalyId },
+        { ...jobOptions['summarize_transcript'], singletonKey: transcriptRecord.id },
+      );
+      await setReprobeStage(anomalyId, 'summarizing');
+      log.info({ jobId, runId, anomalyId, transcriptId: transcriptRecord.id }, 'Enqueued summarize for reprobe pipeline');
     }
 
     log.info(

--- a/cloud/apps/api/src/queue/handlers/summarize-transcript.ts
+++ b/cloud/apps/api/src/queue/handlers/summarize-transcript.ts
@@ -26,6 +26,7 @@ import {
   isSummaryCache,
   type WinnerFirstSummaryCache,
 } from './summarize-types.js';
+import { setReprobeStage } from '../../services/run/anomaly-persistence.js';
 import {
   isCacheRecordMatch,
   persistCachedSummary,
@@ -518,6 +519,19 @@ export function createSummarizeTranscriptHandler(): PgBoss.WorkHandler<Summarize
       },
       'Summarize batch processing complete'
     );
+
+    // Reprobe pipeline: advance stage for any jobs that carried an anomalyId.
+    for (const job of jobs) {
+      const { anomalyId, transcriptId } = job.data;
+      if (anomalyId == null || anomalyId === '') continue;
+      const transcript = await db.transcript.findUnique({
+        where: { id: transcriptId },
+        select: { summarizedAt: true },
+      });
+      if (transcript?.summarizedAt == null) continue;
+      await setReprobeStage(anomalyId, 'analyzing');
+      log.info({ anomalyId, transcriptId, runId: job.data.runId }, 'Advanced reprobe stage to analyzing');
+    }
 
     if (retryableError !== null) {
       throw retryableError;

--- a/cloud/apps/api/src/queue/types.ts
+++ b/cloud/apps/api/src/queue/types.ts
@@ -34,6 +34,8 @@ export type ProbeScenarioJobData = {
   // Only set by the reprobeAnomalySlot mutation. Bypasses the isRunTerminal guard
   // so manual re-probes can execute on completed runs.
   manualReprobe?: boolean;
+  // Set by reprobeAnomalySlot so the probe→summarize pipeline can track stage.
+  anomalyId?: string;
 };
 
 export type TopUpProbesJobData = {
@@ -45,12 +47,14 @@ export type SummarizeTranscriptJobData = {
   transcriptId: string;
   summaryModelId?: string; // Optional: defaults to configured summary model
   forceSummarize?: boolean; // Optional: bypasses cache and summarization short-circuits
+  anomalyId?: string; // Set by reprobe pipeline to track stage progression
 };
 
 export type AnalyzeBasicJobData = {
   runId: string;
   transcriptIds?: string[]; // Optional: will be fetched from DB if not provided
   force?: boolean; // Force recomputation even if cached
+  anomalyId?: string; // Set by reprobe pipeline to track stage progression
 };
 
 export type ExpandScenariosJobData = {

--- a/cloud/apps/api/src/services/run/anomaly-persistence.ts
+++ b/cloud/apps/api/src/services/run/anomaly-persistence.ts
@@ -1,4 +1,4 @@
-import { db } from '@valuerank/db';
+import { db, type Prisma } from '@valuerank/db';
 import type { RunAnomalySource } from '@valuerank/db';
 import { createLogger } from '@valuerank/shared';
 import type { AnomalyDraft, RunAnomalyType } from './anomaly-detection.js';
@@ -79,14 +79,49 @@ export async function syncAnomalies(
       source,
       resolvedAt: null,
     },
-    select: { subject: true },
+    select: { subject: true, details: true },
   });
 
   for (const anomaly of existing) {
     if (!currentSubjects.has(anomaly.subject)) {
+      // Don't auto-resolve when a reprobe pipeline is in flight or has completed.
+      // 'fixed' anomalies must be resolved explicitly by the user; intermediate
+      // stages must not be resolved before the pipeline finishes.
+      const details = anomaly.details as Record<string, unknown> | null;
+      const reprobeStage = typeof details?.reprobeStage === 'string' ? details.reprobeStage : null;
+      if (reprobeStage !== null) {
+        continue;
+      }
       await resolveAnomaly({ runId, type, subject: anomaly.subject, source });
     }
   }
+}
+
+/**
+ * Merge-updates the reprobeStage field inside an anomaly's JSONB details.
+ * Safe to call even if the anomaly has been resolved; logs a warning and no-ops.
+ */
+export async function setReprobeStage(anomalyId: string, stage: string): Promise<void> {
+  const anomaly = await db.runAnomaly.findUnique({
+    where: { id: anomalyId },
+    select: { details: true },
+  });
+  if (anomaly === null) {
+    log.warn({ anomalyId, stage }, 'setReprobeStage: anomaly not found');
+    return;
+  }
+  const current: Record<string, unknown> =
+    anomaly.details !== null &&
+    typeof anomaly.details === 'object' &&
+    !Array.isArray(anomaly.details)
+      ? { ...(anomaly.details as Record<string, unknown>) }
+      : {};
+  current.reprobeStage = stage;
+  await db.runAnomaly.update({
+    where: { id: anomalyId },
+    data: { details: current as Prisma.InputJsonValue },
+  });
+  log.info({ anomalyId, stage }, 'Set reprobeStage');
 }
 
 export async function resolveAnomaly(key: RunAnomalyKey): Promise<void> {

--- a/cloud/apps/api/tests/services/run/anomaly-persistence.test.ts
+++ b/cloud/apps/api/tests/services/run/anomaly-persistence.test.ts
@@ -115,7 +115,7 @@ describe('run anomaly persistence helpers', () => {
 
   it('syncs anomalies without touching other sources', async () => {
     mockAnomalyUpsert.mockResolvedValue(undefined);
-    mockAnomalyFindMany.mockResolvedValue([{ subject: 'group-1' }]);
+    mockAnomalyFindMany.mockResolvedValue([{ subject: 'group-1', details: null }]);
 
     await syncAnomalies('run_1', 'PAIR_ASYMMETRY', [], 'audit');
 
@@ -126,7 +126,7 @@ describe('run anomaly persistence helpers', () => {
         source: 'audit',
         resolvedAt: null,
       },
-      select: { subject: true },
+      select: { subject: true, details: true },
     });
     expect(mockAnomalyUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/cloud/apps/web/src/api/operations/run-anomaly.graphql
+++ b/cloud/apps/web/src/api/operations/run-anomaly.graphql
@@ -13,6 +13,7 @@ query OpenRunAnomalies($domainId: ID, $type: RunAnomalyType) {
     reprobeEligible
     reprobeCount
     reprobeLimitReached
+    reprobeStage
     estimatedCost
     run {
       id

--- a/cloud/apps/web/src/components/status/AnomalyRow.tsx
+++ b/cloud/apps/web/src/components/status/AnomalyRow.tsx
@@ -240,7 +240,39 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
   const renderPrimaryAction = () => {
     switch (anomaly.type) {
       case 'INVALID_RESPONSE_FAILURE': {
-        const disabled = !anomaly.reprobeEligible || anomaly.reprobeLimitReached || isReprobing || isResolving;
+        const { reprobeStage } = anomaly;
+
+        // Active pipeline stage: show spinner + label, disable Re-probe.
+        if (reprobeStage != null && reprobeStage !== 'fixed') {
+          const stageLabel: Record<string, string> = {
+            probing: 'Probing…',
+            summarizing: 'Summarizing…',
+            analyzing: 'Analyzing…',
+            aggregating: 'Aggregating…',
+          };
+          const label = stageLabel[reprobeStage] ?? `${reprobeStage}…`;
+          return (
+            <span className="inline-flex items-center gap-1.5 text-sm text-gray-500">
+              <span
+                className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-gray-300 border-t-gray-500"
+                aria-hidden="true"
+              />
+              {label}
+            </span>
+          );
+        }
+
+        // Fixed: pipeline complete, waiting for user to resolve.
+        if (reprobeStage === 'fixed') {
+          return (
+            <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800">
+              Fixed ✓
+            </span>
+          );
+        }
+
+        const isActivePipeline = isReprobing;
+        const disabled = !anomaly.reprobeEligible || anomaly.reprobeLimitReached || isActivePipeline || isResolving;
         const title = anomaly.reprobeLimitReached
           ? 'This slot has been re-probed 3 times. Use [Resolve] to close manually; if the underlying issue persists, the next sweep will re-create the anomaly.'
           : (!anomaly.reprobeEligible ? 'This slot cannot be re-probed.' : undefined);
@@ -266,7 +298,7 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
               title={title}
               aria-describedby={anomaly.reprobeLimitReached ? limitReachedDescriptionId : undefined}
             >
-              {isReprobing ? 'Re-probing…' : 'Re-probe'}
+              {isActivePipeline ? 'Re-probing…' : 'Re-probe'}
             </Button>
           </div>
         );

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -3442,6 +3442,8 @@ export type RunAnomaly = {
   reprobeEligible: Scalars['Boolean']['output'];
   /** True when reprobeCount has reached the circuit-breaker limit (3). UI should disable the [Re-probe] button. */
   reprobeLimitReached: Scalars['Boolean']['output'];
+  /** Current pipeline stage for an in-progress manual re-probe: probing | summarizing | analyzing | aggregating | fixed. Null when no re-probe is in flight. */
+  reprobeStage?: Maybe<Scalars['String']['output']>;
   resolvedAt?: Maybe<Scalars['DateTime']['output']>;
   /** The run this anomaly belongs to */
   run: Run;
@@ -4598,7 +4600,7 @@ export type OpenRunAnomaliesQueryVariables = Exact<{
 }>;
 
 
-export type OpenRunAnomaliesQuery = { __typename?: 'Query', openRunAnomalies: Array<{ __typename?: 'RunAnomaly', id: string, runId: string, type: RunAnomalyType, subject: string, source: RunAnomalySource, details: unknown, firstSeenAt: string, lastSeenAt: string, displayLabel: string, displaySubject: string, reprobeEligible: boolean, reprobeCount: number, reprobeLimitReached: boolean, estimatedCost?: number | null, run: { __typename?: 'Run', id: string, name?: string | null, status: string }, domain?: { __typename?: 'Domain', id: string, name: string } | null }> };
+export type OpenRunAnomaliesQuery = { __typename?: 'Query', openRunAnomalies: Array<{ __typename?: 'RunAnomaly', id: string, runId: string, type: RunAnomalyType, subject: string, source: RunAnomalySource, details: unknown, firstSeenAt: string, lastSeenAt: string, displayLabel: string, displaySubject: string, reprobeEligible: boolean, reprobeCount: number, reprobeLimitReached: boolean, reprobeStage?: string | null, estimatedCost?: number | null, run: { __typename?: 'Run', id: string, name?: string | null, status: string }, domain?: { __typename?: 'Domain', id: string, name: string } | null }> };
 
 export type ReprobeAnomalySlotMutationVariables = Exact<{
   anomalyId: Scalars['ID']['input'];
@@ -7178,6 +7180,7 @@ export const OpenRunAnomaliesDocument = gql`
     reprobeEligible
     reprobeCount
     reprobeLimitReached
+    reprobeStage
     estimatedCost
     run {
       id


### PR DESCRIPTION
## Summary
- Threads `anomalyId` through the `probe_scenario → summarize_transcript → analyze_basic → aggregate_analysis` job chain so each step can update `details.reprobeStage` on the RunAnomaly row
- Each stage transition writes a JSONB field: `probing | summarizing | analyzing | aggregating | fixed`
- `syncAnomalies` guard blocks auto-resolve while `reprobeStage` is non-null (prevents the row disappearing mid-pipeline or before the user resolves it)
- `/status` AnomalyRow shows the current stage with a spinner; shows "Fixed ✓" badge when done; Re-probe button is disabled during active pipeline stages
- Fixes from adversarial review (Gemini + Codex): cache-hit path in `analyze_basic` now also advances stage; aggregate's legacy `continue` path replaced so finalization always runs; `syncAnomalies` guard blocks all non-null stages including `'fixed'`

## Validation
- `npm run build --workspace @valuerank/api` → only pre-existing `@types/compression` error
- `npm run build --workspace @valuerank/web` → clean
- `npm run lint --workspace @valuerank/api` → 0 errors
- `npm run lint --workspace @valuerank/web` → 0 errors
- Adversarial review by Gemini + Codex; all flagged issues resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)