### PR TITLE
[codex] default domain analysis to all domains

### DIFF
--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -48,10 +48,11 @@ export function DomainAnalysis() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { domains, queryLoading: domainsLoading, error: domainsError } = useDomains();
+  const initialDomainId = searchParams.get('domainId') ?? '';
   const [selectedScope, setSelectedScope] = useState<'DOMAIN' | 'ALL_DOMAINS'>(
-    searchParams.get('scope') === ALL_DOMAINS_SCOPE ? 'ALL_DOMAINS' : 'DOMAIN',
+    searchParams.get('scope') === ALL_DOMAINS_SCOPE || initialDomainId.trim() === '' ? 'ALL_DOMAINS' : 'DOMAIN',
   );
-  const [selectedDomainId, setSelectedDomainId] = useState<string>(searchParams.get('domainId') ?? '');
+  const [selectedDomainId, setSelectedDomainId] = useState<string>(initialDomainId);
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
   const initializedModelSelection = useRef(false);

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -214,7 +214,7 @@ describe('DomainAnalysis', () => {
     expect(dominance.compareDocumentPosition(similarity) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it('defaults the signature dropdown to latest default when available', async () => {
+  it('defaults the scope dropdown to all domains when no domain is selected', async () => {
     render(
       <MemoryRouter>
         <DomainAnalysis />
@@ -226,12 +226,14 @@ describe('DomainAnalysis', () => {
         expect.objectContaining({
           variables: expect.objectContaining({
             domainId: 'domain-a',
+            scope: 'all-domains',
             signature: 'vnewtd',
           }),
         }),
       );
     });
 
+    expect(screen.getByRole('button', { name: /all domains/i })).toBeInTheDocument();
     const signatureSelect = screen.getByRole('button', { name: /latest @ default/i });
     expect(signatureSelect).toBeInTheDocument();
   });


### PR DESCRIPTION
## What changed
- Default the Domain Analysis scope dropdown to `All domains` on first load when there is no explicit `domainId` in the URL.
- Keep the existing behavior when a domain is explicitly selected in the URL.
- Update the page test to match the new default scope.

## Why
- This makes the Domain Analysis page land on the broad view first, which matches the intended default for analysis.

## Validation
- `npm run test --workspace @valuerank/web -- tests/pages/DomainAnalysis.test.tsx`
- `npm run lint --workspace @valuerank/web`
- `npm run build --workspace @valuerank/web`