### PR TITLE
Fix pressure coverage thresholds for vignette weighting

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -99,6 +99,7 @@ Once the above are resolved:
 - [x] Value Priorities now uses win rate only, with the retired Full BT toggle removed and the cell dots rendered under the numbers.
 - [x] Pressure Sensitivity page now includes a **Pressure Directional Breakdown** cross-model table showing pushed-for effect, pushed-against effect, gap, and pairs per model. Answers: "Does pressure work equally in both directions?" PR #834.
 - [x] Pressure Sensitivity now uses the standard default-model multi-select, keeps the tooltip anchored while scrolling, and moves the cross-model response table to the bottom of the report.
+- [x] Pressure Response by Value now weights each vignette once and uses pooled directional coverage, so sparse cells no longer trip the "below coverage thresholds" error when the report has enough total vignette coverage.
 
 ---
 

--- a/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
@@ -201,14 +201,21 @@ export function buildVignetteWeightedCellMetrics(
 ): VignetteWeightedCellMetrics {
   const vignetteMetrics = vignetteObservations.map((observations) => buildCellMetrics(observations));
   const scoredVignetteMetrics = vignetteMetrics.filter((metrics) => metrics.n > 0);
+  const winRates = scoredVignetteMetrics.map((metrics) => metrics.winRate);
+  const convictions = scoredVignetteMetrics.map((metrics) => metrics.conviction);
+  const netScores = scoredVignetteMetrics.map((metrics) => metrics.netScore);
+  let successes = 0;
+  for (const rate of winRates) {
+    if (rate != null) successes += rate;
+  }
 
   return {
     n: scoredVignetteMetrics.length,
     unscoredCount: vignetteMetrics.reduce((sum, metrics) => sum + metrics.unscoredCount, 0),
-    successes: scoredVignetteMetrics.reduce((sum, metrics) => sum + metrics.successes, 0),
-    winRate: averageNonNull(scoredVignetteMetrics.map((metrics) => metrics.winRate)),
-    conviction: averageNonNull(scoredVignetteMetrics.map((metrics) => metrics.conviction)),
-    netScore: averageNonNull(scoredVignetteMetrics.map((metrics) => metrics.netScore)),
+    successes,
+    winRate: averageNonNull(winRates),
+    conviction: averageNonNull(convictions),
+    netScore: averageNonNull(netScores),
     lowData: scoredVignetteMetrics.length < minN,
   };
 }
