### PR TITLE
fix(status): active transcript lookup, value-pair vignette, compact layout

### DIFF
--- a/cloud/apps/api/src/graphql/types/run-anomaly.ts
+++ b/cloud/apps/api/src/graphql/types/run-anomaly.ts
@@ -181,6 +181,28 @@ builder.objectType(RunAnomalyRef, {
       },
     }),
 
+    activeTranscriptId: t.string({
+      nullable: true,
+      description: 'ID of the most recent non-deleted transcript for this slot. For INVALID_RESPONSE_FAILURE only — queries by (runId, scenarioId, modelId, sampleIndex). Handles reprobe-fixed anomalies where details.transcriptId still points to the original. Null for non-slot types.',
+      resolve: async (anomaly) => {
+        if (!SLOT_KEYED_TYPES.has(anomaly.type)) return null;
+        const slot = parseSlotSubject(anomaly.subject);
+        if (slot === null) return null;
+        const transcript = await db.transcript.findFirst({
+          where: {
+            runId: slot.runId,
+            scenarioId: slot.scenarioId ?? null,
+            modelId: slot.modelId,
+            sampleIndex: slot.sampleIndex,
+            deletedAt: null,
+          },
+          select: { id: true },
+          orderBy: { createdAt: 'desc' },
+        });
+        return transcript?.id ?? null;
+      },
+    }),
+
     scenarioName: t.string({
       nullable: true,
       description: 'Scenario (vignette) name for slot-keyed anomaly types. Null for non-slot types or when the scenario cannot be found.',

--- a/cloud/apps/web/src/api/operations/run-anomaly.graphql
+++ b/cloud/apps/web/src/api/operations/run-anomaly.graphql
@@ -15,6 +15,7 @@ query OpenRunAnomalies($domainId: ID, $type: RunAnomalyType) {
     reprobeLimitReached
     reprobeStage
     estimatedCost
+    activeTranscriptId
     scenarioName
     dimensionValues
     run {

--- a/cloud/apps/web/src/components/status/AnomalyRow.tsx
+++ b/cloud/apps/web/src/components/status/AnomalyRow.tsx
@@ -56,6 +56,17 @@ function extractStrengthPair(dimensionValues: unknown): [string, string] {
   return [first, second];
 }
 
+function formatDimensionKey(key: string): string {
+  return key.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+}
+
+function formatValuePair(dimensionValues: unknown): string | null {
+  if (!isRecord(dimensionValues)) return null;
+  const keys = Object.keys(dimensionValues);
+  if (keys.length === 0) return null;
+  return keys.map(formatDimensionKey).join(' / ');
+}
+
 export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps) {
   const navigate = useNavigate();
   const [isReprobeModalOpen, setIsReprobeModalOpen] = useState(false);
@@ -81,13 +92,15 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
   const rowHoverClass = tone === 'amber' ? 'hover:bg-amber-100/50' : 'hover:bg-gray-50';
   const transcriptId = useMemo(() => {
     if (anomaly.type === 'INVALID_RESPONSE_FAILURE') {
-      return extractTranscriptId(anomaly.details);
+      // Prefer activeTranscriptId (latest for the slot) — handles reprobe-fixed rows
+      // where details.transcriptId still points to the original transcript.
+      return anomaly.activeTranscriptId ?? extractTranscriptId(anomaly.details);
     }
     if (anomaly.type === 'STRANDED_TRANSCRIPT' || anomaly.type === 'ORPHAN_TRANSCRIPT') {
       return anomaly.subject;
     }
     return null;
-  }, [anomaly.details, anomaly.subject, anomaly.type]);
+  }, [anomaly.activeTranscriptId, anomaly.details, anomaly.subject, anomaly.type]);
 
   useEffect(() => {
     return () => {
@@ -168,6 +181,7 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
   const modelId = isRecord(anomaly.details) && typeof anomaly.details.modelId === 'string'
     ? anomaly.details.modelId
     : null;
+  const vignetteLabel = formatValuePair(anomaly.dimensionValues) ?? '—';
   const [firstStrength, secondStrength] = extractStrengthPair(anomaly.dimensionValues);
 
   const renderViewTranscriptButton = () => {
@@ -312,30 +326,32 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
   return (
     <>
       <tr className={rowHoverClass}>
-        <td className="px-4 py-3 align-top text-sm text-gray-700">
-          {anomaly.domain?.name ?? '—'}
-        </td>
-        <td className="px-4 py-3 align-top text-sm text-gray-700">
-          <span className="block max-w-[16rem] truncate" title={anomaly.scenarioName ?? undefined}>
-            {anomaly.scenarioName ?? '—'}
+        <td className="px-3 py-2 align-middle text-sm text-gray-700">
+          <span className="block max-w-[8rem] truncate" title={anomaly.domain?.name ?? undefined}>
+            {anomaly.domain?.name ?? '—'}
           </span>
         </td>
-        <td className="px-4 py-3 align-top text-sm text-gray-700">
+        <td className="px-3 py-2 align-middle text-sm text-gray-700">
+          <span className="block max-w-[12rem] truncate" title={vignetteLabel !== '—' ? vignetteLabel : undefined}>
+            {vignetteLabel}
+          </span>
+        </td>
+        <td className="px-3 py-2 align-middle text-sm text-gray-700">
           <span className="font-medium text-gray-900">{anomaly.displayLabel}</span>
         </td>
-        <td className="px-4 py-3 align-top text-sm text-gray-700">
-          <span className="block max-w-[16rem] truncate font-mono text-xs" title={modelId ?? undefined}>
+        <td className="px-3 py-2 align-middle text-sm text-gray-700">
+          <span className="block max-w-[10rem] truncate font-mono text-xs" title={modelId ?? undefined}>
             {modelId ?? '—'}
           </span>
         </td>
-        <td className="px-4 py-3 align-top text-sm text-gray-700 whitespace-nowrap">
+        <td className="px-3 py-2 align-middle text-sm text-gray-700 whitespace-nowrap">
           {firstStrength}
         </td>
-        <td className="px-4 py-3 align-top text-sm text-gray-700 whitespace-nowrap">
+        <td className="px-3 py-2 align-middle text-sm text-gray-700 whitespace-nowrap">
           {secondStrength}
         </td>
-        <td className="px-4 py-3 align-top text-sm text-gray-700">
-          <div className="flex flex-wrap items-center justify-end gap-2">
+        <td className="px-3 py-2 align-middle text-sm text-gray-700">
+          <div className="flex items-center justify-end gap-1.5 flex-nowrap">
             {renderPrimaryAction()}
             {renderViewTranscriptButton()}
             <Button
@@ -349,7 +365,7 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
             </Button>
           </div>
           {errorMessage && (
-            <p className="mt-2 max-w-xs text-right text-xs text-red-600">
+            <p className="mt-1 text-right text-xs text-red-600">
               {errorMessage}
             </p>
           )}

--- a/cloud/apps/web/src/components/status/OpenAnomaliesSection.tsx
+++ b/cloud/apps/web/src/components/status/OpenAnomaliesSection.tsx
@@ -209,25 +209,25 @@ export function OpenAnomaliesSection({
               <table className="min-w-full divide-y divide-amber-200">
                 <thead className="bg-amber-50">
                   <tr>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
                       Domain
                     </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
                       Vignette
                     </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
                       Type
                     </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
                       Model
                     </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
                       Strength of First Value
                     </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-amber-900">
                       Strength of Second Value
                     </th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-amber-900">
+                    <th className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-amber-900">
                       Actions
                     </th>
                   </tr>

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -3457,6 +3457,8 @@ export type RunAnomaly = {
   /** The run this anomaly belongs to */
   run: Run;
   runId: Scalars['String']['output'];
+  /** ID of the most recent non-deleted transcript for this slot. Null for non-slot types. */
+  activeTranscriptId?: Maybe<Scalars['String']['output']>;
   /** Scenario (vignette) name for slot-keyed anomaly types. Null for non-slot types or when the scenario cannot be found. */
   scenarioName?: Maybe<Scalars['String']['output']>;
   /** Dimension values from the scenario content for slot-keyed anomaly types. */
@@ -4623,7 +4625,7 @@ export type OpenRunAnomaliesQueryVariables = Exact<{
 }>;
 
 
-export type OpenRunAnomaliesQuery = { __typename?: 'Query', openRunAnomalies: Array<{ __typename?: 'RunAnomaly', id: string, runId: string, type: RunAnomalyType, subject: string, source: RunAnomalySource, details: unknown, firstSeenAt: string, lastSeenAt: string, displayLabel: string, displaySubject: string, reprobeEligible: boolean, reprobeCount: number, reprobeLimitReached: boolean, reprobeStage?: string | null, estimatedCost?: number | null, scenarioName?: string | null, dimensionValues?: unknown | null, run: { __typename?: 'Run', id: string, name?: string | null, status: string }, domain?: { __typename?: 'Domain', id: string, name: string } | null }> };
+export type OpenRunAnomaliesQuery = { __typename?: 'Query', openRunAnomalies: Array<{ __typename?: 'RunAnomaly', id: string, runId: string, type: RunAnomalyType, subject: string, source: RunAnomalySource, details: unknown, firstSeenAt: string, lastSeenAt: string, displayLabel: string, displaySubject: string, reprobeEligible: boolean, reprobeCount: number, reprobeLimitReached: boolean, reprobeStage?: string | null, estimatedCost?: number | null, activeTranscriptId?: string | null, scenarioName?: string | null, dimensionValues?: unknown | null, run: { __typename?: 'Run', id: string, name?: string | null, status: string }, domain?: { __typename?: 'Domain', id: string, name: string } | null }> };
 
 export type ReprobeAnomalySlotMutationVariables = Exact<{
   anomalyId: Scalars['ID']['input'];
@@ -7230,6 +7232,7 @@ export const OpenRunAnomaliesDocument = gql`
     reprobeLimitReached
     reprobeStage
     estimatedCost
+    activeTranscriptId
     scenarioName
     dimensionValues
     run {


### PR DESCRIPTION
## Summary
- **View Transcript fix for already-reprobe-fixed rows**: new `activeTranscriptId` GraphQL field always queries the latest transcript by slot coordinates `(runId, scenarioId, modelId, sampleIndex)` — fixes rows where `details.transcriptId` still pointed to the original (pre-reprobe) transcript
- **Vignette shows value names**: formatted dimension key names ("Achievement / Self Direction Action") instead of the scenario level name ("moderate / minimal")  
- **Compact layout**: reduced padding (px-3/py-2), smaller max-widths for Domain/Vignette/Model, flex-nowrap actions row so all buttons stay on one line

## Test plan
- [ ] CI passes
- [ ] Smoke test: `activeTranscriptId` resolves to a non-null transcript ID for INVALID_RESPONSE_FAILURE anomalies

🤖 Generated with [Claude Code](https://claude.com/claude-code)