### PR TITLE
feat(models-confidence): full-page condition detail + model filter

### DIFF
--- a/cloud/apps/api/src/graphql/queries/confidence-transcripts.ts
+++ b/cloud/apps/api/src/graphql/queries/confidence-transcripts.ts
@@ -14,10 +14,20 @@ builder.queryField('confidenceTranscripts', (t) =>
       valueKey: t.arg.string({ required: true }),
       signature: t.arg.string({ required: false }),
       limit: t.arg.int({ required: false }),
+      definitionId: t.arg.string({ required: false }),
+      scenarioId: t.arg.string({ required: false }),
     },
     resolve: async (_root, args) => {
       const modelId = args.modelId;
       const rawValueKey = args.valueKey;
+      const filterDefinitionId =
+        typeof args.definitionId === 'string' && args.definitionId.trim() !== ''
+          ? args.definitionId.trim()
+          : null;
+      const filterScenarioId =
+        typeof args.scenarioId === 'string' && args.scenarioId.trim() !== ''
+          ? args.scenarioId.trim()
+          : null;
       if (!isDomainAnalysisValueKey(rawValueKey)) {
         throw new ValidationError(`Unsupported value key: ${rawValueKey}`);
       }
@@ -69,6 +79,8 @@ builder.queryField('confidenceTranscripts', (t) =>
       const matchingDefIds = new Set(
         definitions
           .filter((definition) => {
+            // When a specific definitionId filter is requested, respect it.
+            if (filterDefinitionId !== null && definition.id !== filterDefinitionId) return false;
             const pair = defValuePairMap.get(definition.id) ?? null;
             return pair?.valueA === valueKey || pair?.valueB === valueKey;
           })
@@ -98,6 +110,7 @@ builder.queryField('confidenceTranscripts', (t) =>
           runId: { in: relevantRunIds },
           modelId,
           deletedAt: null,
+          ...(filterScenarioId !== null ? { scenarioId: filterScenarioId } : {}),
         },
         orderBy: { createdAt: 'desc' },
         take: limit,

--- a/cloud/apps/api/src/graphql/queries/confidence-value-detail.ts
+++ b/cloud/apps/api/src/graphql/queries/confidence-value-detail.ts
@@ -1,0 +1,253 @@
+import { db } from '@valuerank/db';
+import { ValidationError } from '@valuerank/shared';
+import { builder } from '../builder.js';
+import { runMatchesSignature } from './domain-coverage-gql-types.js';
+import { extractValuePair, type DomainAnalysisValuePair } from './domain-analysis-values.js';
+import { isDomainAnalysisValueKey } from './domain/shared.js';
+import { resolveTranscriptDecisionModel } from './domain/decision-model.js';
+import { mapVignette, type MutableVignette, type MutableCondition } from './domain/analysis/value-detail-types.js';
+import { buildScenarioAnalysisDimensionRecord, normalizeScenarioAnalysisMetadata } from '../../services/analysis/scenario-metadata.js';
+import { ConfidenceValueDetailResultRef } from '../types/confidence-value-detail.js';
+
+builder.queryField('confidenceValueDetail', (t) =>
+  t.field({
+    type: ConfidenceValueDetailResultRef,
+    args: {
+      modelId: t.arg.string({ required: true }),
+      valueKey: t.arg.string({ required: true }),
+      signature: t.arg.string({ required: false }),
+    },
+    resolve: async (_root, args) => {
+      const modelId = args.modelId;
+      const rawValueKey = args.valueKey;
+      if (!isDomainAnalysisValueKey(rawValueKey)) {
+        throw new ValidationError(`Unsupported value key: ${rawValueKey}`);
+      }
+      const valueKey = rawValueKey;
+      const requestedSignature =
+        typeof args.signature === 'string' && args.signature.trim() !== ''
+          ? args.signature.trim()
+          : null;
+
+      // Resolve model display name.
+      const modelMeta = await db.llmModel.findFirst({
+        where: { modelId, status: 'ACTIVE' },
+        select: { displayName: true },
+      });
+      const modelLabel = modelMeta?.displayName ?? modelId;
+
+      // Fetch all completed non-Aggregate source runs (same as confidenceTranscripts).
+      const runs = await db.run.findMany({
+        where: {
+          status: 'COMPLETED',
+          deletedAt: null,
+          tags: { none: { tag: { name: 'Aggregate' } } },
+        },
+        select: {
+          id: true,
+          definitionId: true,
+          config: true,
+        },
+      });
+
+      const matchingRuns =
+        requestedSignature == null
+          ? runs
+          : runs.filter((run) => runMatchesSignature(run.config, requestedSignature));
+
+      const definitionIds = [
+        ...new Set(
+          matchingRuns
+            .map((run) => run.definitionId)
+            .filter((id): id is string => id !== null),
+        ),
+      ];
+
+      if (definitionIds.length === 0) {
+        return { modelLabel, valueKey, vignettes: [] };
+      }
+
+      // Find definitions that have this valueKey in their pair.
+      const definitions = await db.definition.findMany({
+        where: { id: { in: definitionIds } },
+        select: { id: true, name: true, version: true, content: true },
+      });
+
+      const defValuePairMap = new Map<string, DomainAnalysisValuePair | null>();
+      for (const definition of definitions) {
+        defValuePairMap.set(definition.id, extractValuePair(definition.content));
+      }
+
+      const matchingDefs = definitions.filter((definition) => {
+        const pair = defValuePairMap.get(definition.id) ?? null;
+        return pair?.valueA === valueKey || pair?.valueB === valueKey;
+      });
+
+      if (matchingDefs.length === 0) {
+        return { modelLabel, valueKey, vignettes: [] };
+      }
+
+      const matchingDefIds = new Set(matchingDefs.map((d) => d.id));
+
+      // Map run → definitionId for matching definitions only.
+      const relevantRunIds: string[] = [];
+      const runToDefId = new Map<string, string>();
+      for (const run of matchingRuns) {
+        if (run.definitionId == null || !matchingDefIds.has(run.definitionId)) continue;
+        relevantRunIds.push(run.id);
+        runToDefId.set(run.id, run.definitionId);
+      }
+
+      if (relevantRunIds.length === 0) {
+        return { modelLabel, valueKey, vignettes: [] };
+      }
+
+      // Build per-definition vignette accumulators.
+      const vignetteByDefinitionId = new Map<string, MutableVignette>();
+      for (const definition of matchingDefs) {
+        const pair = defValuePairMap.get(definition.id);
+        if (!pair) continue;
+        const otherValueKey = pair.valueA === valueKey ? pair.valueB : pair.valueA;
+        vignetteByDefinitionId.set(definition.id, {
+          definitionId: definition.id,
+          definitionName: definition.name,
+          definitionVersion: definition.version,
+          aggregateRunId: null,
+          otherValueKey,
+          prioritized: 0,
+          deprioritized: 0,
+          neutral: 0,
+          totalTrials: 0,
+          conditions: new Map(),
+        });
+      }
+
+      // Fetch transcripts for the model across all relevant runs.
+      const transcripts = await db.transcript.findMany({
+        where: {
+          runId: { in: relevantRunIds },
+          modelId,
+          deletedAt: null,
+        },
+        select: {
+          runId: true,
+          scenarioId: true,
+          decisionMetadata: true,
+          scenario: {
+            select: { orientationFlipped: true },
+          },
+        },
+      });
+
+      // Pre-fetch scenario names and dimensions.
+      const scenarioIds = [
+        ...new Set(
+          transcripts
+            .map((t) => t.scenarioId)
+            .filter((id): id is string => id !== null && id !== ''),
+        ),
+      ];
+
+      const scenarios =
+        scenarioIds.length === 0
+          ? []
+          : await db.scenario.findMany({
+              where: { id: { in: scenarioIds } },
+              select: { id: true, name: true, content: true },
+            });
+
+      const scenarioNameById = new Map(scenarios.map((s) => [s.id, s.name]));
+      const scenarioDimensionsById = new Map<string, Record<string, string | number>>();
+      for (const scenario of scenarios) {
+        const metadata = normalizeScenarioAnalysisMetadata(scenario.content);
+        if (metadata === null) continue;
+        const dimensions = buildScenarioAnalysisDimensionRecord(metadata);
+        if (Object.keys(dimensions).length > 0) {
+          scenarioDimensionsById.set(scenario.id, dimensions);
+        }
+      }
+
+      // Accumulate counts per vignette + condition.
+      for (const transcript of transcripts) {
+        const definitionId = runToDefId.get(transcript.runId);
+        if (definitionId == null) continue;
+        const pair = defValuePairMap.get(definitionId);
+        const vignette = vignetteByDefinitionId.get(definitionId);
+        if (!pair || !vignette) continue;
+
+        const canon = resolveTranscriptDecisionModel({
+          decisionMetadata: transcript.decisionMetadata,
+          orientationFlipped: transcript.scenario?.orientationFlipped ?? null,
+          pairOverride: pair,
+        }).canonical;
+
+        const scenarioKey = transcript.scenarioId ?? '__unknown__';
+        const hasScenarioId = transcript.scenarioId !== null && transcript.scenarioId !== '';
+        const scenarioId = hasScenarioId ? transcript.scenarioId : null;
+        const conditionName =
+          scenarioId === null ? 'Unknown Condition' : (scenarioNameById.get(scenarioId) ?? scenarioId);
+
+        let existingCondition = vignette.conditions.get(scenarioKey);
+        if (!existingCondition) {
+          existingCondition = {
+            scenarioId,
+            conditionName,
+            dimensions: scenarioId === null ? null : (scenarioDimensionsById.get(scenarioId) ?? null),
+            prioritized: 0,
+            deprioritized: 0,
+            neutral: 0,
+            totalTrials: 0,
+            strongly: 0,
+            somewhat: 0,
+            opponentSomewhat: 0,
+            opponentStrongly: 0,
+            unknownCount: 0,
+          } satisfies MutableCondition;
+          vignette.conditions.set(scenarioKey, existingCondition);
+        }
+
+        if (canon.direction === 'unknown') {
+          existingCondition.unknownCount += 1;
+          continue;
+        }
+
+        const outcome =
+          canon.direction === 'neutral'
+            ? 'neutral'
+            : canon.favoredValueKey === valueKey
+              ? 'prioritized'
+              : 'deprioritized';
+
+        if (outcome === 'prioritized') {
+          vignette.prioritized += 1;
+          existingCondition.prioritized += 1;
+          if (canon.strength === 'strong') {
+            existingCondition.strongly += 1;
+          } else if (canon.strength === 'lean') {
+            existingCondition.somewhat += 1;
+          }
+        } else if (outcome === 'deprioritized') {
+          vignette.deprioritized += 1;
+          existingCondition.deprioritized += 1;
+          if (canon.strength === 'strong') {
+            existingCondition.opponentStrongly += 1;
+          } else if (canon.strength === 'lean') {
+            existingCondition.opponentSomewhat += 1;
+          }
+        } else {
+          vignette.neutral += 1;
+          existingCondition.neutral += 1;
+        }
+        vignette.totalTrials += 1;
+        existingCondition.totalTrials += 1;
+      }
+
+      const vignettes = Array.from(vignetteByDefinitionId.values())
+        .filter((v) => v.totalTrials > 0 || v.conditions.size > 0)
+        .sort((a, b) => a.definitionName.localeCompare(b.definitionName))
+        .map(mapVignette);
+
+      return { modelLabel, valueKey, vignettes };
+    },
+  }),
+);

--- a/cloud/apps/api/src/graphql/types/confidence-value-detail.ts
+++ b/cloud/apps/api/src/graphql/types/confidence-value-detail.ts
@@ -1,0 +1,24 @@
+import { builder } from '../builder.js';
+import { DomainAnalysisVignetteDetailRef } from '../queries/domain/types-detail.js';
+import type { DomainAnalysisVignetteDetail } from '../queries/domain/types-detail.js';
+
+export type ConfidenceValueDetailResult = {
+  modelLabel: string;
+  valueKey: string;
+  vignettes: DomainAnalysisVignetteDetail[];
+};
+
+export const ConfidenceValueDetailResultRef = builder.objectRef<ConfidenceValueDetailResult>(
+  'ConfidenceValueDetailResult',
+);
+
+builder.objectType(ConfidenceValueDetailResultRef, {
+  fields: (t) => ({
+    modelLabel: t.exposeString('modelLabel'),
+    valueKey: t.exposeString('valueKey'),
+    vignettes: t.field({
+      type: [DomainAnalysisVignetteDetailRef],
+      resolve: (parent) => parent.vignettes,
+    }),
+  }),
+});

--- a/cloud/apps/api/src/graphql/types/index.ts
+++ b/cloud/apps/api/src/graphql/types/index.ts
@@ -29,6 +29,7 @@ import './probe-result.js';
 import './available-model.js';
 import './models-analysis.js';
 import './models-confidence.js';
+import './confidence-value-detail.js';
 import './models-consistency.js';
 import './pressure-sensitivity.js';
 import './circumplex.js';

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -369,6 +369,12 @@ type CompletionEvent {
   success: Boolean!
 }
 
+type ConfidenceValueDetailResult {
+  modelLabel: String!
+  valueKey: String!
+  vignettes: [DomainAnalysisVignetteDetail!]!
+}
+
 type ConsistencyPerCondition {
   matches: Int!
   netPressureRank: Int!
@@ -2353,7 +2359,8 @@ type Query {
   ): [AvailableModel!]!
   availableSignatures: [AvailableSignature!]!
   circumplexAnalysis(minTrialsPerValue: Int, modelIds: [String!]!, signature: String!): CircumplexAnalysisResult!
-  confidenceTranscripts(limit: Int, modelId: String!, signature: String, valueKey: String!): [DomainAnalysisConditionTranscript!]!
+  confidenceTranscripts(definitionId: String, limit: Int, modelId: String!, scenarioId: String, signature: String, valueKey: String!): [DomainAnalysisConditionTranscript!]!
+  confidenceValueDetail(modelId: String!, signature: String, valueKey: String!): ConfidenceValueDetailResult!
 
   """Fetch a single definition by ID. Returns null if not found."""
   definition(

--- a/cloud/apps/web/src/App.tsx
+++ b/cloud/apps/web/src/App.tsx
@@ -21,6 +21,7 @@ import { ModelsConsistency } from './pages/ModelsConsistency';
 import { PressureSensitivity } from './pages/PressureSensitivity';
 import { ModelsCircumplex } from './pages/ModelsCircumplex';
 import { ModelsConfidence } from './pages/ModelsConfidence';
+import { ModelsConfidenceValueDetail } from './pages/ModelsConfidenceValueDetail';
 import { DefinitionDetail } from './pages/DefinitionDetail';
 import { StartPairedBatchPage } from './pages/DefinitionDetail/StartPairedBatchPage';
 import { Runs } from './pages/Runs';
@@ -208,6 +209,14 @@ function App() {
               element={
                 <ProtectedLayout>
                   <ModelsConfidence />
+                </ProtectedLayout>
+              }
+            />
+            <Route
+              path="/models/confidence/detail"
+              element={
+                <ProtectedLayout fullWidth>
+                  <ModelsConfidenceValueDetail />
                 </ProtectedLayout>
               }
             />

--- a/cloud/apps/web/src/api/operations/confidenceTranscripts.graphql
+++ b/cloud/apps/web/src/api/operations/confidenceTranscripts.graphql
@@ -1,5 +1,5 @@
-query ConfidenceTranscripts($modelId: String!, $valueKey: String!, $signature: String, $limit: Int) {
-  confidenceTranscripts(modelId: $modelId, valueKey: $valueKey, signature: $signature, limit: $limit) {
+query ConfidenceTranscripts($modelId: String!, $valueKey: String!, $signature: String, $limit: Int, $definitionId: String, $scenarioId: String) {
+  confidenceTranscripts(modelId: $modelId, valueKey: $valueKey, signature: $signature, limit: $limit, definitionId: $definitionId, scenarioId: $scenarioId) {
     id
     runId
     scenarioId

--- a/cloud/apps/web/src/api/operations/confidenceTranscripts.ts
+++ b/cloud/apps/web/src/api/operations/confidenceTranscripts.ts
@@ -6,6 +6,7 @@ import type { TranscriptDecisionModelV2 } from './runs';
 
 export { ConfidenceTranscriptsDocument as CONFIDENCE_TRANSCRIPTS_QUERY } from '../../generated/graphql';
 
+// ConfidenceTranscriptsQueryVariables now includes optional definitionId + scenarioId for condition-level filtering.
 export type ConfidenceTranscriptsQueryVariables = GeneratedConfidenceTranscriptsQueryVariables;
 export type ConfidenceTranscriptsQueryResult = GeneratedConfidenceTranscriptsQuery;
 

--- a/cloud/apps/web/src/api/operations/confidenceValueDetail.graphql
+++ b/cloud/apps/web/src/api/operations/confidenceValueDetail.graphql
@@ -1,0 +1,27 @@
+query ConfidenceValueDetail($modelId: String!, $valueKey: String!, $signature: String) {
+  confidenceValueDetail(modelId: $modelId, valueKey: $valueKey, signature: $signature) {
+    modelLabel
+    valueKey
+    vignettes {
+      definitionId
+      definitionName
+      definitionVersion
+      otherValueKey
+      totalTrials
+      conditions {
+        scenarioId
+        conditionName
+        dimensions
+        prioritized
+        deprioritized
+        neutral
+        totalTrials
+        unknownCount
+        strongly
+        somewhat
+        opponentSomewhat
+        opponentStrongly
+      }
+    }
+  }
+}

--- a/cloud/apps/web/src/api/operations/confidenceValueDetail.ts
+++ b/cloud/apps/web/src/api/operations/confidenceValueDetail.ts
@@ -1,0 +1,15 @@
+import type {
+  ConfidenceValueDetailQuery as GeneratedConfidenceValueDetailQuery,
+  ConfidenceValueDetailQueryVariables as GeneratedConfidenceValueDetailQueryVariables,
+} from '../../generated/graphql';
+
+export { ConfidenceValueDetailDocument as CONFIDENCE_VALUE_DETAIL_QUERY } from '../../generated/graphql';
+
+export type ConfidenceValueDetailQueryVariables = GeneratedConfidenceValueDetailQueryVariables;
+export type ConfidenceValueDetailQueryResult = GeneratedConfidenceValueDetailQuery;
+
+// Derive shapes from codegen for type safety without hand-written object literals.
+export type ConfidenceValueDetailVignette =
+  GeneratedConfidenceValueDetailQuery['confidenceValueDetail']['vignettes'][number];
+
+export type ConfidenceValueDetailCondition = ConfidenceValueDetailVignette['conditions'][number];

--- a/cloud/apps/web/src/components/models/ConfidenceHeatmap.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceHeatmap.tsx
@@ -24,17 +24,24 @@ function buildTooltip(valueKey: string, result: ModelsConfidenceModelResult['val
 
 type ConfidenceHeatmapProps = {
   models: ModelsConfidenceModelResult[];
+  /** When provided, only rows whose modelId is in this list are shown. */
+  selectedModelIds?: string[];
   onCellClick?: (modelId: string, modelLabel: string, valueKey: string) => void;
 };
 
-export function ConfidenceHeatmap({ models, onCellClick }: ConfidenceHeatmapProps) {
-  const sorted = [...models].sort((a, b) => {
+export function ConfidenceHeatmap({ models, selectedModelIds, onCellClick }: ConfidenceHeatmapProps) {
+  const visibleModels =
+    selectedModelIds != null
+      ? models.filter((m) => selectedModelIds.includes(m.modelId))
+      : models;
+
+  const sorted = [...visibleModels].sort((a, b) => {
     const aConf = a.overallConfidence ?? -1;
     const bConf = b.overallConfidence ?? -1;
     return bConf - aConf;
   });
 
-  if (models.length === 0) {
+  if (visibleModels.length === 0) {
     return <p className="text-sm text-gray-500">No data</p>;
   }
 

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -354,6 +354,13 @@ export type CompletionEvent = {
   success: Scalars['Boolean']['output'];
 };
 
+export type ConfidenceValueDetailResult = {
+  __typename?: 'ConfidenceValueDetailResult';
+  modelLabel: Scalars['String']['output'];
+  valueKey: Scalars['String']['output'];
+  vignettes: Array<DomainAnalysisVignetteDetail>;
+};
+
 export type ConsistencyPerCondition = {
   __typename?: 'ConsistencyPerCondition';
   matches: Scalars['Int']['output'];
@@ -2552,6 +2559,7 @@ export type Query = {
   availableSignatures: Array<AvailableSignature>;
   circumplexAnalysis: CircumplexAnalysisResult;
   confidenceTranscripts: Array<DomainAnalysisConditionTranscript>;
+  confidenceValueDetail: ConfidenceValueDetailResult;
   /** Fetch a single definition by ID. Returns null if not found. */
   definition?: Maybe<Definition>;
   /** Get ancestors of a definition (full chain to root). Returns definitions ordered from root to immediate parent. */
@@ -2803,7 +2811,16 @@ export type QueryCircumplexAnalysisArgs = {
 
 
 export type QueryConfidenceTranscriptsArgs = {
+  definitionId?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  modelId: Scalars['String']['input'];
+  scenarioId?: InputMaybe<Scalars['String']['input']>;
+  signature?: InputMaybe<Scalars['String']['input']>;
+  valueKey: Scalars['String']['input'];
+};
+
+
+export type QueryConfidenceValueDetailArgs = {
   modelId: Scalars['String']['input'];
   signature?: InputMaybe<Scalars['String']['input']>;
   valueKey: Scalars['String']['input'];
@@ -4030,10 +4047,21 @@ export type ConfidenceTranscriptsQueryVariables = Exact<{
   valueKey: Scalars['String']['input'];
   signature?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  definitionId?: InputMaybe<Scalars['String']['input']>;
+  scenarioId?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
 export type ConfidenceTranscriptsQuery = { __typename?: 'Query', confidenceTranscripts: Array<{ __typename?: 'DomainAnalysisConditionTranscript', id: string, runId: string, scenarioId?: string | null, modelId: string, decisionModelV2?: unknown | null, turnCount: number, tokenCount: number, durationMs: number, createdAt: string, content: unknown }> };
+
+export type ConfidenceValueDetailQueryVariables = Exact<{
+  modelId: Scalars['String']['input'];
+  valueKey: Scalars['String']['input'];
+  signature?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type ConfidenceValueDetailQuery = { __typename?: 'Query', confidenceValueDetail: { __typename?: 'ConfidenceValueDetailResult', modelLabel: string, valueKey: string, vignettes: Array<{ __typename?: 'DomainAnalysisVignetteDetail', definitionId: string, definitionName: string, definitionVersion: number, otherValueKey: string, totalTrials: number, conditions: Array<{ __typename?: 'DomainAnalysisConditionDetail', scenarioId?: string | null, conditionName: string, dimensions?: unknown | null, prioritized: number, deprioritized: number, neutral: number, totalTrials: number, unknownCount: number, strongly: number, somewhat: number, opponentSomewhat: number, opponentStrongly: number }> }> } };
 
 export type EstimateCostQueryVariables = Exact<{
   definitionId: Scalars['ID']['input'];
@@ -5390,12 +5418,14 @@ export function useComparisonRunsListQuery(options?: Omit<Urql.UseQueryArgs<Comp
   return Urql.useQuery<ComparisonRunsListQuery, ComparisonRunsListQueryVariables>({ query: ComparisonRunsListDocument, ...options });
 };
 export const ConfidenceTranscriptsDocument = gql`
-    query ConfidenceTranscripts($modelId: String!, $valueKey: String!, $signature: String, $limit: Int) {
+    query ConfidenceTranscripts($modelId: String!, $valueKey: String!, $signature: String, $limit: Int, $definitionId: String, $scenarioId: String) {
   confidenceTranscripts(
     modelId: $modelId
     valueKey: $valueKey
     signature: $signature
     limit: $limit
+    definitionId: $definitionId
+    scenarioId: $scenarioId
   ) {
     id
     runId
@@ -5413,6 +5443,43 @@ export const ConfidenceTranscriptsDocument = gql`
 
 export function useConfidenceTranscriptsQuery(options: Omit<Urql.UseQueryArgs<ConfidenceTranscriptsQueryVariables>, 'query'>) {
   return Urql.useQuery<ConfidenceTranscriptsQuery, ConfidenceTranscriptsQueryVariables>({ query: ConfidenceTranscriptsDocument, ...options });
+};
+export const ConfidenceValueDetailDocument = gql`
+    query ConfidenceValueDetail($modelId: String!, $valueKey: String!, $signature: String) {
+  confidenceValueDetail(
+    modelId: $modelId
+    valueKey: $valueKey
+    signature: $signature
+  ) {
+    modelLabel
+    valueKey
+    vignettes {
+      definitionId
+      definitionName
+      definitionVersion
+      otherValueKey
+      totalTrials
+      conditions {
+        scenarioId
+        conditionName
+        dimensions
+        prioritized
+        deprioritized
+        neutral
+        totalTrials
+        unknownCount
+        strongly
+        somewhat
+        opponentSomewhat
+        opponentStrongly
+      }
+    }
+  }
+}
+    `;
+
+export function useConfidenceValueDetailQuery(options: Omit<Urql.UseQueryArgs<ConfidenceValueDetailQueryVariables>, 'query'>) {
+  return Urql.useQuery<ConfidenceValueDetailQuery, ConfidenceValueDetailQueryVariables>({ query: ConfidenceValueDetailDocument, ...options });
 };
 export const EstimateCostDocument = gql`
     query EstimateCost($definitionId: ID!, $models: [String!]!, $samplePercentage: Int, $samplesPerScenario: Int) {

--- a/cloud/apps/web/src/pages/ModelsConfidence.tsx
+++ b/cloud/apps/web/src/pages/ModelsConfidence.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'urql';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { Loading } from '../components/ui/Loading';
 import { Select } from '../components/ui/Select';
@@ -13,14 +13,15 @@ import {
   type ModelsConfidenceQueryResult,
   type ModelsConfidenceQueryVariables,
 } from '../api/operations/modelsConfidence';
+import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { ConfidenceHeatmap } from '../components/models/ConfidenceHeatmap';
-import { ConfidenceTranscriptsDrawer } from '../components/models/ConfidenceTranscriptsDrawer';
 import {
   buildDomainShiftSignatureOptions,
   getDefaultDomainShiftSignature,
 } from './domainValueShiftHeatmapUtils';
 
 export function ModelsConfidence() {
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const signatureParam = searchParams.get('signature');
 
@@ -63,18 +64,66 @@ export function ModelsConfidence() {
     requestPolicy: 'cache-and-network',
   });
 
+  const [{ data: llmModelsData }] = useQuery<LlmModelsQueryResult>({
+    query: LLM_MODELS_QUERY,
+    variables: { status: 'ACTIVE' },
+    requestPolicy: 'cache-and-network',
+  });
+
+  const allModels = useMemo(
+    () => (llmModelsData?.llmModels ?? []).filter((m) => m.status === 'ACTIVE'),
+    [llmModelsData],
+  );
+
+  const defaultModelIds = useMemo(
+    () => allModels.filter((m) => m.isDefault).map((m) => m.modelId),
+    [allModels],
+  );
+
+  const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
+
+  // Once default IDs are resolved, initialise selection to defaults.
+  useEffect(() => {
+    if (selectedModelIds === null && defaultModelIds.length > 0) {
+      setSelectedModelIds(defaultModelIds);
+    }
+  }, [defaultModelIds, selectedModelIds]);
+
   const models = useMemo(() => data?.modelsConfidence.models ?? [], [data]);
   const loading = fetching && data == null;
 
-  const [drawerState, setDrawerState] = useState<{
-    modelId: string;
-    modelLabel: string;
-    valueKey: string;
-  } | null>(null);
+  // Filter heatmap rows to selected models (null = not yet loaded, show all).
+  const filteredModelIds = selectedModelIds;
 
-  const handleCellClick = useCallback((modelId: string, modelLabel: string, valueKey: string) => {
-    setDrawerState({ modelId, modelLabel, valueKey });
-  }, []);
+  const handleCellClick = useCallback(
+    (modelId: string, modelLabel: string, valueKey: string) => {
+      const params = new URLSearchParams({
+        modelId,
+        modelLabel,
+        valueKey,
+        signature: selectedSignature,
+      });
+      navigate(`/models/confidence/detail?${params.toString()}`);
+    },
+    [navigate, selectedSignature],
+  );
+
+  // Model filter state helpers.
+  const isDefaultSelection =
+    selectedModelIds !== null &&
+    defaultModelIds.length > 0 &&
+    selectedModelIds.length === defaultModelIds.length &&
+    defaultModelIds.every((id) => selectedModelIds.includes(id));
+
+  const [modelFilterOpen, setModelFilterOpen] = useState(false);
+
+  const handleToggleModel = (modelId: string) => {
+    const current = selectedModelIds ?? [];
+    const next = current.includes(modelId)
+      ? current.filter((id) => id !== modelId)
+      : [...current, modelId];
+    setSelectedModelIds(next);
+  };
 
   return (
     <div className="space-y-6">
@@ -87,7 +136,7 @@ export function ModelsConfidence() {
         </p>
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <label className="text-sm text-gray-600">Signature</label>
         <Select
           value={selectedSignature}
@@ -99,17 +148,99 @@ export function ModelsConfidence() {
         />
       </div>
 
-      {error != null && <ErrorMessage message={error.message} />}
-      {loading ? <Loading /> : <ConfidenceHeatmap models={models} onCellClick={handleCellClick} />}
+      {/* Model filter */}
+      {allModels.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Models:</span>
+            {selectedModelIds === null || isDefaultSelection ? (
+              <span className="text-xs font-medium text-gray-700">Default</span>
+            ) : selectedModelIds.length === 0 ? (
+              <span className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700">
+                None selected
+              </span>
+            ) : (
+              <span className="text-xs font-medium text-gray-700">
+                {selectedModelIds.length} of {allModels.length}
+              </span>
+            )}
+            {selectedModelIds !== null && !isDefaultSelection && defaultModelIds.length > 0 && (
+              // eslint-disable-next-line react/forbid-elements
+              <button
+                type="button"
+                className="text-xs text-teal-600 underline-offset-2 hover:text-teal-800 hover:underline"
+                onClick={() => setSelectedModelIds(defaultModelIds)}
+              >
+                Reset to default
+              </button>
+            )}
+            {/* eslint-disable-next-line react/forbid-elements */}
+            <button
+              type="button"
+              className="text-xs text-gray-500 underline-offset-2 hover:text-gray-700 hover:underline"
+              onClick={() => setModelFilterOpen((v) => !v)}
+            >
+              {modelFilterOpen ? '▴ Close' : '▾ Change'}
+            </button>
+          </div>
+          {modelFilterOpen && (
+            <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-xs font-medium uppercase tracking-wide text-gray-600">
+                  Select models
+                </span>
+                <div className="flex items-center gap-3">
+                  {/* eslint-disable-next-line react/forbid-elements */}
+                  <button
+                    type="button"
+                    className="text-xs font-medium text-teal-700 hover:text-teal-800"
+                    onClick={() => setSelectedModelIds(allModels.map((m) => m.modelId))}
+                  >
+                    Select all
+                  </button>
+                  {/* eslint-disable-next-line react/forbid-elements */}
+                  <button
+                    type="button"
+                    className="text-xs font-medium text-gray-600 hover:text-gray-800"
+                    onClick={() => setSelectedModelIds([])}
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+              <div className="max-h-52 space-y-2 overflow-y-auto">
+                {allModels.map((m) => (
+                  <label
+                    key={m.modelId}
+                    className="flex cursor-pointer items-center gap-2 text-sm text-gray-700"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={(selectedModelIds ?? []).includes(m.modelId)}
+                      onChange={() => handleToggleModel(m.modelId)}
+                      className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+                    />
+                    <span className="flex-1 truncate" title={m.modelId}>
+                      {m.displayName}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
 
-      <ConfidenceTranscriptsDrawer
-        open={drawerState != null}
-        modelId={drawerState?.modelId ?? ''}
-        modelLabel={drawerState?.modelLabel ?? ''}
-        valueKey={drawerState?.valueKey ?? null}
-        signature={selectedSignature}
-        onClose={() => setDrawerState(null)}
-      />
+      {error != null && <ErrorMessage message={error.message} />}
+      {loading ? (
+        <Loading />
+      ) : (
+        <ConfidenceHeatmap
+          models={models}
+          selectedModelIds={filteredModelIds ?? undefined}
+          onCellClick={handleCellClick}
+        />
+      )}
     </div>
   );
 }

--- a/cloud/apps/web/src/pages/ModelsConfidenceValueDetail.tsx
+++ b/cloud/apps/web/src/pages/ModelsConfidenceValueDetail.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useQuery } from 'urql';
+import { ErrorMessage } from '../components/ui/ErrorMessage';
+import { Loading } from '../components/ui/Loading';
+import { TranscriptList } from '../components/runs/TranscriptList';
+import { TranscriptViewer } from '../components/runs/TranscriptViewer';
+import { ConditionMatrix, type MatrixCondition } from '../components/domains/ConditionMatrix';
+import type { Transcript } from '../api/operations/runs';
+import {
+  CONFIDENCE_VALUE_DETAIL_QUERY,
+  type ConfidenceValueDetailQueryResult,
+  type ConfidenceValueDetailQueryVariables,
+  type ConfidenceValueDetailCondition,
+} from '../api/operations/confidenceValueDetail';
+import {
+  CONFIDENCE_TRANSCRIPTS_QUERY,
+  type ConfidenceTranscript,
+  type ConfidenceTranscriptsQueryResult,
+  type ConfidenceTranscriptsQueryVariables,
+} from '../api/operations/confidenceTranscripts';
+import { VALUE_LABELS, type ValueKey } from '../data/domainAnalysisData';
+
+function mapToTranscript(t: ConfidenceTranscript): Transcript {
+  return {
+    id: t.id,
+    runId: t.runId,
+    scenarioId: t.scenarioId ?? null,
+    modelId: t.modelId,
+    modelVersion: null,
+    content: t.content,
+    decisionModelV2: t.decisionModelV2,
+    turnCount: t.turnCount,
+    tokenCount: t.tokenCount,
+    durationMs: t.durationMs,
+    estimatedCost: null,
+    createdAt: t.createdAt,
+    lastAccessedAt: null,
+  };
+}
+
+function toMatrixCondition(c: ConfidenceValueDetailCondition): MatrixCondition {
+  return {
+    scenarioId: c.scenarioId ?? null,
+    conditionName: c.conditionName,
+    dimensions: (c.dimensions as Record<string, string | number> | null) ?? null,
+    prioritized: c.prioritized,
+    deprioritized: c.deprioritized,
+    neutral: c.neutral,
+    totalTrials: c.totalTrials,
+    unknownCount: c.unknownCount,
+    strongly: c.strongly,
+    somewhat: c.somewhat,
+    opponentSomewhat: c.opponentSomewhat,
+    opponentStrongly: c.opponentStrongly,
+  };
+}
+
+export function ModelsConfidenceValueDetail() {
+  const [searchParams] = useSearchParams();
+  const modelId = searchParams.get('modelId') ?? '';
+  const valueKey = searchParams.get('valueKey') ?? '';
+  const signature = searchParams.get('signature') ?? '';
+  const modelLabelParam = searchParams.get('modelLabel');
+
+  const backParams = new URLSearchParams();
+  if (signature !== '') backParams.set('signature', signature);
+  const backLink = `/models/confidence${backParams.size > 0 ? `?${backParams.toString()}` : ''}`;
+
+  const [selectedCondition, setSelectedCondition] = useState<{
+    definitionId: string;
+    conditionName: string;
+    scenarioId: string | null;
+  } | null>(null);
+  const [selectedTranscript, setSelectedTranscript] = useState<Transcript | null>(null);
+
+  const [{ data, fetching, error }] = useQuery<
+    ConfidenceValueDetailQueryResult,
+    ConfidenceValueDetailQueryVariables
+  >({
+    query: CONFIDENCE_VALUE_DETAIL_QUERY,
+    variables: {
+      modelId,
+      valueKey,
+      signature: signature !== '' ? signature : undefined,
+    },
+    pause: modelId === '' || valueKey === '',
+    requestPolicy: 'cache-and-network',
+  });
+
+  const [{ data: transcriptData, fetching: transcriptsFetching, error: transcriptsError }] =
+    useQuery<ConfidenceTranscriptsQueryResult, ConfidenceTranscriptsQueryVariables>({
+      query: CONFIDENCE_TRANSCRIPTS_QUERY,
+      variables: {
+        modelId,
+        valueKey,
+        signature: signature !== '' ? signature : undefined,
+        limit: 100,
+        definitionId: selectedCondition?.definitionId ?? undefined,
+        scenarioId: selectedCondition?.scenarioId ?? undefined,
+      },
+      pause: selectedCondition === null || modelId === '' || valueKey === '',
+      requestPolicy: 'cache-and-network',
+    });
+
+  useEffect(() => {
+    setSelectedTranscript(null);
+  }, [selectedCondition?.definitionId, selectedCondition?.scenarioId]);
+
+  const detail = data?.confidenceValueDetail ?? null;
+
+  const transcripts = useMemo(
+    () =>
+      ((transcriptData?.confidenceTranscripts ?? []) as ConfidenceTranscript[]).map(mapToTranscript),
+    [transcriptData],
+  );
+
+  const valueLabel = VALUE_LABELS[valueKey as ValueKey] ?? valueKey;
+  const modelLabel = detail?.modelLabel ?? modelLabelParam ?? modelId;
+
+  const selectedConditionKey =
+    selectedCondition === null
+      ? ''
+      : `${selectedCondition.definitionId}:${selectedCondition.scenarioId ?? '__unknown__'}`;
+
+  const handleConditionClick = (
+    definitionId: string,
+    conditionName: string,
+    scenarioId: string | null,
+  ) => {
+    const clickedKey = `${definitionId}:${scenarioId ?? '__unknown__'}`;
+    if (selectedConditionKey === clickedKey) {
+      setSelectedCondition(null);
+      return;
+    }
+    setSelectedCondition({ definitionId, conditionName, scenarioId });
+  };
+
+  if (modelId === '' || valueKey === '') {
+    return (
+      <div className="space-y-4">
+        <ErrorMessage message="Missing parameters. Open this page from a confidence heatmap cell." />
+        <Link
+          to="/models/confidence"
+          className="inline-flex text-sm text-sky-700 hover:text-sky-900 hover:underline"
+        >
+          Back to Confidence Heatmap
+        </Link>
+      </div>
+    );
+  }
+
+  if (fetching && data == null) return <Loading size="lg" text="Loading detail…" />;
+
+  if (error != null || detail == null) {
+    return (
+      <div className="space-y-4">
+        <ErrorMessage
+          message={`Failed to load confidence detail: ${error?.message ?? 'Unknown error'}`}
+        />
+        <Link
+          to={backLink}
+          className="inline-flex text-sm text-sky-700 hover:text-sky-900 hover:underline"
+        >
+          ← Back to Confidence Heatmap
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Link
+          to={backLink}
+          className="inline-flex text-sm text-sky-700 hover:text-sky-900 hover:underline"
+        >
+          ← Back to Confidence Heatmap
+        </Link>
+        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Confidence Detail</h1>
+        <p className="text-sm text-gray-600">
+          {modelLabel} · {valueLabel}
+        </p>
+      </div>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-4">
+        <h2 className="text-base font-medium text-gray-900">
+          Vignette Condition Tables ({valueLabel})
+        </h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Each table is one vignette containing this value, filtered to {modelLabel}.
+        </p>
+        <div className="mt-4 space-y-4">
+          {detail.vignettes.length === 0 && (
+            <div className="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+              No transcript data found for this model and value.
+            </div>
+          )}
+          {detail.vignettes.map((vignette) => {
+            const otherLabel = VALUE_LABELS[vignette.otherValueKey as ValueKey] ?? vignette.otherValueKey;
+            const matrixConditions = vignette.conditions.map(toMatrixCondition);
+            return (
+              <article
+                key={vignette.definitionId}
+                className="rounded border border-gray-200 bg-white"
+              >
+                <header className="border-b border-gray-200 bg-gray-50 px-3 py-2">
+                  <p className="text-sm font-medium text-gray-900">
+                    {vignette.definitionName} (v{vignette.definitionVersion})
+                  </p>
+                  <p className="text-xs text-gray-600">
+                    Pair:{' '}
+                    <strong className="font-semibold text-blue-700">{valueLabel}</strong> vs{' '}
+                    <strong className="font-semibold text-orange-700">{otherLabel}</strong>
+                    {' '}· Trials: {vignette.totalTrials}
+                  </p>
+                </header>
+                {matrixConditions.length === 0 ? (
+                  <div className="px-3 py-3 text-center text-xs text-gray-500">
+                    No condition-level trials available.
+                  </div>
+                ) : (
+                  <div className="space-y-3 px-3 py-3">
+                    <ConditionMatrix
+                      vignetteId={vignette.definitionId}
+                      conditions={matrixConditions}
+                      selectedConditionKey={selectedConditionKey}
+                      onSelect={handleConditionClick}
+                    />
+                  </div>
+                )}
+                {selectedCondition !== null &&
+                  selectedCondition.definitionId === vignette.definitionId && (
+                    <div className="border-t border-gray-200 bg-gray-50 px-3 py-3">
+                      <div className="mb-2 flex items-center justify-between gap-3">
+                        <p className="text-xs font-medium text-gray-800">
+                          Transcripts for condition: {selectedCondition.conditionName}
+                        </p>
+                        <p className="text-[11px] text-gray-500">
+                          Click transcript to view full conversation
+                        </p>
+                      </div>
+                      {transcriptsFetching && (
+                        <Loading size="sm" text="Loading transcripts…" />
+                      )}
+                      {transcriptsError != null && (
+                        <ErrorMessage
+                          message={`Failed to load transcripts: ${transcriptsError.message}`}
+                        />
+                      )}
+                      {!transcriptsFetching &&
+                        transcriptsError == null &&
+                        transcripts.length === 0 && (
+                          <p className="text-xs text-gray-500">
+                            No transcripts found for this condition and model.
+                          </p>
+                        )}
+                      {!transcriptsFetching &&
+                        transcriptsError == null &&
+                        transcripts.length > 0 && (
+                          <TranscriptList
+                            transcripts={transcripts}
+                            onSelect={setSelectedTranscript}
+                            groupByModel={false}
+                            decisionDisplayMode="audit"
+                          />
+                        )}
+                    </div>
+                  )}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      {selectedTranscript !== null && (
+        <TranscriptViewer
+          transcript={selectedTranscript}
+          onClose={() => setSelectedTranscript(null)}
+          decisionDisplayMode="audit"
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Clicking a confidence heatmap cell now navigates to a full detail page (`/models/confidence/detail`) instead of opening a drawer
- The detail page shows per-vignette condition tables (ConditionMatrix) with inline transcript drill-down — same pattern as Domain Analysis Value Detail
- Added model filter to the heatmap page that defaults to Settings → Default models; supports select all / clear / reset to default
- New `confidenceValueDetail` API resolver groups transcripts by vignette + condition (strong/lean/neutral counts) cross-domain for a given modelId + valueKey + signature
- Extended `confidenceTranscripts` with optional `definitionId` + `scenarioId` args for condition-level transcript filtering

## Test plan
- [ ] Preflight passed (lint + build — both clean, 0 errors)
- [ ] Click a heatmap cell → navigates to /models/confidence/detail with correct params
- [ ] Detail page shows vignette headers with condition matrices
- [ ] Click a condition cell → transcript list appears inline
- [ ] Click a transcript → TranscriptViewer opens
- [ ] Back link returns to /models/confidence with signature preserved
- [ ] Model filter defaults to Default models from Settings
- [ ] Toggling checkboxes filters heatmap rows immediately

## Production smoke test
New resolver confidenceValueDetail — verify after deploy returns non-empty vignettes for a known model + valueKey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)