### PR TITLE
Weight pressure report by vignette

### DIFF
--- a/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
@@ -17,7 +17,7 @@ import {
 import { buildSafeLevelLookup, type DefinitionDimension } from './scenarios-utils.js';
 import { normalizeScenarioAnalysisMetadata } from '../../services/analysis/scenario-metadata.js';
 import {
-  buildCellMetrics,
+  buildVignetteWeightedCellMetrics,
   pooledDirectionalReduction,
   summarizePressureResponse,
   FLAT_DELTA_THRESHOLD,
@@ -95,7 +95,7 @@ type DefinitionMetadata = {
 type CellAccumulator = {
   ownLevel: number;
   opponentLevel: number;
-  observations: Observation[];
+  observationsByDefinition: Map<string, Observation[]>;
 };
 
 type PairAccumulator = {
@@ -497,7 +497,12 @@ builder.queryField('pressureSensitivity', (t) =>
 
         if (outcome === 'unscored') {
           const unscoredCell = ensureUnscoredCell(pairAcc);
-          unscoredCell.observations.push({ outcome, strength });
+          const observations = unscoredCell.observationsByDefinition.get(defId);
+          if (observations) {
+            observations.push({ outcome, strength });
+          } else {
+            unscoredCell.observationsByDefinition.set(defId, [{ outcome, strength }]);
+          }
           continue;
         }
 
@@ -527,10 +532,19 @@ builder.queryField('pressureSensitivity', (t) =>
         const key = cellKey(levels.ownLevel, levels.opponentLevel);
         let cell = pairAcc.cells.get(key);
         if (!cell) {
-          cell = { ownLevel: levels.ownLevel, opponentLevel: levels.opponentLevel, observations: [] };
+          cell = {
+            ownLevel: levels.ownLevel,
+            opponentLevel: levels.opponentLevel,
+            observationsByDefinition: new Map(),
+          };
           pairAcc.cells.set(key, cell);
         }
-        cell.observations.push({ outcome, strength });
+        const observations = cell.observationsByDefinition.get(defId);
+        if (observations) {
+          observations.push({ outcome, strength });
+        } else {
+          cell.observationsByDefinition.set(defId, [{ outcome, strength }]);
+        }
       }
 
       // 9-13. Build per-model output.
@@ -553,7 +567,11 @@ builder.queryField('pressureSensitivity', (t) =>
           let pairN = 0;
           let pairUnscored = 0;
           for (const [, cellAcc] of acc.cells) {
-            const metrics = buildCellMetrics(cellAcc.observations);
+            const metrics = buildVignetteWeightedCellMetrics(
+              [...cellAcc.observationsByDefinition.values()],
+              MIN_N,
+            );
+
             pairN += metrics.n;
             pairUnscored += metrics.unscoredCount;
             grid.push({
@@ -565,7 +583,7 @@ builder.queryField('pressureSensitivity', (t) =>
               winRate: metrics.winRate,
               conviction: metrics.conviction,
               netScore: metrics.netScore,
-              lowData: metrics.n < MIN_N,
+              lowData: metrics.lowData,
             });
           }
           modelUnscored += pairUnscored;
@@ -703,7 +721,11 @@ function ensureUnscoredCell(pairAcc: PairAccumulator): CellAccumulator {
   const key = cellKey(0, 0);
   let cell = pairAcc.cells.get(key);
   if (!cell) {
-    cell = { ownLevel: 0, opponentLevel: 0, observations: [] };
+    cell = {
+      ownLevel: 0,
+      opponentLevel: 0,
+      observationsByDefinition: new Map(),
+    };
     pairAcc.cells.set(key, cell);
   }
   return cell;

--- a/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
@@ -33,6 +33,11 @@ export type Cell = CellMetrics & {
   lowData: boolean;
 };
 
+export type VignetteWeightedCellMetrics = CellMetrics & {
+  n: number;
+  lowData: boolean;
+};
+
 export type PressureResponseReason =
   | 'directional-thin'
   | 'inverted-thin'
@@ -169,6 +174,43 @@ export function buildCellMetrics(observations: ReadonlyArray<Observation>): Cell
   const netScore = (2 * ownStrong + ownLean - 2 * opponentStrong - opponentLean) / n;
 
   return { n, unscoredCount, successes: ownPicked, winRate, conviction, netScore };
+}
+
+function averageNonNull(values: Array<number | null>): number | null {
+  let sum = 0;
+  let count = 0;
+
+  for (const value of values) {
+    if (value == null) continue;
+    sum += value;
+    count += 1;
+  }
+
+  return count === 0 ? null : sum / count;
+}
+
+/**
+ * Aggregate vignette-level observations into a single cell using equal weight per vignette.
+ *
+ * This is the unit-of-analysis rule used by the pressure-response report when the goal is to
+ * compare values as vignette-level objects instead of transcript-level observations.
+ */
+export function buildVignetteWeightedCellMetrics(
+  vignetteObservations: ReadonlyArray<ReadonlyArray<Observation>>,
+  minN = 3,
+): VignetteWeightedCellMetrics {
+  const vignetteMetrics = vignetteObservations.map((observations) => buildCellMetrics(observations));
+  const scoredVignetteMetrics = vignetteMetrics.filter((metrics) => metrics.n > 0);
+
+  return {
+    n: scoredVignetteMetrics.length,
+    unscoredCount: vignetteMetrics.reduce((sum, metrics) => sum + metrics.unscoredCount, 0),
+    successes: scoredVignetteMetrics.reduce((sum, metrics) => sum + metrics.successes, 0),
+    winRate: averageNonNull(scoredVignetteMetrics.map((metrics) => metrics.winRate)),
+    conviction: averageNonNull(scoredVignetteMetrics.map((metrics) => metrics.conviction)),
+    netScore: averageNonNull(scoredVignetteMetrics.map((metrics) => metrics.netScore)),
+    lowData: scoredVignetteMetrics.length < minN,
+  };
 }
 
 function isFiniteNumber(value: unknown): value is number {

--- a/cloud/apps/api/tests/services/pressure-sensitivity/aggregation.test.ts
+++ b/cloud/apps/api/tests/services/pressure-sensitivity/aggregation.test.ts
@@ -3,6 +3,7 @@ import {
   type Cell,
   type Observation,
   buildCellMetrics,
+  buildVignetteWeightedCellMetrics,
   diffProportionCI,
   pooledDirectionalReduction,
   summarizePressureResponse,
@@ -80,6 +81,48 @@ describe('buildCellMetrics', () => {
 
     expect(result.netScore).toBeCloseTo(2 / 3, 10);
     expect(result.conviction).toBe(1.5);
+  });
+});
+
+describe('buildVignetteWeightedCellMetrics', () => {
+  it('counts each vignette once inside a cell and averages vignette win rates equally', () => {
+    const result = buildVignetteWeightedCellMetrics([
+      [
+        { outcome: 'own_picked', strength: 'strong' },
+      ],
+      [
+        { outcome: 'own_picked', strength: 'lean' },
+        { outcome: 'opponent_picked', strength: 'lean' },
+        { outcome: 'opponent_picked', strength: 'lean' },
+      ],
+    ]);
+
+    expect(result).toEqual({
+      n: 2,
+      unscoredCount: 0,
+      successes: 2,
+      winRate: (1 + 1 / 3) / 2,
+      conviction: 1.5,
+      netScore: (2 + (-1 / 3)) / 2,
+      lowData: true,
+    });
+  });
+
+  it('ignores vignette groups with no scored observations', () => {
+    const result = buildVignetteWeightedCellMetrics([
+      [{ outcome: 'unscored', strength: null }],
+      [{ outcome: 'own_picked', strength: 'lean' }],
+    ]);
+
+    expect(result).toEqual({
+      n: 1,
+      unscoredCount: 1,
+      successes: 1,
+      winRate: 1,
+      conviction: 1,
+      netScore: 1,
+      lowData: true,
+    });
   });
 });
 

--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
@@ -350,9 +350,9 @@ export function PressureResponseByValueTable({ valuePairs }: Props) {
             its 9 pairings, broken down by what the prompt was doing.
           </p>
           <p className="text-xs text-gray-500">
-            All four rates are averaged across the 9 pairs containing this value. For pairs where this value is
-            alphabetically second, we approximate its rate from the first value&apos;s rate (small error from neutral
-            picks, typically under 1 pp).
+            Each pressure cell counts each vignette once. The pair rows are then averaged equally across the 9 pairs
+            containing this value. For pairs where this value is alphabetically second, we approximate its rate from
+            the first value&apos;s rate (small error from neutral picks, typically under 1 pp).
           </p>
         </div>
         <CopyVisualButton targetRef={tableRef} label="Pressure Response by Value" />


### PR DESCRIPTION
## Summary
- Weight each pressure cell by vignette, not transcript count, so the report compares values at the vignette level.
- Keep the pair-level summary equal-weighted across the 9 pairings, but make each pair's cell stats vignette-weighted.
- Update the pressure report copy and add a regression test for vignette-level weighting.

## Test plan
- [x] `npm run test --workspace @valuerank/api -- tests/services/pressure-sensitivity/aggregation.test.ts`
- [x] `npm run build --workspace @valuerank/api`
- [x] `npm run test --workspace @valuerank/web -- src/components/models/PressureResponseByValueTable.test.tsx`
- [x] `npm run build --workspace @valuerank/web`

🤖 Generated with [Codex](https://claude.com/code)