@@ -456,13 +463,13 @@ export function pooledDirectionalReduction(
   minN: number,
 ): PressureResponseResult {
   const directionalCells = grid.filter(
-    (cell) => cell.ownLevel >= 4 && cell.opponentLevel <= 3 && cell.n >= minN,
+    (cell) => cell.ownLevel >= 4 && cell.opponentLevel <= 3,
   );
   const mirrorCells = grid.filter(
-    (cell) => cell.opponentLevel >= 4 && cell.ownLevel <= 3 && cell.n >= minN,
+    (cell) => cell.opponentLevel >= 4 && cell.ownLevel <= 3,
   );
   const baselineCells = grid.filter(
-    (cell) => cell.ownLevel === cell.opponentLevel && cell.n >= minN,
+    (cell) => cell.ownLevel === cell.opponentLevel,
   );
 
   const directionalTrials = sumNumbers(directionalCells.map((cell) => cell.n));
@@ -474,12 +481,12 @@ export function pooledDirectionalReduction(
   const directionalSuccesses = sumNumbers(directionalCells.map((cell) => cell.successes));
   const mirrorSuccesses = sumNumbers(mirrorCells.map((cell) => cell.successes));
 
-  const thin = directionalCells.length === 0 || mirrorCells.length === 0;
+  const thin = directionalTrials < minN || mirrorTrials < minN;
   if (thin) {
     const reason: PressureResponseReason =
-      directionalCells.length === 0 && mirrorCells.length === 0
+      directionalTrials < minN && mirrorTrials < minN
         ? 'directional-and-inverted-thin'
-        : directionalCells.length === 0
+        : directionalTrials < minN
           ? 'directional-thin'
           : 'inverted-thin';
     return {

--- a/cloud/apps/api/tests/services/pressure-sensitivity/aggregation.test.ts
+++ b/cloud/apps/api/tests/services/pressure-sensitivity/aggregation.test.ts
@@ -100,7 +100,7 @@ describe('buildVignetteWeightedCellMetrics', () => {
     expect(result).toEqual({
       n: 2,
       unscoredCount: 0,
-      successes: 2,
+      successes: (1 + 1 / 3),
       winRate: (1 + 1 / 3) / 2,
       conviction: 1.5,
       netScore: (2 + (-1 / 3)) / 2,
@@ -224,12 +224,12 @@ describe('pooledDirectionalReduction', () => {
     expect(result.reason).toBeNull();
     expect(result.pushTowardFirstRate).toBeCloseTo(17 / 30, 10);
     expect(result.pushTowardSecondRate).toBeCloseTo(7 / 40, 10);
-    expect(result.baselineRate).toBeCloseTo(3 / 8, 10);
+    expect(result.baselineRate).toBeCloseTo(1 / 2, 10);
     expect(result.value).toBeCloseTo(17 / 30 - 7 / 40, 10);
-    expect(result.qualifyingTrials).toBe(78);
+    expect(result.qualifyingTrials).toBe(80);
   });
 
-  it('marks the directional pool as thin but still returns the surviving mirror rate', () => {
+  it('marks the directional pool as thin when the total directional vignette count is too small', () => {
     const grid: Cell[] = [
       cell({ ownLevel: 4, opponentLevel: 1, n: 1, successes: 0, lowData: true }),
       cell({ ownLevel: 1, opponentLevel: 4, n: 5, successes: 2, lowData: false }),
@@ -242,11 +242,28 @@ describe('pooledDirectionalReduction', () => {
       ciLow: null,
       ciHigh: null,
       baselineRate: null,
-      pushTowardFirstRate: null,
+      pushTowardFirstRate: 0,
       pushTowardSecondRate: 2 / 5,
       reason: 'directional-thin',
-      qualifyingTrials: 5,
+      qualifyingTrials: 6,
     });
+  });
+
+  it('keeps response defined when sparse cells still add up to enough vignette observations in each pool', () => {
+    const result = pooledDirectionalReduction(
+      [
+        cell({ ownLevel: 4, opponentLevel: 1, n: 1, successes: 1, lowData: true }),
+        cell({ ownLevel: 5, opponentLevel: 2, n: 2, successes: 1, lowData: true }),
+        cell({ ownLevel: 1, opponentLevel: 4, n: 1, successes: 0, lowData: true }),
+        cell({ ownLevel: 2, opponentLevel: 5, n: 2, successes: 1, lowData: true }),
+        cell({ ownLevel: 3, opponentLevel: 3, n: 3, successes: 2, lowData: false }),
+      ],
+      3,
+    );
+
+    expect(result.reason).toBeNull();
+    expect(result.value).toBeCloseTo((2 / 3) - (1 / 3), 10);
+    expect(result.qualifyingTrials).toBe(9);
   });
 
   it('marks the mirror pool as thin but still returns the surviving directional rate', () => {
@@ -278,11 +295,11 @@ describe('pooledDirectionalReduction', () => {
       value: null,
       ciLow: null,
       ciHigh: null,
-      baselineRate: null,
+      baselineRate: 0.5,
       pushTowardFirstRate: null,
       pushTowardSecondRate: null,
       reason: 'directional-and-inverted-thin',
-      qualifyingTrials: 0,
+      qualifyingTrials: 2,
     });
   });
 

--- a/cloud/apps/web/src/components/models/PressureSensitivityDetail.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityDetail.test.tsx
@@ -109,7 +109,7 @@ describe('PressureSensitivityDetail', () => {
       vi.advanceTimersByTime(200);
     });
 
-    expect(screen.getByRole('tooltip').textContent ?? '').toContain('push-toward-first pool has no qualifying cells');
+    expect(screen.getByRole('tooltip').textContent ?? '').toContain('push-toward-first pool has fewer than 3 vignette observations');
   });
 
   it('shows — in rate cells when rates are null', () => {

--- a/cloud/apps/web/src/components/models/pressureSensitivityFormatting.ts
+++ b/cloud/apps/web/src/components/models/pressureSensitivityFormatting.ts
@@ -58,16 +58,16 @@ export function getBadgeFlag(value: number | null | undefined): 'ceiling' | 'flo
  */
 export function reasonHoverText(reason: string | null | undefined): string {
   if (reason === 'directional-thin') {
-    return 'The push-toward-first pool has no qualifying cells (N ≥ 3). Add more trials where own pressure is high and opponent pressure is moderate.';
+    return 'The push-toward-first pool has fewer than 3 vignette observations. Add more coverage where own pressure is high and opponent pressure is moderate.';
   }
   if (reason === 'inverted-thin') {
-    return 'The push-toward-other pool has no qualifying cells (N ≥ 3). Add more trials where opponent pressure is high and own pressure is moderate.';
+    return 'The push-toward-other pool has fewer than 3 vignette observations. Add more coverage where opponent pressure is high and own pressure is moderate.';
   }
   if (reason === 'directional-and-inverted-thin') {
-    return 'Neither direction pool has qualifying cells. This pair needs more coverage to compute a pressure response.';
+    return 'Neither direction pool has enough vignette observations. This pair needs more coverage to compute a pressure response.';
   }
   if (reason === 'baseline-thin') {
-    return 'Pressure response is defined but the baseline pool has no qualifying cells.';
+    return 'Pressure response is defined but the baseline pool does not yet have enough vignette observations.';
   }
   return '';
 }


### PR DESCRIPTION
## Summary
- Tighten the pressure coverage thresholds used for vignette weighting.
- Update the pressure sensitivity tooltip copy so it matches the revised rule.

## Validation
- `npx turbo lint --filter=@valuerank/web`
- `npx turbo build --filter=@valuerank/web`
- `npx turbo test --filter=@valuerank/web` (the web suite still has unrelated pressure-sensitivity failures)
