### PR TITLE
Move domain analysis controls to the top

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -90,7 +90,11 @@ Once the above are resolved:
 - [x] Domain Shifts by Value heatmap implemented at `/models/domain-shifts`; focused tests and web preflight pass.
 - [x] Domain Shifts readability controls added locally: cells can toggle between shift and raw win rate, and table columns are sortable.
 - [x] Domain Shifts model picker now groups default models first and separates non-default models with `---` before alphabetical non-default options.
+- [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, and model rows no longer repeat the model ID line.
 - [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, the all-domains value priorities table now includes stability circles, and the comparison table stays below it.
+- [x] Value Priorities now reuses the `/models` pooled win rate when available, so both reports show the same domain-equal first number for the same model/value cell.
+- [x] Domain Analysis findings controls now live at the top of the page, and the model focus selector applies across the model groups, value priorities, dominance, and similarity sections.
+- [x] Value Priorities now uses win rate only, with the retired Full BT toggle removed and the cell dots rendered under the numbers.
 
 ---
 

--- a/cloud/apps/web/src/components/domains/DominanceSection.tsx
+++ b/cloud/apps/web/src/components/domains/DominanceSection.tsx
@@ -17,6 +17,7 @@ import {
 type DominanceSectionProps = {
   models: ModelEntry[];
   unavailableModels: DomainAnalysisModelAvailability[];
+  selectedModelId: string | null;
 };
 
 const THEME_COLORS: DominanceSectionThemeColors = {
@@ -37,9 +38,8 @@ const THEME_COLORS: DominanceSectionThemeColors = {
   idleRingColor: '#38bdf8',
 };
 
-export function DominanceSection({ models, unavailableModels }: DominanceSectionProps) {
+export function DominanceSection({ models, unavailableModels, selectedModelId }: DominanceSectionProps) {
   const chartRef = useRef<HTMLDivElement>(null);
-  const [selectedModelId, setSelectedModelId] = useState(models[0]?.model ?? '');
   const [focusedValue, setFocusedValue] = useState<ValueKey | null>(null);
   const [hoveredValue, setHoveredValue] = useState<ValueKey | null>(null);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
@@ -73,17 +73,14 @@ export function DominanceSection({ models, unavailableModels }: DominanceSection
     };
   }, [prefersReducedMotion, selectedModelId, slowestDuration]);
 
-  useEffect(() => {
-    if (!models.some((model) => model.model === selectedModelId)) {
-      setSelectedModelId(models[0]?.model ?? '');
-    }
-  }, [models, selectedModelId]);
-
   const modelById = useMemo(
     () => new Map(models.map((model) => [model.model, model])),
     [models],
   );
-  const selectedModel = modelById.get(selectedModelId);
+  const activeModelId = selectedModelId !== null && modelById.has(selectedModelId)
+    ? selectedModelId
+    : models[0]?.model ?? '';
+  const selectedModel = modelById.get(activeModelId);
 
   const {
     contestedPairs,
@@ -110,30 +107,15 @@ export function DominanceSection({ models, unavailableModels }: DominanceSection
         <CopyVisualButton targetRef={chartRef} label="ranking and cycles chart" />
       </div>
 
-      <div className="mb-3 flex flex-wrap items-center gap-2">
-        <span className={`text-xs font-medium ${THEME_COLORS.panelMutedText}`}>Select AI:</span>
-        <select
-          className="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-800"
-          value={selectedModelId}
-          onChange={(event) => setSelectedModelId(event.target.value)}
-        >
-          {models.map((model) => (
-            <option key={model.model} value={model.model}>
-              {model.label}
-            </option>
-          ))}
-          {unavailableModels.length > 0 && (
-            <option disabled value="">
-              ----------
-            </option>
-          )}
-          {unavailableModels.map((model) => (
-            <option key={model.model} value={model.model} disabled>
-              {model.label} (Unavailable)
-            </option>
-          ))}
-        </select>
+      <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">
+        <span className={`font-medium ${THEME_COLORS.panelMutedText}`}>Model focus:</span>
+        <span className={THEME_COLORS.panelText}>{selectedModel?.label ?? 'No model selected'}</span>
       </div>
+      {unavailableModels.length > 0 && (
+        <p className={`mb-3 text-xs ${THEME_COLORS.panelMutedText}`}>
+          {unavailableModels.length} unavailable model{unavailableModels.length === 1 ? '' : 's'} stay hidden from this analysis.
+        </p>
+      )}
 
       {models.length === 0 && (
         <p className={`mb-3 text-xs ${THEME_COLORS.panelMutedText}`}>

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -66,15 +66,20 @@ function getClusterPersonality(cluster: DomainCluster): ClusterPersonality {
 
 type ModelGroupsSectionProps = {
   clusterAnalysis?: ClusterAnalysis;
+  selectedModelId?: string | null;
 };
 
-export function ModelGroupsSection({ clusterAnalysis }: ModelGroupsSectionProps) {
+export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: ModelGroupsSectionProps) {
   const summaryTableRef = useRef<HTMLDivElement>(null);
   const [showModelGroupsHelp, setShowModelGroupsHelp] = useState(false);
 
   const clusters = useMemo(
-    () => (clusterAnalysis == null || clusterAnalysis.skipped ? [] : clusterAnalysis.clusters),
-    [clusterAnalysis],
+    () => {
+      if (clusterAnalysis == null || clusterAnalysis.skipped) return [];
+      if (selectedModelId == null) return clusterAnalysis.clusters;
+      return clusterAnalysis.clusters.filter((cluster) => cluster.members.some((member) => member.model === selectedModelId));
+    },
+    [clusterAnalysis, selectedModelId],
   );
 
   return (

--- a/cloud/apps/web/src/components/domains/ValuePrioritiesHelpPanel.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesHelpPanel.tsx
@@ -1,45 +1,20 @@
-type ScoreMode = 'WIN_RATE' | 'FULL_BT';
-
-type Props = { scoreMode: ScoreMode };
-
-export function ValuePrioritiesHelpPanel({ scoreMode }: Props) {
+export function ValuePrioritiesHelpPanel() {
   return (
     <div className="mt-2 rounded-lg border border-blue-100 bg-blue-50 p-2.5 text-xs text-gray-700">
-      {scoreMode === 'FULL_BT' ? (
-        <>
-          <p className="font-medium text-gray-800">Score Method: Full Bradley-Terry</p>
-          <p className="mt-1">
-            We fit a full Bradley-Terry model over pairwise value matchups for this AI. The model estimates
-            a latent strength for each value that best explains observed wins and losses.
-          </p>
-          <p className="mt-2 font-medium text-gray-800">Formula</p>
-          <p className="mt-0.5 font-mono text-[11px] text-sky-900">
-            Score = logarithm(estimated BT strength for this value)
-          </p>
-          <ul className="mt-2 list-disc space-y-0.5 pl-4">
-            <li>Better than simple ratios when comparisons form a connected network across values.</li>
-            <li>Strengths are estimated jointly, so each value is calibrated against all others.</li>
-            <li>Positive values indicate above-average latent strength; negative values indicate below-average.</li>
-          </ul>
-        </>
-      ) : (
-        <>
-          <p className="font-medium text-gray-800">Score Method: Win Rate</p>
-          <p className="mt-1">
-            The percentage of pairwise comparisons in which the AI prioritized this value across all decisions,
-            including neutral responses.
-          </p>
-          <p className="mt-2 font-medium text-gray-800">Formula</p>
-          <p className="mt-0.5 font-mono text-[11px] text-sky-900">
-            Win Rate = prioritized / (prioritized + deprioritized + neutral) × 100%
-          </p>
-          <ul className="mt-2 list-disc space-y-0.5 pl-4">
-            <li>50% means the AI prioritized this value in half of all recorded decisions.</li>
-            <li>Easy to interpret: higher % = model prioritizes this value more often.</li>
-            <li>Shows &ldquo;n/a&rdquo; when no comparison data exists for a value.</li>
-          </ul>
-        </>
-      )}
+      <p className="font-medium text-gray-800">Score Method: Win Rate</p>
+      <p className="mt-1">
+        The percentage of pairwise comparisons in which the AI prioritized this value across all decisions,
+        including neutral responses.
+      </p>
+      <p className="mt-2 font-medium text-gray-800">Formula</p>
+      <p className="mt-0.5 font-mono text-[11px] text-sky-900">
+        Win Rate = prioritized / (prioritized + deprioritized + neutral) × 100%
+      </p>
+      <ul className="mt-2 list-disc space-y-0.5 pl-4">
+        <li>50% means the AI prioritized this value in half of all recorded decisions.</li>
+        <li>Easy to interpret: higher % = model prioritizes this value more often.</li>
+        <li>Shows &ldquo;n/a&rdquo; when no comparison data exists for a value.</li>
+      </ul>
     </div>
   );
 }

--- a/cloud/apps/web/src/components/domains/ValuePrioritiesSection.test.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesSection.test.tsx
@@ -77,9 +77,9 @@ describe('ValuePrioritiesSection', () => {
     expect(naCell).toBeDefined();
   });
 
-  it('does not render a support rate toggle', () => {
+  it('does not render a Full BT toggle', () => {
     renderSection();
 
-    expect(screen.queryByRole('button', { name: /support rate/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /full bt/i })).toBeNull();
   });
 });

--- a/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
@@ -67,7 +67,6 @@ export function ValuePrioritiesSection({
   const detailedTableRef = useRef<HTMLDivElement>(null);
   const opennessGroupRef = useRef<HTMLTableCellElement>(null);
   const hedonismCellRef = useRef<HTMLTableCellElement>(null);
-  const [scoreMode, setScoreMode] = useState<'WIN_RATE' | 'FULL_BT'>('WIN_RATE');
   const [sortState, setSortState] = useState<SortState>({ key: 'model', direction: 'asc' });
   const [showSectionHelp, setShowSectionHelp] = useState(false);
   const [opennessSplitPercent, setOpennessSplitPercent] = useState(33.3333);
@@ -90,22 +89,15 @@ export function ValuePrioritiesSection({
       );
     } else {
       nextModels.sort((a, b) => {
-        const aVal = scoreMode === 'WIN_RATE' ? (a.winRates?.[key] ?? -Infinity) : a.values[key];
-        const bVal = scoreMode === 'WIN_RATE' ? (b.winRates?.[key] ?? -Infinity) : b.values[key];
+        const aVal = a.winRates?.[key] ?? -Infinity;
+        const bVal = b.winRates?.[key] ?? -Infinity;
         return sortState.direction === 'asc' ? aVal - bVal : bVal - aVal;
       });
     }
     return nextModels;
-  }, [models, sortState, scoreMode]);
+  }, [models, sortState]);
 
-  const valueRange = useMemo(() => {
-    if (scoreMode === 'WIN_RATE') {
-      return { min: 0, max: 100 };
-    }
-    const all = models.flatMap((model) => COLUMN_VALUES.map((v) => model.values[v]));
-    if (all.length === 0) return { min: -1, max: 1 };
-    return { min: Math.min(...all), max: Math.max(...all) };
-  }, [models, scoreMode]);
+  const valueRange = useMemo(() => ({ min: 0, max: 100 }), []);
 
   useLayoutEffect(() => {
     const updateSplitPosition = () => {
@@ -139,7 +131,7 @@ export function ValuePrioritiesSection({
       observer.disconnect();
       window.removeEventListener('resize', updateSplitPosition);
     };
-  }, [scoreMode, models.length]);
+  }, [models.length]);
 
   const handleValueCellClick = (modelId: string, valueKey: ValueKey) => {
     if (isReadOnly || selectedDomainId === '') return;
@@ -147,7 +139,6 @@ export function ValuePrioritiesSection({
       domainId: selectedDomainId,
       modelId,
       valueKey,
-      scoreMethod: 'FULL_BT',
     });
     if (selectedSignature !== null) {
       params.set('signature', selectedSignature);
@@ -156,7 +147,6 @@ export function ValuePrioritiesSection({
   };
 
   function getCellValue(model: ModelEntry, valueKey: ValueKey): number | null {
-    if (scoreMode === 'FULL_BT') return model.values[valueKey];
     return model.winRates?.[valueKey] ?? null;
   }
 
@@ -177,30 +167,10 @@ export function ValuePrioritiesSection({
             </Button>
           </div>
           <p className="text-sm text-gray-600">Which values each model favors most and least.</p>
-          {showSectionHelp && <ValuePrioritiesHelpPanel scoreMode={scoreMode} />}
+          {showSectionHelp && <ValuePrioritiesHelpPanel />}
         </div>
         <div className="flex items-center gap-3">
           <p className="text-xs text-gray-500">Click a column heading to sort.</p>
-          <div className="flex rounded border border-gray-200 text-xs">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => setScoreMode('WIN_RATE')}
-              className={`h-auto rounded-none px-3 py-1 text-xs ${scoreMode === 'WIN_RATE' ? 'bg-sky-600 text-white hover:bg-sky-600 hover:text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
-            >
-              Win Rate
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => setScoreMode('FULL_BT')}
-              className={`h-auto rounded-none border-l border-gray-200 px-3 py-1 text-xs ${scoreMode === 'FULL_BT' ? 'bg-sky-600 text-white hover:bg-sky-600 hover:text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
-            >
-              Full BT
-            </Button>
-          </div>
         </div>
       </div>
 
@@ -346,25 +316,21 @@ export function ValuePrioritiesSection({
                           onClick={() => handleValueCellClick(model.model, value)}
                           disabled={selectedDomainId === '' || isReadOnly}
                           title={isReadOnly ? 'Value drill-down is unavailable in All domains mode' : undefined}
-                      >
-                          <span>
-                            {(() => {
-                              if (cellValue === null) return '—';
-                              if (scoreMode === 'WIN_RATE') return `${cellValue.toFixed(1)}%`;
-                              return `${cellValue > 0 ? '+' : ''}${cellValue.toFixed(2)}`;
-                            })()}
-                          </span>
-                          {showStabilityDots && (
-                            <StabilityDots
-                              score={stabilityScore}
-                              className="mt-1 text-current"
-                              title={
-                                stabilityScore != null
+                        >
+                          <span className="flex flex-col items-end gap-1">
+                            <span>
+                              {cellValue === null ? 'n/a' : `${cellValue.toFixed(1)}%`}
+                            </span>
+                            {showStabilityDots && (
+                              <StabilityDots
+                                score={stabilityScore}
+                                className={cellValue === null ? 'text-gray-300' : 'text-gray-700'}
+                                title={stabilityScore != null
                                   ? `Stability ${Math.round(stabilityScore)}/100`
-                                  : 'Stability unavailable'
-                              }
-                            />
-                          )}
+                                  : 'Stability unavailable'}
+                              />
+                            )}
+                          </span>
                         </Button>
                       </td>
                     );

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery } from 'urql';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { Loading } from '../components/ui/Loading';
 import { Button } from '../components/ui/Button';
+import { Select } from '../components/ui/Select';
 import {
   DOMAIN_AVAILABLE_SIGNATURES_QUERY,
   DOMAIN_ANALYSIS_QUERY,
@@ -17,6 +18,11 @@ import {
   type RefreshDomainAnalysisMutationResult,
   type RefreshDomainAnalysisMutationVariables,
 } from '../api/operations/domainAnalysis';
+import {
+  MODELS_ANALYSIS_QUERY,
+  type ModelsAnalysisQueryResult,
+  type ModelsAnalysisQueryVariables,
+} from '../api/operations/modelsAnalysis';
 import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
 import { DominanceSection } from '../components/domains/DominanceSection';
 import { SimilaritySection } from '../components/domains/SimilaritySection';
@@ -47,6 +53,7 @@ export function DomainAnalysis() {
   );
   const [selectedDomainId, setSelectedDomainId] = useState<string>(searchParams.get('domainId') ?? '');
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
   const [exportLoading, setExportLoading] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
@@ -107,7 +114,6 @@ export function DomainAnalysis() {
     const next = new URLSearchParams(searchParams);
     if (nextDomainId !== '') next.set('domainId', nextDomainId);
     else next.delete('domainId');
-    next.set('scoreMethod', 'FULL_BT');
     if (selectedScope === 'ALL_DOMAINS') next.set('scope', ALL_DOMAINS_SCOPE);
     else next.delete('scope');
     if (selectedSignature === '') next.delete('signature');
@@ -124,7 +130,6 @@ export function DomainAnalysis() {
     variables: {
       domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
       scope: selectedScope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined,
-      scoreMethod: 'FULL_BT',
       signature: selectedSignature === '' ? undefined : selectedSignature,
     },
     pause: selectedDomainId === '' || activeUseLegacyQuery,
@@ -134,6 +139,15 @@ export function DomainAnalysis() {
     query: DOMAIN_ANALYSIS_QUERY_LEGACY,
     variables: { domainId: selectedDomainId },
     pause: selectedDomainId === '' || !activeUseLegacyQuery,
+    requestPolicy: 'cache-and-network',
+  });
+  const [{ data: modelsAnalysisData }] = useQuery<ModelsAnalysisQueryResult, ModelsAnalysisQueryVariables>({
+    query: MODELS_ANALYSIS_QUERY,
+    variables: {
+      ...(selectedScope === 'DOMAIN' && selectedDomainId !== '' ? { domainId: selectedDomainId } : {}),
+      ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
+    },
+    pause: selectedScope === 'DOMAIN' && selectedDomainId === '',
     requestPolicy: 'cache-and-network',
   });
   const [{ fetching: refreshFetching }, refreshDomainAnalysis] = useMutation<
@@ -162,12 +176,20 @@ export function DomainAnalysis() {
 
   const models = useMemo<ModelEntry[]>(() => {
     const sourceModels = data?.domainAnalysis.models ?? [];
+    const pooledWinRatesByModel = new Map<string, Map<string, number | null>>(
+      (modelsAnalysisData?.modelsAnalysis.models ?? []).map((model) => [
+        model.modelId,
+        new Map(model.values.map((value) => [value.valueKey, value.pooledWinRate])),
+      ]),
+    );
+
     return sourceModels.map((model) => {
       const valueMap = new Map(model.values.map((e) => [e.valueKey, e.score]));
       const winRateMap = new Map(model.values.map((e) => {
         const neutral = e.neutral ?? 0;
         const denom = e.prioritized + e.deprioritized + neutral;
-        return [e.valueKey, denom > 0 ? (e.prioritized / denom) * 100 : null] as const;
+        const pooledWinRate = pooledWinRatesByModel.get(model.model)?.get(e.valueKey) ?? null;
+        return [e.valueKey, pooledWinRate ?? (denom > 0 ? (e.prioritized / denom) * 100 : null)] as const;
       }));
       const values = VALUES.reduce<Record<ValueKey, number>>((acc, valueKey) => {
         acc[valueKey] = valueMap.get(valueKey) ?? 0;
@@ -184,7 +206,24 @@ export function DomainAnalysis() {
         winRates,
       };
     });
-  }, [data]);
+  }, [data, modelsAnalysisData]);
+  useEffect(() => {
+    if (selectedModelId == null) return;
+    if (models.some((model) => model.model === selectedModelId)) return;
+    setSelectedModelId(null);
+  }, [models, selectedModelId]);
+
+  const modelOptions = useMemo(
+    () => [
+      { value: 'all', label: 'All models' },
+      ...models.map((model) => ({ value: model.model, label: model.label })),
+    ],
+    [models],
+  );
+  const visibleModels = useMemo(
+    () => (selectedModelId == null ? models : models.filter((model) => model.model === selectedModelId)),
+    [models, selectedModelId],
+  );
 
   const unavailableModels = useMemo<DomainAnalysisModelAvailability[]>(
     () => (data?.domainAnalysis.unavailableModels ?? []).map((m) => ({ model: m.model, label: m.label, reason: m.reason })),
@@ -287,37 +326,51 @@ export function DomainAnalysis() {
                 : 'Analysis is shown from the latest saved snapshot for this domain.'}
             </p>
           </div>
-          <div className="flex flex-col gap-2 md:flex-row md:items-center">
-            <select
-              className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800"
-              value={isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId}
-              onChange={(e) => {
-                if (e.target.value === ALL_DOMAINS_SCOPE) {
-                  setSelectedScope('ALL_DOMAINS');
-                  return;
+          <div className="flex flex-col gap-2 md:flex-row md:items-end">
+            <div className="min-w-[210px]">
+              <Select
+                label="Domain scope"
+                options={[
+                  { value: ALL_DOMAINS_SCOPE, label: 'All domains' },
+                  ...domains.map((domain) => ({ value: domain.id, label: domain.name })),
+                ]}
+                value={isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId}
+                onChange={(value) => {
+                  if (value === ALL_DOMAINS_SCOPE) {
+                    setSelectedScope('ALL_DOMAINS');
+                    return;
+                  }
+                  setSelectedScope('DOMAIN');
+                  setSelectedDomainId(value);
+                }}
+                disabled={domainsLoading || (domains.length === 0 && !isAllDomains)}
+              />
+            </div>
+            <div className="min-w-[210px]">
+              <Select
+                label="Signature"
+                options={
+                  signatureOptions.length === 0
+                    ? [{ value: '', label: 'No signatures with completed runs', disabled: true }]
+                    : signatureOptions.map((opt) => ({
+                      value: opt.signature,
+                      label: formatSignatureOptionLabel(opt),
+                    }))
                 }
-                setSelectedScope('DOMAIN');
-                setSelectedDomainId(e.target.value);
-              }}
-              disabled={domainsLoading || (domains.length === 0 && !isAllDomains)}
-            >
-              <option value={ALL_DOMAINS_SCOPE}>All domains</option>
-              {domains.length === 0 && !domainsLoading && <option value="">No domains available</option>}
-              {domains.map((domain) => (
-                <option key={domain.id} value={domain.id}>{domain.name}</option>
-              ))}
-            </select>
-            <select
-              className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800"
-              value={selectedSignature}
-              onChange={(e) => setSelectedSignature(e.target.value)}
-              disabled={signaturesLoading || signatureOptions.length === 0}
-            >
-              {signatureOptions.length === 0 && <option value="">No signatures with completed runs</option>}
-              {signatureOptions.map((opt) => (
-                <option key={opt.signature} value={opt.signature}>{formatSignatureOptionLabel(opt)}</option>
-              ))}
-            </select>
+                value={selectedSignature}
+                onChange={(value) => setSelectedSignature(value)}
+                disabled={signaturesLoading || signatureOptions.length === 0}
+              />
+            </div>
+            <div className="min-w-[210px]">
+              <Select
+                label="Model focus"
+                options={modelOptions}
+                value={selectedModelId ?? 'all'}
+                onChange={(value) => setSelectedModelId(value === 'all' ? null : value)}
+                disabled={models.length === 0}
+              />
+            </div>
             <Button
               type="button"
               variant="secondary"
@@ -331,6 +384,11 @@ export function DomainAnalysis() {
           </div>
           {exportError !== null && <p className="mt-1 text-xs text-amber-700">{exportError}</p>}
         </div>
+        {selectedModelId !== null && (
+          <p className="mt-2 text-xs text-gray-500">
+            Showing only {models.find((model) => model.model === selectedModelId)?.label ?? 'the selected model'} across all tables.
+          </p>
+        )}
         {data?.domainAnalysis != null && missingDefinitionCount > 0 && !isAllDomains && (
           <div className="mt-2 space-y-1 text-xs text-gray-500">
             <>
@@ -356,15 +414,20 @@ export function DomainAnalysis() {
         <Loading size="lg" text="Loading domain analysis..." />
       ) : (
         <>
-          <ModelGroupsSection clusterAnalysis={data?.domainAnalysis.clusterAnalysis} />
+          <ModelGroupsSection clusterAnalysis={data?.domainAnalysis.clusterAnalysis} selectedModelId={selectedModelId} />
           <ValuePrioritiesSection
-            models={models}
+            models={visibleModels}
             selectedDomainId={selectedDomainId}
             selectedSignature={selectedSignature === '' ? null : selectedSignature}
             isReadOnly={isAllDomains}
+            showStabilityDots
           />
-          <DominanceSection models={models} unavailableModels={unavailableModels} />
-          <SimilaritySection models={models} clusterAnalysis={data?.domainAnalysis.clusterAnalysis} />
+          <DominanceSection
+            models={visibleModels}
+            unavailableModels={unavailableModels}
+            selectedModelId={selectedModelId}
+          />
+          <SimilaritySection models={visibleModels} clusterAnalysis={data?.domainAnalysis.clusterAnalysis} />
         </>
       )}
 

--- a/cloud/apps/web/src/pages/DomainAnalysisValueDetail.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysisValueDetail.tsx
@@ -33,12 +33,11 @@ export function DomainAnalysisValueDetail() {
   const modelId = searchParams.get('modelId') ?? '';
   const valueKey = searchParams.get('valueKey') ?? '';
   const signature = searchParams.get('signature');
-  const scoreMethod: 'LOG_ODDS' | 'FULL_BT' = searchParams.get('scoreMethod') === 'FULL_BT' ? 'FULL_BT' : 'LOG_ODDS';
   const backParams = new URLSearchParams();
   if (domainId !== '') backParams.set('domainId', domainId);
-  backParams.set('scoreMethod', scoreMethod);
   if (signature !== null && signature !== '') backParams.set('signature', signature);
   const backLink = `/domains/analysis?${backParams.toString()}`;
+  const scoreMethod = 'LOG_ODDS' as const;
 
   const [{ data: scoredData, fetching: scoredFetching, error: scoredError }] = useQuery<
     DomainAnalysisValueDetailQueryResult,
@@ -187,14 +186,11 @@ export function DomainAnalysisValueDetail() {
       </div>
 
       {showMethodology && (
-        <section className="rounded-lg border border-gray-200 bg-white p-4">
-          <h2 className="text-base font-medium text-gray-900">
-            {scoreMethod === 'FULL_BT' ? 'Score Method (Full Bradley-Terry)' : 'Score Method (Smoothed Log-Odds)'}
-          </h2>
+      <section className="rounded-lg border border-gray-200 bg-white p-4">
+          <h2 className="text-base font-medium text-gray-900">Score Method (Smoothed Log-Odds)</h2>
           <p className="mt-1 text-sm text-gray-600">
-            {scoreMethod === 'FULL_BT'
-              ? 'We fit a full Bradley-Terry model over pairwise value matchups for this AI. The model estimates a latent strength for each value that best explains observed wins and losses.'
-              : 'We compare how often this value wins vs. loses across relevant vignettes. Neutral outcomes are still shown, but the score itself uses wins and losses.'}
+            We compare how often this value wins vs. loses across relevant vignettes. Neutral outcomes are still shown,
+            but the score itself uses wins and losses.
           </p>
           <div className="mt-3 grid gap-2 text-sm text-gray-700 md:grid-cols-2">
             <div className="rounded border border-gray-200 bg-gray-50 p-2">Wins (prioritized): {detail.prioritized}</div>
@@ -204,42 +200,21 @@ export function DomainAnalysisValueDetail() {
           </div>
           <div className="mt-3 rounded border border-sky-200 bg-sky-50 p-3 text-sm text-sky-900">
             <p className="font-medium">Formula (high-school version)</p>
-            {scoreMethod === 'FULL_BT' ? (
-              <>
-                <p className="mt-1">Score = logarithm(estimated BT strength for this value)</p>
-                <p className="mt-1 text-xs text-sky-800">
-                  The BT model uses all pairwise wins/losses together, then solves for a best-fit strength per value.
-                </p>
-                <p className="mt-1">
-                  Final BT score shown here = {detail.score.toFixed(4)}
-                </p>
-                <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-sky-800">
-                  <li>Name: Full Bradley-Terry score.</li>
-                  <li>Used for pairwise ranking problems where many items compete head-to-head.</li>
-                  <li>Better than simple ratios when comparisons form a connected network across values.</li>
-                  <li>Strengths are estimated jointly, so each value is calibrated against all others.</li>
-                  <li>Positive values indicate above-average latent strength; negative values indicate below-average.</li>
-                </ul>
-              </>
-            ) : (
-              <>
-                <p className="mt-1">Score = logarithm((wins + 1) / (losses + 1))</p>
-                <p className="mt-1 text-xs text-sky-800">
-                  Here, “logarithm” means the natural logarithm (often written as <code>ln</code>).
-                </p>
-                <p className="mt-1">
-                  Score = logarithm(({detail.prioritized} + 1) / ({detail.deprioritized} + 1)) = logarithm({ratio.toFixed(4)}) ={' '}
-                  {detail.score.toFixed(4)}
-                </p>
-                <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-sky-800">
-                  <li>Name: Bradley-Terry-style smoothed log-odds approximation.</li>
-                  <li>Faster to compute and easy to trace directly from wins/losses.</li>
-                  <li>The +1 smoothing avoids divide-by-zero and extreme jumps with sparse data.</li>
-                  <li>Log scaling controls extreme ratios so one matchup does not dominate.</li>
-                  <li>Positive values mean favored more often; negative values mean disfavored more often.</li>
-                </ul>
-              </>
-            )}
+            <p className="mt-1">Score = logarithm((wins + 1) / (losses + 1))</p>
+            <p className="mt-1 text-xs text-sky-800">
+              Here, “logarithm” means the natural logarithm (often written as <code>ln</code>).
+            </p>
+            <p className="mt-1">
+              Score = logarithm(({detail.prioritized} + 1) / ({detail.deprioritized} + 1)) = logarithm({ratio.toFixed(4)}) ={' '}
+              {detail.score.toFixed(4)}
+            </p>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-sky-800">
+              <li>Name: Bradley-Terry-style smoothed log-odds approximation.</li>
+              <li>Faster to compute and easy to trace directly from wins/losses.</li>
+              <li>The +1 smoothing avoids divide-by-zero and extreme jumps with sparse data.</li>
+              <li>Log scaling controls extreme ratios so one matchup does not dominate.</li>
+              <li>Positive values mean favored more often; negative values mean disfavored more often.</li>
+            </ul>
           </div>
         </section>
       )}

--- a/cloud/apps/web/tests/components/DominanceSection.test.tsx
+++ b/cloud/apps/web/tests/components/DominanceSection.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import type {
   DomainAnalysisModelAvailability,
   ModelEntry,
@@ -51,7 +50,7 @@ const unavailableModels: DomainAnalysisModelAvailability[] = [
 ];
 
 describe('DominanceSection', () => {
-  it('renders the shell, keeps unavailable options disabled, and updates summary content on model change', async () => {
+  it('renders the shell and updates summary content when the selected model changes', async () => {
     vi.spyOn(window, 'matchMedia').mockImplementation(
       (query) =>
         ({
@@ -65,12 +64,16 @@ describe('DominanceSection', () => {
           dispatchEvent: vi.fn(),
         }) as MediaQueryList,
     );
-    const user = userEvent.setup();
     let container: HTMLElement;
+    const { rerender } = render(
+      <DominanceSection
+        models={models}
+        unavailableModels={unavailableModels}
+        selectedModelId="model-a"
+      />,
+    );
     await act(async () => {
-      ({ container } = render(
-        <DominanceSection models={models} unavailableModels={unavailableModels} />,
-      ));
+      container = screen.getByRole('img', { name: 'Value dominance graph' }).parentElement!.parentElement!;
       await Promise.resolve();
     });
 
@@ -86,22 +89,23 @@ describe('DominanceSection', () => {
     expect(
       screen.getByRole('heading', { name: 'Most Contestable Value Pairs' }),
     ).toBeInTheDocument();
-
-    const modelSelect = screen.getByRole('combobox');
-    expect(modelSelect).toHaveValue('model-a');
-
-    const unavailableOption = screen.getByRole('option', {
-      name: 'Offline Model (Unavailable)',
-    });
-    expect(unavailableOption).toBeDisabled();
+    expect(screen.getByText('Model focus:')).toBeInTheDocument();
+    expect(screen.getByText('Model A')).toBeInTheDocument();
+    expect(screen.getByText('1 unavailable model stay hidden from this analysis.')).toBeInTheDocument();
 
     const summaryList = container!.querySelector('ol');
     expect(summaryList?.textContent).toBeTruthy();
     const initialSummary = summaryList?.textContent ?? '';
 
-    await user.selectOptions(modelSelect, 'model-b');
+    rerender(
+      <DominanceSection
+        models={models}
+        unavailableModels={unavailableModels}
+        selectedModelId="model-b"
+      />,
+    );
 
-    expect(modelSelect).toHaveValue('model-b');
+    expect(screen.getByText('Model B')).toBeInTheDocument();
     expect(summaryList?.textContent).not.toEqual(initialSummary);
   });
 });

--- a/cloud/apps/web/tests/components/ValuePrioritiesSection.test.tsx
+++ b/cloud/apps/web/tests/components/ValuePrioritiesSection.test.tsx
@@ -21,7 +21,7 @@ function buildModel(label: string): ModelEntry {
 }
 
 describe('ValuePrioritiesSection', () => {
-  it('renders the value priorities heading without the old combined model groups block', () => {
+  it('renders the value priorities heading without the retired BT toggle', () => {
     render(
       <MemoryRouter>
         <ValuePrioritiesSection
@@ -34,6 +34,6 @@ describe('ValuePrioritiesSection', () => {
 
     expect(screen.getByRole('heading', { name: 'Value Priorities' })).toBeInTheDocument();
     expect(screen.queryByText(/model groups/i)).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^win rate$/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /full bt/i })).not.toBeInTheDocument();
   });
 });

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { DomainAnalysis } from '../../src/pages/DomainAnalysis';
 import {
@@ -9,6 +8,7 @@ import {
   DOMAIN_FINDINGS_ELIGIBILITY_QUERY,
   REFRESH_DOMAIN_ANALYSIS_MUTATION,
 } from '../../src/api/operations/domainAnalysis';
+import { MODELS_ANALYSIS_QUERY } from '../../src/api/operations/modelsAnalysis';
 
 const useQueryMock = vi.fn();
 const useMutationMock = vi.fn();
@@ -71,6 +71,14 @@ const defaultDomainAnalysis = {
   },
 };
 
+const defaultModelsAnalysis = {
+  modelsAnalysis: {
+    models: [],
+  },
+};
+
+const valuePrioritiesSectionMock = vi.fn(() => <div>Mock value priorities section</div>);
+
 function installQueryResponses(options?: {
   findingsData?: typeof defaultFindingsEligibility | undefined;
   findingsFetching?: boolean;
@@ -81,6 +89,7 @@ function installQueryResponses(options?: {
   analysisData?: typeof defaultDomainAnalysis | undefined;
   analysisFetching?: boolean;
   analysisError?: Error | undefined;
+  modelsAnalysisData?: typeof defaultModelsAnalysis | undefined;
 }) {
   const findingsData = options && 'findingsData' in options ? options.findingsData : defaultFindingsEligibility;
   const findingsFetching = options?.findingsFetching ?? false;
@@ -91,6 +100,7 @@ function installQueryResponses(options?: {
   const analysisData = options && 'analysisData' in options ? options.analysisData : defaultDomainAnalysis;
   const analysisFetching = options?.analysisFetching ?? false;
   const analysisError = options?.analysisError;
+  const modelsAnalysisData = options && 'modelsAnalysisData' in options ? options.modelsAnalysisData : defaultModelsAnalysis;
 
   useQueryMock.mockImplementation((args: { query: unknown }) => {
     if (args.query === DOMAIN_AVAILABLE_SIGNATURES_QUERY) {
@@ -112,6 +122,13 @@ function installQueryResponses(options?: {
         data: analysisData,
         fetching: analysisFetching,
         error: analysisError,
+      }];
+    }
+    if (args.query === MODELS_ANALYSIS_QUERY) {
+      return [{
+        data: modelsAnalysisData,
+        fetching: false,
+        error: undefined,
       }];
     }
     return [{ data: undefined, fetching: false, error: undefined }];
@@ -148,7 +165,7 @@ vi.mock('../../src/components/domains/SimilaritySection', () => ({
 }));
 
 vi.mock('../../src/components/domains/ValuePrioritiesSection', () => ({
-  ValuePrioritiesSection: () => <div>Mock value priorities section</div>,
+  ValuePrioritiesSection: (props: unknown) => valuePrioritiesSectionMock(props),
 }));
 
 describe('DomainAnalysis', () => {
@@ -156,6 +173,7 @@ describe('DomainAnalysis', () => {
     useQueryMock.mockReset();
     useMutationMock.mockReset();
     refreshMutationExecuteMock.mockReset();
+    valuePrioritiesSectionMock.mockClear();
     useMutationMock.mockImplementation((query: unknown) => {
       if (query === REFRESH_DOMAIN_ANALYSIS_MUTATION) {
         return [{ fetching: false }, refreshMutationExecuteMock];
@@ -205,19 +223,14 @@ describe('DomainAnalysis', () => {
         expect.objectContaining({
           variables: expect.objectContaining({
             domainId: 'domain-a',
-            scoreMethod: 'FULL_BT',
             signature: 'vnewtd',
           }),
         }),
       );
     });
 
-    const comboboxes = screen.getAllByRole('combobox');
-    const signatureSelect = comboboxes[1];
-    expect(signatureSelect).toHaveValue('vnewtd');
-
-    const optionLabels = within(signatureSelect).getAllByRole('option').map((option) => option.textContent);
-    expect(optionLabels.slice(0, 3)).toEqual(['Latest @ default', 'v1 @ default', 'Latest @ t=0']);
+    const signatureSelect = screen.getByRole('button', { name: /latest @ default/i });
+    expect(signatureSelect).toBeInTheDocument();
   });
 
   it('does not wait for signatures before starting the analysis query', async () => {
@@ -265,5 +278,76 @@ describe('DomainAnalysis', () => {
     expect(screen.queryByText(/raw trials/i)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /export csv/i })).toBeDisabled();
     expect(screen.queryByRole('button', { name: /run missing vignettes/i })).not.toBeInTheDocument();
+  });
+
+  it('passes domain-equal win rates to the value priorities report when models analysis is available', async () => {
+    installQueryResponses({
+      analysisData: {
+        domainAnalysis: {
+          ...defaultDomainAnalysis.domainAnalysis,
+          models: [
+            {
+              model: 'model-a',
+              label: 'Model A',
+              values: [
+                {
+                  valueKey: 'Achievement',
+                  score: 0,
+                  prioritized: 9,
+                  deprioritized: 1,
+                  neutral: 0,
+                  totalComparisons: 10,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      modelsAnalysisData: {
+        modelsAnalysis: {
+          models: [
+            {
+              modelId: 'model-a',
+              label: 'Model A',
+              values: [
+                {
+                  valueKey: 'Achievement',
+                  pooledWinRate: 61,
+                  stabilityScore: 80,
+                  eligibleDomainCount: 2,
+                  domains: [],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <DomainAnalysis />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(valuePrioritiesSectionMock).toHaveBeenCalled();
+    });
+
+    const lastCall = valuePrioritiesSectionMock.mock.calls.at(-1)?.[0] as {
+      models: Array<{
+        model: string;
+        winRates?: Record<string, number | null>;
+      }>;
+    };
+
+    expect(lastCall.models).toEqual([
+      expect.objectContaining({
+        model: 'model-a',
+        winRates: expect.objectContaining({
+          Achievement: 61,
+        }),
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Move the domain analysis controls to the top of the page so domain scope and model focus drive every table.
- Remove the retired Full BT toggle and make Value Priorities win-rate only, with the dots rendered under the percentage.
- Keep the value detail page on the log-odds explanation path and update the affected tests.

## Validation
- `npm run test --workspace @valuerank/web -- --run tests/pages/DomainAnalysis.test.tsx tests/components/ValuePrioritiesSection.test.tsx tests/components/domains/ValuePrioritiesSection.test.tsx tests/components/domains/ModelValueDetailDrawer.test.tsx` ✅
- `npm run lint --workspace @valuerank/web` ✅ (warnings remain in unrelated files)
- `npm run build --workspace @valuerank/web` ⚠️ failed on pre-existing missing imports in `src/App.tsx` (`PressureSensitivity`, `ModelsConfidence`, `Status`)
