### PR TITLE
ff-test-isolation-hard-block: stop tests dirtying live state + flip PR #765 gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,6 @@ jobs:
 
       - name: Verify workflow isolation
         if: always()
-        # continue-on-error: the gate IS working as designed and exposes
-        # pre-existing test bugs (tests under feature-factory/scripts/tests/
-        # that mutate the live workflow state in docs/workflow/feature-runs/
-        # for various legacy slugs). Those tests need to be fixed in a
-        # follow-up PR (one-by-one patch FACTORY_RUNS_ROOT). For this PR,
-        # the gate emits the warning so operators are aware, without
-        # blocking unrelated PRs from shipping.
-        continue-on-error: true
         run: python3 docs/workflow/operations/codex-skills/feature-factory/scripts/check_workflow_isolation.py --check --baseline /tmp/ff-baseline.json
 
   web-tests:

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_pollution_check.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_pollution_check.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Auto-revert polluted test-only state.json files at runner startup.
+
+Tests that call factory_state.update_workflow_state (directly or via the
+@mutates_state decorator) can leave modified state.json files under
+docs/workflow/feature-runs/<slug>/ when their FACTORY_RUNS_ROOT patch is
+incomplete (see PR #765 / PR #ff-test-isolation-hard-block for the root
+cause and the fix).
+
+This module reverts those files at startup so the operator never has to
+run ``git checkout --`` manually before committing.
+
+Usage (from run_factory.py main()):
+
+    from factory_pollution_check import auto_revert_polluted_state
+    auto_revert_polluted_state()
+
+Behaviour:
+- Walks ``git status --porcelain docs/workflow/feature-runs/`` from the repo root.
+- For every modified-but-unstaged state.json whose slug appears in
+  KNOWN_TEST_ONLY_SLUGS, runs ``git checkout -- <path>``.
+- Prints to stderr: ``[ff] auto-reverted N polluted test-only state.json
+  files: <list>``.
+- Silent if there is nothing to revert.
+- Silent (skips entirely) when:
+  - Not inside a git repo.
+  - Env var FF_NO_POLLUTION_AUTO_CLEAN=1 is set.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Known test-only slugs whose state.json may be left dirty by the test suite.
+# These slugs exist ONLY to support tests — they are not real feature runs.
+#
+# If you add a new test that creates a slug whose state.json leaks into the
+# working tree, add it here as belt-and-suspenders while you fix the test.
+# ---------------------------------------------------------------------------
+KNOWN_TEST_ONLY_SLUGS: frozenset[str] = frozenset(
+    {
+        # test_review_gc.py — SLUG = "ff-gc-checkpoint"
+        "ff-gc-checkpoint",
+    }
+)
+
+_WORKFLOW_RUNS_PREFIX = "docs/workflow/feature-runs/"
+
+
+def _find_repo_root() -> Path | None:
+    """Return the git repo root, or None if not inside a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    except FileNotFoundError:
+        pass
+    return None
+
+
+def _dirty_state_json_slugs(repo_root: Path) -> list[tuple[str, Path]]:
+    """Return (slug, abs_path) pairs for modified-but-unstaged state.json files."""
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "--", _WORKFLOW_RUNS_PREFIX],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    found: list[tuple[str, Path]] = []
+    for line in result.stdout.splitlines():
+        # --porcelain format: XY <path>
+        # Modified-but-unstaged: " M" in columns 0-1 (index column is space)
+        if len(line) < 4:
+            continue
+        xy = line[:2]
+        # Unstaged modification: worktree column (index 1) is 'M'
+        if xy[1] != "M":
+            continue
+        rel = line[3:]
+        # Must be inside docs/workflow/feature-runs/
+        if not rel.startswith(_WORKFLOW_RUNS_PREFIX):
+            continue
+        # Must be a state.json file
+        if not rel.endswith("/state.json"):
+            continue
+        # Extract slug from path: docs/workflow/feature-runs/<slug>/state.json
+        remainder = rel[len(_WORKFLOW_RUNS_PREFIX):]
+        parts = remainder.split("/")
+        if len(parts) != 2 or parts[1] != "state.json":
+            continue
+        slug = parts[0]
+        found.append((slug, repo_root / rel))
+    return found
+
+
+def auto_revert_polluted_state(*, repo_root: Path | None = None) -> list[str]:
+    """Revert polluted test-only state.json files.
+
+    Returns the list of slugs that were reverted (empty when nothing to do).
+    Prints a one-line diagnostic to stderr when any revert happens.
+    """
+    if os.environ.get("FF_NO_POLLUTION_AUTO_CLEAN") == "1":
+        return []
+
+    if repo_root is None:
+        repo_root = _find_repo_root()
+    if repo_root is None:
+        return []
+
+    dirty = _dirty_state_json_slugs(repo_root)
+    reverted: list[str] = []
+
+    for slug, abs_path in dirty:
+        if slug not in KNOWN_TEST_ONLY_SLUGS:
+            continue
+        rel = abs_path.relative_to(repo_root)
+        result = subprocess.run(
+            ["git", "checkout", "--", str(rel)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            reverted.append(slug)
+        else:
+            print(
+                f"[ff] warning: failed to revert {rel}: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+
+    if reverted:
+        print(
+            f"[ff] auto-reverted {len(reverted)} polluted test-only state.json "
+            f"file(s): {', '.join(reverted)}",
+            file=sys.stderr,
+        )
+
+    return reverted

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py
@@ -402,6 +402,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
+    from factory_pollution_check import auto_revert_polluted_state  # noqa: E402
+    auto_revert_polluted_state()
     parser = build_parser()
     args = parser.parse_args()
     # FR-009: route invariant-warning output to stderr (always).

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_checkpoint.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_checkpoint.py
@@ -1,11 +1,13 @@
 import argparse
 import contextlib
+import gc
 import importlib.util
 import io
 import json
 import subprocess
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -123,9 +125,20 @@ class FactoryCheckpointTests(unittest.TestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
-        self._root_patch = patch.object(FACTORY_STATE, "FACTORY_RUNS_ROOT", Path(self._tmpdir.name))
-        self._root_patch.start()
-        self.addCleanup(self._root_patch.stop)
+        # Patch every loaded factory_state module instance so that lazy imports
+        # inside record_command_telemetry (and similar) also see the tmpdir.
+        self._patches: list = []
+        for mod in list(gc.get_objects()):
+            if not isinstance(mod, types.ModuleType):
+                continue
+            if getattr(mod, "__name__", "") != "factory_state":
+                continue
+            if not hasattr(mod, "FACTORY_RUNS_ROOT"):
+                continue
+            p = patch.object(mod, "FACTORY_RUNS_ROOT", Path(self._tmpdir.name))
+            p.start()
+            self._patches.append(p)
+        self.addCleanup(lambda: [p.stop() for p in self._patches])
 
     def _prepare_state(self, adversarial_rounds: int) -> Path:
         return _write_workflow_state(self._tmpdir.name, _spec_stage_state(adversarial_rounds))

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_deliver.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_deliver.py
@@ -1,11 +1,13 @@
 import argparse
 import contextlib
+import gc
 import importlib.util
 import io
 import json
 import subprocess
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -95,9 +97,20 @@ class FactoryDeliverTests(unittest.TestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
-        self._root_patch = patch.object(FACTORY_STATE, "FACTORY_RUNS_ROOT", Path(self._tmpdir.name))
-        self._root_patch.start()
-        self.addCleanup(self._root_patch.stop)
+        # Patch every loaded factory_state module instance so that lazy imports
+        # inside record_command_telemetry (and similar) also see the tmpdir.
+        self._patches: list = []
+        for mod in list(gc.get_objects()):
+            if not isinstance(mod, types.ModuleType):
+                continue
+            if getattr(mod, "__name__", "") != "factory_state":
+                continue
+            if not hasattr(mod, "FACTORY_RUNS_ROOT"):
+                continue
+            p = patch.object(mod, "FACTORY_RUNS_ROOT", Path(self._tmpdir.name))
+            p.start()
+            self._patches.append(p)
+        self.addCleanup(lambda: [p.stop() for p in self._patches])
 
     def _write_state(self, state: dict) -> None:
         path = FACTORY_STATE.factory_state_path(SLUG)

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_pollution_check.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_pollution_check.py
@@ -1,0 +1,115 @@
+"""Tests for factory_pollution_check.auto_revert_polluted_state."""
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+
+POLLUTION_SPEC = importlib.util.spec_from_file_location(
+    "factory_pollution_check", SCRIPT_DIR / "factory_pollution_check.py"
+)
+assert POLLUTION_SPEC and POLLUTION_SPEC.loader
+POLLUTION_CHECK = importlib.util.module_from_spec(POLLUTION_SPEC)
+sys.modules[POLLUTION_SPEC.name] = POLLUTION_CHECK
+POLLUTION_SPEC.loader.exec_module(POLLUTION_CHECK)
+
+
+def _make_porcelain_line(rel_path: str, status: str = " M") -> str:
+    """Return a git --porcelain status line."""
+    return f"{status} {rel_path}"
+
+
+class PollutionCheckTests(unittest.TestCase):
+    """factory_pollution_check.auto_revert_polluted_state behaviour."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self._fake_root = Path(self._tmpdir.name)
+
+    def _run(self, porcelain_output: str, checkout_returncode: int = 0) -> list[str]:
+        """Run auto_revert_polluted_state with mocked git calls."""
+        fake_status = subprocess.CompletedProcess(
+            ["git", "status"], 0, stdout=porcelain_output, stderr=""
+        )
+        fake_checkout = subprocess.CompletedProcess(
+            ["git", "checkout"], checkout_returncode, stdout="", stderr=""
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            if "status" in cmd:
+                return fake_status
+            if "checkout" in cmd:
+                return fake_checkout
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch.object(POLLUTION_CHECK.subprocess, "run", side_effect=fake_run):
+            result = POLLUTION_CHECK.auto_revert_polluted_state(repo_root=self._fake_root)
+
+        self._calls = calls
+        return result
+
+    def test_reverts_dirty_state_json_for_known_slug(self) -> None:
+        """Known-slug dirty state.json triggers a git checkout."""
+        # ff-gc-checkpoint is in KNOWN_TEST_ONLY_SLUGS
+        slug = next(iter(POLLUTION_CHECK.KNOWN_TEST_ONLY_SLUGS))
+        porcelain = _make_porcelain_line(
+            f"docs/workflow/feature-runs/{slug}/state.json"
+        )
+        reverted = self._run(porcelain)
+        self.assertEqual(reverted, [slug])
+        checkout_calls = [c for c in self._calls if "checkout" in c]
+        self.assertEqual(len(checkout_calls), 1)
+        self.assertIn(f"docs/workflow/feature-runs/{slug}/state.json", checkout_calls[0])
+
+    def test_does_not_touch_unknown_slug(self) -> None:
+        """A dirty state.json for an unknown slug is left alone."""
+        porcelain = _make_porcelain_line(
+            "docs/workflow/feature-runs/real-production-slug/state.json"
+        )
+        reverted = self._run(porcelain)
+        self.assertEqual(reverted, [])
+        checkout_calls = [c for c in self._calls if "checkout" in c]
+        self.assertEqual(len(checkout_calls), 0)
+
+    def test_skips_when_env_var_set(self) -> None:
+        """FF_NO_POLLUTION_AUTO_CLEAN=1 disables all revert logic."""
+        slug = next(iter(POLLUTION_CHECK.KNOWN_TEST_ONLY_SLUGS))
+        porcelain = _make_porcelain_line(
+            f"docs/workflow/feature-runs/{slug}/state.json"
+        )
+        with patch.dict("os.environ", {"FF_NO_POLLUTION_AUTO_CLEAN": "1"}):
+            reverted = POLLUTION_CHECK.auto_revert_polluted_state(repo_root=self._fake_root)
+        self.assertEqual(reverted, [])
+
+    def test_ignores_staged_only_changes(self) -> None:
+        """Files with only staged changes (M in index column) are not reverted."""
+        slug = next(iter(POLLUTION_CHECK.KNOWN_TEST_ONLY_SLUGS))
+        # "M " means staged (index), not unstaged (worktree)
+        porcelain = _make_porcelain_line(
+            f"docs/workflow/feature-runs/{slug}/state.json",
+            status="M ",
+        )
+        reverted = self._run(porcelain)
+        self.assertEqual(reverted, [])
+
+    def test_ignores_non_state_json_files(self) -> None:
+        """Non-state.json files under a known slug are not reverted."""
+        slug = next(iter(POLLUTION_CHECK.KNOWN_TEST_ONLY_SLUGS))
+        porcelain = _make_porcelain_line(
+            f"docs/workflow/feature-runs/{slug}/spec.md"
+        )
+        reverted = self._run(porcelain)
+        self.assertEqual(reverted, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_review_gc.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_review_gc.py
@@ -1,11 +1,13 @@
 import argparse
 import contextlib
+import gc
 import importlib.util
 import io
 import json
 import subprocess
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -116,9 +118,23 @@ class ReviewGcTests(unittest.TestCase):
     def setUp(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmpdir.cleanup)
-        self._root_patch = patch.object(FACTORY_STATE, "FACTORY_RUNS_ROOT", Path(self._tmpdir.name))
-        self._root_patch.start()
-        self.addCleanup(self._root_patch.stop)
+        # Patch every loaded factory_state module instance so that lazy imports
+        # inside record_command_telemetry (and similar) also see the tmpdir.
+        # Multiple test files each load factory_state via importlib into separate
+        # module objects; patching only FACTORY_STATE misses instances referenced
+        # by other already-loaded modules.
+        self._patches: list = []
+        for mod in list(gc.get_objects()):
+            if not isinstance(mod, types.ModuleType):
+                continue
+            if getattr(mod, "__name__", "") != "factory_state":
+                continue
+            if not hasattr(mod, "FACTORY_RUNS_ROOT"):
+                continue
+            p = patch.object(mod, "FACTORY_RUNS_ROOT", Path(self._tmpdir.name))
+            p.start()
+            self._patches.append(p)
+        self.addCleanup(lambda: [p.stop() for p in self._patches])
 
     def _run_checkpoint(self, args: argparse.Namespace) -> tuple[int, str, str]:
         fake_result = subprocess.CompletedProcess(args=["repair"], returncode=0, stdout="", stderr="")

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_self_documenting_errors.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_self_documenting_errors.py
@@ -1,10 +1,12 @@
 import argparse
 import contextlib
+import gc
 import importlib.util
 import io
 import subprocess
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -37,16 +39,28 @@ class SelfDocumentingErrorTests(unittest.TestCase):
         self.workflow_dir = self.runs_root / self.slug
         self.workflow_dir.mkdir(parents=True, exist_ok=True)
 
-        self._repo_patch = mock.patch.object(FACTORY_STATE, "REPO_ROOT", self.repo_root)
-        self._runs_patch = mock.patch.object(FACTORY_STATE, "FACTORY_RUNS_ROOT", self.runs_root)
+        # Patch every loaded factory_state module instance so that lazy imports
+        # inside record_command_telemetry (and similar) also see the tmpdir.
+        self._patches: list = []
+        for mod in list(gc.get_objects()):
+            if not isinstance(mod, types.ModuleType):
+                continue
+            if getattr(mod, "__name__", "") != "factory_state":
+                continue
+            if hasattr(mod, "FACTORY_RUNS_ROOT"):
+                p = mock.patch.object(mod, "FACTORY_RUNS_ROOT", self.runs_root)
+                p.start()
+                self._patches.append(p)
+            if hasattr(mod, "REPO_ROOT"):
+                p = mock.patch.object(mod, "REPO_ROOT", self.repo_root)
+                p.start()
+                self._patches.append(p)
+        self.addCleanup(lambda: [p.stop() for p in self._patches])
+
         self._cmd_checkpoint_repo_patch = mock.patch.object(FACTORY_CMD_CHECKPOINT, "REPO_ROOT", self.repo_root)
         self._cmd_deliver_repo_patch = mock.patch.object(FACTORY_CMD_DELIVER, "REPO_ROOT", self.repo_root)
-        self._repo_patch.start()
-        self._runs_patch.start()
         self._cmd_checkpoint_repo_patch.start()
         self._cmd_deliver_repo_patch.start()
-        self.addCleanup(self._repo_patch.stop)
-        self.addCleanup(self._runs_patch.stop)
         self.addCleanup(self._cmd_checkpoint_repo_patch.stop)
         self.addCleanup(self._cmd_deliver_repo_patch.stop)
 


### PR DESCRIPTION
## Summary
- **Change 1 — startup auto-clean**: new `factory_pollution_check.py`; `run_factory.py:main()` reverts modified-but-unstaged `state.json` for known test-only slugs before argparse dispatch. Skips outside git or with `FF_NO_POLLUTION_AUTO_CLEAN=1`.
- **Change 2 — fix leaking tests**: 4 test files (`test_review_gc`, `test_factory_cmd_checkpoint`, `test_factory_cmd_deliver`, `test_self_documenting_errors`) now use a `gc.get_objects()` walk in `setUp` to patch `FACTORY_RUNS_ROOT` on every loaded `factory_state` module instance.
- **Change 3 — flip the gate**: removed `continue-on-error: true` from the workflow-isolation step in `.github/workflows/ci.yml`. Pollution now hard-fails CI.

## Why
Every Codex/Sonnet dispatch in this worktree was burning ~30 seconds on a manual `git checkout -- docs/workflow/feature-runs/<slug>/state.json` cleanup before each commit. PR #765 added a warn-only gate but never blocked, so new leaks went undetected. This PR fixes the root cause and turns the gate teeth on.

## Root cause finding (worth noting for future runner work)
`factory_telemetry_commands.record_command_telemetry()` does a **lazy import** inside the function: `from factory_state import _cap_command_telemetry, update_workflow_state`. That import resolves at call time via `sys.modules["factory_state"]` — always the **last** instance registered, not whichever instance a particular test's `setUp` patched. The `@mutates_state("checkpoint")` decorator on `command_checkpoint` triggers this on every test that calls the real command. Tests that load `factory_state` via `importlib.util.spec_from_file_location` create independent module instances; only one wins the `sys.modules` slot. The `gc.get_objects()` walk patches all of them.

## Test plan
- [x] 273 tests pass locally (up from 268; +5 for the auto-clean helper)
- [x] `git status --porcelain docs/workflow/feature-runs/` is empty after a full suite run
- [ ] CI passes — the isolation gate is now hard-fail, so this is the canary

🤖 Generated with [Claude Code](https://claude.com/claude-code)