### PR TITLE
Add radar chart to Model Groups section

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
@@ -1,0 +1,77 @@
+import {
+  Legend,
+  PolarAngleAxis,
+  PolarGrid,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+import { type DomainCluster } from '../../api/operations/domainAnalysis';
+import { VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
+
+type ClusterRadarChartProps = {
+  clusters: DomainCluster[];
+};
+
+type ClusterRadarDatum = {
+  subject: string;
+  [key: string]: string | number;
+};
+
+const COLUMN_VALUES: ValueKey[] = [
+  'Universalism_Nature',
+  'Benevolence_Dependability',
+  'Conformity_Interpersonal',
+  'Tradition',
+  'Security_Personal',
+  'Power_Dominance',
+  'Achievement',
+  'Hedonism',
+  'Stimulation',
+  'Self_Direction_Action',
+];
+
+const RADAR_COLORS = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'];
+
+export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
+  const data: ClusterRadarDatum[] = COLUMN_VALUES.map((valueKey) => ({
+    subject: VALUE_LABELS[valueKey],
+    ...Object.fromEntries(
+      clusters.map((cluster, index) => [`cluster${index}`, cluster.centroid[valueKey] ?? 0] as const),
+    ),
+  }));
+
+  return (
+    <div className="mb-4 rounded-lg border border-gray-100 bg-gray-50 p-3">
+      <div className="h-[320px]">
+        <ResponsiveContainer width="100%" height={320}>
+          <RadarChart data={data}>
+            <PolarGrid />
+            <PolarAngleAxis dataKey="subject" tick={{ fontSize: 11 }} />
+            <Tooltip />
+            <Legend
+              formatter={(value) => {
+                const key = String(value);
+                const clusterIndex = Number.parseInt(key.replace('cluster', ''), 10);
+                return clusters[clusterIndex]?.members.map((member) => member.label).join(', ') ?? key;
+              }}
+            />
+            {clusters.map((cluster, index) => {
+              const color = RADAR_COLORS[index % RADAR_COLORS.length];
+              return (
+                <Radar
+                  key={cluster.id}
+                  dataKey={`cluster${index}`}
+                  stroke={color}
+                  fill={color}
+                  fillOpacity={0.2}
+                />
+              );
+            })}
+          </RadarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -5,6 +5,7 @@ import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { type ClusterAnalysis, type DomainCluster } from '../../api/operations/domainAnalysis';
 import { VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
 import { formatDisplayLabel } from '../../utils/displayLabels';
+import { ClusterRadarChart } from './ClusterRadarChart';
 
 const CLUSTER_COLORS = [
   { border: 'border-blue-500', text: 'text-blue-700', light: 'bg-blue-50' },
@@ -112,25 +113,28 @@ export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: 
             {clusterAnalysis?.skipReason && <p>{clusterAnalysis.skipReason}</p>}
           </div>
         ) : (
-          <div className="flex flex-wrap gap-4">
-            {clusters.map((cluster, index) => {
-              const style = getClusterColor(index);
-              const personality = getClusterPersonality(cluster);
-              return (
-                <div key={cluster.id} className={`min-w-[280px] max-w-[520px] rounded-lg border ${style.border} ${style.light} p-3`}>
-                  <p className={`text-sm font-semibold ${style.text}`}>
-                    <span className="font-medium">Members:</span> {cluster.members.map((member) => member.label).join(', ')}
-                  </p>
-                  <p className="mt-2 text-xs text-gray-700">
-                    <span className="font-medium">Prioritizes:</span> {personality.topValues.join(', ')}
-                  </p>
-                  <p className="mt-1 text-xs text-gray-700">
-                    <span className="font-medium">De-prioritizes:</span> {personality.bottomValues.join(', ')}
-                  </p>
-                </div>
-              );
-            })}
-          </div>
+          <>
+            {clusters.length >= 2 ? <ClusterRadarChart clusters={clusters} /> : null}
+            <div className="flex flex-wrap gap-4">
+              {clusters.map((cluster, index) => {
+                const style = getClusterColor(index);
+                const personality = getClusterPersonality(cluster);
+                return (
+                  <div key={cluster.id} className={`min-w-[280px] max-w-[520px] rounded-lg border ${style.border} ${style.light} p-3`}>
+                    <p className={`text-sm font-semibold ${style.text}`}>
+                      <span className="font-medium">Members:</span> {cluster.members.map((member) => member.label).join(', ')}
+                    </p>
+                    <p className="mt-2 text-xs text-gray-700">
+                      <span className="font-medium">Prioritizes:</span> {personality.topValues.join(', ')}
+                    </p>
+                    <p className="mt-1 text-xs text-gray-700">
+                      <span className="font-medium">De-prioritizes:</span> {personality.bottomValues.join(', ')}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </>
         )}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Adds a radar chart above the existing cluster cards in the Model Groups section of Domain Analysis
- One polygon per cluster, using the cluster centroid scores across all 10 Schwartz values
- Colors match the existing cluster card palette (blue, amber, emerald, rose)
- Legend labels show each cluster's member list
- Chart only renders when 2+ clusters exist; existing skip message is unchanged
- No backend changes

## Validation
- `npm run lint --workspace @valuerank/web`: pass (warnings pre-existing)
- `npm run build --workspace @valuerank/web`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)