### PR TITLE
feat(models-confidence): click heatmap cell to see contributing transcripts

### DIFF
--- a/cloud/apps/api/src/graphql/queries/confidence-transcripts.ts
+++ b/cloud/apps/api/src/graphql/queries/confidence-transcripts.ts
@@ -1,0 +1,128 @@
+import { db } from '@valuerank/db';
+import { ValidationError } from '@valuerank/shared';
+import { builder } from '../builder.js';
+import { runMatchesSignature } from './domain-coverage-gql-types.js';
+import { extractValuePair, type DomainAnalysisValueKey, type DomainAnalysisValuePair } from './domain-analysis-values.js';
+import { isDomainAnalysisValueKey } from './domain/shared.js';
+import { DomainAnalysisConditionTranscriptRef } from './domain/types.js';
+
+builder.queryField('confidenceTranscripts', (t) =>
+  t.field({
+    type: [DomainAnalysisConditionTranscriptRef],
+    args: {
+      modelId: t.arg.string({ required: true }),
+      valueKey: t.arg.string({ required: true }),
+      signature: t.arg.string({ required: false }),
+      limit: t.arg.int({ required: false }),
+    },
+    resolve: async (_root, args) => {
+      const modelId = args.modelId;
+      const rawValueKey = args.valueKey;
+      if (!isDomainAnalysisValueKey(rawValueKey)) {
+        throw new ValidationError(`Unsupported value key: ${rawValueKey}`);
+      }
+      const valueKey: DomainAnalysisValueKey = rawValueKey;
+      const limit = Math.max(1, Math.min(args.limit ?? 200, 500));
+      const requestedSignature = typeof args.signature === 'string' && args.signature.trim() !== ''
+        ? args.signature.trim()
+        : null;
+
+      const runs = await db.run.findMany({
+        where: {
+          status: 'COMPLETED',
+          deletedAt: null,
+          tags: { none: { tag: { name: 'Aggregate' } } },
+        },
+        select: {
+          id: true,
+          definitionId: true,
+          config: true,
+        },
+      });
+
+      const matchingRuns = requestedSignature == null
+        ? runs
+        : runs.filter((run) => runMatchesSignature(run.config, requestedSignature));
+
+      const definitionIds = [
+        ...new Set(
+          matchingRuns
+            .map((run) => run.definitionId)
+            .filter((id): id is string => id !== null),
+        ),
+      ];
+
+      if (definitionIds.length === 0) {
+        return [];
+      }
+
+      const definitions = await db.definition.findMany({
+        where: { id: { in: definitionIds } },
+        select: { id: true, content: true },
+      });
+
+      const defValuePairMap = new Map<string, DomainAnalysisValuePair | null>();
+      for (const definition of definitions) {
+        defValuePairMap.set(definition.id, extractValuePair(definition.content));
+      }
+
+      const matchingDefIds = new Set(
+        definitions
+          .filter((definition) => {
+            const pair = defValuePairMap.get(definition.id) ?? null;
+            return pair?.valueA === valueKey || pair?.valueB === valueKey;
+          })
+          .map((definition) => definition.id),
+      );
+
+      if (matchingDefIds.size === 0) {
+        return [];
+      }
+
+      const relevantRunIds: string[] = [];
+      const runToDefId = new Map<string, string>();
+      for (const run of matchingRuns) {
+        if (run.definitionId == null || !matchingDefIds.has(run.definitionId)) {
+          continue;
+        }
+        relevantRunIds.push(run.id);
+        runToDefId.set(run.id, run.definitionId);
+      }
+
+      if (relevantRunIds.length === 0) {
+        return [];
+      }
+
+      const transcripts = await db.transcript.findMany({
+        where: {
+          runId: { in: relevantRunIds },
+          modelId,
+          deletedAt: null,
+        },
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        select: {
+          id: true,
+          runId: true,
+          scenarioId: true,
+          modelId: true,
+          decisionMetadata: true,
+          turnCount: true,
+          tokenCount: true,
+          durationMs: true,
+          createdAt: true,
+          content: true,
+        },
+      });
+
+      return transcripts.map((transcript) => {
+        const defId = runToDefId.get(transcript.runId);
+        const pair = defId != null ? (defValuePairMap.get(defId) ?? null) : null;
+        return {
+          ...transcript,
+          pairOverride: pair ?? undefined,
+        };
+      });
+    },
+  }),
+);

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -2353,6 +2353,7 @@ type Query {
   ): [AvailableModel!]!
   availableSignatures: [AvailableSignature!]!
   circumplexAnalysis(minTrialsPerValue: Int, modelIds: [String!]!, signature: String!): CircumplexAnalysisResult!
