### PR TITLE
Pressure Sensitivity polish: duplicate labels, sort indicator, decimal precision, column renames

### DIFF
--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
@@ -216,9 +216,9 @@ describe('PressureResponseByValueTable', () => {
     }
 
     const cells = within(row).getAllByRole('cell');
-    expect(cells[1]?.textContent ?? '').toBe('60%');
-    expect(cells[2]?.textContent ?? '').toBe('40%');
-    expect(cells[3]?.textContent ?? '').toBe('80%');
-    expect(cells[4]?.textContent ?? '').toBe('30%');
+    expect(cells[1]?.textContent ?? '').toBe('60.0%');
+    expect(cells[2]?.textContent ?? '').toBe('40.0%');
+    expect(cells[3]?.textContent ?? '').toBe('80.0%');
+    expect(cells[4]?.textContent ?? '').toBe('30.0%');
   });
 });

--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { CopyVisualButton } from '../ui/CopyVisualButton';
-import { HeaderTooltip } from '../ui/HeaderTooltip';
+import { TooltipIcon } from '../ui/TooltipIcon';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/Table';
 import type { PressureSensitivityCell, PressureSensitivityValuePair } from '../../api/operations/pressureSensitivity';
 import { formatPercent } from './pressureSensitivityFormatting';
@@ -218,7 +218,7 @@ function SortHeaderCell({
 
   return (
     <TableHead
-      className={`${numeric ? 'text-right' : 'text-left'} text-xs uppercase tracking-wide text-gray-500`}
+      className={`${numeric ? 'text-right' : 'text-left'} text-xs uppercase tracking-wide text-gray-700`}
       aria-sort={active ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'}
     >
       <div className={`flex w-full items-center gap-1 ${numeric ? 'justify-end' : 'justify-start'}`}>
@@ -227,16 +227,18 @@ function SortHeaderCell({
           type="button"
           onClick={() => onSort(sortKey)}
           className={`inline-flex items-center gap-1 text-left transition-colors ${
-            active ? 'text-gray-700' : 'text-gray-400 hover:text-gray-600'
+            active ? 'text-gray-900' : 'text-gray-700 hover:text-gray-900'
           }`}
           aria-label={`Sort by ${ariaLabel}${active ? ` (${sortDirection === 'asc' ? 'ascending' : 'descending'})` : ''}`}
         >
           <span>{label}</span>
-          <span aria-hidden="true" className={`text-[11px] leading-none ${active ? 'text-gray-700' : 'text-gray-300'}`}>
-            {active ? (direction === 'asc' ? '↑' : '↓') : '↕'}
-          </span>
+          {active ? (
+            <span aria-hidden="true" className="text-[11px] leading-none text-gray-900">
+              {direction === 'asc' ? '↑' : '↓'}
+            </span>
+          ) : null}
         </button>
-        {tooltip ? <HeaderTooltip label={label} content={tooltip} /> : null}
+        {tooltip ? <TooltipIcon ariaLabel={`Help: ${ariaLabel}`} content={tooltip} /> : null}
       </div>
     </TableHead>
   );
@@ -319,8 +321,8 @@ export function PressureResponseByValueTable({ valuePairs }: Props) {
                 numeric
               />
               <SortHeaderCell
-                label="High pressure on this value"
-                ariaLabel="High pressure on this value"
+                label="High pressure value win rate"
+                ariaLabel="High pressure value win rate"
                 sortKey="highPressureOnThisValue"
                 activeSortKey={sortKey}
                 direction={sortDirection}
@@ -329,8 +331,8 @@ export function PressureResponseByValueTable({ valuePairs }: Props) {
                 numeric
               />
               <SortHeaderCell
-                label="High pressure on opposing value"
-                ariaLabel="High pressure on opposing value"
+                label="High pressure on opposing value win rate"
+                ariaLabel="High pressure on opposing value win rate"
                 sortKey="highPressureOnOpposingValue"
                 activeSortKey={sortKey}
                 direction={sortDirection}

--- a/cloud/apps/web/src/components/models/PressureSensitivityDetail.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityDetail.tsx
@@ -132,20 +132,20 @@ export function PressureSensitivityDetail({ model }: Props) {
         <Table variant="bordered">
           <TableHeader variant="bordered">
             <TableRow>
-              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+              <TableHead className="text-xs uppercase tracking-wide text-gray-700">
                 <HeaderTooltip label="Value Pair" content={VALUE_PAIR_TOOLTIP} />
               </TableHead>
-              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+              <TableHead className="text-xs uppercase tracking-wide text-gray-700">
                 <HeaderTooltip label="Baseline" content={BASELINE_TOOLTIP} />
               </TableHead>
-              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+              <TableHead className="text-xs uppercase tracking-wide text-gray-700">
                 <HeaderTooltip label="Push toward first" content={PUSH_TOWARD_FIRST_TOOLTIP} />
               </TableHead>
-              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+              <TableHead className="text-xs uppercase tracking-wide text-gray-700">
                 <HeaderTooltip label="Push toward other" content={PUSH_TOWARD_OTHER_TOOLTIP} />
               </TableHead>
               <TableHead
-                className="cursor-pointer select-none text-xs uppercase tracking-wide text-gray-500"
+                className="cursor-pointer select-none text-xs uppercase tracking-wide text-gray-700"
                 onClick={() => setSortDirection((current) => (current === 'asc' ? 'desc' : 'asc'))}
                 aria-sort={sortDirection === 'asc' ? 'ascending' : 'descending'}
               >
@@ -156,7 +156,7 @@ export function PressureSensitivityDetail({ model }: Props) {
                   </span>
                 </div>
               </TableHead>
-              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+              <TableHead className="text-xs uppercase tracking-wide text-gray-700">
                 <HeaderTooltip label="Trials" content={TRIALS_TOOLTIP} />
               </TableHead>
             </TableRow>

--- a/cloud/apps/web/src/components/models/PressureSensitivitySummary.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivitySummary.tsx
@@ -69,10 +69,10 @@ export function PressureSensitivitySummary({ models, selectedModelId, onSelectMo
         <Table variant="bordered">
           <TableHeader variant="bordered">
             <TableRow>
-              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+              <TableHead className="text-xs uppercase tracking-wide text-gray-700">
                 <HeaderTooltip label="Model" content={MODEL_TOOLTIP} />
               </TableHead>
-              <TableHead className="text-xs uppercase tracking-wide text-gray-500">
+              <TableHead className="text-xs uppercase tracking-wide text-gray-700">
                 <HeaderTooltip label="Pressure response" content={SUMMARY_PRESSURE_RESPONSE_TOOLTIP} />
               </TableHead>
             </TableRow>

--- a/cloud/apps/web/src/components/models/pressureSensitivityFormatting.ts
+++ b/cloud/apps/web/src/components/models/pressureSensitivityFormatting.ts
@@ -22,7 +22,7 @@ export const TRIALS_TOOLTIP =
   'Qualifying scored trials that contributed to the Baseline, Push toward first, and Push toward other rates. These are the trials used to compute the Pressure response and its confidence interval.';
 
 export function formatPercent(value: number): string {
-  return `${(value * 100).toFixed(0)}%`;
+  return `${(value * 100).toFixed(1)}%`;
 }
 
 /** Unsigned percentage-points string, one decimal place. */

--- a/cloud/apps/web/src/components/ui/TooltipIcon.tsx
+++ b/cloud/apps/web/src/components/ui/TooltipIcon.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import { Info } from 'lucide-react';
+import { Tooltip } from './Tooltip';
+
+type Props = {
+  ariaLabel: string;
+  content: string | ReactNode;
+};
+
+/**
+ * Icon-only tooltip control. Use this when the surrounding context already renders
+ * the column/cell label text (e.g., inside a sortable header button) and you only
+ * need the ⓘ tooltip trigger. Mirror of HeaderTooltip without the leading label span.
+ */
+export function TooltipIcon({ ariaLabel, content }: Props) {
+  return (
+    <Tooltip
+      content={<div className="max-w-[280px] whitespace-normal text-xs leading-5">{content}</div>}
+      position="top"
+      variant="light"
+      className="max-w-[280px] whitespace-normal"
+    >
+      {/* eslint-disable-next-line react/forbid-elements -- Lightweight tooltip trigger requires an inline button */}
+      <button
+        type="button"
+        className="inline-flex cursor-help rounded-sm text-gray-500 transition-colors hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+        aria-label={ariaLabel}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <Info className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Summary

Six polish fixes follow up on PR #801. Frontend-only.

1. **Duplicate column labels gone.** The new `PressureResponseByValueTable` rendered each column label twice — once in the sort button, once in `HeaderTooltip`'s leading span. Added `<TooltipIcon>` (icon-only variant of HeaderTooltip) and swapped it in for the SortHeaderCell tooltip slot.

2. **Tooltip surfacing fixed implicitly.** The duplicate label was the most likely source of the "tooltip doesn't work" complaint — users were hovering the duplicate text rather than the actual ⓘ trigger. Default icon color also bumped slightly darker (`text-gray-500` instead of `text-gray-400`) so it's easier to spot.

3. **Removed `↕` indicator on inactive sort columns.** Only the active column shows ↑/↓.

4. **Darker header text.** `text-gray-400`/`text-gray-500` → `text-gray-700` for inactive labels, `text-gray-900` on hover and active sort. Applied across all three pressure-sensitivity tables.

5. **One decimal place on win-rate percentages.** `formatPercent` now uses `.toFixed(1)`. Affects all three tables uniformly.

6. **Renamed two columns in the new By Value table:**
   - "High pressure on this value" → "High pressure value win rate"
   - "High pressure on opposing value" → "High pressure on opposing value win rate"

Average and Balanced columns keep their existing names. Per-pair detail columns are unchanged (different framing intentionally).

## Test plan

- [x] Web build clean: `npx turbo build --filter=@valuerank/web`
- [x] All 28 pressure-sensitivity tests pass: `npm run test --workspace @valuerank/web -- --run pressure`
- [ ] Manual verification on `/models/pressure-sensitivity` after deploy: column labels render once, tooltip ⓘ icons surface tooltips on hover, no `↕` indicators, headers are readable, all win rates show one decimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)