### PR TITLE
fix(models-confidence): skip definitionSnapshot blobs, use definition value pairs

### DIFF
--- a/cloud/apps/api/src/graphql/queries/models-confidence.ts
+++ b/cloud/apps/api/src/graphql/queries/models-confidence.ts
@@ -2,7 +2,12 @@ import { db } from '@valuerank/db';
 import { getModelsFromDatabase } from '../../config/models.js';
 import { runMatchesSignature } from './domain-coverage-gql-types.js';
 import { resolveTranscriptDecisionModel } from './domain/shared.js';
-import { DOMAIN_ANALYSIS_VALUE_KEYS, type DomainAnalysisValueKey } from './domain-analysis-values.js';
+import {
+  DOMAIN_ANALYSIS_VALUE_KEYS,
+  extractValuePair,
+  type DomainAnalysisValueKey,
+  type DomainAnalysisValuePair,
+} from './domain-analysis-values.js';
 import { builder } from '../builder.js';
 import {
   ModelsConfidenceResultRef,
@@ -23,13 +28,6 @@ function computeConfidence(counts: ConfidenceCounts): number | null {
   return (counts.strong / total) * 100;
 }
 
-type TranscriptRow = {
-  modelId: string;
-  decisionMetadata: unknown;
-  definitionSnapshot: unknown;
-  scenario: { orientationFlipped: boolean } | null;
-};
-
 builder.queryField('modelsConfidence', (t) =>
   t.field({
     type: ModelsConfidenceResultRef,
@@ -44,22 +42,6 @@ builder.queryField('modelsConfidence', (t) =>
         availableOnly: false,
       });
 
-      // Aggregate runs are pooling views — they own metadata but transcripts live on
-      // source runs. Fetch aggregate runs (small set), filter by signature, then
-      // follow config.sourceRunIds to reach the actual transcript-bearing runs.
-      const aggregateRuns = await db.run.findMany({
-        where: {
-          status: 'COMPLETED',
-          deletedAt: null,
-          tags: { some: { tag: { name: 'Aggregate' } } },
-        },
-        select: { id: true, config: true },
-      });
-
-      const scopedAggregateRuns = signature != null
-        ? aggregateRuns.filter((run) => runMatchesSignature(run.config, signature))
-        : aggregateRuns;
-
       const emptyValues = (): ModelsConfidenceValueResultShape[] =>
         DOMAIN_ANALYSIS_VALUE_KEYS.map((k) => ({
           valueKey: k,
@@ -68,52 +50,86 @@ builder.queryField('modelsConfidence', (t) =>
           leanCount: 0,
         }));
 
-      if (scopedAggregateRuns.length === 0) {
-        return {
-          models: activeModels.map((m) => ({
-            modelId: m.modelId,
-            label: m.displayName,
-            overallConfidence: null,
-            overallStrongCount: 0,
-            overallLeanCount: 0,
-            values: emptyValues(),
-          })),
-        };
-      }
+      const emptyResult = {
+        models: activeModels.map((m) => ({
+          modelId: m.modelId,
+          label: m.displayName,
+          overallConfidence: null,
+          overallStrongCount: 0,
+          overallLeanCount: 0,
+          values: emptyValues(),
+        })),
+      };
 
-      // Collect unique source run IDs from all matching aggregate run configs.
+      // Aggregate runs are pooling views — transcripts live on source runs.
+      // Fetch aggregate runs (small set), filter by signature, then follow
+      // config.sourceRunIds to reach transcript-bearing source runs.
+      const aggregateRuns = await db.run.findMany({
+        where: {
+          status: 'COMPLETED',
+          deletedAt: null,
+          tags: { some: { tag: { name: 'Aggregate' } } },
+        },
+        select: { config: true },
+      });
+
+      const scopedAggregateRuns = signature != null
+        ? aggregateRuns.filter((run) => runMatchesSignature(run.config, signature))
+        : aggregateRuns;
+
+      if (scopedAggregateRuns.length === 0) return emptyResult;
+
       const sourceRunIdSet = new Set<string>();
       for (const run of scopedAggregateRuns) {
         const config = run.config as { sourceRunIds?: string[] } | null;
-        if (config?.sourceRunIds != null) {
-          for (const id of config.sourceRunIds) {
-            sourceRunIdSet.add(id);
-          }
+        for (const id of config?.sourceRunIds ?? []) {
+          sourceRunIdSet.add(id);
         }
       }
 
-      if (sourceRunIdSet.size === 0) {
-        return {
-          models: activeModels.map((m) => ({
-            modelId: m.modelId,
-            label: m.displayName,
-            overallConfidence: null,
-            overallStrongCount: 0,
-            overallLeanCount: 0,
-            values: emptyValues(),
-          })),
-        };
+      if (sourceRunIdSet.size === 0) return emptyResult;
+
+      const sourceRunIds = Array.from(sourceRunIdSet);
+
+      // Load source runs to get their definitionId — lets us pre-fetch value pairs
+      // by definition rather than per-transcript via the expensive definitionSnapshot blob.
+      const sourceRuns = await db.run.findMany({
+        where: { id: { in: sourceRunIds } },
+        select: { id: true, definitionId: true },
+      });
+
+      const runToDefinitionId = new Map(
+        sourceRuns
+          .filter((r): r is typeof r & { definitionId: string } => r.definitionId != null)
+          .map((r) => [r.id, r.definitionId]),
+      );
+
+      const definitionIds = [...new Set(
+        sourceRuns.map((r) => r.definitionId).filter((id): id is string => id != null),
+      )];
+
+      // Fetch definition content once per definition (much cheaper than loading
+      // definitionSnapshot JSON blob per transcript).
+      const definitions = await db.definition.findMany({
+        where: { id: { in: definitionIds } },
+        select: { id: true, content: true },
+      });
+
+      const defValuePairMap = new Map<string, DomainAnalysisValuePair | null>();
+      for (const def of definitions) {
+        defValuePairMap.set(def.id, extractValuePair(def.content));
       }
 
+      // Fetch transcripts without definitionSnapshot — we supply pairOverride instead,
+      // which resolveTranscriptDecisionModel uses directly (skipping snapshot parsing).
       const transcripts = await db.transcript.findMany({
-        where: { runId: { in: Array.from(sourceRunIdSet) }, deletedAt: null },
+        where: { runId: { in: sourceRunIds }, deletedAt: null },
         select: {
           modelId: true,
+          runId: true,
           decisionMetadata: true,
-          definitionSnapshot: true,
-          scenario: { select: { orientationFlipped: true } },
         },
-      }) as TranscriptRow[];
+      });
 
       // modelId -> counts
       const countsMap = new Map<string, ModelConfidenceCounts>();
@@ -122,21 +138,22 @@ builder.queryField('modelsConfidence', (t) =>
         for (const key of DOMAIN_ANALYSIS_VALUE_KEYS) {
           valueMap.set(key, { strong: 0, lean: 0 });
         }
-        countsMap.set(model.modelId, {
-          valueMap,
-          rawStrong: 0,
-          rawLean: 0,
-        });
+        countsMap.set(model.modelId, { valueMap, rawStrong: 0, rawLean: 0 });
       }
 
       for (const transcript of transcripts) {
         const modelCounts = countsMap.get(transcript.modelId);
         if (modelCounts == null) continue;
 
+        const definitionId = runToDefinitionId.get(transcript.runId);
+        const pairOverride = definitionId != null ? defValuePairMap.get(definitionId) : undefined;
+
+        // orientationFlipped is not needed: both values in a pair receive the same
+        // strength count regardless of which was favored, so direction doesn't matter.
         const { canonical } = resolveTranscriptDecisionModel({
           decisionMetadata: transcript.decisionMetadata,
-          definitionSnapshot: transcript.definitionSnapshot,
-          orientationFlipped: transcript.scenario?.orientationFlipped ?? null,
+          orientationFlipped: null,
+          pairOverride: pairOverride ?? undefined,
         });
 
         if (canonical.direction !== 'favor_first' && canonical.direction !== 'favor_second') continue;


### PR DESCRIPTION
## Summary

- Loading `definitionSnapshot` (large JSON blob) per transcript caused a DB statement timeout with thousands of transcripts → `[GraphQL] Unexpected error occurred`
- Fix: pre-load value pairs from `definition.content` once per definition, pass as `pairOverride` to `resolveTranscriptDecisionModel` — skips the per-transcript snapshot parsing entirely
- Also drops the `scenario` join (`orientationFlipped`) — confidence assigns the same strength count to both values in a pair regardless of direction, so orientation has no effect

**Query sequence after fix:**
1. Aggregate-tagged runs → filter by signature → extract `sourceRunIds` (small set, configs only)
2. Source runs → `definitionId` map (IDs only, no blobs)
3. Definitions → value pair map (one `content` blob per definition, not per transcript)
4. Transcripts — `modelId`, `runId`, `decisionMetadata` only (no `definitionSnapshot`, no `scenario` join)

## Validation

- `npm run build --workspace @valuerank/api` → 1 pre-existing error (compression types, matches main)
- `npm run lint --workspace @valuerank/api` → 0 errors
- `npm run test --workspace @valuerank/web` → 137/137 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)