### PR TITLE
fix(models-confidence): read sourceRunIds from analysisResult.output

### DIFF
--- a/cloud/apps/api/src/graphql/queries/models-confidence.ts
+++ b/cloud/apps/api/src/graphql/queries/models-confidence.ts
@@ -70,7 +70,7 @@ builder.queryField('modelsConfidence', (t) =>
           deletedAt: null,
           tags: { some: { tag: { name: 'Aggregate' } } },
         },
-        select: { config: true },
+        select: { id: true, config: true },
       });
 
       const scopedAggregateRuns = signature != null
@@ -79,10 +79,17 @@ builder.queryField('modelsConfidence', (t) =>
 
       if (scopedAggregateRuns.length === 0) return emptyResult;
 
+      // sourceRunIds lives in analysisResult.output, not run.config — follow the join.
+      const aggregateRunIds = scopedAggregateRuns.map((r) => r.id);
+      const aggregateResults = await db.analysisResult.findMany({
+        where: { runId: { in: aggregateRunIds }, status: 'CURRENT' },
+        select: { output: true },
+      });
+
       const sourceRunIdSet = new Set<string>();
-      for (const run of scopedAggregateRuns) {
-        const config = run.config as { sourceRunIds?: string[] } | null;
-        for (const id of config?.sourceRunIds ?? []) {
+      for (const result of aggregateResults) {
+        const output = result.output as { sourceRunIds?: string[] } | null;
+        for (const id of output?.sourceRunIds ?? []) {
           sourceRunIdSet.add(id);
         }
       }


### PR DESCRIPTION
## Root cause

`sourceRunIds` is written into `finalOutput` in `persistAggregateRun` and stored in the `analysisResult` table — not in `run.config`. Every previous fix read `config.sourceRunIds` which is always `undefined`, causing the resolver to hit the early-return guard and return all-dashes immediately.

## Fix

Added `id: true` to the aggregate runs select, then join to `analysisResult` (status CURRENT) to read `output.sourceRunIds`.

```
aggregate runs → analysisResult (CURRENT) → output.sourceRunIds → source run IDs
```

## Validation

- `npx turbo lint --filter=@valuerank/api` — 0 errors (28 pre-existing warnings, none in this file)
- Build failure (`@types/compression` missing) is pre-existing on `main`, not introduced here

🤖 Generated with [Claude Code](https://claude.com/claude-code)