### PR TITLE
[codex] add bar view for model groups

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
@@ -10,11 +10,23 @@ import {
   isClusterScoreClipped,
 } from './clusterVisualizationUtils';
 
-type ClusterDotPlotProps = {
+type ClusterBarPlotProps = {
   clusters: DomainCluster[];
 };
 
-export function ClusterDotPlot({ clusters }: ClusterDotPlotProps) {
+const CLUSTER_PALETTE = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'] as const;
+
+function getClusterBarOrder(clusters: DomainCluster[], valueKey: string): DomainCluster[] {
+  return [...clusters].sort((left, right) => {
+    const leftScore = Math.abs(left.centroid[valueKey] ?? 0);
+    const rightScore = Math.abs(right.centroid[valueKey] ?? 0);
+    const lengthDiff = rightScore - leftScore;
+    if (Math.abs(lengthDiff) > 1e-9) return lengthDiff;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
   const sortedValues = useMemo(() => getClusterValueOrder(clusters), [clusters]);
 
   if (clusters.length === 0) {
@@ -51,36 +63,42 @@ export function ClusterDotPlot({ clusters }: ClusterDotPlotProps) {
 
           {sortedValues.map((valueKey) => {
             const label = VALUE_LABELS[valueKey];
+            const midpoint = getClusterScorePosition(0);
+            const rankedClusters = getClusterBarOrder(clusters, valueKey);
 
             return (
               <div key={valueKey} className="flex items-center gap-2">
                 <div className="w-32 shrink-0 pr-2 text-right text-xs text-gray-700">{label}</div>
-                <div className="relative h-5 flex-1 rounded-md bg-gray-50">
+                <div className="relative h-6 flex-1 rounded-md bg-gray-50">
                   <div className="absolute bottom-0 top-0 w-px bg-gray-300" style={{ left: '50%' }} />
                   <div className="absolute bottom-1 top-1 w-px border-l border-dashed border-gray-200" style={{ left: '25%' }} />
                   <div className="absolute bottom-1 top-1 w-px border-l border-dashed border-gray-200" style={{ left: '75%' }} />
-                  {clusters.map((cluster, index) => {
+
+                  {rankedClusters.map((cluster, index) => {
                     const score = cluster.centroid[valueKey] ?? 0;
-                    const xPct = getClusterScorePosition(score);
-                    const color = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'][index % 4];
-                    const memberLabels = cluster.members.map((member) => member.label).join(', ');
+                    const endPosition = getClusterScorePosition(score);
+                    const left = Math.min(midpoint, endPosition);
+                    const width = Math.max(Math.abs(endPosition - midpoint), 1);
+                    const clusterIndex = clusters.findIndex((candidate) => candidate.id === cluster.id);
+                    const safeClusterIndex = clusterIndex >= 0 ? clusterIndex : 0;
+                    const color = CLUSTER_PALETTE[safeClusterIndex % CLUSTER_PALETTE.length];
+                    const memberLabels = getClusterMemberLabelText(cluster);
                     const clipped = isClusterScoreClipped(score);
 
                     return (
                       <div
                         key={cluster.id}
                         title={`${memberLabels}: ${score.toFixed(2)}`}
-                        className="absolute"
+                        className="absolute top-1/2 h-2.5 rounded-full"
                         style={{
-                          left: `${xPct}%`,
-                          top: '50%',
-                          transform: 'translate(-50%, -50%)',
+                          left: `${left}%`,
+                          width: `${width}%`,
+                          transform: 'translateY(-50%)',
                           backgroundColor: color,
-                          width: '12px',
-                          height: '12px',
-                          borderRadius: '50%',
-                          border: clipped ? '2px solid rgba(15, 23, 42, 0.45)' : '2px solid white',
+                          opacity: 0.78,
+                          zIndex: index + 1,
                           boxShadow: clipped ? '0 0 0 1px rgba(15, 23, 42, 0.12)' : undefined,
+                          border: clipped ? '1px solid rgba(15, 23, 42, 0.4)' : '1px solid rgba(255, 255, 255, 0.8)',
                         }}
                       />
                     );
@@ -117,7 +135,7 @@ export function ClusterDotPlot({ clusters }: ClusterDotPlotProps) {
 
       <div className="flex flex-wrap gap-3">
         {clusters.map((cluster, index) => {
-          const color = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'][index % 4];
+          const color = CLUSTER_PALETTE[index % CLUSTER_PALETTE.length]!;
           const memberList = getClusterMemberLabelText(cluster);
 
           return (

--- a/cloud/apps/web/src/components/domains/ClusterHeatmap.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterHeatmap.tsx
@@ -2,7 +2,12 @@ import { useMemo } from 'react';
 import { type DomainCluster } from '../../api/operations/domainAnalysis';
 import { VALUE_LABELS } from '../../data/domainAnalysisData';
 import { getPriorityColor } from './domainAnalysisColors';
-import { CLUSTER_SCORE_MAX, CLUSTER_SCORE_MIN, getClusterValueOrder } from './clusterVisualizationUtils';
+import {
+  CLUSTER_SCORE_MAX,
+  CLUSTER_SCORE_MIN,
+  getClusterMemberLabelText,
+  getClusterValueOrder,
+} from './clusterVisualizationUtils';
 
 type ClusterHeatmapProps = {
   clusters: DomainCluster[];
@@ -52,12 +57,12 @@ export function ClusterHeatmap({ clusters }: ClusterHeatmapProps) {
             </tr>
           </thead>
           <tbody>
-            {clusters.map((cluster, index) => {
-              const palette = CLUSTER_PALETTE[index % CLUSTER_PALETTE.length]!;
-              const memberLabels = cluster.members.map((member) => member.label).join(', ');
-              const clusterName = cluster.name.length > 0 ? cluster.name : memberLabels;
-              return (
-                <tr key={cluster.id}>
+          {clusters.map((cluster, index) => {
+            const palette = CLUSTER_PALETTE[index % CLUSTER_PALETTE.length]!;
+            const memberLabels = getClusterMemberLabelText(cluster);
+            const clusterName = cluster.name.length > 0 ? cluster.name : memberLabels;
+            return (
+              <tr key={cluster.id}>
                   <th
                     scope="row"
                     className={`sticky left-0 z-10 border-b border-gray-100 px-3 py-2 text-left align-top ${palette.accent}`}
@@ -66,8 +71,8 @@ export function ClusterHeatmap({ clusters }: ClusterHeatmapProps) {
                     <div className="flex items-start gap-2">
                       <span className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${palette.dot}`} />
                       <div className="min-w-0">
-                        <div className="truncate text-sm font-semibold text-gray-900">{clusterName}</div>
-                        <div className="text-[11px] text-gray-500">{cluster.members.length} model{cluster.members.length === 1 ? '' : 's'}</div>
+                        <div className="truncate text-sm font-semibold text-gray-900">Models: {memberLabels}</div>
+                        <div className="truncate text-[11px] text-gray-500">Cluster: {clusterName}</div>
                       </div>
                     </div>
                   </th>

--- a/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
@@ -5,6 +5,7 @@ import {
   CLUSTER_SCORE_MAX,
   CLUSTER_SCORE_MIN,
   CLUSTER_SCORE_RANGE,
+  getClusterMemberLabelText,
   getClusterValueOrder,
 } from './clusterVisualizationUtils';
 
@@ -66,7 +67,7 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
             Radar chart
           </text>
           <text x={24} y={44} className="fill-gray-400 text-[10px]">
-            Center ring = -2.5, outer ring = +2.5
+            Scale = -3.25 to +3.25
           </text>
 
           {[0, 0.25, 0.5, 0.75, 1].map((fraction) => {
@@ -160,13 +161,13 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
             <line x1={24} y1={512} x2={132} y2={512} stroke="#d1d5db" strokeWidth="1.5" />
             <line x1={78} y1={502} x2={78} y2={522} stroke="#d1d5db" strokeWidth="1.5" />
             <text x={24} y={500} className="fill-gray-400 text-[10px]">
-              -2.5
+              -3.25
             </text>
             <text x={71} y={500} className="fill-gray-500 text-[10px] font-semibold">
               0
             </text>
-            <text x={122} y={500} className="fill-gray-400 text-[10px]">
-              +2.5
+            <text x={116} y={500} className="fill-gray-400 text-[10px]">
+              +3.25
             </text>
           </g>
 
@@ -185,18 +186,17 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
       <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
         {clusters.map((cluster, index) => {
           const palette = CLUSTER_PALETTE[index % CLUSTER_PALETTE.length]!;
-          const memberLabels = cluster.members.map((member) => member.label).join(', ');
+          const memberLabels = getClusterMemberLabelText(cluster);
           const title = cluster.name.length > 0 ? cluster.name : memberLabels;
           return (
             <div key={cluster.id} className="rounded-lg border border-gray-200 bg-white p-3">
               <div className="flex items-start gap-2">
                 <span className="mt-1 h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: palette.stroke }} />
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-semibold text-gray-900">{title}</p>
-                  <p className="text-xs text-gray-500">{cluster.members.length} model{cluster.members.length === 1 ? '' : 's'}</p>
+                  <p className="truncate text-sm font-semibold text-gray-900">Models: {memberLabels}</p>
+                  <p className="text-xs text-gray-500">Cluster: {title}</p>
                 </div>
               </div>
-              <p className="mt-2 max-h-10 overflow-hidden text-xs text-gray-600">{memberLabels}</p>
             </div>
           );
         })}

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -5,6 +5,8 @@ import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { type ClusterAnalysis, type DomainCluster } from '../../api/operations/domainAnalysis';
 import { VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
 import { formatDisplayLabel } from '../../utils/displayLabels';
+import { getClusterMemberLabelText } from './clusterVisualizationUtils';
+import { ClusterBarPlot } from './ClusterBarPlot';
 import { ClusterDotPlot } from './ClusterDotPlot';
 import { ClusterHeatmap } from './ClusterHeatmap';
 import { ClusterRadarChart } from './ClusterRadarChart';
@@ -72,11 +74,12 @@ type ModelGroupsSectionProps = {
   selectedModelId?: string | null;
 };
 
-type ClusterViewMode = 'dot' | 'radar' | 'heatmap';
+type ClusterViewMode = 'dot' | 'bar' | 'radar' | 'heatmap';
 
 const CLUSTER_VIEW_OPTIONS: Array<{ value: ClusterViewMode; label: string }> = [
   { value: 'radar', label: 'Radar' },
   { value: 'dot', label: 'Dot map' },
+  { value: 'bar', label: 'Bar' },
   { value: 'heatmap', label: 'Heatmap' },
 ];
 
@@ -96,9 +99,11 @@ export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: 
 
   const copyLabel = viewMode === 'dot'
     ? 'model groups dot map'
-    : viewMode === 'radar'
-      ? 'model groups radar chart'
-      : 'model groups heatmap';
+    : viewMode === 'bar'
+      ? 'model groups bar chart'
+      : viewMode === 'radar'
+        ? 'model groups radar chart'
+        : 'model groups heatmap';
 
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-4">
@@ -192,8 +197,9 @@ export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: 
             <p className="mt-1">
               The default dot map shows each value on a fixed scale from -3.25 to +3.25, with 0 in the
               middle. Values are sorted from the ones the groups favor most on average to the ones they
-              favor least. Use the toggle above to compare the radar chart, dot map, and heatmap views of
-              the same cluster data.
+              favor least. The bar view shows the same scores as bars instead of dots, with shorter bars
+              rendered on top so they stay visible. Use the toggle above to compare the radar chart, dot
+              map, bar chart, and heatmap views of the same cluster data.
             </p>
           </div>
         </div>
@@ -207,16 +213,18 @@ export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: 
         ) : (
           <>
             {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} />}
+            {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} />}
             {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} />}
             {viewMode === 'heatmap' && <ClusterHeatmap clusters={clusters} />}
             <div className="flex flex-wrap gap-4">
               {clusters.map((cluster, index) => {
                 const style = getClusterColor(index);
                 const personality = getClusterPersonality(cluster);
+                const memberLabels = getClusterMemberLabelText(cluster);
                 return (
                   <div key={cluster.id} className={`min-w-[280px] max-w-[520px] rounded-lg border ${style.border} ${style.light} p-3`}>
                     <p className={`text-sm font-semibold ${style.text}`}>
-                      <span className="font-medium">Members:</span> {cluster.members.map((member) => member.label).join(', ')}
+                      <span className="font-medium">Models:</span> {memberLabels}
                     </p>
                     <p className="mt-2 text-xs text-gray-700">
                       <span className="font-medium">Prioritizes:</span> {personality.topValues.join(', ')}

--- a/cloud/apps/web/src/components/domains/clusterVisualizationUtils.ts
+++ b/cloud/apps/web/src/components/domains/clusterVisualizationUtils.ts
@@ -29,6 +29,14 @@ export function getClusterValueOrder(clusters: DomainCluster[]): ValueKey[] {
   });
 }
 
+export function getClusterMemberLabels(cluster: DomainCluster): string[] {
+  return cluster.members.map((member) => member.label);
+}
+
+export function getClusterMemberLabelText(cluster: DomainCluster): string {
+  return getClusterMemberLabels(cluster).join(', ');
+}
+
 export function clampClusterScore(score: number): number {
   return Math.max(CLUSTER_SCORE_MIN, Math.min(CLUSTER_SCORE_MAX, score));
 }

--- a/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
+++ b/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { ModelGroupsSection } from '../../src/components/domains/ModelGroupsSection';
@@ -11,6 +12,55 @@ const skippedClusterAnalysis: ClusterAnalysis = {
   faultLinesByPair: {},
 };
 
+const populatedClusterAnalysis: ClusterAnalysis = {
+  skipped: false,
+  skipReason: null,
+  defaultPair: null,
+  clusters: [
+    {
+      id: 'cluster-1',
+      name: '',
+      definingValues: [],
+      centroid: {
+        Achievement: 1.6,
+        Benevolence: -0.1,
+        Universalism_Nature: 0.7,
+      },
+      members: [
+        {
+          model: 'model-a',
+          label: 'Model A',
+          silhouetteScore: 0.52,
+          isOutlier: false,
+          nearestClusterIds: null,
+          distancesToNearestClusters: null,
+        },
+      ],
+    },
+    {
+      id: 'cluster-2',
+      name: '',
+      definingValues: [],
+      centroid: {
+        Achievement: 0.6,
+        Benevolence: 1.2,
+        Universalism_Nature: -0.4,
+      },
+      members: [
+        {
+          model: 'model-b',
+          label: 'Model B',
+          silhouetteScore: 0.41,
+          isOutlier: false,
+          nearestClusterIds: null,
+          distancesToNearestClusters: null,
+        },
+      ],
+    },
+  ],
+  faultLinesByPair: {},
+};
+
 describe('ModelGroupsSection', () => {
   it('renders the plain model groups heading without numbering', () => {
     render(<ModelGroupsSection clusterAnalysis={skippedClusterAnalysis} />);
@@ -18,5 +68,19 @@ describe('ModelGroupsSection', () => {
     expect(screen.getByRole('heading', { name: 'Model Groups' })).toBeInTheDocument();
     expect(screen.getByText(/cluster analysis not available/i)).toBeInTheDocument();
     expect(screen.queryByText(/^1\./i)).not.toBeInTheDocument();
+  });
+
+  it('offers a bar view and keeps the legend focused on model names', async () => {
+    const user = userEvent.setup();
+
+    render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} />);
+
+    expect(screen.getByRole('button', { name: 'Bar' })).toBeInTheDocument();
+    expect(screen.getByText(/Models: Model A/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Bar' }));
+
+    expect(screen.getByText(/Models: Model A/i)).toBeInTheDocument();
+    expect(screen.getByText(/Models: Model B/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Keep the existing dot plot and add a separate bar view for the same cluster comparison.
- Use the same fixed symmetric scale and draw shorter bars on top so every bar stays visible.
- Show model names in the legends across the visualizations.

## Base branch
- This PR is stacked on `codex/pressure-response-tooltip-grid` so it stays separate from the pressure fix work.

## Validation
- `npx turbo lint --filter=@valuerank/web`
- `npx turbo build --filter=@valuerank/web`
- `npx turbo test --filter=@valuerank/web` (the web suite still has unrelated pressure-sensitivity failures)
