### PR TITLE
Domain Analysis: avg similarity row + model picker for ranking cycles

### DIFF
--- a/cloud/apps/web/src/components/domains/DominanceSection.tsx
+++ b/cloud/apps/web/src/components/domains/DominanceSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
+  VALUES,
   type ModelEntry,
   type ValueKey,
 } from '../../data/domainAnalysisData';
@@ -15,7 +16,7 @@ import {
 
 type DominanceSectionProps = {
   models: ModelEntry[];
-  selectedModelId: string | null;
+  defaultModelIds: Set<string>;
 };
 
 const THEME_COLORS: DominanceSectionThemeColors = {
@@ -36,13 +37,13 @@ const THEME_COLORS: DominanceSectionThemeColors = {
   idleRingColor: '#38bdf8',
 };
 
-export function DominanceSection({ models, selectedModelId }: DominanceSectionProps) {
+export function DominanceSection({ models, defaultModelIds }: DominanceSectionProps) {
   const chartRef = useRef<HTMLDivElement>(null);
   const [focusedValue, setFocusedValue] = useState<ValueKey | null>(null);
   const [hoveredValue, setHoveredValue] = useState<ValueKey | null>(null);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const [animationPhase, setAnimationPhase] = useState<'idle' | 'collapse' | 'expand'>('idle');
-  const prevModelId = useRef(selectedModelId);
+  const [pickedModelId, setPickedModelId] = useState<string>(''); // '' = All models
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
@@ -57,11 +58,54 @@ export function DominanceSection({ models, selectedModelId }: DominanceSectionPr
     NODE_ANIMATION_BASE_DURATION_MS +
     (DISPLAY_VALUES.length - 1) * NODE_ANIMATION_PER_NODE_SLOWDOWN_MS;
 
-  useEffect(() => {
-    if (selectedModelId === prevModelId.current) return;
-    prevModelId.current = selectedModelId;
-    if (prefersReducedMotion) return;
+  const pickerModels = useMemo(
+    () => models.filter((m) => defaultModelIds.has(m.model)),
+    [models, defaultModelIds],
+  );
 
+  const allModelsEntry = useMemo<ModelEntry>(() => {
+    const modelsWithRates = models.filter((m) =>
+      VALUES.some((v) => m.winRates?.[v] != null),
+    );
+    const count = Math.max(modelsWithRates.length, 1);
+    const avgWinRates = Object.fromEntries(
+      VALUES.map((v) => {
+        const rates = modelsWithRates
+          .map((m) => m.winRates?.[v])
+          .filter((r): r is number => r != null);
+        return [v, rates.length > 0 ? rates.reduce((a, b) => a + b, 0) / rates.length : null];
+      }),
+    ) as Record<ValueKey, number | null>;
+    const avgValues = Object.fromEntries(
+      VALUES.map((v) => [
+        v,
+        models.reduce((sum, m) => sum + (m.values[v] ?? 0), 0) / count,
+      ]),
+    ) as Record<ValueKey, number>;
+    return {
+      model: '__all__',
+      label: 'All models (average)',
+      values: avgValues,
+      winRates: avgWinRates,
+    };
+  }, [models]);
+
+  const modelById = useMemo(
+    () => new Map<string, ModelEntry>([
+      ...models.map((m): [string, ModelEntry] => [m.model, m]),
+      ['__all__', allModelsEntry],
+    ]),
+    [models, allModelsEntry],
+  );
+
+  const effectiveModelId = pickedModelId !== '' ? pickedModelId : '__all__';
+  const selectedModel = modelById.get(effectiveModelId);
+
+  const prevActiveId = useRef(effectiveModelId);
+  useEffect(() => {
+    if (effectiveModelId === prevActiveId.current) return;
+    prevActiveId.current = effectiveModelId;
+    if (prefersReducedMotion) return;
     setAnimationPhase('collapse');
     const expandTimer = setTimeout(() => setAnimationPhase('expand'), slowestDuration);
     const idleTimer = setTimeout(() => setAnimationPhase('idle'), 2 * slowestDuration);
@@ -69,16 +113,7 @@ export function DominanceSection({ models, selectedModelId }: DominanceSectionPr
       clearTimeout(expandTimer);
       clearTimeout(idleTimer);
     };
-  }, [prefersReducedMotion, selectedModelId, slowestDuration]);
-
-  const modelById = useMemo(
-    () => new Map(models.map((model) => [model.model, model])),
-    [models],
-  );
-  const activeModelId = selectedModelId !== null && modelById.has(selectedModelId)
-    ? selectedModelId
-    : models[0]?.model ?? '';
-  const selectedModel = modelById.get(activeModelId);
+  }, [effectiveModelId, prefersReducedMotion, slowestDuration]);
 
   const {
     contestedPairs,
@@ -106,9 +141,22 @@ export function DominanceSection({ models, selectedModelId }: DominanceSectionPr
       </div>
 
       <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">
-        <span className={`font-medium ${THEME_COLORS.panelMutedText}`}>Model focus:</span>
-        <span className={THEME_COLORS.panelText}>{selectedModel?.label ?? 'No model selected'}</span>
+        <label htmlFor="dominance-model-picker" className={`font-medium ${THEME_COLORS.panelMutedText}`}>
+          Model focus:
+        </label>
+        <select
+          id="dominance-model-picker"
+          className="rounded border border-gray-300 px-1.5 py-0.5 text-xs text-gray-800"
+          value={pickedModelId}
+          onChange={(e) => setPickedModelId(e.target.value)}
+        >
+          <option value="">All models (average)</option>
+          {pickerModels.map((m) => (
+            <option key={m.model} value={m.model}>{m.label}</option>
+          ))}
+        </select>
       </div>
+
       {models.length === 0 && (
         <p className={`mb-3 text-xs ${THEME_COLORS.panelMutedText}`}>
           No analyzed model data is available for this domain yet.

--- a/cloud/apps/web/src/components/domains/SimilaritySection.tsx
+++ b/cloud/apps/web/src/components/domains/SimilaritySection.tsx
@@ -87,7 +87,18 @@ export function SimilaritySection({ models, clusterAnalysis }: SimilaritySection
       similarities.set(a.model, row);
     }
 
-    return { similarities, pairs };
+    const averages = new Map<string, number>();
+    for (const b of models) {
+      const others = models.filter((a) => a.model !== b.model);
+      if (others.length === 0) {
+        averages.set(b.model, 0);
+        continue;
+      }
+      const sum = others.reduce((acc, a) => acc + (similarities.get(a.model)?.get(b.model) ?? 0), 0);
+      averages.set(b.model, sum / others.length);
+    }
+
+    return { similarities, pairs, averages };
   }, [models]);
 
   const modelClusterIndex = useMemo(() => {
@@ -183,6 +194,19 @@ export function SimilaritySection({ models, clusterAnalysis }: SimilaritySection
                   </tr>
                 );
               })}
+            {models.length > 1 && (
+                <tr className="border-t-2 border-gray-300">
+                  <th scope="row" className="px-2 py-2 text-left text-xs font-medium italic text-gray-600">Avg similarity</th>
+                  {models.map((col) => {
+                    const avg = matrix.averages.get(col.model) ?? 0;
+                    return (
+                      <td key={col.model} className="px-2 py-2 text-right text-gray-800" style={{ background: getSimilarityColor(avg) }}>
+                        {avg.toFixed(2)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              )}
             </tbody>
           </table>
         </div>

--- a/cloud/apps/web/src/components/domains/SimilaritySection.tsx
+++ b/cloud/apps/web/src/components/domains/SimilaritySection.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState } from 'react';
 import { HelpCircle, X } from 'lucide-react';
 import { cosineSimilarity } from '@valuerank/shared';
 import { VALUES, type ModelEntry } from '../../data/domainAnalysisData';
+import { Button } from '../ui/Button';
 import { CopyVisualButton } from '../ui/CopyVisualButton';
 import type { ClusterAnalysis } from '../../api/operations/domainAnalysis';
 
@@ -104,14 +105,16 @@ export function SimilaritySection({ models, clusterAnalysis }: SimilaritySection
     <section className="rounded-lg border border-gray-200 bg-white p-4">
       <div className="mb-3 flex items-center gap-2">
         <h2 className="text-base font-medium text-gray-900">Similarities and Differences</h2>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon"
           onClick={() => setShowMatrixHelp((v) => !v)}
-          className="text-gray-400 hover:text-gray-600"
+          className="h-5 w-5 text-gray-400 hover:text-gray-600"
           aria-label={showMatrixHelp ? 'Hide explanation' : 'Show explanation'}
         >
           <HelpCircle className="h-4 w-4" />
-        </button>
+        </Button>
       </div>
 
       <div ref={matrixRef} className="rounded border border-gray-100 bg-white p-2">
@@ -132,14 +135,16 @@ export function SimilaritySection({ models, clusterAnalysis }: SimilaritySection
                 </ol>
                 <p className="mt-1 text-gray-600"><span className="font-medium text-green-700">1.0</span> = identical relative priorities · <span className="font-medium text-yellow-600">0</span> = no relationship · <span className="font-medium text-red-700">−1</span> = opposite priorities</p>
               </div>
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="icon"
                 onClick={() => setShowMatrixHelp(false)}
-                className="shrink-0 text-gray-400 hover:text-gray-600"
+                className="shrink-0 h-6 w-6 text-gray-400 hover:text-gray-600"
                 aria-label="Close explanation"
               >
                 <X className="h-4 w-4" />
-              </button>
+              </Button>
             </div>
           </div>
         )}

--- a/cloud/apps/web/src/components/domains/SimilaritySection.tsx
+++ b/cloud/apps/web/src/components/domains/SimilaritySection.tsx
@@ -2,7 +2,6 @@ import { useMemo, useRef, useState } from 'react';
 import { HelpCircle, X } from 'lucide-react';
 import { cosineSimilarity } from '@valuerank/shared';
 import { VALUES, type ModelEntry } from '../../data/domainAnalysisData';
-import { Button } from '../ui/Button';
 import { CopyVisualButton } from '../ui/CopyVisualButton';
 import type { ClusterAnalysis } from '../../api/operations/domainAnalysis';
 
@@ -60,7 +59,9 @@ export function SimilaritySection({ models, clusterAnalysis }: SimilaritySection
   const matrix = useMemo(() => {
     const vectors = new Map<string, number[]>();
     for (const model of models) {
-      vectors.set(model.model, VALUES.map((value) => model.winRates?.[value] ?? 0));
+      const raw = VALUES.map((value) => model.winRates?.[value] ?? 0);
+      const mean = raw.reduce((s, v) => s + v, 0) / raw.length;
+      vectors.set(model.model, raw.map((v) => v - mean));
     }
 
     const similarities = new Map<string, Map<string, number>>();
@@ -101,33 +102,47 @@ export function SimilaritySection({ models, clusterAnalysis }: SimilaritySection
 
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-4">
-      <div className="mb-3">
+      <div className="mb-3 flex items-center gap-2">
         <h2 className="text-base font-medium text-gray-900">Similarities and Differences</h2>
+        <button
+          type="button"
+          onClick={() => setShowMatrixHelp((v) => !v)}
+          className="text-gray-400 hover:text-gray-600"
+          aria-label={showMatrixHelp ? 'Hide explanation' : 'Show explanation'}
+        >
+          <HelpCircle className="h-4 w-4" />
+        </button>
       </div>
 
       <div ref={matrixRef} className="rounded border border-gray-100 bg-white p-2">
-        <div className="mb-2 flex items-center justify-between">
-          <div className="flex flex-wrap items-center gap-1.5">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setShowMatrixHelp((v) => !v)}
-              className="h-8 w-8 text-gray-500 hover:text-gray-700"
-              aria-label={showMatrixHelp ? 'Hide explanation' : 'Show explanation'}
-            >
-              {showMatrixHelp ? <X className="h-8 w-8" /> : <HelpCircle className="h-8 w-8" />}
-            </Button>
-            {showMatrixHelp && (
-              <div className="mt-2 basis-full rounded-lg border border-blue-100 bg-blue-50 p-2.5 text-xs text-gray-700">
-                Each cell shows how similar two models&apos; value profiles are — how much they agree on
-                which values matter most. 1.0 = identical priorities, 0 = unrelated.
-                Green = think alike, yellow = partial overlap, red = consistently prioritize different things.
-                The diagonal is always 1.0 (a model compared to itself).
-              </div>
-            )}
-          </div>
+        <div className="mb-3 flex items-center justify-between">
           <CopyVisualButton targetRef={matrixRef} label="similarity matrix table" />
         </div>
+        {showMatrixHelp && (
+          <div className="mb-3 rounded-lg border border-blue-100 bg-blue-50 p-3 text-xs text-gray-700">
+            <div className="flex items-start justify-between gap-2">
+              <div className="space-y-2">
+                <p>Each number shows how similar two models&apos; value priorities are — not whether their win rates are close, but whether they prioritize the same values relative to their own average.</p>
+                <p>For example, if Model A strongly favors Security and avoids Power, and Model B does the same, they score near 1.0 even if Model A wins more overall.</p>
+                <p className="font-medium text-gray-800">How it is calculated (Pearson correlation):</p>
+                <ol className="list-decimal space-y-1 pl-4">
+                  <li>Each model&apos;s win rates are centered — subtract that model&apos;s average so the numbers balance around zero. This removes the effect of one model just being more decisive overall.</li>
+                  <li>We measure how much the two centered profiles move together across all 10 values.</li>
+                  <li>The result is divided by the size of each profile, so the score always falls between −1 and 1.</li>
+                </ol>
+                <p className="mt-1 text-gray-600"><span className="font-medium text-green-700">1.0</span> = identical relative priorities · <span className="font-medium text-yellow-600">0</span> = no relationship · <span className="font-medium text-red-700">−1</span> = opposite priorities</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setShowMatrixHelp(false)}
+                className="shrink-0 text-gray-400 hover:text-gray-600"
+                aria-label="Close explanation"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        )}
         <div className="overflow-x-auto">
           <table className="min-w-full text-xs">
             <caption className="sr-only">Pairwise similarity matrix</caption>

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -515,8 +515,8 @@ export function DomainAnalysis() {
             showStabilityDots
           />
           <DominanceSection
-            models={visibleModels}
-            selectedModelId={singleSelectedModelId}
+            models={models}
+            defaultModelIds={defaultModelIds}
           />
           <SimilaritySection models={visibleModels} clusterAnalysis={data?.domainAnalysis.clusterAnalysis} />
         </>

--- a/cloud/apps/web/tests/components/DominanceSection.test.tsx
+++ b/cloud/apps/web/tests/components/DominanceSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import type {
   ModelEntry,
 } from '../../src/data/domainAnalysisData';
@@ -64,9 +64,10 @@ const models: ModelEntry[] = [
   },
 ];
 
+const defaultModelIds = new Set(['model-a', 'model-b']);
 
 describe('DominanceSection', () => {
-  it('renders the shell and updates summary content when the selected model changes', async () => {
+  it('renders shell, model picker, and updates summary when model changes', async () => {
     vi.spyOn(window, 'matchMedia').mockImplementation(
       (query) =>
         ({
@@ -80,44 +81,40 @@ describe('DominanceSection', () => {
           dispatchEvent: vi.fn(),
         }) as MediaQueryList,
     );
-    let container: HTMLElement;
-    const { rerender } = render(
+
+    render(
       <DominanceSection
         models={models}
-        selectedModelId="model-a"
+        defaultModelIds={defaultModelIds}
       />,
     );
+
+    let container: HTMLElement;
     await act(async () => {
       container = screen.getByRole('img', { name: 'Value dominance graph' }).parentElement!.parentElement!;
       await Promise.resolve();
     });
 
-    expect(
-      screen.getByRole('heading', { name: 'Ranking and Cycles' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Ranking and Cycles' })).toBeInTheDocument();
     expect(
       screen.getByText(
         'Directed value graph for one selected AI: arrows point from stronger value to weaker value.',
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'Value dominance graph' })).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { name: 'Most Contestable Value Pairs' }),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Model focus:')).toBeInTheDocument();
-    expect(screen.getByText('Model A')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Most Contestable Value Pairs' })).toBeInTheDocument();
+
+    const picker = screen.getByLabelText('Model focus:');
+    expect(picker).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'All models (average)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Model A' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Model B' })).toBeInTheDocument();
+
     const summaryList = container!.querySelector('ol');
     expect(summaryList?.textContent).toBeTruthy();
     const initialSummary = summaryList?.textContent ?? '';
 
-    rerender(
-      <DominanceSection
-        models={models}
-        selectedModelId="model-b"
-      />,
-    );
-
-    expect(screen.getByText('Model B')).toBeInTheDocument();
+    fireEvent.change(picker, { target: { value: 'model-a' } });
     expect(summaryList?.textContent).not.toEqual(initialSummary);
   });
 });


### PR DESCRIPTION
## Summary
- **SimilaritySection:** adds an "Avg similarity" row at the bottom of the matrix, showing each model's average Pearson r against all other models (same coloring scale as the other cells)
- **DominanceSection:** adds a "Model focus" picker inside the Ranking and Cycles section; shows only default models (from settings) plus an "All models (average)" synthetic composite; selection is owned internally — caller just passes `defaultModelIds`
- **DomainAnalysis:** updated callsite to pass `models` + `defaultModelIds` (Set of default model IDs from `llmModels` query) instead of `selectedModelId`

## Validation
- `npm run lint --workspace @valuerank/web` — 0 errors
- `DominanceSection.test.tsx` — 1 passed
- Full web test suite — 1 pre-existing failure in `StartPairedBatchPage.test.tsx` (unrelated to this change), all other tests pass

## Test plan
- [ ] Preflight passed (lint + web tests)
- [ ] Manual smoke: navigate to Domain Analysis, verify avg row appears in similarity matrix, verify model picker in Ranking and Cycles shows default models + "All models (average)", verify switching models updates the graph and summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)