### PR TITLE
Cluster only default models, mean-center vectors for Pearson similarity

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-clustering.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-clustering.ts
@@ -307,9 +307,14 @@ export function computeClusterAnalysis(models: ClusterModelInput[]): ClusterAnal
     };
   }
 
-  // Build value key list and score vectors
+  // Build value key list and score vectors, mean-centered so cosine distance
+  // measures shape of priorities (like Pearson r) rather than raw magnitude.
   const valueKeys = Object.keys(models[0]!.scores);
-  const vectors = models.map((m) => valueKeys.map((vk) => m.scores[vk] ?? 0));
+  const rawVectors = models.map((m) => valueKeys.map((vk) => m.scores[vk] ?? 0));
+  const vectors = rawVectors.map((v) => {
+    const mean = v.reduce((s, x) => s + x, 0) / v.length;
+    return v.map((x) => x - mean);
+  });
 
   const distMatrix = cosineDistanceMatrix(vectors);
   const { mergeHeights, snapshots } = upgma(distMatrix, n);

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -54,7 +54,7 @@ async function getCurrentSnapshot(
 
 function buildDomainAnalysisResultFromSnapshot(params: {
   snapshot: DomainAnalysisSnapshotOutput;
-  activeModels: Array<{ modelId: string; displayName: string }>;
+  activeModels: Array<{ modelId: string; displayName: string; isDefault: boolean }>;
   generatedAt: Date;
   cacheStatus: DomainAnalysisCacheStatus;
 }): DomainAnalysisResult {
@@ -86,11 +86,14 @@ function buildDomainAnalysisResultFromSnapshot(params: {
   });
 
   const { shapes, benchmarks } = computeRankingShapes(modelsSortedScores);
-  const clusterModels = modelsBase.map((model) => ({
-    model: model.model,
-    label: model.label,
-    scores: Object.fromEntries(model.values.map((value) => [value.valueKey, value.score])),
-  }));
+  const defaultModelIds = new Set(params.activeModels.filter((m) => m.isDefault).map((m) => m.modelId));
+  const clusterModels = modelsBase
+    .filter((model) => defaultModelIds.has(model.model))
+    .map((model) => ({
+      model: model.model,
+      label: model.label,
+      scores: Object.fromEntries(model.values.map((value) => [value.valueKey, value.score])),
+    }));
   const clusterAnalysis = computeClusterAnalysis(clusterModels);
 
   const models: DomainAnalysisModel[] = modelsBase.map((model) => ({
@@ -207,7 +210,7 @@ export async function getDomainAnalysisResult(params: {
   });
   const activeModels = await db.llmModel.findMany({
     where: { status: 'ACTIVE' },
-    select: { modelId: true, displayName: true },
+    select: { modelId: true, displayName: true, isDefault: true },
   });
 
   if (state.definitions.length === 0) {


### PR DESCRIPTION
## Summary
- Model groups (cluster analysis) now only use models with `isDefault = true` as clustering inputs — non-default models like Grok 4 full and Gemini 2.5 Pro are excluded from group assignments
- Score vectors are mean-centered before computing cosine distance, making the clustering equivalent to Pearson r: it captures the *shape* of value priorities (which values are relatively high vs. low) rather than absolute magnitude

## Changes
- `domain-analysis-cache.ts`: add `isDefault` to the `db.llmModel.findMany` select; filter `clusterModels` to only default models before calling `computeClusterAnalysis`
- `domain-clustering.ts`: subtract each model's mean score from its vector before `cosineDistanceMatrix`, so the algorithm clusters on relative priorities

## Validation
- 41 domain-clustering tests: all pass
- API `tsc`: no errors in changed files
- Web lint + build: clean (warnings pre-existing, no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)