### PR TITLE
ff-consent-by-invocation: don't re-prompt on push/PR for invoked delivery actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Canonical source: `docs/canonical-glossary.md`
 
 - Open PRs against `chrislawcodes/valuerank`.
 - Follow the Preflight Gate in `cloud/CLAUDE.md` before any `git push` or PR creation.
+- Invoked delivery actions (Feature Factory `deliver`, `/ship`, explicit "push and open the PR" instructions) do not need re-confirmation. The invocation is the consent. See `cloud/CLAUDE.md` for the full rule.
 - One feature per branch. Do not stack new work on top of an open feature PR unless the human asks.
 - Fix the root cause when CI fails. Do not retry blindly.
 

--- a/cloud/CLAUDE.md
+++ b/cloud/CLAUDE.md
@@ -7,7 +7,9 @@ Repo-wide agent behavior, delivery paths, terminology policy, and memory policy 
 ## Push And PR Checks
 
 - Use Pull Requests for changes that will land on `main`.
-- Ask the human before running `git push`.
+- Never push directly to `main`. Always go via a feature branch + PR.
+- For invoked delivery actions (Feature Factory `deliver`, `/ship`, explicit "push and open the PR" instructions): the invocation IS the consent. Push the feature branch and create the PR without re-prompting.
+- For ad-hoc work where no explicit delivery instruction was given: ask before `git push`.
 - Run the Preflight Gate before any `git push` or PR creation.
 
 ## Workflow State

--- a/docs/workflow/operations/codex-skills/feature-factory/SKILL.md
+++ b/docs/workflow/operations/codex-skills/feature-factory/SKILL.md
@@ -99,7 +99,7 @@ Do not duplicate checkpoint manifest logic, review file validation, diff writing
 | Implementation slice | Implement one `[CHECKPOINT]`-bounded slice from `tasks.md`, run build and tests, commit | Codex | Codex |
 | Diff checkpoint | Adversarial attack on the slice diff only (not the full branch), correctness review, reconcile findings | Codex (1 adversarial review: `correctness`) · Gemini (1 adversarial review: `quality`) · Claude (reconciles) | Codex (1 adversarial review: `correctness`) · Gemini (1 adversarial review: `quality`) · Codex (reconciles, escalates blockers to human) |
 | *(repeat per slice)* | Implementation slice → Diff checkpoint repeats for each `[CHECKPOINT]` boundary in `tasks.md` | | |
-| Deliver | Create PR, watch CI, record delivery state in workflow | Claude | Codex (stages) · Human (approves and creates PR) |
+| Deliver | Push branch, create PR, watch CI, record delivery state in workflow. The `deliver` invocation is itself the consent — do not re-prompt before push or PR creation. The human still squash-merges. | Claude | Codex (stages, push, create PR) · Human (approves and squash-merges) |
 | CI failure | Extract errors, implement fix, re-run CI | Claude (reviews fix) · Codex (fixes) | Codex (fixes) · Human (approves) |
 | Write closeout | Write summary of what shipped, what remains open, and deferred risks | Claude | Codex |
 | Closeout checkpoint | Adversarial attack on closeout, final state review, reconcile findings | Codex (2 adversarial reviews: `fidelity` + `completeness`) · Gemini (1 adversarial review: `residual-risk`) · Claude (reconciles) | Codex (2 adversarial reviews: `fidelity` + `completeness`) · Gemini (1 adversarial review: `residual-risk`) · Codex (reconciles, escalates blockers to human) |


### PR DESCRIPTION
## Summary

The "ask the human before running `git push`" rule was firing inside FF `deliver` invocations (and `/ship` runs), making the runner pause for human confirmation after the human had already explicitly invoked the delivery action. Each invocation IS the consent; re-prompting is friction without safety value.

This PR scopes the ask-before-push rule to ad-hoc work only:

- **Invoked delivery actions** (FF `deliver`, `/ship`, explicit "push and open the PR" instructions): push and create the PR without re-prompting.
- **Ad-hoc work** (no explicit delivery instruction): ask before `git push`. Unchanged.
- **Direct push to `main`**: still forbidden, period.
- **Human still squash-merges**: still required, period.

## Files

- `cloud/CLAUDE.md` — replaces the blunt "ask before git push" rule with the explicit carve-out.
- `AGENTS.md` — adds a matching line under Repo Rules (the FF runner reads AGENTS.md).
- `docs/workflow/operations/codex-skills/feature-factory/SKILL.md` — fixes the Deliver row that read "Human (approves and creates PR)" — that's the proximate source of the prompt-loop. Now reads "Codex (push, create PR) · Human (approves and squash-merges)".

## Out of scope

- `CODEX-ORCHESTRATOR.md` section 8 was already correct (Step 1 = push, Step 2 = create PR, with no "ask first" gate). Left as-is.
- Other skills that reference push behavior (e.g., `experiment` skill) already key off "if the human asked for PR creation" — already aligned with this rule.

## Test plan
- [x] Reviewed for contradictions across `cloud/CLAUDE.md`, `AGENTS.md`, FF docs, and skills
- [ ] Next FF `deliver` run pushes + creates PR without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)