### PR TITLE
Polish domain shifts table interactions

### DIFF
--- a/cloud/apps/api/src/services/queue/probe-queues.ts
+++ b/cloud/apps/api/src/services/queue/probe-queues.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@valuerank/db';
+import { Prisma } from '@prisma/client';
 
 export const PROBE_QUEUE_PREFIX = 'probe_' as const;
 export const LEGACY_PROBE_QUEUE_NAME = 'probe_scenario' as const;

--- a/cloud/apps/api/src/services/queue/probe-queues.ts
+++ b/cloud/apps/api/src/services/queue/probe-queues.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@valuerank/db';
 
 export const PROBE_QUEUE_PREFIX = 'probe_' as const;
 export const LEGACY_PROBE_QUEUE_NAME = 'probe_scenario' as const;

--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -31,7 +31,7 @@ const MAX_COLOR_SHIFT = 25;
 
 export { buildDomainShiftHeatmap, formatEvidenceWeight, formatPercent, formatPointShift, getDefaultDomainShiftSignature, getDefaultModelId, sortHeatmapRows } from './domainValueShiftHeatmapUtils';
 
-function getCellTone(shift: number): string {
+function getCellToneClass(shift: number): string {
   const clamped = Math.max(-MAX_COLOR_SHIFT, Math.min(MAX_COLOR_SHIFT, shift));
   const intensity = Math.abs(clamped) / MAX_COLOR_SHIFT;
   if (Math.abs(shift) < 0.5) {
@@ -51,7 +51,7 @@ function getCellTone(shift: number): string {
       : 'border-rose-100 bg-rose-50/60 text-rose-700';
 }
 
-function getWinRateTone(winRate: number): string {
+function getWinRateToneClass(winRate: number): string {
   if (winRate >= 75) return 'border-sky-300 bg-sky-100 text-sky-950';
   if (winRate >= 50) return 'border-sky-200 bg-sky-50 text-sky-900';
   if (winRate >= 25) return 'border-gray-200 bg-gray-50 text-gray-800';
@@ -94,13 +94,11 @@ function SortableHeader({
         className,
       )}
     >
-      <Button
+      <button
         type="button"
-        variant="ghost"
-        size="sm"
         onClick={() => onSort(getNextDomainShiftSort(sort, sortKey))}
         className={cn(
-          'inline-flex w-full items-center rounded px-1 py-1 cursor-pointer hover:bg-gray-100 hover:text-gray-900',
+          'inline-flex w-full items-center gap-1 bg-transparent px-0 py-0 text-[11px] font-semibold uppercase tracking-wide text-gray-500 transition-colors hover:text-gray-900 focus:outline-none focus-visible:ring-1 focus-visible:ring-teal-500',
           align === 'left' && 'justify-start text-left',
           align === 'center' && 'justify-center text-center',
           align === 'right' && 'justify-end text-right',
@@ -109,7 +107,12 @@ function SortableHeader({
         aria-label={`Sort by ${label} ${nextDirection}`}
       >
         <span className="whitespace-nowrap">{label}</span>
-      </Button>
+        {isActive && (
+          <span aria-hidden="true" className="text-[11px] leading-none text-gray-400">
+            {sort.direction === 'desc' ? '↑' : '↓'}
+          </span>
+        )}
+      </button>
     </th>
   );
 }
@@ -161,23 +164,14 @@ function Cell({
   displayMode: DomainShiftDisplayMode;
 }) {
   if (cell == null) {
-    return (
-      <span className="inline-flex min-w-[82px] justify-center rounded-md border border-gray-100 bg-gray-50 px-2 py-1 text-xs text-gray-400">
-        n/a
-      </span>
-    );
+    return <span className="inline-flex w-full justify-center text-xs font-semibold text-gray-400">n/a</span>;
   }
 
   const detail = `${valueLabel} in ${cell.domainName}: raw win rate ${formatPercent(cell.winRate)}; shift ${formatPointShift(cell.shift)} versus this value's equal-domain average; average ${formatPercent(cell.averageWinRate)}; evidence vignettes ${formatEvidenceWeight(cell.evidenceWeight)}.`;
   const visibleValue = displayMode === 'shift' ? formatPointShift(cell.shift) : formatPercent(cell.winRate);
-  const tone = displayMode === 'shift' ? getCellTone(cell.shift) : getWinRateTone(cell.winRate);
 
   return (
-    <span
-      className={`inline-flex min-w-[82px] justify-center rounded-md border px-2 py-1 text-xs font-semibold ${tone}`}
-      title={detail}
-      aria-label={detail}
-    >
+    <span className="inline-flex w-full justify-center text-xs font-semibold" title={detail} aria-label={detail}>
       {visibleValue}
     </span>
   );
@@ -243,6 +237,8 @@ export function DomainValueShiftHeatmap() {
     () => buildDomainShiftModelOptions(models, defaultModelIds),
     [defaultModelIds, models],
   );
+  const tableColumnCount = heatmap.columns.length + 2;
+  const columnWidth = tableColumnCount > 0 ? `${100 / tableColumnCount}%` : '100%';
   const loading = fetching && data == null;
 
   return (
@@ -325,7 +321,12 @@ export function DomainValueShiftHeatmap() {
           </div>
 
           <div className="overflow-x-auto rounded border border-gray-100 bg-white p-2">
-            <table className="min-w-full border-collapse text-xs">
+            <table className="w-full table-fixed border-collapse text-xs">
+              <colgroup>
+                {Array.from({ length: tableColumnCount }).map((_, index) => (
+                  <col key={index} style={{ width: columnWidth }} />
+                ))}
+              </colgroup>
               <thead>
                 <tr className="border-b border-gray-200 text-gray-600">
                   <SortableHeader
@@ -375,15 +376,23 @@ export function DomainValueShiftHeatmap() {
                         </span>
                       )}
                     </td>
-                    {heatmap.columns.map((domain) => (
-                      <td key={domain.domainId} className="border-b border-gray-100 px-2 py-2 text-center">
-                        <Cell
-                          cell={row.cells.get(domain.domainId) ?? null}
-                          valueLabel={row.valueLabel}
-                          displayMode={displayMode}
-                        />
-                      </td>
-                    ))}
+                    {heatmap.columns.map((domain) => {
+                      const cell = row.cells.get(domain.domainId) ?? null;
+                      const tdClassName = cn(
+                        'border-b border-gray-100 px-2 py-2 text-center align-middle transition-colors',
+                        cell == null
+                          ? 'border-gray-100 bg-gray-50 text-gray-400'
+                          : displayMode === 'shift'
+                            ? getCellToneClass(cell.shift)
+                            : getWinRateToneClass(cell.winRate),
+                      );
+
+                      return (
+                        <td key={domain.domainId} className={tdClassName}>
+                          <Cell cell={cell} valueLabel={row.valueLabel} displayMode={displayMode} />
+                        </td>
+                      );
+                    })}
                   </tr>
                 ))}
               </tbody>

--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -94,11 +94,13 @@ function SortableHeader({
         className,
       )}
     >
-      <button
+      <Button
         type="button"
+        variant="ghost"
+        size="sm"
         onClick={() => onSort(getNextDomainShiftSort(sort, sortKey))}
         className={cn(
-          'inline-flex w-full items-center gap-1 bg-transparent px-0 py-0 text-[11px] font-semibold uppercase tracking-wide text-gray-500 transition-colors hover:text-gray-900 focus:outline-none focus-visible:ring-1 focus-visible:ring-teal-500',
+          'w-full gap-1 rounded-none bg-transparent px-0 py-0 min-h-0 text-[11px] font-semibold uppercase tracking-wide text-gray-500 shadow-none transition-colors hover:bg-transparent hover:text-gray-900 focus:ring-0 focus:ring-offset-0',
           align === 'left' && 'justify-start text-left',
           align === 'center' && 'justify-center text-center',
           align === 'right' && 'justify-end text-right',
@@ -112,7 +114,7 @@ function SortableHeader({
             {sort.direction === 'desc' ? '↑' : '↓'}
           </span>
         )}
-      </button>
+      </Button>
     </th>
   );
 }

--- a/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
@@ -250,9 +250,11 @@ describe('DomainValueShiftHeatmap page', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Domain Shifts by Value' })).toBeInTheDocument();
     });
+    expect(screen.getByRole('table')).toHaveClass('table-fixed');
     expect(screen.getByRole('button', { name: /model a/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Latest @ default/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sort by Avg Win Rate descending/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sort by Value descending/i })).toHaveTextContent('Value↓');
     expect(screen.getByLabelText(/Achievement in City Planning: raw win rate 80%; shift \+20 pts/i)).toHaveAccessibleName(
       /average 60%; evidence vignettes —/i,
     );
@@ -262,6 +264,7 @@ describe('DomainValueShiftHeatmap page', () => {
     const firstDataRow = screen.getAllByRole('row')[1];
     expect(within(firstDataRow).getAllByRole('rowheader')[0]).toHaveTextContent('Achievement');
     expect(within(firstDataRow).getAllByRole('cell')[0]).toHaveTextContent('60%');
+    expect(within(firstDataRow).getAllByRole('cell')[1]).toHaveClass('bg-emerald-100');
   });
 
   it('passes the selected signature to the models analysis query', async () => {
@@ -311,6 +314,19 @@ describe('DomainValueShiftHeatmap page', () => {
     const firstDataRow = screen.getAllByRole('row')[1];
     expect(firstDataRow).toBeDefined();
     expect(within(firstDataRow as HTMLElement).getByRole('rowheader', { name: 'Achievement' })).toBeInTheDocument();
+  });
+
+  it('toggles active sort arrows between highest-first and lowest-first', async () => {
+    const user = userEvent.setup({ delay: null });
+    installModels([makeModel()]);
+
+    renderPage();
+
+    expect(await screen.findByRole('button', { name: /Sort by Value descending/i })).toHaveTextContent('Value↓');
+
+    await user.click(screen.getByRole('button', { name: /Sort by Avg Win Rate descending/i }));
+
+    expect(screen.getByRole('button', { name: /Sort by Avg Win Rate ascending/i })).toHaveTextContent('Avg Win Rate↑');
   });
 
   it('lets the user select a different model', async () => {


### PR DESCRIPTION
## Summary
- Match the domain shifts table to the domain analysis grid style.
- Make all columns equal width and keep the Avg Win Rate column on the left.
- Show simple sort arrows in the header text and tint the cell background instead of the header chrome.

## Test plan
- [x] `npm run test --workspace @valuerank/web -- tests/pages/DomainValueShiftHeatmap.test.tsx`
- [ ] Preflight passed (blocked by unrelated repo build errors in `@valuerank/api`)
- [ ] Manual smoke test done

🤖 Generated with [Codex](https://openai.com/codex)
