### PR TITLE
Pressure Sensitivity: add Pressure Response by Value section + snapshot buttons + heading renames

### DIFF
--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { PressureResponseByValueTable } from './PressureResponseByValueTable';
+import type {
+  PressureSensitivityCell,
+  PressureSensitivityModel,
+  PressureSensitivityValuePair,
+} from '../../api/operations/pressureSensitivity';
+
+const TEN_VALUE_LABELS = [
+  'Alpha',
+  'Bravo',
+  'Charlie',
+  'Delta',
+  'Echo',
+  'Foxtrot',
+  'Golf',
+  'Hotel',
+  'India',
+  'Juliet',
+];
+
+function createCell(
+  ownLevel: number,
+  opponentLevel: number,
+  n: number,
+  winRate: number,
+): PressureSensitivityCell {
+  return {
+    ownLevel,
+    opponentLevel,
+    n,
+    unscoredCount: 0,
+    winRate,
+    conviction: null,
+    netScore: null,
+    lowData: false,
+  };
+}
+
+function createPair(
+  pairKey: string,
+  firstValueLabel: string,
+  secondValueLabel: string,
+  grid: PressureSensitivityCell[],
+): PressureSensitivityValuePair {
+  const n = grid.reduce((sum, cell) => sum + cell.n, 0);
+
+  return {
+    pairKey,
+    firstValueToken: firstValueLabel.toLowerCase(),
+    firstValueLabel,
+    secondValueToken: secondValueLabel.toLowerCase(),
+    secondValueLabel,
+    n,
+    unscoredCount: 0,
+    definitionsMeasured: 1,
+    pressureResponse: {
+      value: null,
+      baselineRate: null,
+      pushTowardFirstRate: null,
+      pushTowardSecondRate: null,
+      qualifyingTrials: n,
+      ciLow: null,
+      ciHigh: null,
+      reason: null,
+    },
+    grid,
+  };
+}
+
+function createModel(valuePairs: PressureSensitivityValuePair[]): PressureSensitivityModel {
+  return {
+    modelId: 'model-a',
+    label: 'Model A',
+    providerName: 'Provider',
+    unscoredCount: 0,
+    pressureResponseSummary: { mean: 0.1, rangeMin: 0.05, rangeMax: 0.15, pairsMeasured: valuePairs.length },
+    valuePairs,
+  };
+}
+
+function createUniformGrid(): PressureSensitivityCell[] {
+  return [
+    createCell(1, 1, 5, 0.6),
+    createCell(4, 1, 5, 0.8),
+    createCell(1, 4, 5, 0.4),
+    createCell(2, 3, 5, 0.6),
+  ];
+}
+
+function createTenValueModel(): PressureSensitivityModel {
+  const pairs: PressureSensitivityValuePair[] = [];
+
+  for (let i = 0; i < TEN_VALUE_LABELS.length; i += 1) {
+    const firstValueLabel = TEN_VALUE_LABELS[i];
+    if (firstValueLabel == null) continue;
+
+    for (let j = i + 1; j < TEN_VALUE_LABELS.length; j += 1) {
+      const secondValueLabel = TEN_VALUE_LABELS[j];
+      if (secondValueLabel == null) continue;
+
+      pairs.push(
+        createPair(
+          `${firstValueLabel.toLowerCase()}::${secondValueLabel.toLowerCase()}`,
+          firstValueLabel,
+          secondValueLabel,
+          createUniformGrid(),
+        ),
+      );
+    }
+  }
+
+  return createModel(pairs);
+}
+
+function createSortFixture(): PressureSensitivityModel {
+  return createModel([
+    createPair(
+      'alpha::beta',
+      'Alpha',
+      'Beta',
+      [
+        createCell(1, 1, 10, 0.3),
+        createCell(4, 1, 10, 0.9),
+        createCell(1, 4, 10, 0),
+        createCell(2, 3, 10, 0),
+      ],
+    ),
+    createPair(
+      'alpha::charlie',
+      'Alpha',
+      'Charlie',
+      [
+        createCell(1, 1, 10, 0.3),
+        createCell(4, 1, 10, 0.9),
+        createCell(1, 4, 10, 0),
+        createCell(2, 3, 10, 0),
+      ],
+    ),
+    createPair(
+      'beta::charlie',
+      'Beta',
+      'Charlie',
+      [
+        createCell(1, 1, 10, 0.8),
+        createCell(4, 1, 10, 0.9),
+        createCell(1, 4, 10, 0.6),
+        createCell(2, 3, 10, 0.9),
+      ],
+    ),
+  ]);
+}
+
+function createMathFixture(): PressureSensitivityModel {
+  return createModel([
+    createPair(
+      'alpha::beta',
+      'Alpha',
+      'Beta',
+      [
+        createCell(1, 1, 5, 0.4),
+        createCell(4, 1, 5, 0.8),
+        createCell(1, 4, 10, 0.3),
+        createCell(2, 3, 10, 0.9),
+      ],
+    ),
+    createPair(
+      'gamma::alpha',
+      'Gamma',
+      'Alpha',
+      [
+        createCell(1, 1, 10, 0.6),
+        createCell(4, 1, 10, 0.7),
+        createCell(1, 4, 10, 0.2),
+        createCell(2, 3, 10, 0.1),
+      ],
+    ),
+  ]);
+}
+
+describe('PressureResponseByValueTable', () => {
+  it('renders 10 rows when the model has 10 values across 9 pairs each', () => {
+    render(<PressureResponseByValueTable valuePairs={createTenValueModel().valuePairs} />);
+
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(11);
+  });
+
+  it('sorts by responsiveness by default and re-sorts when a header is clicked', () => {
+    render(<PressureResponseByValueTable valuePairs={createSortFixture().valuePairs} />);
+
+    const rows = screen.getAllByRole('row');
+    expect(rows[1]?.textContent ?? '').toContain('Alpha');
+
+    fireEvent.click(screen.getByRole('button', { name: /sort by average win rate/i }));
+
+    const resortedRows = screen.getAllByRole('row');
+    expect(resortedRows[1]?.textContent ?? '').toContain('Beta');
+  });
+
+  it('renders the snapshot button with the correct label', () => {
+    render(<PressureResponseByValueTable valuePairs={createSortFixture().valuePairs} />);
+
+    expect(
+      screen.getByRole('button', { name: /copy pressure response by value as image/i }),
+    ).toBeDefined();
+  });
+
+  it('aggregates pooled win rates across multiple pairs', () => {
+    render(<PressureResponseByValueTable valuePairs={createMathFixture().valuePairs} />);
+
+    const row = screen.getByText('Alpha').closest('tr');
+    if (row == null) {
+      throw new Error('Missing Alpha row');
+    }
+
+    const cells = within(row).getAllByRole('cell');
+    expect(cells[1]?.textContent ?? '').toBe('60%');
+    expect(cells[2]?.textContent ?? '').toBe('40%');
+    expect(cells[3]?.textContent ?? '').toBe('80%');
+    expect(cells[4]?.textContent ?? '').toBe('30%');
+  });
+});