+  confidenceTranscripts(limit: Int, modelId: String!, signature: String, valueKey: String!): [DomainAnalysisConditionTranscript!]!
 
   """Fetch a single definition by ID. Returns null if not found."""
   definition(
@@ -3109,6 +3110,11 @@ type RunAnomaly {
   True when reprobeCount has reached the circuit-breaker limit (3). UI should disable the [Re-probe] button.
   """
   reprobeLimitReached: Boolean!
+
+  """
+  Current pipeline stage for an in-progress manual re-probe: probing | summarizing | analyzing | aggregating | fixed. Null when no re-probe is in flight.
+  """
+  reprobeStage: String
   resolvedAt: DateTime
 
   """The run this anomaly belongs to"""

--- a/cloud/apps/web/src/api/operations/confidenceTranscripts.graphql
+++ b/cloud/apps/web/src/api/operations/confidenceTranscripts.graphql
@@ -1,0 +1,14 @@
+query ConfidenceTranscripts($modelId: String!, $valueKey: String!, $signature: String, $limit: Int) {
+  confidenceTranscripts(modelId: $modelId, valueKey: $valueKey, signature: $signature, limit: $limit) {
+    id
+    runId
+    scenarioId
+    modelId
+    decisionModelV2
+    turnCount
+    tokenCount
+    durationMs
+    createdAt
+    content
+  }
+}

--- a/cloud/apps/web/src/api/operations/confidenceTranscripts.ts
+++ b/cloud/apps/web/src/api/operations/confidenceTranscripts.ts
@@ -1,0 +1,16 @@
+import type {
+  ConfidenceTranscriptsQuery as GeneratedConfidenceTranscriptsQuery,
+  ConfidenceTranscriptsQueryVariables as GeneratedConfidenceTranscriptsQueryVariables,
+} from '../../generated/graphql';
+import type { TranscriptDecisionModelV2 } from './runs';
+
+export { ConfidenceTranscriptsDocument as CONFIDENCE_TRANSCRIPTS_QUERY } from '../../generated/graphql';
+
+export type ConfidenceTranscriptsQueryVariables = GeneratedConfidenceTranscriptsQueryVariables;
+export type ConfidenceTranscriptsQueryResult = GeneratedConfidenceTranscriptsQuery;
+
+// Derive base shape from codegen; narrow decisionModelV2 from unknown to the proper type.
+export type ConfidenceTranscript = Omit<
+  GeneratedConfidenceTranscriptsQuery['confidenceTranscripts'][number],
+  'decisionModelV2'
+> & { decisionModelV2?: TranscriptDecisionModelV2 | null };

--- a/cloud/apps/web/src/components/models/ConfidenceHeatmap.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceHeatmap.tsx
@@ -22,7 +22,12 @@ function buildTooltip(valueKey: string, result: ModelsConfidenceModelResult['val
   return `${formatFullSchwartzValueName(valueKey as Parameters<typeof formatFullSchwartzValueName>[0])}\nStrong: ${result.strongCount} · Lean: ${result.leanCount} · Total: ${total}`;
 }
 
-export function ConfidenceHeatmap({ models }: { models: ModelsConfidenceModelResult[] }) {
+type ConfidenceHeatmapProps = {
+  models: ModelsConfidenceModelResult[];
+  onCellClick?: (modelId: string, modelLabel: string, valueKey: string) => void;
+};
+
+export function ConfidenceHeatmap({ models, onCellClick }: ConfidenceHeatmapProps) {
   const sorted = [...models].sort((a, b) => {
     const aConf = a.overallConfidence ?? -1;
     const bConf = b.overallConfidence ?? -1;
@@ -69,9 +74,11 @@ export function ConfidenceHeatmap({ models }: { models: ModelsConfidenceModelRes
                     <td
                       key={key}
                       title={buildTooltip(key, v)}
+                      onClick={onCellClick != null ? () => onCellClick(model.modelId, model.label, key) : undefined}
                       className={cn(
                         'px-2 py-2 text-center border border-gray-100 tabular-nums',
                         getConfidenceTone(v?.confidence ?? null),
+                        onCellClick != null && 'cursor-pointer hover:ring-1 hover:ring-inset hover:ring-violet-400',
                       )}
                     >
                       {formatConfidence(v?.confidence ?? null)}

--- a/cloud/apps/web/src/components/models/ConfidenceTranscriptsDrawer.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceTranscriptsDrawer.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { useQuery } from 'urql';
+import { Button } from '../ui/Button';
+import { ErrorMessage } from '../ui/ErrorMessage';
+import { Loading } from '../ui/Loading';
+import { TranscriptList } from '../runs/TranscriptList';
+import { TranscriptViewer } from '../runs/TranscriptViewer';
+import type { Transcript } from '../../api/operations/runs';
+import {
+  CONFIDENCE_TRANSCRIPTS_QUERY,
+  type ConfidenceTranscript,
+  type ConfidenceTranscriptsQueryResult,
+  type ConfidenceTranscriptsQueryVariables,
+} from '../../api/operations/confidenceTranscripts';
+import { VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
+
+type ConfidenceTranscriptsDrawerProps = {
+  open: boolean;
+  modelId: string;
+  modelLabel: string;
+  valueKey: string | null;
+  signature: string;
+  onClose: () => void;
+};
+
+function mapToTranscript(t: ConfidenceTranscript): Transcript {
+  return {
+    id: t.id,
+    runId: t.runId,
+    scenarioId: t.scenarioId ?? null,
+    modelId: t.modelId,
+    modelVersion: null,
+    content: t.content,
+    decisionModelV2: t.decisionModelV2,
+    turnCount: t.turnCount,
+    tokenCount: t.tokenCount,
+    durationMs: t.durationMs,
+    estimatedCost: null,
+    createdAt: t.createdAt,
+    lastAccessedAt: null,
+  };
+}
+
+export function ConfidenceTranscriptsDrawer({
+  open,
+  modelId,
+  modelLabel,
+  valueKey,
+  signature,
+  onClose,
+}: ConfidenceTranscriptsDrawerProps) {
+  const [selectedTranscript, setSelectedTranscript] = useState<Transcript | null>(null);
+
+  const valueLabel = valueKey != null ? (VALUE_LABELS[valueKey as ValueKey] ?? valueKey) : '';
+
+  const [{ data, fetching, error }] = useQuery<ConfidenceTranscriptsQueryResult, ConfidenceTranscriptsQueryVariables>({
+    query: CONFIDENCE_TRANSCRIPTS_QUERY,
+    variables: { modelId, valueKey: valueKey ?? '', signature, limit: 200 },
+    pause: !open || valueKey == null,
+    requestPolicy: 'cache-and-network',
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedTranscript(null);
+      return;
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    window.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.body.style.overflow = prev;
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open, onClose]);
+
+  useEffect(() => {
+    setSelectedTranscript(null);
+  }, [modelId, valueKey, signature]);
+
+  const transcripts = useMemo(
+    () => ((data?.confidenceTranscripts ?? []) as ConfidenceTranscript[]).map(mapToTranscript),
+    [data],
+  );
+
+  if (!open || valueKey == null) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50">
+      <div
+        className="absolute inset-0 bg-black/40"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+      <aside className="absolute right-0 top-0 flex h-full w-full max-w-3xl flex-col border-l border-gray-200 bg-white shadow-2xl">
+        <div className="flex items-start justify-between gap-3 border-b border-gray-200 px-5 py-4">
+          <div className="min-w-0">
+            <h2 className="truncate text-lg font-semibold text-gray-900">
+              {modelLabel} — {valueLabel}
+            </h2>
+            <p className="text-sm text-gray-600">
+              {fetching && data == null ? 'Loading…' : `${transcripts.length} transcript${transcripts.length === 1 ? '' : 's'}`}
+            </p>
+          </div>
+          <Button type="button" variant="ghost" size="icon" onClick={onClose} aria-label="Close transcripts drawer">
+            <X className="h-5 w-5" />
+          </Button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-5">
+          {fetching && data == null ? (
+            <Loading />
+          ) : error != null ? (
+            <ErrorMessage message={error.message} />
+          ) : transcripts.length === 0 ? (
+            <p className="text-sm text-gray-500">No transcripts found.</p>
+          ) : (
+            <TranscriptList
+              transcripts={transcripts}
+              onSelect={setSelectedTranscript}
+              groupByModel={false}
+              decisionDisplayMode="audit"
+            />
+          )}
+        </div>
+
+        {selectedTranscript != null && (
+          <TranscriptViewer
+            transcript={selectedTranscript}
+            onClose={() => setSelectedTranscript(null)}
+            decisionDisplayMode="audit"
+          />
+        )}
+      </aside>
+    </div>,
+    document.body,
+  );
+}

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -2551,6 +2551,7 @@ export type Query = {
   availableModels: Array<AvailableModel>;
   availableSignatures: Array<AvailableSignature>;
   circumplexAnalysis: CircumplexAnalysisResult;
+  confidenceTranscripts: Array<DomainAnalysisConditionTranscript>;
   /** Fetch a single definition by ID. Returns null if not found. */
   definition?: Maybe<Definition>;
   /** Get ancestors of a definition (full chain to root). Returns definitions ordered from root to immediate parent. */
@@ -2798,6 +2799,14 @@ export type QueryCircumplexAnalysisArgs = {
   minTrialsPerValue?: InputMaybe<Scalars['Int']['input']>;
   modelIds: Array<Scalars['String']['input']>;
   signature: Scalars['String']['input'];
+};
+
+
+export type QueryConfidenceTranscriptsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  modelId: Scalars['String']['input'];
+  signature?: InputMaybe<Scalars['String']['input']>;
+  valueKey: Scalars['String']['input'];
 };
 
 
@@ -4011,6 +4020,16 @@ export type ComparisonRunsListQueryVariables = Exact<{
 
 
 export type ComparisonRunsListQuery = { __typename?: 'Query', runs: Array<{ __typename?: 'Run', id: string, name?: string | null, definitionId: string, status: string, config: unknown, progress?: unknown | null, startedAt?: string | null, completedAt?: string | null, createdAt: string, transcriptCount: number, analysisStatus?: string | null, definition?: { __typename?: 'Definition', id: string, name: string, tags: Array<{ __typename?: 'Tag', id: string, name: string }> } | null }> };
+
+export type ConfidenceTranscriptsQueryVariables = Exact<{
+  modelId: Scalars['String']['input'];
+  valueKey: Scalars['String']['input'];
+  signature?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+
+export type ConfidenceTranscriptsQuery = { __typename?: 'Query', confidenceTranscripts: Array<{ __typename?: 'DomainAnalysisConditionTranscript', id: string, runId: string, scenarioId?: string | null, modelId: string, decisionModelV2?: unknown | null, turnCount: number, tokenCount: number, durationMs: number, createdAt: string, content: unknown }> };
 
 export type EstimateCostQueryVariables = Exact<{
   definitionId: Scalars['ID']['input'];
@@ -5367,6 +5386,31 @@ export const ComparisonRunsListDocument = gql`
 
 export function useComparisonRunsListQuery(options?: Omit<Urql.UseQueryArgs<ComparisonRunsListQueryVariables>, 'query'>) {
   return Urql.useQuery<ComparisonRunsListQuery, ComparisonRunsListQueryVariables>({ query: ComparisonRunsListDocument, ...options });
+};
+export const ConfidenceTranscriptsDocument = gql`
+    query ConfidenceTranscripts($modelId: String!, $valueKey: String!, $signature: String, $limit: Int) {
+  confidenceTranscripts(
+    modelId: $modelId
+    valueKey: $valueKey
+    signature: $signature
+    limit: $limit
+  ) {
+    id
+    runId
+    scenarioId
+    modelId
+    decisionModelV2
+    turnCount
+    tokenCount
+    durationMs
+    createdAt
+    content
+  }
+}
+    `;
+
+export function useConfidenceTranscriptsQuery(options: Omit<Urql.UseQueryArgs<ConfidenceTranscriptsQueryVariables>, 'query'>) {
+  return Urql.useQuery<ConfidenceTranscriptsQuery, ConfidenceTranscriptsQueryVariables>({ query: ConfidenceTranscriptsDocument, ...options });
 };
 export const EstimateCostDocument = gql`
     query EstimateCost($definitionId: ID!, $models: [String!]!, $samplePercentage: Int, $samplesPerScenario: Int) {

--- a/cloud/apps/web/src/pages/ModelsConfidence.tsx
+++ b/cloud/apps/web/src/pages/ModelsConfidence.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'urql';
 import { useSearchParams } from 'react-router-dom';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
@@ -14,6 +14,7 @@ import {
   type ModelsConfidenceQueryVariables,
 } from '../api/operations/modelsConfidence';
 import { ConfidenceHeatmap } from '../components/models/ConfidenceHeatmap';
+import { ConfidenceTranscriptsDrawer } from '../components/models/ConfidenceTranscriptsDrawer';
 import {
   buildDomainShiftSignatureOptions,
   getDefaultDomainShiftSignature,
@@ -65,6 +66,16 @@ export function ModelsConfidence() {
   const models = useMemo(() => data?.modelsConfidence.models ?? [], [data]);
   const loading = fetching && data == null;
 
+  const [drawerState, setDrawerState] = useState<{
+    modelId: string;
+    modelLabel: string;
+    valueKey: string;
+  } | null>(null);
+
+  const handleCellClick = useCallback((modelId: string, modelLabel: string, valueKey: string) => {
+    setDrawerState({ modelId, modelLabel, valueKey });
+  }, []);
+
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -89,7 +100,16 @@ export function ModelsConfidence() {
       </div>
 
       {error != null && <ErrorMessage message={error.message} />}
-      {loading ? <Loading /> : <ConfidenceHeatmap models={models} />}
+      {loading ? <Loading /> : <ConfidenceHeatmap models={models} onCellClick={handleCellClick} />}
+
+      <ConfidenceTranscriptsDrawer
+        open={drawerState != null}
+        modelId={drawerState?.modelId ?? ''}
+        modelLabel={drawerState?.modelLabel ?? ''}
+        valueKey={drawerState?.valueKey ?? null}
+        signature={selectedSignature}
+        onClose={() => setDrawerState(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- New `confidenceTranscripts(modelId, valueKey, signature, limit)` API resolver — finds completed non-aggregate source runs matching the signature, filters to definitions where the value key appears in either dimension, returns transcripts with `pairOverride` for correct decision display
- New `ConfidenceTranscriptsDrawer` — right-side portal panel using the standard `TranscriptList` + `TranscriptViewer` controls
- `ConfidenceHeatmap` — adds optional `onCellClick` prop; cells get `cursor-pointer` + violet ring hover state when the handler is wired
- `ModelsConfidence` page — manages drawer state, passes `onCellClick` to the heatmap

## Test plan

- [ ] Open `/models/confidence?signature=vnewtd`
- [ ] Click any value cell (e.g. Gemini 2.5 Pro × Benevolence_Dependability)
- [ ] Drawer opens showing that model's transcripts for that value
- [ ] Click a transcript row — viewer opens showing full conversation + decision
- [ ] Escape key or backdrop click closes the drawer
- [ ] Switching signature closes any open drawer
- [ ] Preflight: api lint ✓ build ✓, web lint ✓ build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)