### PR TITLE
feat(status): redesign anomaly table with Vignette, Model, and Strength columns

### DIFF
--- a/cloud/apps/api/src/graphql/types/run-anomaly.ts
+++ b/cloud/apps/api/src/graphql/types/run-anomaly.ts
@@ -181,6 +181,35 @@ builder.objectType(RunAnomalyRef, {
       },
     }),
 
+    scenarioName: t.string({
+      nullable: true,
+      description: 'Scenario (vignette) name for slot-keyed anomaly types. Null for non-slot types or when the scenario cannot be found.',
+      resolve: async (anomaly) => {
+        const details = anomaly.details as Record<string, unknown> | null;
+        const scenarioId = typeof details?.scenarioId === 'string' && details.scenarioId.length > 0 ? details.scenarioId : null;
+        if (scenarioId === null) return null;
+        const scenario = await db.scenario.findUnique({ where: { id: scenarioId }, select: { name: true } });
+        return scenario?.name ?? null;
+      },
+    }),
+
+    dimensionValues: t.field({
+      type: 'JSON',
+      nullable: true,
+      description: 'Dimension values from the scenario content for slot-keyed anomaly types (Record<string, string>). Null for non-slot types.',
+      resolve: async (anomaly) => {
+        const details = anomaly.details as Record<string, unknown> | null;
+        const scenarioId = typeof details?.scenarioId === 'string' && details.scenarioId.length > 0 ? details.scenarioId : null;
+        if (scenarioId === null) return null;
+        const scenario = await db.scenario.findUnique({ where: { id: scenarioId }, select: { content: true } });
+        if (scenario === null) return null;
+        const content = scenario.content as { dimension_values?: Record<string, string> } | null;
+        const dv = content?.dimension_values;
+        if (dv == null || typeof dv !== 'object' || Object.keys(dv).length === 0) return null;
+        return dv;
+      },
+    }),
+
     estimatedCost: t.float({
       nullable: true,
       description: 'Best-effort cost estimate for the next re-probe attempt, computed as the average estimatedCost of the last 10 successful (non-deleted, summarized) transcripts for the same modelId across all runs. Returns null when the anomaly is not reprobable, no modelId is available, or no recent transcripts have cost data.',

--- a/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
@@ -349,7 +349,7 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
         { runId, transcriptId: transcriptRecord.id, anomalyId },
         { ...jobOptions['summarize_transcript'], singletonKey: transcriptRecord.id },
       );
-      await setReprobeStage(anomalyId, 'summarizing');
+      await setReprobeStage(anomalyId, 'summarizing', { transcriptId: transcriptRecord.id });
       log.info({ jobId, runId, anomalyId, transcriptId: transcriptRecord.id }, 'Enqueued summarize for reprobe pipeline');
     }
 

