### PR TITLE
FF size estimate + per-feature metrics + cost docs

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/SKILL.md
+++ b/docs/workflow/operations/codex-skills/feature-factory/SKILL.md
@@ -374,6 +374,22 @@ Each workflow lives in `docs/workflow/feature-runs/<slug>/`. The files have diff
 
 When in doubt about current workflow state, read `state.json` or run `status --slug <slug>`. Do not infer state from which artifact files exist.
 
+## Measuring FF Cost
+
+The FF runner captures these signals automatically during every command:
+
+- **Per-command wall clock** — recorded in `state.json` under `command_telemetry[].wall_seconds`.
+- **Per-Codex-call tokens** — recorded in `token_usage[]` for entries where `model` starts with `gpt-`. Includes `input_tokens` and `output_tokens`.
+- **Per-Gemini-call tokens** — recorded in `token_usage[]` for entries where `model` starts with `gemini-`.
+- **TTL crossings per command** — `command_telemetry[].ttl_crossed` is `true` when a command ran longer than 270 seconds (the Anthropic prompt-cache TTL). Each crossing means the orchestrator's cache likely expired, requiring an uncached re-read on the next command.
+
+What the runner does **not** measure: Claude orchestrator session tokens. Claude Code does not expose those to the runner. To see session-level Claude usage, run `/cost` in Claude Code after the workflow completes.
+
+Where to look for cross-feature aggregation:
+
+- Run `analyze-reviews` to generate a full report. Section 7a shows per-feature rollups (wall seconds, Codex tokens, Gemini tokens, TTL crossings, command count) sorted by total wall time. The report is saved to `docs/workflow/analysis/review-performance-<date>.md`.
+- Run `status --slug <slug> --tokens` to see the last 10 command-telemetry records for a single feature (wall seconds, bytes read/written, TTL crossed). This was shipped in PR #792.
+
 ## Notes
 
 - The skill should stay lean and prefer the existing Python scripts over new helper code.

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_analyze_reviews.py
@@ -585,6 +585,71 @@ def _largest_artifact_rows(artifact_records: list[dict[str, object]]) -> list[li
     return [[item["slug"], item["stage"], item["char_count"]] for item in ordered]
 
 
+def _per_feature_rows(top_n: int = 20) -> list[list[object]]:
+    """Return rows for the per-feature metrics rollup section."""
+    rows: list[list[object]] = []
+    runs_root = factory_state.FACTORY_RUNS_ROOT
+    if not runs_root.exists():
+        return rows
+
+    for state_path in sorted(runs_root.glob("*/state.json")):
+        slug = state_path.parent.name
+        try:
+            raw_state = json.loads(state_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+
+        command_telemetry = raw_state.get("command_telemetry", [])
+        if not isinstance(command_telemetry, list):
+            command_telemetry = []
+
+        token_usage = raw_state.get("token_usage", [])
+        if not isinstance(token_usage, list):
+            token_usage = []
+
+        total_wall_seconds = 0.0
+        ttl_crossings = 0
+        command_count = 0
+        for entry in command_telemetry:
+            if not isinstance(entry, dict):
+                continue
+            command_count += 1
+            ws = entry.get("wall_seconds")
+            if isinstance(ws, (int, float)) and not isinstance(ws, bool):
+                total_wall_seconds += float(ws)
+            if entry.get("ttl_crossed") is True:
+                ttl_crossings += 1
+
+        codex_tokens = 0
+        gemini_tokens = 0
+        for entry in token_usage:
+            if not isinstance(entry, dict):
+                continue
+            model = entry.get("model", "")
+            if not isinstance(model, str):
+                continue
+            model_lower = model.lower()
+            in_tok = _coerce_int(entry.get("input_tokens")) or 0
+            out_tok = _coerce_int(entry.get("output_tokens")) or 0
+            total = in_tok + out_tok
+            if model_lower.startswith("gpt-"):
+                codex_tokens += total
+            elif model_lower.startswith("gemini-"):
+                gemini_tokens += total
+
+        rows.append([
+            slug,
+            round(total_wall_seconds, 1),
+            codex_tokens,
+            gemini_tokens,
+            ttl_crossings,
+            command_count,
+        ])
+
+    rows.sort(key=lambda row: float(str(row[1])), reverse=True)
+    return rows[:top_n]
+
+
 def _cap_pressure_rows(records: list[dict[str, object]]) -> list[list[object]]:
     grouped: dict[tuple[str, str], list[dict[str, object]]] = defaultdict(list)
     for record in records:
@@ -798,6 +863,35 @@ def _render_report(records: list[dict[str, object]], data_quality: dict[str, obj
         )
     else:
         lines.append("No relevant records found.")
+
+    per_feature_rows = _per_feature_rows(top_n)
+    lines.extend(["", "## 7a. Per-Feature Metrics Rollup (Top 20 by Wall Seconds)", ""])
+    if per_feature_rows:
+        lines.extend(
+            _markdown_table(
+                [
+                    "slug",
+                    "total_wall_seconds",
+                    "codex_tokens",
+                    "gemini_tokens",
+                    "ttl_crossings",
+                    "command_count",
+                ],
+                per_feature_rows,
+            )
+        )
+    else:
+        lines.append("No command telemetry found.")
+    lines.extend([
+        "",
+        "**Note on Claude token measurement.** This table aggregates Codex and Gemini token usage "
+        "(those tools' CLIs report token counts the runner captures). It does NOT include Claude "
+        "orchestrator session tokens — Claude Code does not expose those to the FF runner. For "
+        "session-level Claude usage, run `/cost` in Claude Code. The `ttl_crossings` column is a "
+        "proxy for cache pressure: each crossing means the orchestrator's prompt cache likely "
+        "expired between commands, requiring an uncached re-read.",
+        "",
+    ])
 
     artifact_distribution_rows = _artifact_distribution_rows(artifact_records)
     largest_artifact_rows = _largest_artifact_rows(artifact_records)

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_discover.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_discover.py
@@ -23,6 +23,7 @@ from factory_review import trim_detail  # noqa: E402
 
 from factory_emit import _emit_next_action  # noqa: E402
 from factory_mutating import mutates_state  # noqa: E402
+from factory_size_estimate import estimate_size  # noqa: E402
 
 
 @mutates_state("discover")
@@ -279,4 +280,33 @@ def command_discover(args: argparse.Namespace) -> int:
             print(f"  - {u['item']}{status}")
     if args.complete or getattr(args, "force_complete", False):
         _emit_next_action(args.slug, "discovery complete")
+        print("[workflow] ✓ discovery complete")
+        try:
+            est = estimate_size(args.slug)
+            size_label = est["size"].upper()
+            signals = est["signals"]
+            scope_count = signals["scope_path_count"]
+            summary_chars = signals["summary_chars"]
+            diff_lines = signals["diff_lines"]
+            diff_note = "no diff yet" if diff_lines is None else f"{diff_lines}-line diff"
+            print(
+                f"[workflow] size-estimate: {size_label} "
+                f"({scope_count} scope path{'s' if scope_count != 1 else ''}, "
+                f"{summary_chars}-char summary, {diff_note})"
+            )
+            if est["recommended_path"] == "quick":
+                prompt_path_hint = ""
+                try:
+                    import factory_state as _fs
+                    prompt_path_file = _fs.workflow_dir(args.slug) / "prompt.md"
+                    if prompt_path_file.exists():
+                        prompt_path_hint = f" --prompt-path {prompt_path_file}"
+                except Exception:
+                    pass
+                print(f"[workflow] → recommended: quick --slug {args.slug}{prompt_path_hint}")
+                print("[workflow] (override: run author_spec for full workflow)")
+            else:
+                print("[workflow] → recommended: author_spec")
+        except Exception:
+            pass  # size estimate is advisory; never fail discover --complete
     return 0

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_status.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_status.py
@@ -57,6 +57,7 @@ from factory_next_action import recommended_next_action  # noqa: E402
 
 from factory_deliver import refresh_delivery_snapshot  # noqa: E402
 from factory_mutating import mutates_state, readonly_command  # noqa: E402
+from factory_size_estimate import estimate_size  # noqa: E402
 
 
 def _print_command_telemetry(state: dict) -> None:
@@ -258,6 +259,13 @@ def command_status(args: argparse.Namespace) -> int:
             stage = entry.get("stage", "")
             detail = trim_detail(str(entry.get("detail", "")))
             print(f"- [{at}] {command} stage={stage}: {detail}")
+
+    try:
+        est = estimate_size(args.slug)
+        print("")
+        print(f"size-estimate: {est['size']} ({est['reasoning']})")
+    except Exception:
+        pass  # size estimate is advisory; never fail status
 
     print("")
     print(f"next-action: {next_action}")

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_size_estimate.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_size_estimate.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Size auto-classification for Feature Factory workflow slugs.
+
+Exports:
+    estimate_size(slug: str) -> dict
+
+The returned dict has the shape:
+    {
+        "size": "small" | "medium" | "large",
+        "recommended_path": "quick" | "full",
+        "signals": {
+            "scope_path_count": int,
+            "summary_chars": int,
+            "diff_lines": int | None,
+            "changed_files": int | None,
+        },
+        "reasoning": "<one-line human explanation>",
+    }
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+import factory_state
+
+
+def _read_scope_path_count(slug: str) -> int:
+    """Return the number of paths in scope.json, or 0 if missing/malformed."""
+    scope_path = factory_state.workflow_dir(slug) / "scope.json"
+    if not scope_path.exists():
+        return 0
+    try:
+        raw = json.loads(scope_path.read_text(encoding="utf-8"))
+    except Exception:
+        return 0
+    if isinstance(raw, list):
+        return len(raw)
+    if isinstance(raw, dict):
+        paths = raw.get("paths", raw.get("scope_paths", []))
+        if isinstance(paths, list):
+            return len(paths)
+    return 0
+
+
+def _read_summary_chars(slug: str) -> int:
+    """Return the character length of discovery.summary in state.json, or 0."""
+    state_path = factory_state.factory_state_path(slug)
+    if not state_path.exists():
+        return 0
+    try:
+        raw = json.loads(state_path.read_text(encoding="utf-8"))
+    except Exception:
+        return 0
+    discovery = raw.get("discovery", {})
+    if not isinstance(discovery, dict):
+        return 0
+    summary = discovery.get("summary", "")
+    if not isinstance(summary, str):
+        return 0
+    return len(summary)
+
+
+def _git_diff_stats() -> tuple[int | None, int | None]:
+    """Return (diff_lines, changed_files) against origin/main, or (None, None).
+
+    Parses the last line of `git diff origin/main --stat`, which looks like:
+        3 files changed, 120 insertions(+), 45 deletions(-)
+
+    Returns None for both values if origin/main does not exist, the repo is not
+    a git repo, or the stat line cannot be parsed.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "origin/main", "--stat"],
+            cwd=factory_state.REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None, None
+    if result.returncode != 0:
+        return None, None
+
+    output = result.stdout.strip()
+    if not output:
+        return 0, 0
+
+    # The summary line is the last line when there are changes, e.g.:
+    # " 3 files changed, 120 insertions(+), 45 deletions(-)"
+    lines = output.splitlines()
+    summary_line = lines[-1].strip()
+
+    diff_lines: int | None = None
+    changed_files: int | None = None
+
+    import re
+
+    m_files = re.search(r"(\d+)\s+files? changed", summary_line)
+    if m_files:
+        changed_files = int(m_files.group(1))
+
+    m_insert = re.search(r"(\d+)\s+insertion", summary_line)
+    m_delete = re.search(r"(\d+)\s+deletion", summary_line)
+    insertions = int(m_insert.group(1)) if m_insert else 0
+    deletions = int(m_delete.group(1)) if m_delete else 0
+    if m_files:
+        diff_lines = insertions + deletions
+
+    return diff_lines, changed_files
+
+
+def _classify(
+    scope_path_count: int,
+    summary_chars: int,
+    diff_lines: int | None,
+    changed_files: int | None,
+) -> str:
+    """Return 'small', 'medium', or 'large' based on heuristics."""
+    # Large: any single signal exceeds the large threshold.
+    if scope_path_count >= 10:
+        return "large"
+    if summary_chars > 1500:
+        return "large"
+    if diff_lines is not None and diff_lines > 800:
+        return "large"
+    if changed_files is not None and changed_files >= 15:
+        return "large"
+
+    # Small: all signals within small bounds.
+    diff_ok = diff_lines is None or diff_lines < 200
+    files_ok = changed_files is None or changed_files <= 5
+    if scope_path_count <= 3 and summary_chars < 500 and diff_ok and files_ok:
+        return "small"
+
+    return "medium"
+
+
+def _build_reasoning(
+    size: str,
+    scope_path_count: int,
+    summary_chars: int,
+    diff_lines: int | None,
+    changed_files: int | None,
+    scope_missing: bool,
+) -> str:
+    if scope_missing:
+        return "scope.json missing — classified as medium with no scope-path signal"
+
+    parts: list[str] = []
+    if size == "large":
+        if scope_path_count >= 10:
+            parts.append(f"{scope_path_count} scope paths (>= 10)")
+        if summary_chars > 1500:
+            parts.append(f"{summary_chars}-char summary (> 1500)")
+        if diff_lines is not None and diff_lines > 800:
+            parts.append(f"{diff_lines} diff lines (> 800)")
+        if changed_files is not None and changed_files >= 15:
+            parts.append(f"{changed_files} changed files (>= 15)")
+        return "large signals: " + ", ".join(parts)
+    elif size == "small":
+        diff_note = "no diff yet" if diff_lines is None else f"{diff_lines} diff lines"
+        return (
+            f"{scope_path_count} scope path{'s' if scope_path_count != 1 else ''}, "
+            f"{summary_chars}-char summary, {diff_note}"
+        )
+    else:
+        # medium — explain what kept it out of small
+        reasons: list[str] = []
+        if scope_path_count > 3:
+            reasons.append(f"{scope_path_count} scope paths (> 3)")
+        if summary_chars >= 500:
+            reasons.append(f"{summary_chars}-char summary (>= 500)")
+        if diff_lines is not None and diff_lines >= 200:
+            reasons.append(f"{diff_lines} diff lines (>= 200)")
+        if changed_files is not None and changed_files > 5:
+            reasons.append(f"{changed_files} changed files (> 5)")
+        if reasons:
+            return "medium: " + ", ".join(reasons)
+        return "medium by default"
+
+
+def estimate_size(slug: str) -> dict:
+    """Return a size-estimate dict for the given workflow slug.
+
+    The dict shape is:
+        {
+            "size": "small" | "medium" | "large",
+            "recommended_path": "quick" | "full",
+            "signals": {
+                "scope_path_count": int,
+                "summary_chars": int,
+                "diff_lines": int | None,
+                "changed_files": int | None,
+            },
+            "reasoning": "<one-line human explanation>",
+        }
+    """
+    # Check if scope.json exists for the reasoning message.
+    scope_path = factory_state.workflow_dir(slug) / "scope.json"
+    scope_missing = not scope_path.exists()
+
+    scope_path_count = _read_scope_path_count(slug)
+    summary_chars = _read_summary_chars(slug)
+    diff_lines, changed_files = _git_diff_stats()
+
+    # If scope.json is missing, default to medium regardless of other signals.
+    if scope_missing:
+        size = "medium"
+    else:
+        size = _classify(scope_path_count, summary_chars, diff_lines, changed_files)
+
+    recommended_path = "quick" if size == "small" else "full"
+    reasoning = _build_reasoning(
+        size, scope_path_count, summary_chars, diff_lines, changed_files, scope_missing
+    )
+
+    return {
+        "size": size,
+        "recommended_path": recommended_path,
+        "signals": {
+            "scope_path_count": scope_path_count,
+            "summary_chars": summary_chars,
+            "diff_lines": diff_lines,
+            "changed_files": changed_files,
+        },
+        "reasoning": reasoning,
+    }

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_analyze_reviews.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_analyze_reviews.py
@@ -313,6 +313,49 @@ class AnalyzeReviewsTests(unittest.TestCase):
         )
         self.assertNotIn("No prompt-size data available yet", report)
 
+    def test_per_feature_metrics_rollup_section(self) -> None:
+        """Section 7a renders correctly with two slugs carrying command telemetry."""
+        ct_alpha = [
+            {"command": "discover", "stage": "spec", "ts": "2026-04-25T10:00:00Z", "wall_seconds": 45.0, "input_bytes_read": 100, "output_bytes_written": 50, "ttl_crossed": False},
+            {"command": "checkpoint", "stage": "spec", "ts": "2026-04-25T10:05:00Z", "wall_seconds": 310.0, "input_bytes_read": 200, "output_bytes_written": 80, "ttl_crossed": True},
+        ]
+        tu_alpha = [
+            {"model": "gpt-5.4-mini", "activity_type": "adversarial_review", "input_tokens": 1000, "output_tokens": 200, "duration_seconds": 10.0},
+            {"model": "gemini-2.5-pro", "activity_type": "adversarial_review", "input_tokens": 800, "output_tokens": 150, "duration_seconds": 12.0},
+        ]
+        ct_beta = [
+            {"command": "discover", "stage": None, "ts": "2026-04-26T10:00:00Z", "wall_seconds": 20.0, "input_bytes_read": 50, "output_bytes_written": 30, "ttl_crossed": False},
+        ]
+        tu_beta = [
+            {"model": "gpt-5.4", "activity_type": "adversarial_review", "input_tokens": 2000, "output_tokens": 300, "duration_seconds": 15.0},
+        ]
+
+        slug_alpha = self.runs_root / "alpha-metrics"
+        slug_alpha.mkdir(parents=True, exist_ok=True)
+        (slug_alpha / "state.json").write_text(
+            json.dumps({"token_usage": tu_alpha, "command_telemetry": ct_alpha}), encoding="utf-8"
+        )
+        slug_beta = self.runs_root / "beta-metrics"
+        slug_beta.mkdir(parents=True, exist_ok=True)
+        (slug_beta / "state.json").write_text(
+            json.dumps({"token_usage": tu_beta, "command_telemetry": ct_beta}), encoding="utf-8"
+        )
+
+        rc, _, stderr, report = self._run()
+        self.assertEqual(rc, 0)
+        self.assertIn("## 7a. Per-Feature Metrics Rollup", report)
+        # alpha has more wall_seconds (355.0) so it should appear before beta (20.0)
+        self.assertIn("alpha-metrics", report)
+        self.assertIn("beta-metrics", report)
+        # alpha: codex_tokens = 1200, gemini_tokens = 950, ttl_crossings = 1, command_count = 2
+        self.assertIn("| alpha-metrics | 355.0 | 1200 | 950 | 1 | 2 |", report)
+        # beta: codex_tokens = 2300, gemini_tokens = 0, ttl_crossings = 0, command_count = 1
+        self.assertIn("| beta-metrics | 20.0 | 2300 | 0 | 0 | 1 |", report)
+        # Note paragraph must be present
+        self.assertIn("Note on Claude token measurement", report)
+        self.assertIn("ttl_crossings", report)
+        self.assertIn("/cost", report)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_size_estimate.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_size_estimate.py
@@ -1,0 +1,121 @@
+"""Unit tests for factory_size_estimate.estimate_size()."""
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_DIR / f"{name}.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+FACTORY_STATE = _load("factory_state")
+SIZE_EST = _load("factory_size_estimate")
+
+
+class SizeEstimateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.repo_root = Path(self._tmpdir.name)
+        self.runs_root = self.repo_root / "docs" / "workflow" / "feature-runs"
+        self.runs_root.mkdir(parents=True, exist_ok=True)
+
+        self._repo_patch = mock.patch.object(FACTORY_STATE, "REPO_ROOT", self.repo_root)
+        self._runs_patch = mock.patch.object(FACTORY_STATE, "FACTORY_RUNS_ROOT", self.runs_root)
+        self._size_repo_patch = mock.patch.object(SIZE_EST.factory_state, "REPO_ROOT", self.repo_root)
+        self._size_runs_patch = mock.patch.object(SIZE_EST.factory_state, "FACTORY_RUNS_ROOT", self.runs_root)
+        self._repo_patch.start()
+        self._runs_patch.start()
+        self._size_repo_patch.start()
+        self._size_runs_patch.start()
+        self.addCleanup(self._repo_patch.stop)
+        self.addCleanup(self._runs_patch.stop)
+        self.addCleanup(self._size_repo_patch.stop)
+        self.addCleanup(self._size_runs_patch.stop)
+
+    def _write_scope(self, slug: str, paths: list[str]) -> None:
+        slug_dir = self.runs_root / slug
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        (slug_dir / "scope.json").write_text(
+            json.dumps({"paths": paths}), encoding="utf-8"
+        )
+
+    def _write_state(self, slug: str, *, summary: str = "") -> None:
+        slug_dir = self.runs_root / slug
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        state = {
+            "discovery": {"summary": summary},
+        }
+        (slug_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+    def _no_diff(self) -> mock.MagicMock:
+        """Patch _git_diff_stats to return (None, None) — no diff yet."""
+        return mock.patch.object(SIZE_EST, "_git_diff_stats", return_value=(None, None))
+
+    def _with_diff(self, diff_lines: int, changed_files: int) -> mock.MagicMock:
+        return mock.patch.object(SIZE_EST, "_git_diff_stats", return_value=(diff_lines, changed_files))
+
+    def test_small_classification(self) -> None:
+        self._write_scope("alpha", ["cloud/apps/api/src/foo.ts", "cloud/apps/web/src/bar.tsx"])
+        self._write_state("alpha", summary="A" * 200)
+        with self._no_diff():
+            result = SIZE_EST.estimate_size("alpha")
+        self.assertEqual(result["size"], "small")
+        self.assertEqual(result["recommended_path"], "quick")
+        self.assertEqual(result["signals"]["scope_path_count"], 2)
+        self.assertEqual(result["signals"]["summary_chars"], 200)
+        self.assertIsNone(result["signals"]["diff_lines"])
+        self.assertIn("2 scope paths", result["reasoning"])
+        self.assertIn("200-char summary", result["reasoning"])
+
+    def test_medium_classification_many_scope_paths(self) -> None:
+        self._write_scope("beta", [f"cloud/path{i}.ts" for i in range(5)])
+        self._write_state("beta", summary="B" * 300)
+        with self._no_diff():
+            result = SIZE_EST.estimate_size("beta")
+        self.assertEqual(result["size"], "medium")
+        self.assertEqual(result["recommended_path"], "full")
+        self.assertIn("medium", result["reasoning"])
+
+    def test_large_classification_many_scope_paths(self) -> None:
+        self._write_scope("gamma", [f"cloud/path{i}.ts" for i in range(12)])
+        self._write_state("gamma", summary="G" * 100)
+        with self._no_diff():
+            result = SIZE_EST.estimate_size("gamma")
+        self.assertEqual(result["size"], "large")
+        self.assertEqual(result["recommended_path"], "full")
+        self.assertIn("large", result["reasoning"])
+
+    def test_large_classification_from_diff(self) -> None:
+        self._write_scope("delta", ["cloud/one.ts"])
+        self._write_state("delta", summary="D" * 100)
+        with self._with_diff(diff_lines=900, changed_files=8):
+            result = SIZE_EST.estimate_size("delta")
+        self.assertEqual(result["size"], "large")
+        self.assertEqual(result["signals"]["diff_lines"], 900)
+        self.assertEqual(result["signals"]["changed_files"], 8)
+
+    def test_missing_scope_json_returns_medium(self) -> None:
+        # Only write state, no scope.json
+        self._write_state("epsilon", summary="E" * 100)
+        with self._no_diff():
+            result = SIZE_EST.estimate_size("epsilon")
+        self.assertEqual(result["size"], "medium")
+        self.assertEqual(result["recommended_path"], "full")
+        self.assertIn("scope.json missing", result["reasoning"])
+        self.assertIsNone(result["signals"]["diff_lines"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Three small additive changes that close the UX gap from PR #813's `--quick` mode and add per-feature metrics aggregation.

## A. Size auto-classification

New `factory_size_estimate.py` — `estimate_size(slug)` returns `{size, recommended_path, signals, reasoning}`. Heuristic:
- **small**: ≤3 scope paths AND <500-char summary AND <200 diff lines AND ≤5 changed files → recommend `quick`
- **large**: ≥10 paths OR >1500 summary OR >800 diff lines OR ≥15 changed files → recommend `author_spec`
- **medium**: everything else → recommend `author_spec`

Surfaced at:
- end of `discover --complete`:
  ```
  [workflow] size-estimate: SMALL (2 scope paths, 200-char summary, no diff yet)
  [workflow] → recommended: quick --slug <slug>
  [workflow] (override: run author_spec for full workflow)
  ```
- `status` output: `size-estimate:` line near `next-action:`

## B. Per-feature metrics rollup in `analyze-reviews`

New Section 7a aggregates `state.command_telemetry` + `state.token_usage` per slug:

| slug | total_wall_seconds | codex_tokens | gemini_tokens | ttl_crossings | command_count |

Sorted by wall time desc, top 20. Verified live: `sensitivity-table-redesign-v2` shows 8 TTL crossings across 29 commands (4874s); `equal-vignette-reporting` shows 134,762 Codex + 56,489 Gemini tokens.

## C. Documentation

`SKILL.md` adds "Measuring FF Cost" section:
- What FF measures: per-command wall clock, per-Codex/Gemini-call tokens, TTL crossings
- What it doesn't: Claude orchestrator session tokens (use `/cost` in Claude Code)
- Where to look: `analyze-reviews` for cross-feature, `status --tokens` for recent commands

## Tests
**268 tests pass** (was 262; +6 new).

## Risk
None — purely additive. No existing flows changed.

## Test plan
- [x] 268 tests pass locally
- [ ] CI green
- [ ] Manual: run `discover --complete` and confirm size-estimate output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
