### PR TITLE
feat: domain filter for confidence heatmap

### DIFF
--- a/cloud/apps/api/src/graphql/queries/confidence-transcripts.ts
+++ b/cloud/apps/api/src/graphql/queries/confidence-transcripts.ts
@@ -16,6 +16,7 @@ builder.queryField('confidenceTranscripts', (t) =>
       limit: t.arg.int({ required: false }),
       definitionId: t.arg.string({ required: false }),
       scenarioId: t.arg.string({ required: false }),
+      domainId: t.arg.id({ required: false }),
     },
     resolve: async (_root, args) => {
       const modelId = args.modelId;
@@ -28,6 +29,7 @@ builder.queryField('confidenceTranscripts', (t) =>
         typeof args.scenarioId === 'string' && args.scenarioId.trim() !== ''
           ? args.scenarioId.trim()
           : null;
+      const domainId = args.domainId != null ? String(args.domainId) : null;
       if (!isDomainAnalysisValueKey(rawValueKey)) {
         throw new ValidationError(`Unsupported value key: ${rawValueKey}`);
       }
@@ -67,7 +69,10 @@ builder.queryField('confidenceTranscripts', (t) =>
       }
 
       const definitions = await db.definition.findMany({
-        where: { id: { in: definitionIds } },
+        where: {
+          id: { in: definitionIds },
+          ...(domainId !== null ? { domainId } : {}),
+        },
         select: { id: true, content: true },
       });
 

--- a/cloud/apps/api/src/graphql/queries/confidence-value-detail.ts
+++ b/cloud/apps/api/src/graphql/queries/confidence-value-detail.ts
@@ -16,6 +16,7 @@ builder.queryField('confidenceValueDetail', (t) =>
       modelId: t.arg.string({ required: true }),
       valueKey: t.arg.string({ required: true }),
       signature: t.arg.string({ required: false }),
+      domainId: t.arg.id({ required: false }),
     },
     resolve: async (_root, args) => {
       const modelId = args.modelId;
@@ -28,6 +29,7 @@ builder.queryField('confidenceValueDetail', (t) =>
         typeof args.signature === 'string' && args.signature.trim() !== ''
           ? args.signature.trim()
           : null;
+      const domainId = args.domainId != null ? String(args.domainId) : null;
 
       // Resolve model display name.
       const modelMeta = await db.llmModel.findFirst({
@@ -68,8 +70,12 @@ builder.queryField('confidenceValueDetail', (t) =>
       }
 
       // Find definitions that have this valueKey in their pair.
+      // When domainId is provided, scope to that domain only.
       const definitions = await db.definition.findMany({
-        where: { id: { in: definitionIds } },
+        where: {
+          id: { in: definitionIds },
+          ...(domainId !== null ? { domainId } : {}),
+        },
         select: { id: true, name: true, version: true, content: true },
       });
 

--- a/cloud/apps/api/src/graphql/queries/models-confidence.ts
+++ b/cloud/apps/api/src/graphql/queries/models-confidence.ts
@@ -19,9 +19,11 @@ builder.queryField('modelsConfidence', (t) =>
     type: ModelsConfidenceResultRef,
     args: {
       signature: t.arg.string({ required: false }),
+      domainId: t.arg.id({ required: false }),
     },
     resolve: async (_root, args) => {
       const signature = args.signature != null ? String(args.signature) : null;
+      const domainId = args.domainId != null ? String(args.domainId) : null;
 
       const activeModels = await getModelsFromDatabase({
         activeOnly: true,
@@ -78,10 +80,23 @@ builder.queryField('modelsConfidence', (t) =>
       )];
 
       // Fetch definition content once per definition to get the value pair.
+      // When domainId is provided, scope to definitions belonging to that domain.
       const definitions = await db.definition.findMany({
-        where: { id: { in: definitionIds } },
+        where: {
+          id: { in: definitionIds },
+          ...(domainId !== null ? { domainId } : {}),
+        },
         select: { id: true, content: true },
       });
+
+      // When domain-scoped, restrict source runs to those whose definition is in the domain.
+      const allowedDefIds = new Set(definitions.map((d) => d.id));
+      const filteredRunIds = domainId !== null
+        ? sourceRunIds.filter((id) => {
+          const defId = runToDefinitionId.get(id);
+          return defId != null && allowedDefIds.has(defId);
+        })
+        : sourceRunIds;
 
       const defValuePairMap = new Map<string, DomainAnalysisValuePair | null>();
       for (const def of definitions) {
@@ -92,6 +107,8 @@ builder.queryField('modelsConfidence', (t) =>
       // in the JSONB. This avoids loading full 1KB decisionMetadata blobs for each
       // transcript (313k transcripts × 1KB = 307 MB overflows the Prisma NAPI buffer).
       // 99.99% of transcripts have a cacheVersion=2 canonical decision in summaryCache.
+      if (filteredRunIds.length === 0) return emptyResult;
+
       const rawRows = await db.$queryRaw<Array<{
         model_id: string;
         run_id: string;
@@ -104,7 +121,7 @@ builder.queryField('modelsConfidence', (t) =>
           SUM(CASE WHEN t.decision_metadata #>> '{summaryCache,summary,canonicalDecision,strength}' = 'strong' THEN 1 ELSE 0 END)::int AS strong_count,
           SUM(CASE WHEN t.decision_metadata #>> '{summaryCache,summary,canonicalDecision,strength}' = 'lean'   THEN 1 ELSE 0 END)::int AS lean_count
         FROM transcripts t
-        WHERE t.run_id = ANY(${sourceRunIds})
+        WHERE t.run_id = ANY(${filteredRunIds})
           AND t.deleted_at IS NULL
           AND t.decision_metadata #>> '{summaryCache,summary,canonicalDecision,cacheVersion}' = '2'
         GROUP BY t.model_id, t.run_id

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -2359,8 +2359,8 @@ type Query {
   ): [AvailableModel!]!
   availableSignatures: [AvailableSignature!]!
   circumplexAnalysis(minTrialsPerValue: Int, modelIds: [String!]!, signature: String!): CircumplexAnalysisResult!
-  confidenceTranscripts(definitionId: String, limit: Int, modelId: String!, scenarioId: String, signature: String, valueKey: String!): [DomainAnalysisConditionTranscript!]!
-  confidenceValueDetail(modelId: String!, signature: String, valueKey: String!): ConfidenceValueDetailResult!
+  confidenceTranscripts(definitionId: String, domainId: ID, limit: Int, modelId: String!, scenarioId: String, signature: String, valueKey: String!): [DomainAnalysisConditionTranscript!]!
+  confidenceValueDetail(domainId: ID, modelId: String!, signature: String, valueKey: String!): ConfidenceValueDetailResult!
 
   """Fetch a single definition by ID. Returns null if not found."""
   definition(
@@ -2447,9 +2447,9 @@ type Query {
     withoutDomain: Boolean
   ): [Definition!]!
   domain(id: ID!): Domain
-  domainAnalysis(domainId: ID!, scope: String, scoreMethod: String, signature: String): DomainAnalysisResult!
+  domainAnalysis(domainId: ID!, scope: String, signature: String): DomainAnalysisResult!
   domainAnalysisConditionTranscripts(definitionId: ID!, domainId: ID!, limit: Int, modelId: String!, scenarioId: ID, signature: String, valueKey: String!): [DomainAnalysisConditionTranscript!]!
-  domainAnalysisValueDetail(domainId: ID!, modelId: String!, scoreMethod: String, signature: String, valueKey: String!): DomainAnalysisValueDetailResult!
+  domainAnalysisValueDetail(domainId: ID!, modelId: String!, signature: String, valueKey: String!): DomainAnalysisValueDetailResult!
   domainAvailableSignatures(domainId: ID!, scope: String): [DomainAvailableSignature!]!
   domainConfigSnapshots(domainId: ID!, limit: Int): [DomainConfigSnapshotSummary!]!
   domainContext(id: ID!): DomainContext
@@ -2592,7 +2592,7 @@ type Query {
     """Optional batch signature to filter snapshots (e.g. vnewtd, vnewt0)"""
     signature: String
   ): ModelsAnalysisResult!
-  modelsConfidence(signature: String): ModelsConfidenceResult!
+  modelsConfidence(domainId: ID, signature: String): ModelsConfidenceResult!
   modelsConsistency(domainId: ID, minScenarios: Int, providerId: ID, signature: String!): ModelsConsistencyResult!
 
   """
@@ -3078,7 +3078,17 @@ type Run {
 """Structured anomaly record for a run"""
 type RunAnomaly {
   acknowledgedByUserId: String
+
+  """
+  ID of the most recent non-deleted transcript for this slot. For INVALID_RESPONSE_FAILURE only — queries by (runId, scenarioId, modelId, sampleIndex). Handles reprobe-fixed anomalies where details.transcriptId still points to the original. Null for non-slot types.
+  """
+  activeTranscriptId: String
   details: JSON!
+
+  """
+  Dimension values from the scenario content for slot-keyed anomaly types (Record<string, string>). Null for non-slot types.
+  """
+  dimensionValues: JSON
 
   """
   Human-friendly anomaly type label. For unknown future enum values, returns the raw enum string.
@@ -3127,6 +3137,11 @@ type RunAnomaly {
   """The run this anomaly belongs to"""
   run: Run!
   runId: String!
+
+  """
+  Scenario (vignette) name for slot-keyed anomaly types. Null for non-slot types or when the scenario cannot be found.
+  """
+  scenarioName: String
   source: RunAnomalySource!
   subject: String!
   type: RunAnomalyType!

--- a/cloud/apps/web/src/api/operations/confidenceTranscripts.graphql
+++ b/cloud/apps/web/src/api/operations/confidenceTranscripts.graphql
@@ -1,5 +1,5 @@
-query ConfidenceTranscripts($modelId: String!, $valueKey: String!, $signature: String, $limit: Int, $definitionId: String, $scenarioId: String) {
-  confidenceTranscripts(modelId: $modelId, valueKey: $valueKey, signature: $signature, limit: $limit, definitionId: $definitionId, scenarioId: $scenarioId) {
+query ConfidenceTranscripts($modelId: String!, $valueKey: String!, $signature: String, $limit: Int, $definitionId: String, $scenarioId: String, $domainId: ID) {
+  confidenceTranscripts(modelId: $modelId, valueKey: $valueKey, signature: $signature, limit: $limit, definitionId: $definitionId, scenarioId: $scenarioId, domainId: $domainId) {
     id
     runId
     scenarioId

--- a/cloud/apps/web/src/api/operations/confidenceValueDetail.graphql
+++ b/cloud/apps/web/src/api/operations/confidenceValueDetail.graphql
@@ -1,5 +1,5 @@
-query ConfidenceValueDetail($modelId: String!, $valueKey: String!, $signature: String) {
-  confidenceValueDetail(modelId: $modelId, valueKey: $valueKey, signature: $signature) {
+query ConfidenceValueDetail($modelId: String!, $valueKey: String!, $signature: String, $domainId: ID) {
+  confidenceValueDetail(modelId: $modelId, valueKey: $valueKey, signature: $signature, domainId: $domainId) {
     modelLabel
     valueKey
     vignettes {

--- a/cloud/apps/web/src/api/operations/modelsConfidence.graphql
+++ b/cloud/apps/web/src/api/operations/modelsConfidence.graphql
@@ -1,5 +1,5 @@
-query ModelsConfidence($signature: String) {
-  modelsConfidence(signature: $signature) {
+query ModelsConfidence($signature: String, $domainId: ID) {
+  modelsConfidence(signature: $signature, domainId: $domainId) {
     models {
       modelId
       label

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -2812,6 +2812,7 @@ export type QueryCircumplexAnalysisArgs = {
 
 export type QueryConfidenceTranscriptsArgs = {
   definitionId?: InputMaybe<Scalars['String']['input']>;
+  domainId?: InputMaybe<Scalars['ID']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   modelId: Scalars['String']['input'];
   scenarioId?: InputMaybe<Scalars['String']['input']>;
@@ -2821,6 +2822,7 @@ export type QueryConfidenceTranscriptsArgs = {
 
 
 export type QueryConfidenceValueDetailArgs = {
+  domainId?: InputMaybe<Scalars['ID']['input']>;
   modelId: Scalars['String']['input'];
   signature?: InputMaybe<Scalars['String']['input']>;
   valueKey: Scalars['String']['input'];
@@ -3067,6 +3069,7 @@ export type QueryModelsAnalysisArgs = {
 
 
 export type QueryModelsConfidenceArgs = {
+  domainId?: InputMaybe<Scalars['ID']['input']>;
   signature?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3448,7 +3451,11 @@ export type RunTranscriptsArgs = {
 export type RunAnomaly = {
   __typename?: 'RunAnomaly';
   acknowledgedByUserId?: Maybe<Scalars['String']['output']>;
+  /** ID of the most recent non-deleted transcript for this slot. For INVALID_RESPONSE_FAILURE only — queries by (runId, scenarioId, modelId, sampleIndex). Handles reprobe-fixed anomalies where details.transcriptId still points to the original. Null for non-slot types. */
+  activeTranscriptId?: Maybe<Scalars['String']['output']>;
   details: Scalars['JSON']['output'];
+  /** Dimension values from the scenario content for slot-keyed anomaly types (Record<string, string>). Null for non-slot types. */
+  dimensionValues?: Maybe<Scalars['JSON']['output']>;
   /** Human-friendly anomaly type label. For unknown future enum values, returns the raw enum string. */
   displayLabel: Scalars['String']['output'];
   /** Human-friendly subject label. Type-aware: slot-keyed types render as "model X · sample N", transcript-keyed types render as "transcript <short>", others return the raw subject. */
@@ -3472,12 +3479,8 @@ export type RunAnomaly = {
   /** The run this anomaly belongs to */
   run: Run;
   runId: Scalars['String']['output'];
-  /** ID of the most recent non-deleted transcript for this slot. Null for non-slot types. */
-  activeTranscriptId?: Maybe<Scalars['String']['output']>;
   /** Scenario (vignette) name for slot-keyed anomaly types. Null for non-slot types or when the scenario cannot be found. */
   scenarioName?: Maybe<Scalars['String']['output']>;
-  /** Dimension values from the scenario content for slot-keyed anomaly types. */
-  dimensionValues?: Maybe<Scalars['JSON']['output']>;
   source: RunAnomalySource;
   subject: Scalars['String']['output'];
   type: RunAnomalyType;
@@ -4049,6 +4052,7 @@ export type ConfidenceTranscriptsQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
   definitionId?: InputMaybe<Scalars['String']['input']>;
   scenarioId?: InputMaybe<Scalars['String']['input']>;
+  domainId?: InputMaybe<Scalars['ID']['input']>;
 }>;
 
 
@@ -4058,6 +4062,7 @@ export type ConfidenceValueDetailQueryVariables = Exact<{
   modelId: Scalars['String']['input'];
   valueKey: Scalars['String']['input'];
   signature?: InputMaybe<Scalars['String']['input']>;
+  domainId?: InputMaybe<Scalars['ID']['input']>;
 }>;
 
 
@@ -4605,6 +4610,7 @@ export type ModelsAnalysisQuery = { __typename?: 'Query', modelsAnalysis: { __ty
 
 export type ModelsConfidenceQueryVariables = Exact<{
   signature?: InputMaybe<Scalars['String']['input']>;
+  domainId?: InputMaybe<Scalars['ID']['input']>;
 }>;
 
 
@@ -5418,7 +5424,7 @@ export function useComparisonRunsListQuery(options?: Omit<Urql.UseQueryArgs<Comp
   return Urql.useQuery<ComparisonRunsListQuery, ComparisonRunsListQueryVariables>({ query: ComparisonRunsListDocument, ...options });
 };
 export const ConfidenceTranscriptsDocument = gql`
-    query ConfidenceTranscripts($modelId: String!, $valueKey: String!, $signature: String, $limit: Int, $definitionId: String, $scenarioId: String) {
+    query ConfidenceTranscripts($modelId: String!, $valueKey: String!, $signature: String, $limit: Int, $definitionId: String, $scenarioId: String, $domainId: ID) {
   confidenceTranscripts(
     modelId: $modelId
     valueKey: $valueKey
@@ -5426,6 +5432,7 @@ export const ConfidenceTranscriptsDocument = gql`
     limit: $limit
     definitionId: $definitionId
     scenarioId: $scenarioId
+    domainId: $domainId
   ) {
     id
     runId
@@ -5445,11 +5452,12 @@ export function useConfidenceTranscriptsQuery(options: Omit<Urql.UseQueryArgs<Co
   return Urql.useQuery<ConfidenceTranscriptsQuery, ConfidenceTranscriptsQueryVariables>({ query: ConfidenceTranscriptsDocument, ...options });
 };
 export const ConfidenceValueDetailDocument = gql`
-    query ConfidenceValueDetail($modelId: String!, $valueKey: String!, $signature: String) {
+    query ConfidenceValueDetail($modelId: String!, $valueKey: String!, $signature: String, $domainId: ID) {
   confidenceValueDetail(
     modelId: $modelId
     valueKey: $valueKey
     signature: $signature
+    domainId: $domainId
   ) {
     modelLabel
     valueKey
@@ -5890,11 +5898,7 @@ export function useDeleteDomainContextMutation() {
 };
 export const DomainAnalysisDocument = gql`
     query DomainAnalysis($domainId: ID!, $scope: String, $signature: String) {
-  domainAnalysis(
-    domainId: $domainId
-    scope: $scope
-    signature: $signature
-  ) {
+  domainAnalysis(domainId: $domainId, scope: $scope, signature: $signature) {
     domainId
     domainName
     contributionSummary {
@@ -7047,8 +7051,8 @@ export function useModelsAnalysisQuery(options?: Omit<Urql.UseQueryArgs<ModelsAn
   return Urql.useQuery<ModelsAnalysisQuery, ModelsAnalysisQueryVariables>({ query: ModelsAnalysisDocument, ...options });
 };
 export const ModelsConfidenceDocument = gql`
-    query ModelsConfidence($signature: String) {
-  modelsConfidence(signature: $signature) {
+    query ModelsConfidence($signature: String, $domainId: ID) {
+  modelsConfidence(signature: $signature, domainId: $domainId) {
     models {
       modelId
       label

--- a/cloud/apps/web/src/pages/ModelsConfidence.tsx
+++ b/cloud/apps/web/src/pages/ModelsConfidence.tsx
@@ -19,11 +19,15 @@ import {
   buildDomainShiftSignatureOptions,
   getDefaultDomainShiftSignature,
 } from './domainValueShiftHeatmapUtils';
+import { useDomains } from '../hooks/useDomains';
 
 export function ModelsConfidence() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const signatureParam = searchParams.get('signature');
+
+  const { domains } = useDomains();
+  const [selectedDomainId, setSelectedDomainId] = useState<string | null>(null);
 
   const [{ data: signatureData }] = useQuery<AvailableSignaturesQueryResult>({
     query: AVAILABLE_SIGNATURES_QUERY,
@@ -58,9 +62,20 @@ export function ModelsConfidence() {
     }
   }, [selectedSignature, signatureParam, availableSignatures.length, setSearchParams]);
 
+  const domainOptions = useMemo(
+    () => [
+      { value: '', label: 'All domains' },
+      ...domains.map((d) => ({ value: d.id, label: d.name })),
+    ],
+    [domains],
+  );
+
   const [{ data, fetching, error }] = useQuery<ModelsConfidenceQueryResult, ModelsConfidenceQueryVariables>({
     query: MODELS_CONFIDENCE_QUERY,
-    variables: { signature: selectedSignature },
+    variables: {
+      signature: selectedSignature,
+      domainId: selectedDomainId ?? undefined,
+    },
     requestPolicy: 'cache-and-network',
   });
 
@@ -103,9 +118,12 @@ export function ModelsConfidence() {
         valueKey,
         signature: selectedSignature,
       });
+      if (selectedDomainId !== null) {
+        params.set('domainId', selectedDomainId);
+      }
       navigate(`/models/confidence/detail?${params.toString()}`);
     },
-    [navigate, selectedSignature],
+    [navigate, selectedSignature, selectedDomainId],
   );
 
   // Model filter state helpers.
@@ -136,100 +154,115 @@ export function ModelsConfidence() {
         </p>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3">
-        <label className="text-sm text-gray-600">Signature</label>
-        <Select
-          value={selectedSignature}
-          onChange={(value) => {
-            setSelectedSignature(value);
-            setSearchParams({ signature: value });
-          }}
-          options={signatureOptions}
-        />
-      </div>
+      {/* Controls row: Signature | Domain | Models */}
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-2">
+            <label className="text-sm text-gray-600">Signature</label>
+            <Select
+              value={selectedSignature}
+              onChange={(value) => {
+                setSelectedSignature(value);
+                setSearchParams({ signature: value });
+              }}
+              options={signatureOptions}
+            />
+          </div>
 
-      {/* Model filter */}
-      {allModels.length > 0 && (
-        <div className="space-y-2">
-          <div className="flex flex-wrap items-center gap-3">
-            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Models:</span>
-            {selectedModelIds === null || isDefaultSelection ? (
-              <span className="text-xs font-medium text-gray-700">Default</span>
-            ) : selectedModelIds.length === 0 ? (
-              <span className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700">
-                None selected
-              </span>
-            ) : (
-              <span className="text-xs font-medium text-gray-700">
-                {selectedModelIds.length} of {allModels.length}
-              </span>
-            )}
-            {selectedModelIds !== null && !isDefaultSelection && defaultModelIds.length > 0 && (
-              // eslint-disable-next-line react/forbid-elements
+          {domains.length > 0 && (
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-gray-600">Domain</label>
+              <Select
+                value={selectedDomainId ?? ''}
+                onChange={(value) => setSelectedDomainId(value === '' ? null : value)}
+                options={domainOptions}
+              />
+            </div>
+          )}
+
+          {allModels.length > 0 && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600">Models:</span>
+              {selectedModelIds === null || isDefaultSelection ? (
+                <span className="text-xs font-medium text-gray-700">Default</span>
+              ) : selectedModelIds.length === 0 ? (
+                <span className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700">
+                  None selected
+                </span>
+              ) : (
+                <span className="text-xs font-medium text-gray-700">
+                  {selectedModelIds.length} of {allModels.length}
+                </span>
+              )}
+              {selectedModelIds !== null && !isDefaultSelection && defaultModelIds.length > 0 && (
+                // eslint-disable-next-line react/forbid-elements
+                <button
+                  type="button"
+                  className="text-xs text-teal-600 underline-offset-2 hover:text-teal-800 hover:underline"
+                  onClick={() => setSelectedModelIds(defaultModelIds)}
+                >
+                  Reset to default
+                </button>
+              )}
+              {/* eslint-disable-next-line react/forbid-elements */}
               <button
                 type="button"
-                className="text-xs text-teal-600 underline-offset-2 hover:text-teal-800 hover:underline"
-                onClick={() => setSelectedModelIds(defaultModelIds)}
+                className="text-xs text-gray-500 underline-offset-2 hover:text-gray-700 hover:underline"
+                onClick={() => setModelFilterOpen((v) => !v)}
               >
-                Reset to default
+                {modelFilterOpen ? '▴ Close' : '▾ Change'}
               </button>
-            )}
-            {/* eslint-disable-next-line react/forbid-elements */}
-            <button
-              type="button"
-              className="text-xs text-gray-500 underline-offset-2 hover:text-gray-700 hover:underline"
-              onClick={() => setModelFilterOpen((v) => !v)}
-            >
-              {modelFilterOpen ? '▴ Close' : '▾ Change'}
-            </button>
-          </div>
-          {modelFilterOpen && (
-            <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-              <div className="mb-3 flex items-center justify-between">
-                <span className="text-xs font-medium uppercase tracking-wide text-gray-600">
-                  Select models
-                </span>
-                <div className="flex items-center gap-3">
-                  {/* eslint-disable-next-line react/forbid-elements */}
-                  <button
-                    type="button"
-                    className="text-xs font-medium text-teal-700 hover:text-teal-800"
-                    onClick={() => setSelectedModelIds(allModels.map((m) => m.modelId))}
-                  >
-                    Select all
-                  </button>
-                  {/* eslint-disable-next-line react/forbid-elements */}
-                  <button
-                    type="button"
-                    className="text-xs font-medium text-gray-600 hover:text-gray-800"
-                    onClick={() => setSelectedModelIds([])}
-                  >
-                    Clear
-                  </button>
-                </div>
-              </div>
-              <div className="max-h-52 space-y-2 overflow-y-auto">
-                {allModels.map((m) => (
-                  <label
-                    key={m.modelId}
-                    className="flex cursor-pointer items-center gap-2 text-sm text-gray-700"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={(selectedModelIds ?? []).includes(m.modelId)}
-                      onChange={() => handleToggleModel(m.modelId)}
-                      className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                    />
-                    <span className="flex-1 truncate" title={m.modelId}>
-                      {m.displayName}
-                    </span>
-                  </label>
-                ))}
-              </div>
             </div>
           )}
         </div>
-      )}
+
+        {/* Model filter panel (expands below the controls row) */}
+        {modelFilterOpen && allModels.length > 0 && (
+          <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+            <div className="mb-3 flex items-center justify-between">
+              <span className="text-xs font-medium uppercase tracking-wide text-gray-600">
+                Select models
+              </span>
+              <div className="flex items-center gap-3">
+                {/* eslint-disable-next-line react/forbid-elements */}
+                <button
+                  type="button"
+                  className="text-xs font-medium text-teal-700 hover:text-teal-800"
+                  onClick={() => setSelectedModelIds(allModels.map((m) => m.modelId))}
+                >
+                  Select all
+                </button>
+                {/* eslint-disable-next-line react/forbid-elements */}
+                <button
+                  type="button"
+                  className="text-xs font-medium text-gray-600 hover:text-gray-800"
+                  onClick={() => setSelectedModelIds([])}
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+            <div className="max-h-52 space-y-2 overflow-y-auto">
+              {allModels.map((m) => (
+                <label
+                  key={m.modelId}
+                  className="flex cursor-pointer items-center gap-2 text-sm text-gray-700"
+                >
+                  <input
+                    type="checkbox"
+                    checked={(selectedModelIds ?? []).includes(m.modelId)}
+                    onChange={() => handleToggleModel(m.modelId)}
+                    className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+                  />
+                  <span className="flex-1 truncate" title={m.modelId}>
+                    {m.displayName}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
 
       {error != null && <ErrorMessage message={error.message} />}
       {loading ? (

--- a/cloud/apps/web/src/pages/ModelsConfidenceValueDetail.tsx
+++ b/cloud/apps/web/src/pages/ModelsConfidenceValueDetail.tsx
@@ -62,9 +62,12 @@ export function ModelsConfidenceValueDetail() {
   const valueKey = searchParams.get('valueKey') ?? '';
   const signature = searchParams.get('signature') ?? '';
   const modelLabelParam = searchParams.get('modelLabel');
+  const domainIdParam = searchParams.get('domainId');
+  const domainId = domainIdParam !== null && domainIdParam !== '' ? domainIdParam : null;
 
   const backParams = new URLSearchParams();
   if (signature !== '') backParams.set('signature', signature);
+  if (domainId !== null) backParams.set('domainId', domainId);
   const backLink = `/models/confidence${backParams.size > 0 ? `?${backParams.toString()}` : ''}`;
 
   const [selectedCondition, setSelectedCondition] = useState<{
@@ -83,6 +86,7 @@ export function ModelsConfidenceValueDetail() {
       modelId,
       valueKey,
       signature: signature !== '' ? signature : undefined,
+      domainId: domainId ?? undefined,
     },
     pause: modelId === '' || valueKey === '',
     requestPolicy: 'cache-and-network',
@@ -98,6 +102,7 @@ export function ModelsConfidenceValueDetail() {
         limit: 100,
         definitionId: selectedCondition?.definitionId ?? undefined,
         scenarioId: selectedCondition?.scenarioId ?? undefined,
+        domainId: domainId ?? undefined,
       },
       pause: selectedCondition === null || modelId === '' || valueKey === '',
       requestPolicy: 'cache-and-network',


### PR DESCRIPTION
## Summary
- Adds a **Domain** dropdown to the confidence heatmap page, beside the existing Signature dropdown, defaulting to "All domains"
- Consolidates Signature, Domain, and Models controls onto a single horizontal row
- Domain selection scopes all three resolvers (`modelsConfidence`, `confidenceValueDetail`, `confidenceTranscripts`) — only vignettes from the selected domain contribute to counts
- Domain filter threads through to the detail page (clicking a cell preserves the selected domain in the URL, and the detail page passes it to both queries)

## Test plan
- [ ] Preflight passed (lint + build, API + web, 0 errors)
- [ ] All domains view matches existing heatmap behaviour
- [ ] Selecting a domain narrows rows to only those models with data in that domain
- [ ] Clicking a cell with a domain selected opens the detail page scoped to that domain
- [ ] Back-link from detail page preserves the domain param

🤖 Generated with [Claude Code](https://claude.com/claude-code)