--- a/cloud/apps/api/src/services/run/anomaly-persistence.ts
+++ b/cloud/apps/api/src/services/run/anomaly-persistence.ts
@@ -101,7 +101,11 @@ export async function syncAnomalies(
  * Merge-updates the reprobeStage field inside an anomaly's JSONB details.
  * Safe to call even if the anomaly has been resolved; logs a warning and no-ops.
  */
-export async function setReprobeStage(anomalyId: string, stage: string): Promise<void> {
+export async function setReprobeStage(
+  anomalyId: string,
+  stage: string,
+  extraFields?: Record<string, unknown>,
+): Promise<void> {
   const anomaly = await db.runAnomaly.findUnique({
     where: { id: anomalyId },
     select: { details: true },
@@ -117,6 +121,9 @@ export async function setReprobeStage(anomalyId: string, stage: string): Promise
       ? { ...(anomaly.details as Record<string, unknown>) }
       : {};
   current.reprobeStage = stage;
+  if (extraFields != null) {
+    Object.assign(current, extraFields);
+  }
   await db.runAnomaly.update({
     where: { id: anomalyId },
     data: { details: current as Prisma.InputJsonValue },

--- a/cloud/apps/web/src/api/operations/run-anomaly.graphql
+++ b/cloud/apps/web/src/api/operations/run-anomaly.graphql
@@ -15,6 +15,8 @@ query OpenRunAnomalies($domainId: ID, $type: RunAnomalyType) {
     reprobeLimitReached
     reprobeStage
     estimatedCost
+    scenarioName
+    dimensionValues
     run {
       id
       name

--- a/cloud/apps/web/src/components/status/AnomalyRow.tsx
+++ b/cloud/apps/web/src/components/status/AnomalyRow.tsx
@@ -21,6 +21,14 @@ type AnomalyRowProps = {
   onViewTranscript: (target: { runId: string; transcriptId: string }) => void;
 };
 
+const LEVEL_WORD_TO_NUMBER: Record<string, number> = {
+  full: 5,
+  substantial: 4,
+  moderate: 3,
+  minimal: 2,
+  negligible: 1,
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -33,51 +41,19 @@ function extractTranscriptId(details: unknown): string | null {
   return typeof transcriptId === 'string' && transcriptId.trim() !== '' ? transcriptId : null;
 }
 
-function formatAge(firstSeenAt: string): string {
-  const ageMs = Date.now() - new Date(firstSeenAt).getTime();
-  if (!Number.isFinite(ageMs) || ageMs <= 0) {
-    return '0s';
-  }
-
-  const seconds = Math.floor(ageMs / 1000);
-  if (seconds < 60) {
-    return `${seconds}s`;
-  }
-
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) {
-    return `${minutes}m`;
-  }
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) {
-    return `${hours}h`;
-  }
-
-  const days = Math.floor(hours / 24);
-  if (days < 7) {
-    return `${days}d`;
-  }
-
-  const weeks = Math.floor(days / 7);
-  if (weeks < 5) {
-    return `${weeks}w`;
-  }
-
-  const months = Math.floor(days / 30);
-  if (months < 12) {
-    return `${months}mo`;
-  }
-
-  const years = Math.floor(days / 365);
-  return `${years}y`;
+function formatStrengthLevel(value: string): string {
+  const lower = value.toLowerCase();
+  const num = LEVEL_WORD_TO_NUMBER[lower];
+  const display = value.charAt(0).toUpperCase() + value.slice(1);
+  return num != null ? `${num} - ${display}` : display;
 }
 
-function formatTimestamp(value: string): string {
-  return new Date(value).toLocaleString('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  });
+function extractStrengthPair(dimensionValues: unknown): [string, string] {
+  if (!isRecord(dimensionValues)) return ['—', '—'];
+  const entries = Object.entries(dimensionValues);
+  const first = entries[0] != null ? formatStrengthLevel(String(entries[0][1])) : '—';
+  const second = entries[1] != null ? formatStrengthLevel(String(entries[1][1])) : '—';
+  return [first, second];
 }
 
 export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps) {
@@ -189,9 +165,10 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
     }
   };
 
-  const runLabel = anomaly.run.id.slice(0, 8);
-  const ageLabel = formatAge(anomaly.firstSeenAt);
-  const ageTitle = formatTimestamp(anomaly.firstSeenAt);
+  const modelId = isRecord(anomaly.details) && typeof anomaly.details.modelId === 'string'
+    ? anomaly.details.modelId
+    : null;
+  const [firstStrength, secondStrength] = extractStrengthPair(anomaly.dimensionValues);
 
   const renderViewTranscriptButton = () => {
     if (anomaly.type === 'INVALID_RESPONSE_FAILURE') {
@@ -339,29 +316,23 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
           {anomaly.domain?.name ?? '—'}
         </td>
         <td className="px-4 py-3 align-top text-sm text-gray-700">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate(`/runs/${anomaly.run.id}`)}
-            className="px-0 text-left font-mono text-sm text-teal-700 hover:bg-transparent hover:text-teal-800"
-            title={anomaly.run.id}
-          >
-            {runLabel}
-          </Button>
+          <span className="block max-w-[16rem] truncate" title={anomaly.scenarioName ?? undefined}>
+            {anomaly.scenarioName ?? '—'}
+          </span>
         </td>
         <td className="px-4 py-3 align-top text-sm text-gray-700">
           <span className="font-medium text-gray-900">{anomaly.displayLabel}</span>
         </td>
         <td className="px-4 py-3 align-top text-sm text-gray-700">
-          <span className="block max-w-[20rem] truncate" title={anomaly.displaySubject}>
-            {anomaly.displaySubject}
+          <span className="block max-w-[16rem] truncate font-mono text-xs" title={modelId ?? undefined}>
+            {modelId ?? '—'}
           </span>
         </td>
-        <td className="px-4 py-3 align-top text-sm text-gray-700">
-          <span title={ageTitle} className="whitespace-nowrap">
-            {ageLabel}
-          </span>
+        <td className="px-4 py-3 align-top text-sm text-gray-700 whitespace-nowrap">
+          {firstStrength}
+        </td>
+        <td className="px-4 py-3 align-top text-sm text-gray-700 whitespace-nowrap">
+          {secondStrength}
         </td>
         <td className="px-4 py-3 align-top text-sm text-gray-700">
           <div className="flex flex-wrap items-center justify-end gap-2">

--- a/cloud/apps/web/src/components/status/OpenAnomaliesSection.tsx
+++ b/cloud/apps/web/src/components/status/OpenAnomaliesSection.tsx
@@ -174,15 +174,8 @@ export function OpenAnomaliesSection({
               <div className="animate-pulse rounded-lg border border-gray-200 bg-white p-4">
                 <div className="space-y-3">
                   <div className="h-4 w-40 rounded bg-gray-200" />
-                  <div className="grid grid-cols-6 gap-3">
+                  <div className="grid grid-cols-7 gap-3">
                     <div className="h-4 rounded bg-gray-100" />
-                    <div className="h-4 rounded bg-gray-100" />
-                    <div className="h-4 rounded bg-gray-100" />
-                    <div className="h-4 rounded bg-gray-100" />
-                    <div className="h-4 rounded bg-gray-100" />
-                    <div className="h-4 rounded bg-gray-100" />
-                  </div>
-                  <div className="grid grid-cols-6 gap-3">
                     <div className="h-4 rounded bg-gray-100" />
                     <div className="h-4 rounded bg-gray-100" />
                     <div className="h-4 rounded bg-gray-100" />
@@ -190,7 +183,17 @@ export function OpenAnomaliesSection({
                     <div className="h-4 rounded bg-gray-100" />
                     <div className="h-4 rounded bg-gray-100" />
                   </div>
-                  <div className="grid grid-cols-6 gap-3">
+                  <div className="grid grid-cols-7 gap-3">
+                    <div className="h-4 rounded bg-gray-100" />
+                    <div className="h-4 rounded bg-gray-100" />
+                    <div className="h-4 rounded bg-gray-100" />
+                    <div className="h-4 rounded bg-gray-100" />
+                    <div className="h-4 rounded bg-gray-100" />
+                    <div className="h-4 rounded bg-gray-100" />
+                    <div className="h-4 rounded bg-gray-100" />
+                  </div>
+                  <div className="grid grid-cols-7 gap-3">
+                    <div className="h-4 rounded bg-gray-100" />
                     <div className="h-4 rounded bg-gray-100" />
                     <div className="h-4 rounded bg-gray-100" />
                     <div className="h-4 rounded bg-gray-100" />
@@ -210,16 +213,19 @@ export function OpenAnomaliesSection({
                       Domain
                     </th>
                     <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
-                      Run
+                      Vignette
                     </th>
                     <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
                       Type
                     </th>
                     <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
-                      Subject
+                      Model
                     </th>
                     <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
-                      Age
+                      Strength of First Value
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
+                      Strength of Second Value
                     </th>
                     <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-amber-900">
                       Actions

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -3448,6 +3448,10 @@ export type RunAnomaly = {
   /** The run this anomaly belongs to */
   run: Run;
   runId: Scalars['String']['output'];
+  /** Scenario (vignette) name for slot-keyed anomaly types. Null for non-slot types or when the scenario cannot be found. */
+  scenarioName?: Maybe<Scalars['String']['output']>;
+  /** Dimension values from the scenario content for slot-keyed anomaly types. */
+  dimensionValues?: Maybe<Scalars['JSON']['output']>;
   source: RunAnomalySource;
   subject: Scalars['String']['output'];
   type: RunAnomalyType;
@@ -4600,7 +4604,7 @@ export type OpenRunAnomaliesQueryVariables = Exact<{
 }>;
 
 
-export type OpenRunAnomaliesQuery = { __typename?: 'Query', openRunAnomalies: Array<{ __typename?: 'RunAnomaly', id: string, runId: string, type: RunAnomalyType, subject: string, source: RunAnomalySource, details: unknown, firstSeenAt: string, lastSeenAt: string, displayLabel: string, displaySubject: string, reprobeEligible: boolean, reprobeCount: number, reprobeLimitReached: boolean, reprobeStage?: string | null, estimatedCost?: number | null, run: { __typename?: 'Run', id: string, name?: string | null, status: string }, domain?: { __typename?: 'Domain', id: string, name: string } | null }> };
+export type OpenRunAnomaliesQuery = { __typename?: 'Query', openRunAnomalies: Array<{ __typename?: 'RunAnomaly', id: string, runId: string, type: RunAnomalyType, subject: string, source: RunAnomalySource, details: unknown, firstSeenAt: string, lastSeenAt: string, displayLabel: string, displaySubject: string, reprobeEligible: boolean, reprobeCount: number, reprobeLimitReached: boolean, reprobeStage?: string | null, estimatedCost?: number | null, scenarioName?: string | null, dimensionValues?: unknown | null, run: { __typename?: 'Run', id: string, name?: string | null, status: string }, domain?: { __typename?: 'Domain', id: string, name: string } | null }> };
 
 export type ReprobeAnomalySlotMutationVariables = Exact<{
   anomalyId: Scalars['ID']['input'];
@@ -7182,6 +7186,8 @@ export const OpenRunAnomaliesDocument = gql`
     reprobeLimitReached
     reprobeStage
     estimatedCost
+    scenarioName
+    dimensionValues
     run {
       id
       name


### PR DESCRIPTION
## Summary
- Replace Run column with **Vignette** (scenario name, looked up from \`details.scenarioId\`)
- Replace Subject column with **Model** (model ID from \`details.modelId\`, shown in monospace)
- Add **Strength of First Value** and **Strength of Second Value** columns (from \`scenario.content.dimension_values\`, formatted as \`N - Label\` e.g. \`4 - Substantial\`)
- Remove Age column and sample index from display
- Fix **View Transcript** after reprobe: probe handler now writes the new \`transcriptId\` back into anomaly details so the button opens the correct (new) transcript once \`reprobeStage\` reaches \`fixed\`
- Non-slot anomaly types (PAIR_ASYMMETRY, STRANDED_TRANSCRIPT, etc.) show \`—\` in Vignette/Model/Strength cells

## Backend changes
- New \`scenarioName\` and \`dimensionValues\` fields on \`RunAnomaly\` GraphQL type
- \`setReprobeStage\` accepts optional \`extraFields\` to merge into anomaly details in one DB round-trip
- Probe handler passes \`{ transcriptId }\` as \`extraFields\` on reprobe success

## Test plan
- [ ] Lint & Build pass
- [ ] API & DB Tests pass
- [ ] Web Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)