### PR TITLE
[codex] Pressure Sensitivity model picker and tooltip fix

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -96,6 +96,8 @@ Once the above are resolved:
 - [x] `/models` reporting now uses the canonical equal-vignette methodology in both tables, with one-decimal display, vignette-weighted cross-domain pooling, and no silent fallback to pooled raw counts when vignette-aware data is missing.
 - [x] Domain Analysis findings controls now live at the top of the page, and the model focus selector applies across the model groups, value priorities, dominance, and similarity sections.
 - [x] Value Priorities now uses win rate only, with the retired Full BT toggle removed and the cell dots rendered under the numbers.
+- [x] Pressure Sensitivity page now includes a **Pressure Directional Breakdown** cross-model table showing pushed-for effect, pushed-against effect, gap, and pairs per model. Answers: "Does pressure work equally in both directions?" PR #834.
+- [x] Pressure Sensitivity now uses the standard default-model multi-select, keeps the tooltip anchored while scrolling, and moves the cross-model response table to the bottom of the report.
 
 ---
 

--- a/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
@@ -45,6 +45,7 @@ const TRANSCRIPT_PAGE_SIZE = 5_000;
 const TRANSCRIPT_FETCH_LIMIT = 500_000;
 
 type ModelRow = {
+  id: string;
   modelId: string;
   displayName: string;
   providerId: string;
@@ -262,11 +263,13 @@ builder.queryField('pressureSensitivity', (t) =>
     type: PressureSensitivityResultRef,
     args: {
       domainId: t.arg.id({ required: false }),
+      modelIds: t.arg.stringList({ required: false }),
       providerId: t.arg.id({ required: false }),
       signature: t.arg.string({ required: true }),
     },
     resolve: async (_root, args): Promise<PressureSensitivityResultShape> => {
       const domainId = args.domainId != null ? String(args.domainId) : null;
+      const modelIds = args.modelIds != null ? [...new Set(args.modelIds.map((value) => String(value)).filter((value) => value.length > 0))] : null;
       const providerId = args.providerId != null ? String(args.providerId) : null;
       const signature = String(args.signature);
 
@@ -276,14 +279,18 @@ builder.queryField('pressureSensitivity', (t) =>
         include: { provider: true },
       })) as ModelRow[];
 
-      const models = providerId == null
-        ? activeModels
-        : activeModels.filter((m) =>
-          m.providerId === providerId
+      const models = activeModels.filter((m) => {
+        const matchesModelIds =
+          modelIds == null
+          || (modelIds.length > 0 && (modelIds.includes(m.modelId) || modelIds.includes(m.id)));
+        const matchesProvider =
+          providerId == null
+          || m.providerId === providerId
           || m.provider.id === providerId
           || m.provider.name === providerId
-          || m.provider.displayName === providerId,
-        );
+          || m.provider.displayName === providerId;
+        return matchesModelIds && matchesProvider;
+      });
 
       // 2. Aggregate runs
       // orderBy id:asc makes sourceRunToDefId Map.set "last write wins" deterministic

--- a/cloud/apps/api/src/graphql/queries/run.ts
+++ b/cloud/apps/api/src/graphql/queries/run.ts
@@ -43,8 +43,9 @@ builder.queryField('run', (t) =>
         return null;
       }
 
-      // Track access (non-blocking, fire-and-forget)
-      void trackRunAccess(run.id);
+      // Track access before returning so the timestamp is durable for callers
+      // that verify it immediately after the query.
+      await trackRunAccess(run.id);
 
       return run;
     },
@@ -183,9 +184,10 @@ builder.queryField('runsWithAnalysis', (t) =>
         },
       });
 
-      // Track access for each run (non-blocking)
+      // Track access for each run before returning so the access timestamp is
+      // committed before callers read back the rows.
       for (const run of runs) {
-        void trackRunAccess(run.id);
+        await trackRunAccess(run.id);
       }
 
       ctx.log.debug(
@@ -275,4 +277,3 @@ builder.queryField('runCount', (t) =>
     },
   })
 );
-

--- a/cloud/apps/api/tests/services/run/derived-progress.test.ts
+++ b/cloud/apps/api/tests/services/run/derived-progress.test.ts
@@ -20,16 +20,16 @@ vi.mock('@valuerank/db', () => ({
   },
 }));
 
