### PR TITLE
[codex] tighten model group dot and bar scale

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
@@ -2,8 +2,9 @@ import { useMemo } from 'react';
 import { type DomainCluster } from '../../api/operations/domainAnalysis';
 import { VALUE_LABELS } from '../../data/domainAnalysisData';
 import {
-  CLUSTER_SCORE_MAX,
-  CLUSTER_SCORE_MIN,
+  DOT_BAR_CLUSTER_SCORE_MAX,
+  DOT_BAR_CLUSTER_SCORE_MIN,
+  formatClusterScoreLabel,
   getClusterMemberLabelText,
   getClusterScorePosition,
   getClusterValueOrder,
@@ -39,7 +40,7 @@ export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
         <div className="mb-2 flex items-center justify-between gap-2 text-[11px] text-gray-500">
           <span>Values ordered by average favorability across the shown clusters.</span>
           <span>
-            Fixed axis: {CLUSTER_SCORE_MIN.toFixed(2)} to {CLUSTER_SCORE_MAX.toFixed(2)} with 0 at the midpoint.
+            Fixed axis: {formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MIN)} to {formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MAX)} with 0 at the midpoint.
           </span>
         </div>
 
@@ -63,7 +64,7 @@ export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
 
           {sortedValues.map((valueKey) => {
             const label = VALUE_LABELS[valueKey];
-            const midpoint = getClusterScorePosition(0);
+            const midpoint = getClusterScorePosition(0, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
             const rankedClusters = getClusterBarOrder(clusters, valueKey);
 
             return (
@@ -76,14 +77,14 @@ export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
 
                   {rankedClusters.map((cluster, index) => {
                     const score = cluster.centroid[valueKey] ?? 0;
-                    const endPosition = getClusterScorePosition(score);
+                    const endPosition = getClusterScorePosition(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
                     const left = Math.min(midpoint, endPosition);
                     const width = Math.max(Math.abs(endPosition - midpoint), 1);
                     const clusterIndex = clusters.findIndex((candidate) => candidate.id === cluster.id);
                     const safeClusterIndex = clusterIndex >= 0 ? clusterIndex : 0;
                     const color = CLUSTER_PALETTE[safeClusterIndex % CLUSTER_PALETTE.length];
                     const memberLabels = getClusterMemberLabelText(cluster);
-                    const clipped = isClusterScoreClipped(score);
+                    const clipped = isClusterScoreClipped(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
 
                     return (
                       <div
@@ -111,7 +112,7 @@ export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
           <div className="flex items-center gap-2">
             <div className="w-32 shrink-0" />
             <div className="relative h-5 flex-1">
-              <div className="absolute left-0 top-0 text-xs text-gray-400">{CLUSTER_SCORE_MIN.toFixed(2)}</div>
+              <div className="absolute left-0 top-0 text-xs text-gray-400">{formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MIN)}</div>
               <div
                 className="absolute top-0 text-xs font-semibold text-gray-500"
                 style={{
@@ -121,11 +122,11 @@ export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
               >
                 0
               </div>
-              <div className="absolute right-0 top-0 text-xs text-gray-400">{CLUSTER_SCORE_MAX.toFixed(2)}</div>
+              <div className="absolute right-0 top-0 text-xs text-gray-400">{formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MAX)}</div>
             </div>
           </div>
 
-          {clusters.some((cluster) => sortedValues.some((valueKey) => isClusterScoreClipped(cluster.centroid[valueKey] ?? 0))) && (
+          {clusters.some((cluster) => sortedValues.some((valueKey) => isClusterScoreClipped(cluster.centroid[valueKey] ?? 0, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX))) && (
             <p className="px-2 pb-1 text-[11px] text-amber-700">
               Scores outside the fixed range are pinned to the edge.
             </p>

--- a/cloud/apps/web/src/components/domains/ClusterDotPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterDotPlot.tsx
@@ -2,8 +2,9 @@ import { useMemo } from 'react';
 import { type DomainCluster } from '../../api/operations/domainAnalysis';
 import { VALUE_LABELS } from '../../data/domainAnalysisData';
 import {
-  CLUSTER_SCORE_MAX,
-  CLUSTER_SCORE_MIN,
+  DOT_BAR_CLUSTER_SCORE_MAX,
+  DOT_BAR_CLUSTER_SCORE_MIN,
+  formatClusterScoreLabel,
   getClusterMemberLabelText,
   getClusterScorePosition,
   getClusterValueOrder,
@@ -27,7 +28,7 @@ export function ClusterDotPlot({ clusters }: ClusterDotPlotProps) {
         <div className="mb-2 flex items-center justify-between gap-2 text-[11px] text-gray-500">
           <span>Values ordered by average favorability across the shown clusters.</span>
           <span>
-            Fixed axis: {CLUSTER_SCORE_MIN.toFixed(2)} to {CLUSTER_SCORE_MAX.toFixed(2)} with 0 at the midpoint.
+            Fixed axis: {formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MIN)} to {formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MAX)} with 0 at the midpoint.
           </span>
         </div>
 
@@ -61,10 +62,10 @@ export function ClusterDotPlot({ clusters }: ClusterDotPlotProps) {
                   <div className="absolute bottom-1 top-1 w-px border-l border-dashed border-gray-200" style={{ left: '75%' }} />
                   {clusters.map((cluster, index) => {
                     const score = cluster.centroid[valueKey] ?? 0;
-                    const xPct = getClusterScorePosition(score);
+                    const xPct = getClusterScorePosition(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
                     const color = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'][index % 4];
                     const memberLabels = cluster.members.map((member) => member.label).join(', ');
-                    const clipped = isClusterScoreClipped(score);
+                    const clipped = isClusterScoreClipped(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
 
                     return (
                       <div
@@ -93,7 +94,7 @@ export function ClusterDotPlot({ clusters }: ClusterDotPlotProps) {
           <div className="flex items-center gap-2">
             <div className="w-32 shrink-0" />
             <div className="relative h-5 flex-1">
-              <div className="absolute left-0 top-0 text-xs text-gray-400">{CLUSTER_SCORE_MIN.toFixed(2)}</div>
+              <div className="absolute left-0 top-0 text-xs text-gray-400">{formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MIN)}</div>
               <div
                 className="absolute top-0 text-xs font-semibold text-gray-500"
                 style={{
@@ -103,11 +104,11 @@ export function ClusterDotPlot({ clusters }: ClusterDotPlotProps) {
               >
                 0
               </div>
-              <div className="absolute right-0 top-0 text-xs text-gray-400">{CLUSTER_SCORE_MAX.toFixed(2)}</div>
+              <div className="absolute right-0 top-0 text-xs text-gray-400">{formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MAX)}</div>
             </div>
           </div>
 
-          {clusters.some((cluster) => sortedValues.some((valueKey) => isClusterScoreClipped(cluster.centroid[valueKey] ?? 0))) && (
+          {clusters.some((cluster) => sortedValues.some((valueKey) => isClusterScoreClipped(cluster.centroid[valueKey] ?? 0, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX))) && (
             <p className="px-2 pb-1 text-[11px] text-amber-700">
               Scores outside the fixed range are pinned to the edge.
             </p>

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -195,7 +195,7 @@ export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: 
               priorities point in different directions — large distance.
             </p>
             <p className="mt-1">
-              The default dot map shows each value on a fixed scale from -3.25 to +3.25, with 0 in the
+              The default dot map shows each value on a fixed scale from -2.5 to +2.5, with 0 in the
               middle. Values are sorted from the ones the groups favor most on average to the ones they
               favor least. The bar view shows the same scores as bars instead of dots, with shorter bars
               rendered on top so they stay visible. Use the toggle above to compare the radar chart, dot

--- a/cloud/apps/web/src/components/domains/clusterVisualizationUtils.ts
+++ b/cloud/apps/web/src/components/domains/clusterVisualizationUtils.ts
@@ -5,6 +5,10 @@ export const CLUSTER_SCORE_MIN = -3.25;
 export const CLUSTER_SCORE_MAX = 3.25;
 export const CLUSTER_SCORE_RANGE = CLUSTER_SCORE_MAX - CLUSTER_SCORE_MIN;
 
+export const DOT_BAR_CLUSTER_SCORE_MIN = -2.5;
+export const DOT_BAR_CLUSTER_SCORE_MAX = 2.5;
+export const DOT_BAR_CLUSTER_SCORE_RANGE = DOT_BAR_CLUSTER_SCORE_MAX - DOT_BAR_CLUSTER_SCORE_MIN;
+
 const VALUE_INDEX = new Map(VALUES.map((valueKey, index) => [valueKey, index] as const));
 
 function averageScore(clusters: DomainCluster[], valueKey: ValueKey): number {
@@ -37,20 +41,38 @@ export function getClusterMemberLabelText(cluster: DomainCluster): string {
   return getClusterMemberLabels(cluster).join(', ');
 }
 
-export function clampClusterScore(score: number): number {
-  return Math.max(CLUSTER_SCORE_MIN, Math.min(CLUSTER_SCORE_MAX, score));
+export function formatClusterScoreLabel(score: number): string {
+  return score > 0 ? `+${score.toFixed(2)}` : score.toFixed(2);
 }
 
-export function getClusterScorePosition(score: number): number {
-  const clamped = clampClusterScore(score);
-  return ((clamped - CLUSTER_SCORE_MIN) / CLUSTER_SCORE_RANGE) * 100;
+export function clampClusterScore(score: number, min = CLUSTER_SCORE_MIN, max = CLUSTER_SCORE_MAX): number {
+  return Math.max(min, Math.min(max, score));
 }
 
-export function getClusterHeatmapScale(score: number): number {
-  const clamped = clampClusterScore(score);
-  return ((clamped - CLUSTER_SCORE_MIN) / CLUSTER_SCORE_RANGE) * 2 - 1;
+export function getClusterScorePosition(
+  score: number,
+  min = CLUSTER_SCORE_MIN,
+  max = CLUSTER_SCORE_MAX,
+): number {
+  const clamped = clampClusterScore(score, min, max);
+  const range = max - min;
+  return ((clamped - min) / range) * 100;
 }
 
-export function isClusterScoreClipped(score: number): boolean {
-  return score < CLUSTER_SCORE_MIN || score > CLUSTER_SCORE_MAX;
+export function getClusterHeatmapScale(
+  score: number,
+  min = CLUSTER_SCORE_MIN,
+  max = CLUSTER_SCORE_MAX,
+): number {
+  const clamped = clampClusterScore(score, min, max);
+  const range = max - min;
+  return ((clamped - min) / range) * 2 - 1;
+}
+
+export function isClusterScoreClipped(
+  score: number,
+  min = CLUSTER_SCORE_MIN,
+  max = CLUSTER_SCORE_MAX,
+): boolean {
+  return score < min || score > max;
 }

--- a/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
+++ b/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
@@ -76,6 +76,8 @@ describe('ModelGroupsSection', () => {
     render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} />);
 
     expect(screen.getByRole('button', { name: 'Bar' })).toBeInTheDocument();
+    expect(screen.getByText('-2.50')).toBeInTheDocument();
+    expect(screen.getByText('+2.50')).toBeInTheDocument();
     expect(screen.getByText(/Models: Model A/i)).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Bar' }));


### PR DESCRIPTION
## Summary
- Tighten the dot map and bar view axes to `-2.5` to `+2.5` to reduce empty space.
- Keep the radar and heatmap views on the wider fixed scale.
- Update the model groups help copy and axis labels so the new range is clear.

## Validation
- `npm run lint --workspace @valuerank/web`
- `npm run build --workspace @valuerank/web`
- `npm run test --workspace @valuerank/web -- tests/components/ModelGroupsSection.test.tsx`