--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
@@ -1,0 +1,395 @@
+import { useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { CopyVisualButton } from '../ui/CopyVisualButton';
+import { HeaderTooltip } from '../ui/HeaderTooltip';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/Table';
+import type { PressureSensitivityCell, PressureSensitivityValuePair } from '../../api/operations/pressureSensitivity';
+import { formatPercent } from './pressureSensitivityFormatting';
+
+type Props = {
+  valuePairs: PressureSensitivityValuePair[];
+};
+
+type SortDirection = 'asc' | 'desc';
+type SortKey =
+  | 'value'
+  | 'averageWinRate'
+  | 'balancedWinRate'
+  | 'highPressureOnThisValue'
+  | 'highPressureOnOpposingValue'
+  | 'responsiveness';
+
+type ValueRow = {
+  valueLabel: string;
+  averageWinRate: number | null;
+  balancedWinRate: number | null;
+  highPressureOnThisValue: number | null;
+  highPressureOnOpposingValue: number | null;
+  responsiveness: number | null;
+};
+
+type PairPerspectiveRates = {
+  averageWinRate: number | null;
+  balancedWinRate: number | null;
+  highPressureOnThisValue: number | null;
+  highPressureOnOpposingValue: number | null;
+};
+
+const MIN_N = 3;
+
+const AVERAGE_WIN_RATE_TOOLTIP =
+  "The model's overall rate of picking this value, pooled across all 25 cells of the 5x5 pressure grid (every combination of own and opposing pressure levels). Tells you how often the model picks this value across the full range of conditions tested.";
+const BALANCED_WIN_RATE_TOOLTIP =
+  "The model's rate of picking this value when own and opposing pressure are at the same level. Pooled across the 5 diagonal cells (negligible/negligible up through full/full). The reference rate when neither value has a directional advantage from the prompt.";
+const HIGH_PRESSURE_ON_THIS_VALUE_TOOLTIP =
+  'The model\'s rate when the prompt pushes toward this value — this value at heavy or full pressure (level 4 or 5) AND the opposing value at light or moderate (level 1, 2, or 3). 6 cells per pair.';
+const HIGH_PRESSURE_ON_OPPOSING_VALUE_TOOLTIP =
+  'The model\'s rate when the prompt pushes toward the OTHER value instead — opposing at heavy or full, this value at light or moderate. 6 cells per pair.';
+
+function formatRate(value: number | null): ReactNode {
+  if (value == null) {
+    return <span className="font-mono text-gray-500">—</span>;
+  }
+
+  return <span className="font-mono text-gray-900">{formatPercent(value)}</span>;
+}
+
+function invertRate(value: number | null): number | null {
+  if (value == null) return null;
+  return 1 - value;
+}
+
+function poolRate(cells: PressureSensitivityCell[], predicate: (cell: PressureSensitivityCell) => boolean): number | null {
+  let weightedSuccesses = 0;
+  let trials = 0;
+
+  for (const cell of cells) {
+    if (cell.n < MIN_N || !predicate(cell)) {
+      continue;
+    }
+
+    if (cell.winRate == null) {
+      continue;
+    }
+
+    weightedSuccesses += cell.winRate * cell.n;
+    trials += cell.n;
+  }
+
+  if (trials === 0) {
+    return null;
+  }
+
+  return weightedSuccesses / trials;
+}
+
+function computePairRates(pair: PressureSensitivityValuePair, valueLabel: string): PairPerspectiveRates {
+  const averageWinRate = poolRate(pair.grid, () => true);
+  const balancedWinRate = poolRate(pair.grid, (cell) => cell.ownLevel === cell.opponentLevel);
+  const highPressureOnFirstValue = poolRate(
+    pair.grid,
+    (cell) => cell.ownLevel >= 4 && cell.opponentLevel <= 3,
+  );
+  const highPressureOnSecondValue = poolRate(
+    pair.grid,
+    (cell) => cell.opponentLevel >= 4 && cell.ownLevel <= 3,
+  );
+
+  if (pair.firstValueLabel === valueLabel) {
+    return {
+      averageWinRate,
+      balancedWinRate,
+      highPressureOnThisValue: highPressureOnFirstValue,
+      highPressureOnOpposingValue: highPressureOnSecondValue,
+    };
+  }
+
+  return {
+    averageWinRate: invertRate(averageWinRate),
+    balancedWinRate: invertRate(balancedWinRate),
+    highPressureOnThisValue: invertRate(highPressureOnSecondValue),
+    highPressureOnOpposingValue: invertRate(highPressureOnFirstValue),
+  };
+}
+
+function mean(values: Array<number | null>): number | null {
+  let sum = 0;
+  let count = 0;
+
+  for (const value of values) {
+    if (value == null) {
+      continue;
+    }
+    sum += value;
+    count += 1;
+  }
+
+  if (count === 0) {
+    return null;
+  }
+
+  return sum / count;
+}
+
+function buildValueRows(valuePairs: PressureSensitivityValuePair[]): ValueRow[] {
+  const valueLabels = [...new Set(valuePairs.flatMap((pair) => [pair.firstValueLabel, pair.secondValueLabel]))].sort((a, b) =>
+    a.localeCompare(b),
+  );
+
+  return valueLabels.map((valueLabel) => {
+    const pairRates = valuePairs
+      .filter((pair) => pair.firstValueLabel === valueLabel || pair.secondValueLabel === valueLabel)
+      .map((pair) => computePairRates(pair, valueLabel));
+
+    const averageWinRate = mean(pairRates.map((rates) => rates.averageWinRate));
+    const balancedWinRate = mean(pairRates.map((rates) => rates.balancedWinRate));
+    const highPressureOnThisValue = mean(pairRates.map((rates) => rates.highPressureOnThisValue));
+    const highPressureOnOpposingValue = mean(pairRates.map((rates) => rates.highPressureOnOpposingValue));
+
+    return {
+      valueLabel,
+      averageWinRate,
+      balancedWinRate,
+      highPressureOnThisValue,
+      highPressureOnOpposingValue,
+      responsiveness:
+        highPressureOnThisValue != null && balancedWinRate != null
+          ? highPressureOnThisValue - balancedWinRate
+          : null,
+    };
+  });
+}
+
+function defaultDirectionForKey(key: SortKey): SortDirection {
+  return key === 'value' ? 'asc' : 'desc';
+}
+
+function compareNullableNumbers(a: number | null, b: number | null, direction: SortDirection): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  return direction === 'asc' ? a - b : b - a;
+}
+
+function sortRows(rows: ValueRow[], sortKey: SortKey, direction: SortDirection): ValueRow[] {
+  return [...rows].sort((a, b) => {
+    if (sortKey === 'value') {
+      return direction === 'asc'
+        ? a.valueLabel.localeCompare(b.valueLabel)
+        : b.valueLabel.localeCompare(a.valueLabel);
+    }
+
+    const aValue = a[sortKey];
+    const bValue = b[sortKey];
+    const numericComparison = compareNullableNumbers(
+      typeof aValue === 'number' ? aValue : null,
+      typeof bValue === 'number' ? bValue : null,
+      direction,
+    );
+    if (numericComparison !== 0) {
+      return numericComparison;
+    }
+
+    return a.valueLabel.localeCompare(b.valueLabel);
+  });
+}
+
+function SortHeaderCell({
+  label,
+  ariaLabel,
+  sortKey,
+  activeSortKey,
+  direction,
+  onSort,
+  tooltip,
+  numeric,
+}: {
+  label: string;
+  ariaLabel: string;
+  sortKey: SortKey;
+  activeSortKey: SortKey;
+  direction: SortDirection;
+  onSort: (key: SortKey) => void;
+  tooltip?: string;
+  numeric?: boolean;
+}) {
+  const active = activeSortKey === sortKey;
+  const sortDirection = active ? direction : 'desc';
+
+  return (
+    <TableHead
+      className={`${numeric ? 'text-right' : 'text-left'} text-xs uppercase tracking-wide text-gray-500`}
+      aria-sort={active ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <div className={`flex w-full items-center gap-1 ${numeric ? 'justify-end' : 'justify-start'}`}>
+        {/* eslint-disable-next-line react/forbid-elements -- Sortable table headers need a semantic inline button control */}
+        <button
+          type="button"
+          onClick={() => onSort(sortKey)}
+          className={`inline-flex items-center gap-1 text-left transition-colors ${
+            active ? 'text-gray-700' : 'text-gray-400 hover:text-gray-600'
+          }`}
+          aria-label={`Sort by ${ariaLabel}${active ? ` (${sortDirection === 'asc' ? 'ascending' : 'descending'})` : ''}`}
+        >
+          <span>{label}</span>
+          <span aria-hidden="true" className={`text-[11px] leading-none ${active ? 'text-gray-700' : 'text-gray-300'}`}>
+            {active ? (direction === 'asc' ? '↑' : '↓') : '↕'}
+          </span>
+        </button>
+        {tooltip ? <HeaderTooltip label={label} content={tooltip} /> : null}
+      </div>
+    </TableHead>
+  );
+}
+
+function RateCell({ value }: { value: number | null }) {
+  return <TableCell className="text-right text-sm">{formatRate(value)}</TableCell>;
+}
+
+export function PressureResponseByValueTable({ valuePairs }: Props) {
+  const tableRef = useRef<HTMLDivElement>(null);
+  const [sortKey, setSortKey] = useState<SortKey>('responsiveness');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+
+  const rows = useMemo(() => buildValueRows(valuePairs), [valuePairs]);
+
+  const sortedRows = useMemo(
+    () => sortRows(rows, sortKey, sortDirection),
+    [rows, sortDirection, sortKey],
+  );
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDirection((currentDirection) => (currentDirection === 'asc' ? 'desc' : 'asc'));
+      return;
+    }
+
+    setSortKey(key);
+    setSortDirection(defaultDirectionForKey(key));
+  };
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-gray-900">Pressure Response by Value</h2>
+          <p className="text-sm text-gray-600">
+            Each row is one of the model&apos;s values. The columns show how often the model picks that value across
+            its 9 pairings, broken down by what the prompt was doing.
+          </p>
+          <p className="text-xs text-gray-500">
+            All four rates are averaged across the 9 pairs containing this value. For pairs where this value is
+            alphabetically second, we approximate its rate from the first value&apos;s rate (small error from neutral
+            picks, typically under 1 pp).
+          </p>
+        </div>
+        <CopyVisualButton targetRef={tableRef} label="Pressure Response by Value" />
+      </div>
+
+      <div ref={tableRef}>
+        <Table variant="bordered">
+          <TableHeader variant="bordered">
+            <TableRow>
+              <SortHeaderCell
+                label="Value"
+                ariaLabel="Value"
+                sortKey="value"
+                activeSortKey={sortKey}
+                direction={sortDirection}
+                onSort={handleSort}
+              />
+              <SortHeaderCell
+                label="Average win rate"
+                ariaLabel="Average win rate"
+                sortKey="averageWinRate"
+                activeSortKey={sortKey}
+                direction={sortDirection}
+                onSort={handleSort}
+                tooltip={AVERAGE_WIN_RATE_TOOLTIP}
+                numeric
+              />
+              <SortHeaderCell
+                label="Balanced win rate"
+                ariaLabel="Balanced win rate"
+                sortKey="balancedWinRate"
+                activeSortKey={sortKey}
+                direction={sortDirection}
+                onSort={handleSort}
+                tooltip={BALANCED_WIN_RATE_TOOLTIP}
+                numeric
+              />
+              <SortHeaderCell
+                label="High pressure on this value"
+                ariaLabel="High pressure on this value"
+                sortKey="highPressureOnThisValue"
+                activeSortKey={sortKey}
+                direction={sortDirection}
+                onSort={handleSort}
+                tooltip={HIGH_PRESSURE_ON_THIS_VALUE_TOOLTIP}
+                numeric
+              />
+              <SortHeaderCell
+                label="High pressure on opposing value"
+                ariaLabel="High pressure on opposing value"
+                sortKey="highPressureOnOpposingValue"
+                activeSortKey={sortKey}
+                direction={sortDirection}
+                onSort={handleSort}
+                tooltip={HIGH_PRESSURE_ON_OPPOSING_VALUE_TOOLTIP}
+                numeric
+              />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sortedRows.map((row) => (
+              <TableRow key={row.valueLabel}>
+                <TableCell className="font-medium text-gray-900">{row.valueLabel}</TableCell>
+                <RateCell value={row.averageWinRate} />
+                <RateCell value={row.balancedWinRate} />
+                <RateCell value={row.highPressureOnThisValue} />
+                <RateCell value={row.highPressureOnOpposingValue} />
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="mt-4 space-y-3 text-sm text-gray-600">
+        <h3 className="text-sm font-semibold text-gray-900">Reading this table</h3>
+        <p>
+          Each row is one of the model&apos;s values. The columns show how often the model picks that value across
+          its 9 pairings, broken down by what the prompt was doing.
+        </p>
+        <p>
+          The two push columns are most informative when compared against the balanced rate. If &quot;high pressure on
+          this value&quot; is well above balanced, the prompt successfully pushes the model toward this value. If
+          &quot;high pressure on opposing value&quot; is well below balanced, the prompt successfully pushes the model
+          away from this value.
+        </p>
+        <div>
+          <p className="font-semibold text-gray-900">Patterns to look for:</p>
+          <ul className="mt-2 list-disc space-y-2 pl-5">
+            <li>
+              <strong>Moral attractor.</strong> Both push columns are higher than balanced. The model leans toward
+              this value regardless of which way the prompt steers. Unusual - most values move in opposite directions
+              under push and pull pressure.
+            </li>
+            <li>
+              <strong>Push-resistant.</strong> &quot;High pressure on this value&quot; is at or below balanced.
+              Pressure to make the model pick this value does not work; sometimes it actively backfires.
+            </li>
+            <li>
+              <strong>Inert.</strong> All four columns are within a few points of each other. The model&apos;s choice
+              on pairs involving this value does not shift much based on prompt pressure.
+            </li>
+          </ul>
+        </div>
+        <p>
+          This summary aggregates across 9 different value pairs per row. The patterns it surfaces are real, but the
+          per-pair detail below tells you which specific pairings drive each value&apos;s profile. Drill in to see the
+          variation.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/cloud/apps/web/src/components/models/PressureSensitivityDetail.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityDetail.test.tsx
@@ -73,6 +73,7 @@ describe('PressureSensitivityDetail', () => {
       ]),
     );
 
+    expect(screen.getByText('Pressure Response by Value Pair')).toBeDefined();
     expect(screen.getByText('Value Pair')).toBeDefined();
     expect(screen.getByText('Baseline')).toBeDefined();
     expect(screen.getByText('Push toward first')).toBeDefined();
@@ -145,5 +146,17 @@ describe('PressureSensitivityDetail', () => {
     fireEvent.focus(trigger);
 
     expect(screen.getByRole('tooltip').textContent ?? '').toContain('Newcombe');
+  });
+
+  it('renders the snapshot button with the new label', () => {
+    renderDetail(
+      createModel([
+        createPair('alpha::delta', 'Alpha', 'Delta', 0.12, 0.48, 0.60, 0.36, 0.08, 0.16, null, 17),
+      ]),
+    );
+
+    expect(
+      screen.getByRole('button', { name: /copy pressure response by value pair as image/i }),
+    ).toBeDefined();
   });
 });

