### PR TITLE
Domain Shifts: scope default-model average to default models only

### DIFF
--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -240,12 +240,16 @@ export function DomainValueShiftHeatmap() {
     }
   }, [models, selectedModelId]);
 
+  const defaultModels = useMemo(
+    () => models.filter((model) => defaultModelIds.has(model.modelId)),
+    [models, defaultModelIds],
+  );
   const selectedModel = selectedModelId === ALL_MODELS_OPTION_VALUE
     ? null
     : models.find((model) => model.modelId === selectedModelId) ?? null;
   const heatmap = useMemo(
-    () => buildDomainShiftHeatmap(selectedModelId === ALL_MODELS_OPTION_VALUE ? models : selectedModel),
-    [models, selectedModel, selectedModelId],
+    () => buildDomainShiftHeatmap(selectedModelId === ALL_MODELS_OPTION_VALUE ? defaultModels : selectedModel),
+    [defaultModels, selectedModel, selectedModelId],
   );
   const sortedRows = useMemo(
     () => sortHeatmapRows(heatmap.rows, sort, displayMode),
@@ -326,10 +330,10 @@ export function DomainValueShiftHeatmap() {
         <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
           <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">{isAllModels ? 'All models' : selectedModel?.label ?? 'All models'}</h2>
+              <h2 className="text-lg font-semibold text-gray-900">{isAllModels ? 'Default models' : selectedModel?.label ?? 'Default models'}</h2>
               <p className="text-sm text-gray-600">
                 {isAllModels
-                  ? 'Averages are across all models. Click any column header to sort. Evidence counts are shown in each cell detail.'
+                  ? 'Averages are across default models. Click any column header to sort. Evidence counts are shown in each cell detail.'
                   : 'Click any column header to sort. Evidence counts are shown in each cell detail.'}{' '}
                 Signature: {selectedSignature}.
               </p>

--- a/cloud/apps/web/src/pages/domainValueShiftHeatmapUtils.ts
+++ b/cloud/apps/web/src/pages/domainValueShiftHeatmapUtils.ts
@@ -131,7 +131,7 @@ export function buildDomainShiftModelOptions(
   const defaults = sorted.filter((model) => defaultModelIds.has(model.modelId));
   const nonDefaults = sorted.filter((model) => !defaultModelIds.has(model.modelId));
   return [
-    { value: ALL_MODELS_OPTION_VALUE, label: 'All models' },
+    { value: ALL_MODELS_OPTION_VALUE, label: 'Default models' },
     ...defaults.map((model) => ({ value: model.modelId, label: model.label })),
     ...(defaults.length > 0 && nonDefaults.length > 0
       ? [{ value: NON_DEFAULT_MODELS_DIVIDER_VALUE, label: '---', disabled: true }]

--- a/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
@@ -314,7 +314,7 @@ describe('DomainValueShiftHeatmap page', () => {
       expect(screen.getByRole('heading', { name: 'Domain Shifts by Value' })).toBeInTheDocument();
     });
     expect(screen.getByRole('table')).toHaveClass('table-auto');
-    expect(screen.getByRole('button', { name: /all models/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /default models/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Latest @ default/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sort by Avg Win Rate descending/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sort by Value descending/i })).toHaveTextContent('Value↓');
@@ -336,7 +336,7 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    await screen.findByRole('button', { name: /all models/i });
+    await screen.findByRole('button', { name: /default models/i });
     const initialModelsCalls = useQueryMock.mock.calls.filter(([args]: [{ query: unknown }]) => args.query === MODELS_ANALYSIS_QUERY);
     expect(initialModelsCalls.at(-1)?.[0]).toEqual(expect.objectContaining({
       variables: { signature: 'vnewtd' },
@@ -401,8 +401,8 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    expect(await screen.findByRole('button', { name: /all models/i })).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: /all models/i }));
+    expect(await screen.findByRole('button', { name: /default models/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /default models/i }));
     await user.click(screen.getByRole('option', { name: 'Zulu' }));
 
     expect(screen.getByRole('heading', { name: 'Zulu' })).toBeInTheDocument();
@@ -418,8 +418,8 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    await screen.findByRole('button', { name: /all models/i });
-    await user.click(screen.getByRole('button', { name: /all models/i }));
+    await screen.findByRole('button', { name: /default models/i });
+    await user.click(screen.getByRole('button', { name: /default models/i }));
 
     const options = screen.getAllByRole('option').map((option) => option.textContent?.trim());
     expect(options).toEqual(['Default models', 'Alpha', 'Charlie', '---', 'Bravo']);

--- a/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
@@ -245,7 +245,7 @@ describe('DomainValueShiftHeatmap helpers', () => {
       new Set(['model-c', 'model-a']),
     );
 
-    expect(options.map((option) => option.label)).toEqual(['All models', 'Alpha', 'Charlie', '---', 'Bravo']);
+    expect(options.map((option) => option.label)).toEqual(['Default models', 'Alpha', 'Charlie', '---', 'Bravo']);
     expect(options[0]?.value).toBe(ALL_MODELS_OPTION_VALUE);
   });
 
@@ -422,7 +422,7 @@ describe('DomainValueShiftHeatmap page', () => {
     await user.click(screen.getByRole('button', { name: /all models/i }));
 
     const options = screen.getAllByRole('option').map((option) => option.textContent?.trim());
-    expect(options).toEqual(['All models', 'Alpha', 'Charlie', '---', 'Bravo']);
+    expect(options).toEqual(['Default models', 'Alpha', 'Charlie', '---', 'Bravo']);
   });
 
   it('shows an empty state when fewer than two domains are eligible', async () => {


### PR DESCRIPTION
## Summary
- The \"All models\" heatmap aggregation on `/models/domain-shifts` now filters to default models only, matching how the Domain Analysis avg row works
- Renamed the dropdown option and section heading from \"All models\" to \"Default models\" so the label matches the behaviour

## Test plan
- [ ] Preflight passed (lint + tests + build)
- [ ] Manual smoke test done

🤖 Generated with [Claude Code](https://claude.com/claude-code)