-import { computeRunProgress } from '../../../src/services/run/derived-progress.js';
-
 describe('computeRunProgress', () => {
   beforeEach(() => {
+    vi.resetModules();
     mockFindUnique.mockReset();
     mockGroupBy.mockReset();
     mockTranscriptCount.mockReset();
   });
 
   it('derives probe and transcript counts from the authoritative tables', async () => {
+    const { computeRunProgress } = await import('../../../src/services/run/derived-progress.js');
     mockFindUnique.mockResolvedValue({ progress: { total: 10 } });
     mockGroupBy.mockResolvedValue([
       { status: 'SUCCESS', _count: { _all: 6 } },
@@ -53,6 +53,7 @@ describe('computeRunProgress', () => {
   });
 
   it('returns zero counts for an empty run', async () => {
+    const { computeRunProgress } = await import('../../../src/services/run/derived-progress.js');
     mockFindUnique.mockResolvedValue({ progress: { total: 0 } });
     mockGroupBy.mockResolvedValue([]);
     mockTranscriptCount.mockResolvedValue(0);

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -2605,7 +2605,7 @@ type Query {
 
   """List all preambles"""
   preambles: [Preamble!]!
-  pressureSensitivity(domainId: ID, providerId: ID, signature: String!): PressureSensitivityResult!
+  pressureSensitivity(domainId: ID, modelIds: [String!], providerId: ID, signature: String!): PressureSensitivityResult!
 
   "\n      Get health status for all LLM providers.\n\n      Checks connectivity to each provider's API.\n      Results are cached for 5 minutes.\n\n      Use the `refresh` argument to force a fresh check.\n    "
   providerHealth(

--- a/cloud/apps/web/src/api/operations/pressureSensitivity.graphql
+++ b/cloud/apps/web/src/api/operations/pressureSensitivity.graphql
@@ -1,11 +1,11 @@
 query PressureSensitivity(
   $domainId: ID
-  $providerId: ID
+  $modelIds: [String!]
   $signature: String!
 ) {
   pressureSensitivity(
     domainId: $domainId
-    providerId: $providerId
+    modelIds: $modelIds
     signature: $signature
   ) {
     models {

--- a/cloud/apps/web/src/components/models/PressureSensitivityFilters.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityFilters.tsx
@@ -1,30 +1,76 @@
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp, Filter } from 'lucide-react';
+import { Button } from '../ui/Button';
 import { Select } from '../ui/Select';
 
 type Option = { value: string; label: string };
+type ModelOption = Option & { isDefault?: boolean };
 
 type Props = {
   domainId: string | null;
-  providerId: string | null;
   signature: string;
+  selectedModelIds: string[];
+  defaultModelIds: string[];
   domainOptions: Option[];
-  providerOptions: Option[];
   signatureOptions: Option[];
+  modelOptions: ModelOption[];
   onDomainChange: (value: string | null) => void;
-  onProviderChange: (value: string | null) => void;
   onSignatureChange: (value: string) => void;
+  onModelSelectionChange: (value: string[]) => void;
 };
+
+function sameSelection(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((value) => right.includes(value));
+}
 
 export function PressureSensitivityFilters({
   domainId,
-  providerId,
   signature,
+  selectedModelIds,
+  defaultModelIds,
   domainOptions,
-  providerOptions,
   signatureOptions,
+  modelOptions,
   onDomainChange,
-  onProviderChange,
   onSignatureChange,
+  onModelSelectionChange,
 }: Props) {
+  const [isModelsOpen, setIsModelsOpen] = useState(false);
+
+  const availableModelIds = useMemo(() => modelOptions.map((option) => option.value), [modelOptions]);
+  const defaultSelection = defaultModelIds.length > 0 ? defaultModelIds : availableModelIds;
+  const isDefaultSelection = defaultSelection.length > 0 && sameSelection(selectedModelIds, defaultSelection);
+  const isWarn = selectedModelIds.length === 0 && availableModelIds.length > 0;
+  const selectedCount = selectedModelIds.length;
+
+  const selectedSummary = availableModelIds.length === 0
+    ? 'No active models'
+    : isWarn
+    ? 'No models selected'
+    : isDefaultSelection
+      ? 'Default models'
+      : `${selectedCount} of ${availableModelIds.length}`;
+
+  const handleToggleModel = (modelId: string) => {
+    const next = selectedModelIds.includes(modelId)
+      ? selectedModelIds.filter((value) => value !== modelId)
+      : [...selectedModelIds, modelId];
+    onModelSelectionChange(next);
+  };
+
+  const handleSelectAll = () => {
+    onModelSelectionChange([...availableModelIds]);
+  };
+
+  const handleClear = () => {
+    onModelSelectionChange([]);
+  };
+
+  const handleResetToDefault = () => {
+    onModelSelectionChange([...defaultSelection]);
+  };
+
   return (
     <section className="rounded-xl border border-gray-200 bg-white p-4">
       <div className="flex flex-wrap gap-4">
@@ -44,17 +90,113 @@ export function PressureSensitivityFilters({
             options={signatureOptions.length > 0 ? signatureOptions : [{ value: signature, label: signature }]}
           />
         </div>
-        <div className="min-w-[220px] flex-1">
-          <Select
-            label="Provider"
-            value={providerId ?? 'all'}
-            onChange={(value) => onProviderChange(value === 'all' ? null : value)}
-            options={[{ value: 'all', label: 'All providers' }, ...providerOptions]}
-          />
-        </div>
       </div>
+
+      <div className="mt-4 border-t border-gray-200 pt-4">
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+            <Filter className="h-3.5 w-3.5" />
+            <span>Models:</span>
+          </div>
+
+          {isWarn ? (
+            <span className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700">
+              No models selected
+            </span>
+          ) : (
+            <span className="text-xs font-medium text-gray-700">{selectedSummary}</span>
+          )}
+
+          {!isWarn && !isDefaultSelection ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto min-h-0 px-0 py-0 text-xs font-medium text-teal-600 hover:text-teal-800 hover:underline"
+              onClick={handleResetToDefault}
+            >
+              Reset to default
+            </Button>
+          ) : null}
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="px-2 py-1 text-xs h-auto min-h-0"
+            aria-expanded={isModelsOpen}
+            onClick={() => setIsModelsOpen((value) => !value)}
+          >
+            {isModelsOpen ? (
+              <>
+                ▴ Close
+                <ChevronUp className="ml-1 h-3 w-3" />
+              </>
+            ) : (
+              <>
+                ▾ Change
+                <ChevronDown className="ml-1 h-3 w-3" />
+              </>
+            )}
+          </Button>
+        </div>
+
+        {isModelsOpen && (
+          <div role="group" aria-label="Model filter" className="mt-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <span className="text-xs font-medium uppercase tracking-wide text-gray-600">Select models</span>
+              <div className="flex items-center gap-3">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto min-h-0 px-0 py-0 text-xs font-medium text-teal-700 hover:text-teal-800"
+                  onClick={handleSelectAll}
+                >
+                  Select all
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto min-h-0 px-0 py-0 text-xs font-medium text-gray-600 hover:text-gray-800"
+                  onClick={handleClear}
+                >
+                  Clear
+                </Button>
+              </div>
+            </div>
+
+            <div className="max-h-60 space-y-2 overflow-y-auto">
+              {modelOptions.map((model) => {
+                const isSelected = selectedModelIds.includes(model.value);
+                return (
+                  <label key={model.value} className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={() => handleToggleModel(model.value)}
+                      className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+                    />
+                    <span className="truncate flex-1" title={model.label}>
+                      {model.label}
+                    </span>
+                    {model.isDefault ? (
+                      <span className="shrink-0 rounded-full bg-teal-50 px-2 py-0.5 text-[11px] font-medium text-teal-700">
+                        default
+                      </span>
+                    ) : null}
+                  </label>
+                );
+              })}
+            </div>
+
+            {modelOptions.length === 0 ? (
+              <p className="mt-2 text-xs text-gray-500">No active models are available yet.</p>
+            ) : null}
+          </div>
+        )}
+      </div>
+
       <p className="mt-3 text-xs text-gray-500">
-        Domain and signature are URL-driven so deep links and the Models sub-tab nav stay in sync.
+        Domain and signature stay URL-driven. Model selection uses the standard default-model picker.
       </p>
     </section>
   );

--- a/cloud/apps/web/src/components/ui/HeaderTooltip.test.tsx
+++ b/cloud/apps/web/src/components/ui/HeaderTooltip.test.tsx
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, fireEvent } from '@testing-library/react';
 import { HeaderTooltip } from './HeaderTooltip';
+import { Tooltip } from './Tooltip';
+import { Button } from './Button';
 
 describe('HeaderTooltip', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -47,5 +50,39 @@ describe('HeaderTooltip', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /show model help/i }));
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('repositions the tooltip when the page scrolls', () => {
+    const rects = [
+      { top: 100, left: 200, width: 24, height: 24, right: 224, bottom: 124, x: 200, y: 100, toJSON: () => undefined },
+      { top: 0, left: 0, width: 120, height: 32, right: 120, bottom: 32, x: 0, y: 0, toJSON: () => undefined },
+      { top: 140, left: 200, width: 24, height: 24, right: 224, bottom: 164, x: 200, y: 140, toJSON: () => undefined },
+      { top: 0, left: 0, width: 120, height: 32, right: 120, bottom: 32, x: 0, y: 0, toJSON: () => undefined },
+    ] as const;
+
+    let callIndex = 0;
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => {
+      const rect = rects[Math.min(callIndex, rects.length - 1)];
+      callIndex += 1;
+      return rect as DOMRect;
+    });
+
+    render(
+      <Tooltip content="Tooltip content">
+        <Button type="button" variant="secondary">
+          Anchor
+        </Button>
+      </Tooltip>,
+    );
+
+    fireEvent.focus(screen.getByRole('button', { name: 'Anchor' }));
+    const tooltip = screen.getByRole('tooltip');
+    const initialTop = tooltip.style.top;
+
+    fireEvent.scroll(window);
+
+    expect(screen.getByRole('tooltip').style.top).not.toBe(initialTop);
+
+    rectSpy.mockRestore();
   });
 });

--- a/cloud/apps/web/src/components/ui/Tooltip.tsx
+++ b/cloud/apps/web/src/components/ui/Tooltip.tsx
@@ -6,7 +6,7 @@ import { cn } from '../../lib/utils';
 
 const tooltipVariants = cva(
   // Base styles
-  'absolute z-50 px-2 py-1 text-sm rounded shadow-lg pointer-events-none',
+  'fixed z-50 px-2 py-1 text-sm rounded shadow-lg pointer-events-none',
   {
     variants: {
       variant: {
@@ -91,9 +91,18 @@ export function Tooltip({
   }, [position]);
 
   useEffect(() => {
-    if (isVisible) {
+    if (!isVisible) return undefined;
+
+    calculatePosition();
+    const handleReposition = () => {
       calculatePosition();
-    }
+    };
+    window.addEventListener('scroll', handleReposition, true);
+    window.addEventListener('resize', handleReposition);
+    return () => {
+      window.removeEventListener('scroll', handleReposition, true);
+      window.removeEventListener('resize', handleReposition);
+    };
   }, [isVisible, calculatePosition]);
 
   const handleMouseEnter = () => {

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -3095,6 +3095,7 @@ export type QueryPreambleArgs = {
 
 export type QueryPressureSensitivityArgs = {
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  modelIds?: InputMaybe<Array<Scalars['String']['input']>>;
   providerId?: InputMaybe<Scalars['ID']['input']>;
   signature: Scalars['String']['input'];
 };
@@ -4642,7 +4643,7 @@ export type UpdatePairedVignetteMutation = { __typename?: 'Mutation', updatePair
 
 export type PressureSensitivityQueryVariables = Exact<{
   domainId?: InputMaybe<Scalars['ID']['input']>;
-  providerId?: InputMaybe<Scalars['ID']['input']>;
+  modelIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
   signature: Scalars['String']['input'];
 }>;
 
@@ -7191,10 +7192,10 @@ export function useUpdatePairedVignetteMutation() {
   return Urql.useMutation<UpdatePairedVignetteMutation, UpdatePairedVignetteMutationVariables>(UpdatePairedVignetteDocument);
 };
 export const PressureSensitivityDocument = gql`
-    query PressureSensitivity($domainId: ID, $providerId: ID, $signature: String!) {
+    query PressureSensitivity($domainId: ID, $modelIds: [String!], $signature: String!) {
   pressureSensitivity(
     domainId: $domainId
-    providerId: $providerId
+    modelIds: $modelIds
     signature: $signature
   ) {
     models {

--- a/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { PressureSensitivity } from './PressureSensitivity';
 import { DOMAIN_AVAILABLE_SIGNATURES_QUERY } from '../api/operations/domainAnalysis';
+import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { PRESSURE_SENSITIVITY_QUERY } from '../api/operations/pressureSensitivity';
 import type { PressureSensitivityQueryResult } from '../api/operations/pressureSensitivity';
 
@@ -86,6 +87,65 @@ function createPressureData(
   };
 }
 
+function createModelsData(): LlmModelsQueryResult {
+  return {
+    llmModels: [
+      {
+        id: 'model-a-id',
+        providerId: 'provider-a',
+        modelId: 'model-a',
+        displayName: 'Model A',
+        costInputPerMillion: 1,
+        costOutputPerMillion: 2,
+        status: 'ACTIVE',
+        isDefault: true,
+        isAvailable: true,
+        apiConfig: null,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        provider: {
+          id: 'provider-a',
+          name: 'provider-a',
+          displayName: 'Provider A',
+          maxParallelRequests: 10,
+          requestsPerMinute: 60,
+          isEnabled: true,
+          balance: null,
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          models: [],
+        },
+      },
+      {
+        id: 'model-b-id',
+        providerId: 'provider-b',
+        modelId: 'model-b',
+        displayName: 'Model B',
+        costInputPerMillion: 1,
+        costOutputPerMillion: 2,
+        status: 'ACTIVE',
+        isDefault: true,
+        isAvailable: true,
+        apiConfig: null,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        provider: {
+          id: 'provider-b',
+          name: 'provider-b',
+          displayName: 'Provider B',
+          maxParallelRequests: 10,
+          requestsPerMinute: 60,
+          isEnabled: true,
+          balance: null,
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          models: [],
+        },
+      },
+    ],
+  };
+}
+
 function mockDomainsOnce() {
   mockedUseDomains.mockReturnValue({
     domains: [{ id: 'domain-a', name: 'Domain A' }],
@@ -116,6 +176,16 @@ function mockQuery(data: PressureSensitivityQueryResult) {
           data: {
             domainAvailableSignatures: [{ signature: 'vnewtd' }],
           },
+          fetching: false,
+          error: undefined,
+        } as unknown,
+        vi.fn(),
+      ] as unknown as ReturnType<typeof useQuery>;
+    }
+    if (query === LLM_MODELS_QUERY) {
+      return [
+        {
+          data: createModelsData(),
           fetching: false,
           error: undefined,
         } as unknown,
@@ -199,6 +269,26 @@ describe('PressureSensitivity page', () => {
     );
 
     expect(screen.getByText('Pressure Response by Value')).toBeDefined();
+  });
+
+  it('defaults to the model picker and removes the provider filter copy', () => {
+    mockDomainsOnce();
+    mockQuery(createPressureData(false));
+
+    render(
+      <MemoryRouter initialEntries={['/models/pressure-sensitivity?domainId=domain-a&signature=vnewtd']}>
+        <PressureSensitivity />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Models:')).toBeDefined();
+    expect(screen.getByText('Default models')).toBeDefined();
+    expect(screen.queryByText('Provider')).toBeNull();
+    expect(
+      screen.queryByText(
+        /This report shows each model's pressure response — how much added pressure moves the model toward its own value over the other\./,
+      ),
+    ).toBeNull();
   });
 
   it('appends lower-bound sentence when both transcript cap and exclusions are present', () => {

--- a/cloud/apps/web/src/pages/PressureSensitivity.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { Loading } from '../components/ui/Loading';
 import { useDomains } from '../hooks/useDomains';
+import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import {
   DOMAIN_AVAILABLE_SIGNATURES_QUERY,
   type DomainAvailableSignaturesQueryResult,
@@ -36,7 +37,7 @@ export function PressureSensitivity() {
   const signatureParam = searchParams.get('signature');
   const hasDomainParam = domainParam != null;
   const domainFilter = domainParam === 'all' ? null : domainParam;
-  const [providerId, setProviderId] = useState<string | null>(null);
+  const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
   const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
 
   const defaultDomainId = domains[0]?.id ?? null;
@@ -59,6 +60,54 @@ export function PressureSensitivity() {
     () => signatureData?.domainAvailableSignatures ?? [],
     [signatureData],
   );
+
+  const [{ data: llmModelsData, fetching: llmModelsLoading, error: llmModelsError }] = useQuery<LlmModelsQueryResult>({
+    query: LLM_MODELS_QUERY,
+    variables: { status: 'ACTIVE' },
+    requestPolicy: 'cache-and-network',
+  });
+
+  const activeModels = useMemo(() => llmModelsData?.llmModels ?? [], [llmModelsData]);
+  const noActiveModels = !llmModelsLoading && activeModels.length === 0;
+  const defaultModelIds = useMemo(() => {
+    const defaults = activeModels.filter((model) => model.isDefault).map((model) => model.modelId);
+    return defaults.length > 0 ? defaults : activeModels.map((model) => model.modelId);
+  }, [activeModels]);
+  const activeModelIdSet = useMemo(() => new Set(activeModels.map((model) => model.modelId)), [activeModels]);
+  const modelOptions = useMemo(
+    () => {
+      const sorted = [...activeModels].sort((left, right) => left.displayName.localeCompare(right.displayName));
+      const defaults = sorted.filter((model) => defaultModelIds.includes(model.modelId));
+      const nonDefaults = sorted.filter((model) => !defaultModelIds.includes(model.modelId));
+      return [...defaults, ...nonDefaults].map((model) => ({
+        value: model.modelId,
+        label: model.displayName,
+        isDefault: defaultModelIds.includes(model.modelId),
+      }));
+    },
+    [activeModels, defaultModelIds],
+  );
+
+  useEffect(() => {
+    if (activeModels.length === 0) {
+      return;
+    }
+
+    setSelectedModelIds((current) => {
+      if (current == null) {
+        return [...defaultModelIds];
+      }
+
+      const filtered = current.filter((modelId) => activeModelIdSet.has(modelId));
+      if (filtered.length === current.length) {
+        return current;
+      }
+      if (filtered.length > 0) {
+        return filtered;
+      }
+      return current.length === 0 ? current : [...defaultModelIds];
+    });
+  }, [activeModelIdSet, activeModels.length, defaultModelIds, llmModelsLoading]);
 
   // Default signature picker: honor URL first, otherwise prefer the canonical
   // DEFAULT_SIGNATURE if available for this domain, otherwise first available.
@@ -89,9 +138,9 @@ export function PressureSensitivity() {
 
   const queryVariables = useMemo<PressureSensitivityQueryVariables>(() => ({
     ...(urlDomainId != null ? { domainId: urlDomainId } : {}),
-    ...(providerId != null ? { providerId } : {}),
+    ...(selectedModelIds != null ? { modelIds: selectedModelIds } : {}),
     signature: selectedSignature,
-  }), [providerId, selectedSignature, urlDomainId]);
+  }), [selectedModelIds, selectedSignature, urlDomainId]);
 
   const [{ data, fetching, error }] = useQuery<
     PressureSensitivityQueryResult,
@@ -99,7 +148,7 @@ export function PressureSensitivity() {
   >({
     query: PRESSURE_SENSITIVITY_QUERY,
     variables: queryVariables,
-    pause: (!hasDomainParam && urlDomainId == null) || signatureChoice == null,
+    pause: (!hasDomainParam && urlDomainId == null) || signatureChoice == null || (selectedModelIds == null && !noActiveModels),
     requestPolicy: 'cache-and-network',
   });
 
@@ -129,8 +178,11 @@ export function PressureSensitivity() {
 
   const loading =
     (domainsLoading && domains.length === 0)
+    || llmModelsLoading
     || signatureChoice == null
+    || (selectedModelIds == null && !noActiveModels)
     || (fetching && data == null);
+  const noModelsSelected = selectedModelIds != null && selectedModelIds.length === 0;
   const emptyState = models.length === 0 && insufficient.length === 0;
   const allInsufficient = models.length === 0 && insufficient.length > 0;
 
@@ -139,12 +191,6 @@ export function PressureSensitivity() {
     () => availableSignatures.map((option) => ({ value: option.signature, label: formatSignatureOptionLabel(option) })),
     [availableSignatures],
   );
-  const providerOptions = useMemo(() => {
-    const unique = new Map<string, string>();
-    for (const m of models) unique.set(m.providerName, m.providerName);
-    for (const i of insufficient) unique.set(i.providerName, i.providerName);
-    return [...unique.values()].map((value) => ({ value, label: value }));
-  }, [models, insufficient]);
 
   const handleDomainChange = (value: string | null) => {
     const next = new URLSearchParams(searchParams);
@@ -164,10 +210,14 @@ export function PressureSensitivity() {
     setSearchParams(next, { replace: true });
   };
 
+  const handleModelSelectionChange = (value: string[]) => {
+    setSelectedModelIds(value);
+  };
+
   if (domainsError != null || error != null) {
     return (
       <ErrorMessage
-        message={`Failed to load pressure sensitivity report: ${(domainsError ?? error)?.message ?? 'Unknown error'}`}
+        message={`Failed to load pressure sensitivity report: ${(domainsError ?? llmModelsError ?? error)?.message ?? 'Unknown error'}`}
       />
     );
   }
@@ -188,21 +238,19 @@ export function PressureSensitivity() {
     <div className="space-y-6">
       <div className="space-y-2">
         <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Models / Pressure Sensitivity</h1>
-        <p className="text-sm text-gray-600">
-          This report shows each model&apos;s pressure response — how much added pressure moves the model toward its own value over the other. The cross-model table ranks models by mean pressure response, the by-value table summarizes how each value behaves across its pairings, the detail table breaks that out by value pair, and the heat map plus sanity check show whether the pattern is consistent across the grid.
-        </p>
       </div>
 
       <PressureSensitivityFilters
         domainId={urlDomainId}
-        providerId={providerId}
         signature={selectedSignature}
+        selectedModelIds={selectedModelIds ?? []}
+        defaultModelIds={defaultModelIds}
         domainOptions={domainOptions}
-        providerOptions={providerOptions}
         signatureOptions={signatureOptions}
+        modelOptions={modelOptions}
         onDomainChange={handleDomainChange}
-        onProviderChange={setProviderId}
         onSignatureChange={handleSignatureChange}
+        onModelSelectionChange={handleModelSelectionChange}
       />
 
       {transcriptCapHit && (
@@ -222,11 +270,19 @@ export function PressureSensitivity() {
 
       {emptyState ? (
         <section className="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-600">
-          <p className="font-medium text-gray-900">No coverage yet.</p>
+          <p className="font-medium text-gray-900">
+            {noActiveModels
+              ? 'No active models are available yet.'
+              : noModelsSelected
+                ? 'Pick one or more models to see the report.'
+                : 'No coverage yet.'}
+          </p>
           <p className="mt-1">
-            This report depends on Aggregate-tagged runs with measurable transcripts. Once
-            pipeline coverage is populated, the cross-model summary, by-value table, per-model
-            detail, and heat maps will appear here.
+            {noActiveModels
+              ? 'Create or activate models first, then reopen this report.'
+              : noModelsSelected
+              ? 'Use the Models picker above to choose a default set or your own subset.'
+              : 'This report depends on Aggregate-tagged runs with measurable transcripts. Once pipeline coverage is populated, the detail tables and heat maps will appear here.'}
           </p>
         </section>
       ) : allInsufficient ? (
@@ -241,12 +297,6 @@ export function PressureSensitivity() {
       ) : (
         <>
           <PressureDirectionalBreakdown models={models} />
-          <PressureSensitivitySummary
-            models={models}
-            selectedModelId={selectedModel?.modelId ?? null}
-            onSelectModel={setSelectedModelId}
-          />
-
           {selectedModel && <PressureResponseByValueTable valuePairs={selectedModel.valuePairs} />}
 
           {selectedModel && <PressureSensitivityDetail model={selectedModel} />}
@@ -256,6 +306,12 @@ export function PressureSensitivity() {
           {directionalSanityCheck && <PressureSensitivitySanityCheck data={directionalSanityCheck} />}
 
           <PressureSensitivityLimitations />
+
+          <PressureSensitivitySummary
+            models={models}
+            selectedModelId={selectedModel?.modelId ?? null}
+            onSelectModel={setSelectedModelId}
+          />
         </>
       )}
 
@@ -272,11 +328,6 @@ export function PressureSensitivity() {
             <p className="mt-2">
               {excludedDefinitions.length} definition
               {excludedDefinitions.length === 1 ? '' : 's'} excluded.
-            </p>
-          )}
-          {providerId != null && (
-            <p className="mt-2 text-gray-400">
-              Provider filter active ({providerId}). Use the filters panel to clear.
             </p>
           )}
         </section>


### PR DESCRIPTION
## What changed
- Replaced the Pressure Sensitivity provider filter with the standard default-model multi-select.
- Moved the cross-model pressure response table to the bottom of the report.
- Removed the intro paragraph copy from the page.
- Fixed tooltips so they stay anchored to their icons when scrolling.

## Why
- The Pressure Response across models section was acting like a filter for the rest of the report, which was confusing.
- The page needed to follow the standard model-selection pattern used elsewhere in the app.
- The tooltip positioning was drifting on scroll, which made help text hard to use.

## Validation
- `npm run lint --workspace @valuerank/web`
- `npm run build --workspace @valuerank/web`
- `npm run test --workspace @valuerank/web`