### PR TITLE
nav: move Circumplex and Consistency to Archive

### DIFF
--- a/cloud/apps/web/src/App.tsx
+++ b/cloud/apps/web/src/App.tsx
@@ -193,10 +193,11 @@ function App() {
                 </ProtectedLayout>
               }
             />
+            <Route path="/models/consistency" element={<Navigate to="/archive/consistency" replace />} />
             <Route
-              path="/models/consistency"
+              path="/archive/consistency"
               element={
-                <ProtectedLayout>
+                <ProtectedLayout requiredRole="ADMIN">
                   <ModelsConsistency />
                 </ProtectedLayout>
               }
@@ -209,10 +210,11 @@ function App() {
                 </ProtectedLayout>
               }
             />
+            <Route path="/models/circumplex" element={<Navigate to="/archive/circumplex" replace />} />
             <Route
-              path="/models/circumplex"
+              path="/archive/circumplex"
               element={
-                <ProtectedLayout>
+                <ProtectedLayout requiredRole="ADMIN">
                   <ModelsCircumplex />
                 </ProtectedLayout>
               }

--- a/cloud/apps/web/src/components/layout/MobileNav.tsx
+++ b/cloud/apps/web/src/components/layout/MobileNav.tsx
@@ -25,9 +25,7 @@ const navItems: NavItem[] = [
     children: [
       { name: 'Matrix', path: '/models', icon: Cpu, match: 'exact' },
       { name: 'Domain Shifts', path: '/models/domain-shifts', icon: BarChart2 },
-      { name: 'Consistency', path: '/models/consistency', icon: BarChart2 },
       { name: 'Pressure Sensitivity', path: '/models/pressure-sensitivity', icon: BarChart2 },
-      { name: 'Circumplex', path: '/models/circumplex', icon: BarChart2 },
     ],
   },
   {
@@ -56,6 +54,8 @@ const navItems: NavItem[] = [
     children: [
       { name: 'Legacy Survey Work', path: '/archive/surveys', icon: Archive },
       { name: 'Legacy Survey Results', path: '/archive/survey-results', icon: Archive },
+      { name: 'Circumplex', path: '/archive/circumplex', icon: Archive },
+      { name: 'Consistency', path: '/archive/consistency', icon: Archive },
     ],
   },
   {

--- a/cloud/apps/web/src/components/layout/NavTabs.tsx
+++ b/cloud/apps/web/src/components/layout/NavTabs.tsx
@@ -38,9 +38,7 @@ const domainMenuItems: MenuItem[] = [
 const modelsMenuItems: MenuItem[] = [
   { name: 'Matrix', path: '/models', match: 'exact' },
   { name: 'Domain Shifts', path: '/models/domain-shifts' },
-  { name: 'Consistency', path: '/models/consistency' },
   { name: 'Pressure Sensitivity', path: '/models/pressure-sensitivity' },
-  { name: 'Circumplex', path: '/models/circumplex' },
   { name: 'Confidence', path: '/models/confidence' },
 ];
 
@@ -48,6 +46,8 @@ const archiveMenuItems: MenuItem[] = [
   { name: 'Overview', path: '/archive', aliases: [] as string[] },
   { name: 'Legacy Survey Work', path: '/archive/surveys' },
   { name: 'Legacy Survey Results', path: '/archive/survey-results' },
+  { name: 'Circumplex', path: '/archive/circumplex' },
+  { name: 'Consistency', path: '/archive/consistency' },
 ];
 
 const adminSettingsMenuItems: MenuItem[] = [

--- a/cloud/apps/web/tests/components/layout/MobileNav.test.tsx
+++ b/cloud/apps/web/tests/components/layout/MobileNav.test.tsx
@@ -38,8 +38,8 @@ describe('MobileNav Component', () => {
     expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Matrix' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Domain Shifts' })).toHaveAttribute('href', '/models/domain-shifts');
-    expect(screen.getByRole('link', { name: 'Consistency' })).toHaveAttribute('href', '/models/consistency');
-    expect(screen.getByRole('link', { name: 'Circumplex' })).toHaveAttribute('href', '/models/circumplex');
+    expect(screen.getByRole('link', { name: 'Consistency' })).toHaveAttribute('href', '/archive/consistency');
+    expect(screen.getByRole('link', { name: 'Circumplex' })).toHaveAttribute('href', '/archive/circumplex');
     expect(screen.getByRole('link', { name: 'Archive' })).toHaveAttribute('href', '/archive');
     expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings/account');
   });

--- a/cloud/apps/web/tests/components/layout/NavTabs.test.tsx
+++ b/cloud/apps/web/tests/components/layout/NavTabs.test.tsx
@@ -63,8 +63,6 @@ describe('NavTabs Component', () => {
     expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Matrix' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Domain Shifts' })).toHaveAttribute('href', '/models/domain-shifts');
-    expect(screen.getByRole('link', { name: 'Consistency' })).toHaveAttribute('href', '/models/consistency');
-    expect(screen.getByRole('link', { name: 'Circumplex' })).toHaveAttribute('href', '/models/circumplex');
   });
 
   it('highlights only Domain Shifts inside the models menu on the domain shifts route', async () => {
@@ -108,6 +106,8 @@ describe('NavTabs Component', () => {
 
     expect(screen.getByRole('link', { name: 'Legacy Survey Work' })).toHaveAttribute('href', '/archive/surveys');
     expect(screen.getByRole('link', { name: 'Legacy Survey Results' })).toHaveAttribute('href', '/archive/survey-results');
+    expect(screen.getByRole('link', { name: 'Circumplex' })).toHaveAttribute('href', '/archive/circumplex');
+    expect(screen.getByRole('link', { name: 'Consistency' })).toHaveAttribute('href', '/archive/consistency');
   });
 
   it('highlights Archive on archive compatibility routes', async () => {


### PR DESCRIPTION
## Summary

- Removes Circumplex and Consistency from the Models dropdown in desktop and mobile nav
- Adds both under Archive at `/archive/circumplex` and `/archive/consistency`
- Old `/models/circumplex` and `/models/consistency` URLs redirect to the new paths so bookmarks keep working
- Both routes now require `ADMIN` role, consistent with the rest of Archive

## Validation

- TypeScript: `tsc --noEmit` passed with no errors
- Changes are additive nav/route renames — no business logic touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)