--- a/cloud/apps/web/src/components/models/PressureSensitivityDetail.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityDetail.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
+import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/Table';
 import { HeaderTooltip } from '../ui/HeaderTooltip';
 import { Tooltip } from '../ui/Tooltip';
@@ -86,6 +87,7 @@ function renderTrialsCell(pair: PressureSensitivityValuePair): ReactNode {
 }
 
 export function PressureSensitivityDetail({ model }: Props) {
+  const tableRef = useRef<HTMLDivElement>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [selectedPairKey, setSelectedPairKey] = useState<string | null>(null);
 
@@ -114,67 +116,74 @@ export function PressureSensitivityDetail({ model }: Props) {
 
   return (
     <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
-      <div className="mb-3">
-        <h2 className="text-lg font-semibold text-gray-900">{model.label} — per-pair pressure response</h2>
-        <p className="text-sm text-gray-600">
-          This table shows the baseline win rate and push rates for each value pair. The Pressure response column is the signed difference between push directions, and the Trials column counts qualifying scored trials.
-        </p>
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-gray-900">Pressure Response by Value Pair</h2>
+          <p className="text-sm text-gray-600">
+            This table shows the baseline win rate and push rates for each value pair. The Pressure response column is
+            the signed difference between push directions, and the Trials column counts qualifying scored trials.
+          </p>
+          <p className="text-xs text-gray-500">Selected model: {model.label}</p>
+        </div>
+        <CopyVisualButton targetRef={tableRef} label="Pressure Response by Value Pair" />
       </div>
 
-      <Table variant="bordered">
-        <TableHeader variant="bordered">
-          <TableRow>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Value Pair" content={VALUE_PAIR_TOOLTIP} />
-            </TableHead>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Baseline" content={BASELINE_TOOLTIP} />
-            </TableHead>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Push toward first" content={PUSH_TOWARD_FIRST_TOOLTIP} />
-            </TableHead>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Push toward other" content={PUSH_TOWARD_OTHER_TOOLTIP} />
-            </TableHead>
-            <TableHead
-              className="cursor-pointer select-none text-xs uppercase tracking-wide text-gray-500"
-              onClick={() => setSortDirection((current) => (current === 'asc' ? 'desc' : 'asc'))}
-              aria-sort={sortDirection === 'asc' ? 'ascending' : 'descending'}
-            >
-              <div className="inline-flex items-center gap-1">
-                <HeaderTooltip label="Pressure response" content={PAIR_PRESSURE_RESPONSE_TOOLTIP} />
-                <span aria-hidden="true" className="text-[11px] leading-none">
-                  {sortDirection === 'asc' ? '▲' : '▼'}
-                </span>
-              </div>
-            </TableHead>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Trials" content={TRIALS_TOOLTIP} />
-            </TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {sortedPairs.map((pair) => {
-            const isSelected = selectedPair?.pairKey === pair.pairKey;
-            const { baselineRate, pushTowardFirstRate, pushTowardSecondRate } = pair.pressureResponse;
-
-            return (
-              <TableRow
-                key={pair.pairKey}
-                className={`cursor-pointer ${isSelected ? 'bg-blue-50' : ''}`}
-                onClick={() => setSelectedPairKey(pair.pairKey)}
+      <div ref={tableRef}>
+        <Table variant="bordered">
+          <TableHeader variant="bordered">
+            <TableRow>
+              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+                <HeaderTooltip label="Value Pair" content={VALUE_PAIR_TOOLTIP} />
+              </TableHead>
+              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+                <HeaderTooltip label="Baseline" content={BASELINE_TOOLTIP} />
+              </TableHead>
+              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+                <HeaderTooltip label="Push toward first" content={PUSH_TOWARD_FIRST_TOOLTIP} />
+              </TableHead>
+              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+                <HeaderTooltip label="Push toward other" content={PUSH_TOWARD_OTHER_TOOLTIP} />
+              </TableHead>
+              <TableHead
+                className="cursor-pointer select-none text-xs uppercase tracking-wide text-gray-500"
+                onClick={() => setSortDirection((current) => (current === 'asc' ? 'desc' : 'asc'))}
+                aria-sort={sortDirection === 'asc' ? 'ascending' : 'descending'}
               >
-                <TableCell className="font-medium text-gray-900">{pairLabel(pair)}</TableCell>
-                <TableCell className="text-sm text-gray-700">{renderRateCell(baselineRate)}</TableCell>
-                <TableCell className="text-sm text-gray-700">{renderRateCell(pushTowardFirstRate)}</TableCell>
-                <TableCell className="text-sm text-gray-700">{renderRateCell(pushTowardSecondRate)}</TableCell>
-                <TableCell className="text-sm text-gray-900">{renderResponseCell(pair)}</TableCell>
-                <TableCell className="text-sm text-gray-700">{renderTrialsCell(pair)}</TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
+                <div className="inline-flex items-center gap-1">
+                  <HeaderTooltip label="Pressure response" content={PAIR_PRESSURE_RESPONSE_TOOLTIP} />
+                  <span aria-hidden="true" className="text-[11px] leading-none">
+                    {sortDirection === 'asc' ? '▲' : '▼'}
+                  </span>
+                </div>
+              </TableHead>
+              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+                <HeaderTooltip label="Trials" content={TRIALS_TOOLTIP} />
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sortedPairs.map((pair) => {
+              const isSelected = selectedPair?.pairKey === pair.pairKey;
+              const { baselineRate, pushTowardFirstRate, pushTowardSecondRate } = pair.pressureResponse;
+
+              return (
+                <TableRow
+                  key={pair.pairKey}
+                  className={`cursor-pointer ${isSelected ? 'bg-blue-50' : ''}`}
+                  onClick={() => setSelectedPairKey(pair.pairKey)}
+                >
+                  <TableCell className="font-medium text-gray-900">{pairLabel(pair)}</TableCell>
+                  <TableCell className="text-sm text-gray-700">{renderRateCell(baselineRate)}</TableCell>
+                  <TableCell className="text-sm text-gray-700">{renderRateCell(pushTowardFirstRate)}</TableCell>
+                  <TableCell className="text-sm text-gray-700">{renderRateCell(pushTowardSecondRate)}</TableCell>
+                  <TableCell className="text-sm text-gray-900">{renderResponseCell(pair)}</TableCell>
+                  <TableCell className="text-sm text-gray-700">{renderTrialsCell(pair)}</TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
 
       {selectedPair != null && (
         <div className="mt-5">

--- a/cloud/apps/web/src/components/models/PressureSensitivitySummary.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivitySummary.test.tsx
@@ -38,6 +38,7 @@ describe('PressureSensitivitySummary', () => {
       createModel('alpha', 'Alpha', 0.05, 0.01, 0.09, 2),
     ]);
 
+    expect(screen.getByText('Pressure Response across models')).toBeDefined();
     expect(screen.getByText('Pressure response')).toBeDefined();
     expect(screen.getByText('Model')).toBeDefined();
     expect(screen.queryByText('Win Rate')).toBeNull();
@@ -84,5 +85,13 @@ describe('PressureSensitivitySummary', () => {
     fireEvent.focus(trigger);
 
     expect(screen.getByRole('tooltip').textContent ?? '').toContain('range in brackets');
+  });
+
+  it('renders the snapshot button with the new label', () => {
+    renderSummary([createModel('alpha', 'Alpha', 0.05, 0.01, 0.09, 2)]);
+
+    expect(
+      screen.getByRole('button', { name: /copy pressure response across models as image/i }),
+    ).toBeDefined();
   });
 });

--- a/cloud/apps/web/src/components/models/PressureSensitivitySummary.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivitySummary.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import type { ReactNode } from 'react';
+import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/Table';
 import { HeaderTooltip } from '../ui/HeaderTooltip';
 import type { PressureSensitivityModel, PressureResponseSummary } from '../../api/operations/pressureSensitivity';
@@ -38,6 +39,7 @@ function renderResponseCell(summary: PressureResponseSummary): ReactNode {
 }
 
 export function PressureSensitivitySummary({ models, selectedModelId, onSelectModel }: Props) {
+  const tableRef = useRef<HTMLDivElement>(null);
   const sortedModels = useMemo(() => {
     return [...models].sort((a, b) => {
       const aMean = a.pressureResponseSummary.mean;
@@ -52,40 +54,46 @@ export function PressureSensitivitySummary({ models, selectedModelId, onSelectMo
 
   return (
     <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
-      <div className="mb-3">
-        <h2 className="text-lg font-semibold text-gray-900">Cross-model pressure response</h2>
-        <p className="text-sm text-gray-600">
-          This table ranks models by their mean pressure response — how much pressure moves their choice toward their own preferred value across measured pairs.
-        </p>
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-gray-900">Pressure Response across models</h2>
+          <p className="text-sm text-gray-600">
+            This table ranks models by their mean pressure response — how much pressure moves their choice toward
+            their own preferred value across measured pairs.
+          </p>
+        </div>
+        <CopyVisualButton targetRef={tableRef} label="Pressure Response across models" />
       </div>
 
-      <Table variant="bordered">
-        <TableHeader variant="bordered">
-          <TableRow>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Model" content={MODEL_TOOLTIP} />
-            </TableHead>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Pressure response" content={SUMMARY_PRESSURE_RESPONSE_TOOLTIP} />
-            </TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {sortedModels.map((model) => {
-            const isSelected = model.modelId === selectedModelId;
-            return (
-              <TableRow
-                key={model.modelId}
-                className={`cursor-pointer ${isSelected ? 'bg-blue-50' : ''}`}
-                onClick={() => onSelectModel(model.modelId)}
-              >
-                <TableCell className="font-medium text-gray-900">{model.label}</TableCell>
-                <TableCell className="text-sm">{renderResponseCell(model.pressureResponseSummary)}</TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
+      <div ref={tableRef}>
+        <Table variant="bordered">
+          <TableHeader variant="bordered">
+            <TableRow>
+              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+                <HeaderTooltip label="Model" content={MODEL_TOOLTIP} />
+              </TableHead>
+              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+                <HeaderTooltip label="Pressure response" content={SUMMARY_PRESSURE_RESPONSE_TOOLTIP} />
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sortedModels.map((model) => {
+              const isSelected = model.modelId === selectedModelId;
+              return (
+                <TableRow
+                  key={model.modelId}
+                  className={`cursor-pointer ${isSelected ? 'bg-blue-50' : ''}`}
+                  onClick={() => onSelectModel(model.modelId)}
+                >
+                  <TableCell className="font-medium text-gray-900">{model.label}</TableCell>
+                  <TableCell className="text-sm">{renderResponseCell(model.pressureResponseSummary)}</TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
     </section>
   );
 }

--- a/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
@@ -188,6 +188,19 @@ describe('PressureSensitivity page', () => {
     expect(screen.getByText(/42 pressure conditions were excluded/)).toBeDefined();
   });
 
+  it('renders the by-value section for the selected model', () => {
+    mockDomainsOnce();
+    mockQuery(createPressureData(false));
+
+    render(
+      <MemoryRouter initialEntries={['/models/pressure-sensitivity?domainId=domain-a&signature=vnewtd']}>
+        <PressureSensitivity />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Pressure Response by Value')).toBeDefined();
+  });
+
   it('appends lower-bound sentence when both transcript cap and exclusions are present', () => {
     mockDomainsOnce();
     mockQuery(createPressureData(true, 10));

--- a/cloud/apps/web/src/pages/PressureSensitivity.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.tsx
@@ -15,6 +15,7 @@ import {
   type PressureSensitivityModel,
 } from '../api/operations/pressureSensitivity';
 import { PressureSensitivitySummary } from '../components/models/PressureSensitivitySummary';
+import { PressureResponseByValueTable } from '../components/models/PressureResponseByValueTable';
 import { PressureSensitivityDetail } from '../components/models/PressureSensitivityDetail';
 import { PressureSensitivityCrossValueMap } from '../components/models/PressureSensitivityCrossValueMap';
 import { PressureSensitivitySanityCheck } from '../components/models/PressureSensitivitySanityCheck';
@@ -187,7 +188,7 @@ export function PressureSensitivity() {
       <div className="space-y-2">
         <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Models / Pressure Sensitivity</h1>
         <p className="text-sm text-gray-600">
-          This report shows each model&apos;s pressure response — how much added pressure moves the model toward its own value over the other. The cross-model table ranks models by mean pressure response, the detail table breaks that out by value pair, and the heat map plus sanity check show whether the pattern is consistent across the grid.
+          This report shows each model&apos;s pressure response — how much added pressure moves the model toward its own value over the other. The cross-model table ranks models by mean pressure response, the by-value table summarizes how each value behaves across its pairings, the detail table breaks that out by value pair, and the heat map plus sanity check show whether the pattern is consistent across the grid.
         </p>
       </div>
 
@@ -223,8 +224,8 @@ export function PressureSensitivity() {
           <p className="font-medium text-gray-900">No coverage yet.</p>
           <p className="mt-1">
             This report depends on Aggregate-tagged runs with measurable transcripts. Once
-            pipeline coverage is populated, the cross-model summary, per-model detail, and
-            heat maps will appear here.
+            pipeline coverage is populated, the cross-model summary, by-value table, per-model
+            detail, and heat maps will appear here.
           </p>
         </section>
       ) : allInsufficient ? (
@@ -243,6 +244,8 @@ export function PressureSensitivity() {
             selectedModelId={selectedModel?.modelId ?? null}
             onSelectModel={setSelectedModelId}
           />
+
+          {selectedModel && <PressureResponseByValueTable valuePairs={selectedModel.valuePairs} />}
 
           {selectedModel && <PressureSensitivityDetail model={selectedModel} />}
 


### PR DESCRIPTION
## Summary
- Added a new client-side Pressure Response by Value section that aggregates the selected model's existing `valuePairs[].grid` data.
- Renamed the Pressure Sensitivity summary and per-pair detail headings, and added snapshot buttons to the three report tables.
- Wired the new section into the Pressure Sensitivity page between the cross-model summary and the per-pair detail view.

## Test Plan
- [x] Build the web workspace
- [x] Run the pressure test suite
- [x] Run web lint
- [x] Verify the new component suites for the by-value table, summary, and detail views

## Validation
- `./node_modules/.bin/turbo build --filter=@valuerank/web` — pass
- `npm run test --workspace @valuerank/web -- pressure` — pass
- `npm run lint --workspace @valuerank/web` — pass

## Note
- The new section is computed entirely on the client from existing GraphQL response data. No backend or schema changes were made.
