### PR TITLE
Add all-models aggregate to domain shifts

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -91,6 +91,7 @@ Once the above are resolved:
 - [x] Domain Shifts readability controls added locally: cells can toggle between shift and raw win rate, and table columns are sortable.
 - [x] Domain Shifts model picker now groups default models first and separates non-default models with `---` before alphabetical non-default options.
 - [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, and model rows no longer repeat the model ID line.
+- [x] Domain Shifts by Value now has an `All models` aggregate view, one-decimal formatting throughout, and content-fit Value / Avg Win Rate columns in the local branch.
 - [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, the all-domains value priorities table now includes stability circles, and the comparison table stays below it.
 - [x] Value Priorities now reuses the `/models` pooled win rate when available, so both reports show the same domain-equal first number for the same model/value cell.
 - [x] Domain Analysis findings controls now live at the top of the page, and the model focus selector applies across the model groups, value priorities, dominance, and similarity sections.

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
@@ -1,4 +1,4 @@
-import type { db, Prisma } from '@valuerank/db';
+import type { Prisma } from '@valuerank/db';
 import type {
   DefinitionRow,
   DomainAnalysisMissingDefinition,
@@ -21,7 +21,7 @@ export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.5.0';
 export const DOMAIN_ANALYSIS_ASSUMPTION_PREFIX = 'domain-analysis';
 export const DOMAIN_ANALYSIS_NONE_SIGNATURE = '__none__';
 
-export type SnapshotClient = typeof db | Prisma.TransactionClient;
+export type SnapshotClient = Prisma.TransactionClient;
 
 export type DomainAnalysisSnapshotModel = {
   model: string;

--- a/cloud/apps/api/src/services/domain-config/snapshot.ts
+++ b/cloud/apps/api/src/services/domain-config/snapshot.ts
@@ -12,7 +12,7 @@ import { createLogger, NotFoundError } from '@valuerank/shared';
 
 const log = createLogger('services:domain-config:snapshot');
 
-type SnapshotClient = typeof db | Prisma.TransactionClient;
+type SnapshotClient = Prisma.TransactionClient;
 
 /**
  * Ensures a DomainConfigSnapshot exists for the current domain configuration.

--- a/cloud/apps/api/src/services/queue/probe-queues.ts
+++ b/cloud/apps/api/src/services/queue/probe-queues.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@valuerank/db';
+import { Prisma } from '@prisma/client';
 
 export const PROBE_QUEUE_PREFIX = 'probe_' as const;
 export const LEGACY_PROBE_QUEUE_NAME = 'probe_scenario' as const;

--- a/cloud/apps/api/src/services/queue/probe-queues.ts
+++ b/cloud/apps/api/src/services/queue/probe-queues.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@valuerank/db';
 
 export const PROBE_QUEUE_PREFIX = 'probe_' as const;
 export const LEGACY_PROBE_QUEUE_NAME = 'probe_scenario' as const;

--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -9,6 +9,7 @@ import { Loading } from '../components/ui/Loading';
 import { Select } from '../components/ui/Select';
 import { cn } from '../lib/utils';
 import {
+  ALL_MODELS_OPTION_VALUE,
   DEFAULT_DOMAIN_SHIFT_SORT,
   DEFAULT_DOMAIN_SHIFT_SIGNATURE,
   buildDomainShiftHeatmap,
@@ -29,7 +30,17 @@ import {
 
 const MAX_COLOR_SHIFT = 25;
 
-export { buildDomainShiftHeatmap, formatEvidenceWeight, formatPercent, formatPointShift, getDefaultDomainShiftSignature, getDefaultModelId, sortHeatmapRows } from './domainValueShiftHeatmapUtils';
+export {
+  ALL_MODELS_OPTION_VALUE,
+  buildDomainShiftHeatmap,
+  buildDomainShiftModelOptions,
+  formatEvidenceWeight,
+  formatPercent,
+  formatPointShift,
+  getDefaultDomainShiftSignature,
+  getDefaultModelId,
+  sortHeatmapRows,
+} from './domainValueShiftHeatmapUtils';
 
 function getCellToneClass(shift: number): string {
   const clamped = Math.max(-MAX_COLOR_SHIFT, Math.min(MAX_COLOR_SHIFT, shift));
@@ -160,16 +171,18 @@ function Cell({
   cell,
   valueLabel,
   displayMode,
+  evidenceLabel,
 }: {
   cell: DomainShiftCell | null;
   valueLabel: string;
   displayMode: DomainShiftDisplayMode;
+  evidenceLabel: string;
 }) {
   if (cell == null) {
     return <span className="inline-flex w-full justify-center text-xs font-semibold text-gray-400">n/a</span>;
   }
 
-  const detail = `${valueLabel} in ${cell.domainName}: raw win rate ${formatPercent(cell.winRate)}; shift ${formatPointShift(cell.shift)} versus this value's equal-domain average; average ${formatPercent(cell.averageWinRate)}; evidence vignettes ${formatEvidenceWeight(cell.evidenceWeight)}.`;
+  const detail = `${valueLabel} in ${cell.domainName}: raw win rate ${formatPercent(cell.winRate)}; shift ${formatPointShift(cell.shift)} versus this value's equal-domain average; average ${formatPercent(cell.averageWinRate)}; ${evidenceLabel} ${formatEvidenceWeight(cell.evidenceWeight)}.`;
   const visibleValue = displayMode === 'shift' ? formatPointShift(cell.shift) : formatPercent(cell.winRate);
 
   return (
@@ -209,7 +222,7 @@ export function DomainValueShiftHeatmap() {
     () => new Set((llmModelsData?.llmModels ?? []).filter((model) => model.isDefault).map((model) => model.modelId)),
     [llmModelsData],
   );
-  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
+  const [selectedModelId, setSelectedModelId] = useState<string>(ALL_MODELS_OPTION_VALUE);
   const [displayMode, setDisplayMode] = useState<DomainShiftDisplayMode>('shift');
   const [sort, setSort] = useState<DomainShiftSort>(DEFAULT_DOMAIN_SHIFT_SORT);
 
@@ -221,16 +234,19 @@ export function DomainValueShiftHeatmap() {
   }, [availableSignatures, selectedSignature]);
 
   useEffect(() => {
-    const nextModelId = getDefaultModelId(models, selectedModelId, defaultModelIds);
+    const nextModelId = getDefaultModelId(models, selectedModelId);
     if (nextModelId !== selectedModelId) {
       setSelectedModelId(nextModelId);
     }
-  }, [defaultModelIds, models, selectedModelId]);
+  }, [models, selectedModelId]);
 
-  const selectedModel = selectedModelId == null
+  const selectedModel = selectedModelId === ALL_MODELS_OPTION_VALUE
     ? null
     : models.find((model) => model.modelId === selectedModelId) ?? null;
-  const heatmap = useMemo(() => buildDomainShiftHeatmap(selectedModel), [selectedModel]);
+  const heatmap = useMemo(
+    () => buildDomainShiftHeatmap(selectedModelId === ALL_MODELS_OPTION_VALUE ? models : selectedModel),
+    [models, selectedModel, selectedModelId],
+  );
   const sortedRows = useMemo(
     () => sortHeatmapRows(heatmap.rows, sort, displayMode),
     [heatmap.rows, sort, displayMode],
@@ -239,8 +255,8 @@ export function DomainValueShiftHeatmap() {
     () => buildDomainShiftModelOptions(models, defaultModelIds),
     [defaultModelIds, models],
   );
-  const tableColumnCount = heatmap.columns.length + 2;
-  const columnWidth = tableColumnCount > 0 ? `${100 / tableColumnCount}%` : '100%';
+  const domainColumnWidth = heatmap.columns.length > 0 ? `${100 / heatmap.columns.length}%` : '100%';
+  const isAllModels = selectedModelId === ALL_MODELS_OPTION_VALUE;
   const loading = fetching && data == null;
 
   return (
@@ -267,10 +283,10 @@ export function DomainValueShiftHeatmap() {
             <Select
               label="Model"
               options={modelOptions}
-              value={selectedModelId ?? undefined}
+              value={selectedModelId}
               onChange={setSelectedModelId}
               placeholder={loading ? 'Loading models...' : 'Select a model'}
-              disabled={loading || modelOptions.length === 0}
+              disabled={loading || models.length === 0}
             />
           </div>
           <div className="min-w-[240px] max-w-xs flex-1">
@@ -295,25 +311,27 @@ export function DomainValueShiftHeatmap() {
         </section>
       )}
 
-      {!loading && models.length > 0 && selectedModel != null && heatmap.eligibleDomainCount < 2 && (
+      {!loading && models.length > 0 && heatmap.eligibleDomainCount < 2 && (
         <section className="rounded-xl border border-amber-200 bg-amber-50 p-6">
           <h2 className="text-base font-semibold text-amber-950">More domain coverage needed</h2>
           <p className="mt-2 text-sm text-amber-900">
             Domain-shift analysis needs at least one value with eligible win-rate data in two or more domains for
-            the selected model. With only one domain for a value, the shift would be 0 pts by definition and would
+            the selected model set. With only one domain for a value, the shift would be 0.0 pts by definition and would
             not be meaningful.
           </p>
         </section>
       )}
 
-      {!loading && selectedModel != null && heatmap.eligibleDomainCount >= 2 && (
+      {!loading && models.length > 0 && heatmap.eligibleDomainCount >= 2 && (
         <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
           <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">{selectedModel.label}</h2>
+              <h2 className="text-lg font-semibold text-gray-900">{isAllModels ? 'All models' : selectedModel?.label ?? 'All models'}</h2>
               <p className="text-sm text-gray-600">
-                Values are rows. Domains are columns. Click any column header to sort. Evidence counts are shown
-                in each cell detail. Signature: {selectedSignature}.
+                {isAllModels
+                  ? 'Averages are across all models. Click any column header to sort. Evidence counts are shown in each cell detail.'
+                  : 'Click any column header to sort. Evidence counts are shown in each cell detail.'}{' '}
+                Signature: {selectedSignature}.
               </p>
             </div>
             <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
@@ -323,10 +341,12 @@ export function DomainValueShiftHeatmap() {
           </div>
 
           <div className="overflow-x-auto rounded border border-gray-100 bg-white p-2">
-            <table className="w-full table-fixed border-collapse text-xs">
+            <table className="w-full table-auto border-collapse text-xs">
               <colgroup>
-                {Array.from({ length: tableColumnCount }).map((_, index) => (
-                  <col key={index} style={{ width: columnWidth }} />
+                <col className="w-max" />
+                <col className="w-max" />
+                {heatmap.columns.map((domain) => (
+                  <col key={domain.domainId} style={{ width: domainColumnWidth }} />
                 ))}
               </colgroup>
               <thead>
@@ -364,10 +384,10 @@ export function DomainValueShiftHeatmap() {
               <tbody>
                 {sortedRows.map((row) => (
                   <tr key={row.valueKey} className="border-b border-gray-100">
-                    <th scope="row" className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 text-left font-medium text-gray-900">
+                    <th scope="row" className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 whitespace-nowrap text-left font-medium text-gray-900">
                       {row.valueLabel}
                     </th>
-                    <td className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 text-right font-mono text-gray-700">
+                    <td className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 whitespace-nowrap text-right font-mono text-gray-700">
                       {formatPercent(row.averageWinRate)}
                       {row.averageMatchesPooled === false && (
                         <span
@@ -391,7 +411,12 @@ export function DomainValueShiftHeatmap() {
 
                       return (
                         <td key={domain.domainId} className={tdClassName}>
-                          <Cell cell={cell} valueLabel={row.valueLabel} displayMode={displayMode} />
+                          <Cell
+                            cell={cell}
+                            valueLabel={row.valueLabel}
+                            displayMode={displayMode}
+                            evidenceLabel={isAllModels ? 'average evidence vignettes' : 'evidence vignettes'}
+                          />
                         </td>
                       );
                     })}

--- a/cloud/apps/web/src/pages/domainValueShiftHeatmapUtils.ts
+++ b/cloud/apps/web/src/pages/domainValueShiftHeatmapUtils.ts
@@ -8,6 +8,7 @@ import { VALUE_LABELS, VALUES, type ValueKey } from '../data/domainAnalysisData'
 
 const AVERAGE_PARITY_TOLERANCE = 0.05;
 export const DEFAULT_DOMAIN_SHIFT_SIGNATURE = 'vnewtd';
+export const ALL_MODELS_OPTION_VALUE = '__all_models__';
 
 export type DomainShiftDisplayMode = 'shift' | 'winRate';
 export type DomainShiftSortDirection = 'asc' | 'desc';
@@ -80,19 +81,19 @@ function formatValueLabel(valueKey: string): string {
 
 export function formatPointShift(value: number | null): string {
   if (value == null || !Number.isFinite(value)) return 'n/a';
-  const rounded = Math.round(value);
-  if (rounded === 0) return '0 pts';
-  return `${rounded > 0 ? '+' : ''}${rounded} pts`;
+  const rounded = Math.round(value * 10) / 10;
+  if (rounded === 0) return '0.0 pts';
+  return `${rounded > 0 ? '+' : ''}${rounded.toFixed(1)} pts`;
 }
 
 export function formatPercent(value: number | null): string {
   if (value == null || !Number.isFinite(value)) return '—';
-  return `${Math.round(value)}%`;
+  return `${(Math.round(value * 10) / 10).toFixed(1)}%`;
 }
 
 export function formatEvidenceWeight(value: number | null): string {
   if (value == null || !Number.isFinite(value) || value <= 0) return '—';
-  return `${Math.round(value)}`;
+  return (Math.round(value * 10) / 10).toFixed(1);
 }
 
 export function formatDomainShiftSignatureLabel(signature: string): string {
@@ -130,6 +131,7 @@ export function buildDomainShiftModelOptions(
   const defaults = sorted.filter((model) => defaultModelIds.has(model.modelId));
   const nonDefaults = sorted.filter((model) => !defaultModelIds.has(model.modelId));
   return [
+    { value: ALL_MODELS_OPTION_VALUE, label: 'All models' },
     ...defaults.map((model) => ({ value: model.modelId, label: model.label })),
     ...(defaults.length > 0 && nonDefaults.length > 0
       ? [{ value: NON_DEFAULT_MODELS_DIVIDER_VALUE, label: '---', disabled: true }]
@@ -141,13 +143,13 @@ export function buildDomainShiftModelOptions(
 export function getDefaultModelId(
   models: ModelsAnalysisModelResult[],
   currentModelId: string | null,
-  defaultModelIds: ReadonlySet<string> = new Set<string>(),
 ): string | null {
   const sorted = sortModels(models);
-  if (currentModelId != null && sorted.some((model) => model.modelId === currentModelId)) {
+  const modelIds = new Set(sorted.map((model) => model.modelId));
+  if (currentModelId != null && (currentModelId === ALL_MODELS_OPTION_VALUE || modelIds.has(currentModelId))) {
     return currentModelId;
   }
-  return sorted.find((model) => defaultModelIds.has(model.modelId))?.modelId ?? sorted[0]?.modelId ?? null;
+  return ALL_MODELS_OPTION_VALUE;
 }
 
 function sortValueKeys(valueKeys: Set<string>): string[] {
@@ -168,11 +170,25 @@ function computeAverage(domains: ModelsAnalysisDomainBreakdown[]): number | null
   return total / domains.length;
 }
 
-export function buildDomainShiftHeatmap(model: ModelsAnalysisModelResult | null): DomainShiftHeatmap {
-  if (model == null) {
-    return { columns: [], rows: [], eligibleDomainCount: 0 };
-  }
+function computeAverageNumber(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return total / values.length;
+}
 
+type AggregateDomainStats = {
+  domainId: string;
+  domainName: string;
+  winRates: number[];
+  evidenceWeights: number[];
+};
+
+type AggregateValueStats = {
+  pooledWinRates: number[];
+  domains: Map<string, AggregateDomainStats>;
+};
+
+function buildDomainShiftHeatmapForModel(model: ModelsAnalysisModelResult): DomainShiftHeatmap {
   const valueKeys = new Set<string>(VALUES);
 
   for (const value of model.values) {
@@ -224,6 +240,105 @@ export function buildDomainShiftHeatmap(model: ModelsAnalysisModelResult | null)
     rows,
     eligibleDomainCount: columns.length,
   };
+}
+
+function buildDomainShiftHeatmapForModels(models: ModelsAnalysisModelResult[]): DomainShiftHeatmap {
+  const valueKeys = new Set<string>(VALUES);
+  const rowsByValue: Map<string, AggregateValueStats> = new Map();
+  const domainById = new Map<string, DomainShiftColumn>();
+
+  for (const model of models) {
+    for (const value of model.values) {
+      valueKeys.add(value.valueKey);
+
+      const existing: AggregateValueStats = rowsByValue.get(value.valueKey) ?? {
+        pooledWinRates: [],
+        domains: new Map(),
+      };
+
+      if (isFiniteNumber(value.pooledWinRate)) {
+        existing.pooledWinRates.push(value.pooledWinRate);
+      }
+
+      for (const domain of eligibleDomainsForValue(value)) {
+        domainById.set(domain.domainId, {
+          domainId: domain.domainId,
+          domainName: domain.domainName,
+        });
+        const aggregate: AggregateDomainStats = existing.domains.get(domain.domainId) ?? {
+          domainId: domain.domainId,
+          domainName: domain.domainName,
+          winRates: [],
+          evidenceWeights: [],
+        };
+        aggregate.winRates.push(domain.winRate);
+        if (isFiniteNumber(domain.evidenceWeight)) {
+          aggregate.evidenceWeights.push(domain.evidenceWeight);
+        }
+        existing.domains.set(domain.domainId, aggregate);
+      }
+
+      rowsByValue.set(value.valueKey, existing);
+    }
+  }
+
+  const rows = sortValueKeys(valueKeys).map((valueKey) => {
+    const aggregate = rowsByValue.get(valueKey);
+    const domainEntries = [...(aggregate?.domains.values() ?? [])];
+    const comparableDomainCount = domainEntries.length;
+    const domainAverages = domainEntries
+      .map((entry) => computeAverageNumber(entry.winRates))
+      .filter((value): value is number => value != null);
+    const averageWinRate = comparableDomainCount >= 2 ? computeAverageNumber(domainAverages) : null;
+    const pooledWinRate = computeAverageNumber(aggregate?.pooledWinRates ?? []);
+    const cells = new Map<string, DomainShiftCell>();
+
+    if (valueKeys.has(valueKey) && averageWinRate != null) {
+      for (const domain of domainEntries) {
+        const winRate = computeAverageNumber(domain.winRates);
+        if (winRate == null) continue;
+
+        cells.set(domain.domainId, {
+          domainId: domain.domainId,
+          domainName: domain.domainName,
+          winRate,
+          averageWinRate,
+          shift: winRate - averageWinRate,
+          evidenceWeight: computeAverageNumber(domain.evidenceWeights),
+        });
+      }
+    }
+
+    return {
+      valueKey,
+      valueLabel: formatValueLabel(valueKey),
+      pooledWinRate,
+      averageWinRate,
+      averageMatchesPooled: averageWinRate == null || pooledWinRate == null
+        ? null
+        : Math.abs(averageWinRate - pooledWinRate) <= AVERAGE_PARITY_TOLERANCE,
+      comparableDomainCount,
+      cells,
+    };
+  });
+  const columns = [...domainById.values()].sort((left, right) => left.domainName.localeCompare(right.domainName));
+
+  return {
+    columns,
+    rows,
+    eligibleDomainCount: columns.length,
+  };
+}
+
+export function buildDomainShiftHeatmap(
+  modelOrModels: ModelsAnalysisModelResult | ModelsAnalysisModelResult[] | null,
+): DomainShiftHeatmap {
+  if (modelOrModels == null) {
+    return { columns: [], rows: [], eligibleDomainCount: 0 };
+  }
+  return Array.isArray(modelOrModels)
+    ? buildDomainShiftHeatmapForModels(modelOrModels)
+    : buildDomainShiftHeatmapForModel(modelOrModels);
 }
 
 export function getNextDomainShiftSort(current: DomainShiftSort, key: DomainShiftSortKey): DomainShiftSort {

--- a/cloud/apps/web/src/pages/domainValueShiftHeatmapUtils.ts
+++ b/cloud/apps/web/src/pages/domainValueShiftHeatmapUtils.ts
@@ -143,7 +143,7 @@ export function buildDomainShiftModelOptions(
 export function getDefaultModelId(
   models: ModelsAnalysisModelResult[],
   currentModelId: string | null,
-): string | null {
+): string {
   const sorted = sortModels(models);
   const modelIds = new Set(sorted.map((model) => model.modelId));
   if (currentModelId != null && (currentModelId === ALL_MODELS_OPTION_VALUE || modelIds.has(currentModelId))) {

--- a/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
@@ -3,10 +3,13 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import {
+  ALL_MODELS_OPTION_VALUE,
   DomainValueShiftHeatmap,
   buildDomainShiftHeatmap,
+  buildDomainShiftModelOptions,
   formatEvidenceWeight,
   formatPointShift,
+  formatPercent,
   getDefaultDomainShiftSignature,
   getDefaultModelId,
   sortHeatmapRows,
@@ -177,13 +180,73 @@ describe('DomainValueShiftHeatmap helpers', () => {
   });
 
   it('formats point shifts and unknown evidence without percent-change language', () => {
-    expect(formatPointShift(12.4)).toBe('+12 pts');
-    expect(formatPointShift(-8.6)).toBe('-9 pts');
-    expect(formatPointShift(0.2)).toBe('0 pts');
+    expect(formatPointShift(12.4)).toBe('+12.4 pts');
+    expect(formatPointShift(-8.6)).toBe('-8.6 pts');
+    expect(formatPointShift(0.2)).toBe('+0.2 pts');
+    expect(formatPercent(42.34)).toBe('42.3%');
     expect(formatEvidenceWeight(null)).toBe('—');
     expect(formatEvidenceWeight(0)).toBe('—');
     expect(formatEvidenceWeight(-1)).toBe('—');
-    expect(formatEvidenceWeight(3)).toBe('3');
+    expect(formatEvidenceWeight(3)).toBe('3.0');
+  });
+
+  it('averages domain win rates across multiple models', () => {
+    const heatmap = buildDomainShiftHeatmap([
+      makeModel({
+        modelId: 'model-a',
+        label: 'Model A',
+        values: [
+          {
+            valueKey: 'Achievement',
+            pooledWinRate: 60,
+            stabilityScore: null,
+            eligibleDomainCount: 2,
+            domains: [
+              { domainId: 'city', domainName: 'City Planning', winRate: 40, evidenceWeight: 2 },
+              { domainId: 'jobs', domainName: 'Jobs', winRate: 80, evidenceWeight: 2 },
+            ],
+          },
+        ],
+      }),
+      makeModel({
+        modelId: 'model-b',
+        label: 'Model B',
+        values: [
+          {
+            valueKey: 'Achievement',
+            pooledWinRate: 50,
+            stabilityScore: null,
+            eligibleDomainCount: 2,
+            domains: [
+              { domainId: 'city', domainName: 'City Planning', winRate: 60, evidenceWeight: 4 },
+              { domainId: 'jobs', domainName: 'Jobs', winRate: 40, evidenceWeight: 6 },
+            ],
+          },
+        ],
+      }),
+    ]);
+    const achievement = heatmap.rows.find((row) => row.valueKey === 'Achievement');
+
+    expect(heatmap.columns.map((column) => column.domainName)).toEqual(['City Planning', 'Jobs']);
+    expect(achievement?.averageWinRate).toBe(55);
+    expect(achievement?.pooledWinRate).toBe(55);
+    expect(achievement?.averageMatchesPooled).toBe(true);
+    expect(achievement?.cells.get('city')?.winRate).toBe(50);
+    expect(achievement?.cells.get('jobs')?.winRate).toBe(60);
+  });
+
+  it('puts the all-models option first and keeps grouped models after it', () => {
+    const options = buildDomainShiftModelOptions(
+      [
+        makeModel({ modelId: 'model-c', label: 'Charlie' }),
+        makeModel({ modelId: 'model-a', label: 'Alpha' }),
+        makeModel({ modelId: 'model-b', label: 'Bravo' }),
+      ],
+      new Set(['model-c', 'model-a']),
+    );
+
+    expect(options.map((option) => option.label)).toEqual(['All models', 'Alpha', 'Charlie', '---', 'Bravo']);
+    expect(options[0]?.value).toBe(ALL_MODELS_OPTION_VALUE);
   });
 
   it('sorts domain columns by the visible metric mode', () => {
@@ -223,11 +286,11 @@ describe('DomainValueShiftHeatmap helpers', () => {
       makeModel({ modelId: 'model-a', label: 'Alpha' }),
     ];
 
-    expect(getDefaultModelId(models, null)).toBe('model-a');
-    expect(getDefaultModelId(models, null, new Set(['model-b']))).toBe('model-b');
+    expect(getDefaultModelId(models, null)).toBe(ALL_MODELS_OPTION_VALUE);
+    expect(getDefaultModelId(models, ALL_MODELS_OPTION_VALUE)).toBe(ALL_MODELS_OPTION_VALUE);
     expect(getDefaultModelId(models, 'model-b')).toBe('model-b');
-    expect(getDefaultModelId(models, 'missing')).toBe('model-a');
-    expect(getDefaultModelId([], 'missing')).toBeNull();
+    expect(getDefaultModelId(models, 'missing')).toBe(ALL_MODELS_OPTION_VALUE);
+    expect(getDefaultModelId([], 'missing')).toBe(ALL_MODELS_OPTION_VALUE);
   });
 
   it('defaults signature selection to latest default temperature', () => {
@@ -250,20 +313,20 @@ describe('DomainValueShiftHeatmap page', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Domain Shifts by Value' })).toBeInTheDocument();
     });
-    expect(screen.getByRole('table')).toHaveClass('table-fixed');
-    expect(screen.getByRole('button', { name: /model a/i })).toBeInTheDocument();
+    expect(screen.getByRole('table')).toHaveClass('table-auto');
+    expect(screen.getByRole('button', { name: /all models/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Latest @ default/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sort by Avg Win Rate descending/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sort by Value descending/i })).toHaveTextContent('Value↓');
-    expect(screen.getByLabelText(/Achievement in City Planning: raw win rate 80%; shift \+20 pts/i)).toHaveAccessibleName(
-      /average 60%; evidence vignettes —/i,
+    expect(screen.getByLabelText(/Achievement in City Planning: raw win rate 80\.0%; shift \+20\.0 pts/i)).toHaveAccessibleName(
+      /average 60\.0%; average evidence vignettes —/i,
     );
     expect(screen.getByText('Metric:')).toBeInTheDocument();
     expect(screen.getByText(/percentage-point shift, not percent change/i)).toBeInTheDocument();
 
     const firstDataRow = screen.getAllByRole('row')[1];
     expect(within(firstDataRow).getAllByRole('rowheader')[0]).toHaveTextContent('Achievement');
-    expect(within(firstDataRow).getAllByRole('cell')[0]).toHaveTextContent('60%');
+    expect(within(firstDataRow).getAllByRole('cell')[0]).toHaveTextContent('60.0%');
     expect(within(firstDataRow).getAllByRole('cell')[1]).toHaveClass('bg-emerald-100');
   });
 
@@ -273,7 +336,7 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    await screen.findByRole('button', { name: /Latest @ default/i });
+    await screen.findByRole('button', { name: /all models/i });
     const initialModelsCalls = useQueryMock.mock.calls.filter(([args]: [{ query: unknown }]) => args.query === MODELS_ANALYSIS_QUERY);
     expect(initialModelsCalls.at(-1)?.[0]).toEqual(expect.objectContaining({
       variables: { signature: 'vnewtd' },
@@ -294,11 +357,11 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    expect(await screen.findByText('+20 pts')).toBeInTheDocument();
+    expect(await screen.findByText('+20.0 pts')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Raw win rate' }));
 
     expect(screen.getByRole('button', { name: 'Raw win rate' })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('80%')).toBeInTheDocument();
+    expect(screen.getByText('80.0%')).toBeInTheDocument();
     expect(screen.getByText(/raw domain win rate/i)).toBeInTheDocument();
   });
 
@@ -338,8 +401,8 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    expect(await screen.findByRole('button', { name: /alpha/i })).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: /alpha/i }));
+    expect(await screen.findByRole('button', { name: /all models/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /all models/i }));
     await user.click(screen.getByRole('option', { name: 'Zulu' }));
 
     expect(screen.getByRole('heading', { name: 'Zulu' })).toBeInTheDocument();
@@ -355,11 +418,11 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    await screen.findByRole('button', { name: /alpha/i });
-    await user.click(screen.getByRole('button', { name: /alpha/i }));
+    await screen.findByRole('button', { name: /all models/i });
+    await user.click(screen.getByRole('button', { name: /all models/i }));
 
     const options = screen.getAllByRole('option').map((option) => option.textContent?.trim());
-    expect(options).toEqual(['Alpha', 'Charlie', '---', 'Bravo']);
+    expect(options).toEqual(['All models', 'Alpha', 'Charlie', '---', 'Bravo']);
   });
 
   it('shows an empty state when fewer than two domains are eligible', async () => {


### PR DESCRIPTION
## Summary
- Add an `All models` option to Domain Shifts by Value as the first dropdown choice
- Aggregate the report across all models when that option is selected
- Remove the explanatory copy about values being rows and domains being columns
- Keep Value and Avg Win Rate columns content-sized, with one-decimal formatting throughout the report

## Notes
- Added coverage for the aggregate option ordering, multi-model aggregation, and updated formatting
- Updated project status tracking for the local branch
