### PR TITLE
[codex] add radar category ring and bar tooltips

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { type DomainCluster } from '../../api/operations/domainAnalysis';
-import { VALUE_LABELS } from '../../data/domainAnalysisData';
+import { VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
+import { Tooltip } from '../ui/Tooltip';
 import {
   DOT_BAR_CLUSTER_SCORE_MAX,
   DOT_BAR_CLUSTER_SCORE_MIN,
@@ -17,7 +18,46 @@ type ClusterBarPlotProps = {
 
 const CLUSTER_PALETTE = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'] as const;
 
-function getClusterBarOrder(clusters: DomainCluster[], valueKey: string): DomainCluster[] {
+function ClusterValueTooltip({
+  clusters,
+  valueKey,
+  rankedClusters,
+}: {
+  clusters: DomainCluster[];
+  valueKey: ValueKey;
+  rankedClusters: DomainCluster[];
+}) {
+  return (
+    <div className="min-w-[220px] max-w-[280px] whitespace-normal">
+      <div className="mb-2 text-xs font-semibold text-gray-900">{VALUE_LABELS[valueKey]}</div>
+      <div className="mb-1 grid grid-cols-[auto_1fr] gap-x-3 text-[10px] font-medium uppercase tracking-wide text-gray-500">
+        <span>Color</span>
+        <span>Logit</span>
+      </div>
+      <div className="space-y-1.5">
+        {rankedClusters.map((cluster) => {
+          const score = cluster.centroid[valueKey] ?? 0;
+          const clusterIndex = clusters.findIndex((candidate) => candidate.id === cluster.id);
+          const safeClusterIndex = clusterIndex >= 0 ? clusterIndex : 0;
+          const color = CLUSTER_PALETTE[safeClusterIndex % CLUSTER_PALETTE.length]!;
+
+          return (
+            <div key={cluster.id} className="grid grid-cols-[auto_1fr] items-center gap-x-3">
+              <span
+                aria-hidden="true"
+                className="h-2.5 w-2.5 shrink-0 rounded-full"
+                style={{ backgroundColor: color }}
+              />
+              <span className="font-mono text-xs text-gray-900">{formatClusterScoreLabel(score)}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function getClusterBarOrder(clusters: DomainCluster[], valueKey: ValueKey): DomainCluster[] {
   return [...clusters].sort((left, right) => {
     const leftScore = Math.abs(left.centroid[valueKey] ?? 0);
     const rightScore = Math.abs(right.centroid[valueKey] ?? 0);
@@ -83,25 +123,36 @@ export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
                     const clusterIndex = clusters.findIndex((candidate) => candidate.id === cluster.id);
                     const safeClusterIndex = clusterIndex >= 0 ? clusterIndex : 0;
                     const color = CLUSTER_PALETTE[safeClusterIndex % CLUSTER_PALETTE.length];
-                    const memberLabels = getClusterMemberLabelText(cluster);
                     const clipped = isClusterScoreClipped(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
 
                     return (
-                      <div
+                      <Tooltip
                         key={cluster.id}
-                        title={`${memberLabels}: ${score.toFixed(2)}`}
-                        className="absolute top-1/2 h-2.5 rounded-full"
-                        style={{
+                        content={<ClusterValueTooltip clusters={clusters} valueKey={valueKey} rankedClusters={rankedClusters} />}
+                        position="top"
+                        variant="light"
+                        className="max-w-[300px] whitespace-normal"
+                        triggerClassName="absolute top-1/2"
+                        triggerStyle={{
                           left: `${left}%`,
                           width: `${width}%`,
                           transform: 'translateY(-50%)',
-                          backgroundColor: color,
-                          opacity: 0.78,
+                          height: '10px',
                           zIndex: index + 1,
-                          boxShadow: clipped ? '0 0 0 1px rgba(15, 23, 42, 0.12)' : undefined,
-                          border: clipped ? '1px solid rgba(15, 23, 42, 0.4)' : '1px solid rgba(255, 255, 255, 0.8)',
                         }}
-                      />
+                      >
+                        <div
+                          data-cluster-id={cluster.id}
+                          data-value-key={valueKey}
+                          className="h-full w-full rounded-full"
+                          style={{
+                            backgroundColor: color,
+                            opacity: 0.78,
+                            boxShadow: clipped ? '0 0 0 1px rgba(15, 23, 42, 0.12)' : undefined,
+                            border: clipped ? '1px solid rgba(15, 23, 42, 0.4)' : '1px solid rgba(255, 255, 255, 0.8)',
+                          }}
+                        />
+                      </Tooltip>
                     );
                   })}
                 </div>

--- a/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { type DomainCluster } from '../../api/operations/domainAnalysis';
-import { VALUE_LABELS } from '../../data/domainAnalysisData';
+import { VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
 import {
   CLUSTER_SCORE_MAX,
   CLUSTER_SCORE_MIN,
@@ -18,6 +18,8 @@ const VIEW_BOX_HEIGHT = 560;
 const CENTER_X = 286;
 const CENTER_Y = 276;
 const OUTER_RADIUS = 184;
+const CATEGORY_RING_INNER_RADIUS = OUTER_RADIUS + 12;
+const CATEGORY_RING_OUTER_RADIUS = OUTER_RADIUS + 24;
 
 const CLUSTER_PALETTE = [
   { stroke: '#2563eb', fill: 'rgba(37, 99, 235, 0.14)' },
@@ -26,11 +28,68 @@ const CLUSTER_PALETTE = [
   { stroke: '#e11d48', fill: 'rgba(225, 29, 72, 0.14)' },
 ] as const;
 
+type SchwartzCategoryName =
+  | 'Self-Transcendence'
+  | 'Conservation'
+  | 'Self-Enhancement'
+  | 'Openness to Change';
+
+type SchwartzCategory = {
+  name: SchwartzCategoryName;
+  label: string;
+  color: string;
+};
+
+const SCHWARTZ_CATEGORIES = [
+  { name: 'Self-Transcendence', label: 'Self-Transcendence', color: '#f59e0b' },
+  { name: 'Conservation', label: 'Conservation', color: '#84cc16' },
+  { name: 'Self-Enhancement', label: 'Self-Enhancement', color: '#f97316' },
+  { name: 'Openness to Change', label: 'Openness to Change', color: '#f472b6' },
+] as const satisfies readonly [SchwartzCategory, SchwartzCategory, SchwartzCategory, SchwartzCategory];
+
 function getPoint(angle: number, radius: number) {
   return {
     x: CENTER_X + Math.cos(angle) * radius,
     y: CENTER_Y + Math.sin(angle) * radius,
   };
+}
+
+function getRingSegmentPath(innerRadius: number, outerRadius: number, startAngle: number, endAngle: number) {
+  const outerStart = getPoint(startAngle, outerRadius);
+  const outerEnd = getPoint(endAngle, outerRadius);
+  const innerEnd = getPoint(endAngle, innerRadius);
+  const innerStart = getPoint(startAngle, innerRadius);
+  const largeArcFlag = endAngle - startAngle > Math.PI ? 1 : 0;
+
+  return [
+    `M ${outerStart.x.toFixed(2)} ${outerStart.y.toFixed(2)}`,
+    `A ${outerRadius} ${outerRadius} 0 ${largeArcFlag} 1 ${outerEnd.x.toFixed(2)} ${outerEnd.y.toFixed(2)}`,
+    `L ${innerEnd.x.toFixed(2)} ${innerEnd.y.toFixed(2)}`,
+    `A ${innerRadius} ${innerRadius} 0 ${largeArcFlag} 0 ${innerStart.x.toFixed(2)} ${innerStart.y.toFixed(2)}`,
+    'Z',
+  ].join(' ');
+}
+
+function getValueCategories(valueKey: ValueKey): readonly SchwartzCategory[] {
+  switch (valueKey) {
+    case 'Universalism_Nature':
+    case 'Benevolence_Dependability':
+      return [SCHWARTZ_CATEGORIES[0]];
+    case 'Conformity_Interpersonal':
+    case 'Tradition':
+    case 'Security_Personal':
+      return [SCHWARTZ_CATEGORIES[1]];
+    case 'Power_Dominance':
+    case 'Achievement':
+      return [SCHWARTZ_CATEGORIES[2]];
+    case 'Hedonism':
+      return [SCHWARTZ_CATEGORIES[2], SCHWARTZ_CATEGORIES[3]];
+    case 'Stimulation':
+    case 'Self_Direction_Action':
+      return [SCHWARTZ_CATEGORIES[3]];
+    default:
+      return [];
+  }
 }
 
 function scoreToRadius(score: number): number {
@@ -61,13 +120,13 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
           viewBox={`0 0 ${CHART_SIZE} ${VIEW_BOX_HEIGHT}`}
           className="h-auto min-w-[640px] w-full"
           role="img"
-          aria-label="Cluster radar chart"
+          aria-label="Cluster radar chart ordered by favorability with Schwartz category ring"
         >
           <text x={24} y={28} className="fill-gray-500 text-[11px] uppercase tracking-wide">
             Radar chart
           </text>
           <text x={24} y={44} className="fill-gray-400 text-[10px]">
-            Scale = -3.25 to +3.25
+            Ordered by average favorability, with a Schwartz category ring.
           </text>
 
           {[0, 0.25, 0.5, 0.75, 1].map((fraction) => {
@@ -93,6 +152,53 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
                   {value.toFixed(1)}
                 </text>
               </g>
+            );
+          })}
+
+          {orderedValues.map((valueKey, index) => {
+            const angleStart = -Math.PI / 2 + angleStep * index;
+            const angleEnd = angleStart + angleStep;
+            const categories = getValueCategories(valueKey);
+
+            if (categories.length === 0) return null;
+
+            if (valueKey === 'Hedonism' && categories.length === 2) {
+              const midAngle = angleStart + angleStep / 2;
+              const firstCategory = categories[0];
+              const secondCategory = categories[1];
+              if (firstCategory == null || secondCategory == null) return null;
+
+              return (
+                <g key={`${valueKey}-category-ring`}>
+                  <path
+                    d={getRingSegmentPath(CATEGORY_RING_INNER_RADIUS, CATEGORY_RING_OUTER_RADIUS, angleStart, midAngle)}
+                    fill={firstCategory.color}
+                    fillOpacity="0.18"
+                    stroke="#ffffff"
+                    strokeWidth="1"
+                  />
+                  <path
+                    d={getRingSegmentPath(CATEGORY_RING_INNER_RADIUS, CATEGORY_RING_OUTER_RADIUS, midAngle, angleEnd)}
+                    fill={secondCategory.color}
+                    fillOpacity="0.18"
+                    stroke="#ffffff"
+                    strokeWidth="1"
+                  />
+                </g>
+              );
+            }
+
+            const category = categories[0];
+            if (category == null) return null;
+            return (
+              <path
+                key={`${valueKey}-category-ring`}
+                d={getRingSegmentPath(CATEGORY_RING_INNER_RADIUS, CATEGORY_RING_OUTER_RADIUS, angleStart, angleEnd)}
+                fill={category.color}
+                fillOpacity="0.18"
+                stroke="#ffffff"
+                strokeWidth="1"
+              />
             );
           })}
 
@@ -175,6 +281,16 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
             Mid-ring = neutral, outer ring = strongest favoring.
           </text>
         </svg>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 text-[11px] text-gray-600">
+        <span className="font-medium text-gray-500">Schwartz categories:</span>
+        {SCHWARTZ_CATEGORIES.map((category) => (
+          <span key={category.label} className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2 py-1">
+            <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: category.color }} />
+            <span>{category.label}</span>
+          </span>
+        ))}
       </div>
 
       {hasClippedScores && (

--- a/cloud/apps/web/src/components/ui/Tooltip.tsx
+++ b/cloud/apps/web/src/components/ui/Tooltip.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import { cloneElement, isValidElement, useState, useRef, useEffect, useCallback, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { cva, type VariantProps } from 'class-variance-authority';
@@ -35,6 +35,10 @@ export type TooltipProps = VariantProps<typeof tooltipVariants> & {
   className?: string;
   /** Disable the tooltip */
   disabled?: boolean;
+  /** Additional class for the trigger wrapper */
+  triggerClassName?: string;
+  /** Additional style for the trigger wrapper */
+  triggerStyle?: CSSProperties;
 };
 
 export function Tooltip({
@@ -45,6 +49,8 @@ export function Tooltip({
   variant,
   className,
   disabled = false,
+  triggerClassName,
+  triggerStyle,
 }: TooltipProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [coords, setCoords] = useState({ top: 0, left: 0 });
@@ -152,7 +158,8 @@ export function Tooltip({
         onMouseLeave={handleMouseLeave}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        className="inline-block"
+        className={cn('inline-block', triggerClassName)}
+        style={triggerStyle}
       >
         {enhancedChildren}
       </div>

--- a/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
+++ b/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
@@ -1,6 +1,5 @@
-import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ModelGroupsSection } from '../../src/components/domains/ModelGroupsSection';
 import type { ClusterAnalysis } from '../../src/api/operations/domainAnalysis';
 
@@ -62,6 +61,10 @@ const populatedClusterAnalysis: ClusterAnalysis = {
 };
 
 describe('ModelGroupsSection', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders the plain model groups heading without numbering', () => {
     render(<ModelGroupsSection clusterAnalysis={skippedClusterAnalysis} />);
 
@@ -70,9 +73,7 @@ describe('ModelGroupsSection', () => {
     expect(screen.queryByText(/^1\./i)).not.toBeInTheDocument();
   });
 
-  it('offers a bar view and keeps the legend focused on model names', async () => {
-    const user = userEvent.setup();
-
+  it('offers a bar view and keeps the legend focused on model names', () => {
     render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} />);
 
     expect(screen.getByRole('button', { name: 'Bar' })).toBeInTheDocument();
@@ -80,9 +81,47 @@ describe('ModelGroupsSection', () => {
     expect(screen.getByText('+2.50')).toBeInTheDocument();
     expect(screen.getByText(/Models: Model A/i)).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Bar' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Bar' }));
 
     expect(screen.getByText(/Models: Model A/i)).toBeInTheDocument();
     expect(screen.getByText(/Models: Model B/i)).toBeInTheDocument();
+  });
+
+  it('shows a value tooltip with color rows and logit values on bar hover', () => {
+    vi.useFakeTimers();
+
+    const { container } = render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bar' }));
+
+    const targetBar = container.querySelector('[data-value-key="Achievement"][data-cluster-id="cluster-1"]');
+    expect(targetBar).not.toBeNull();
+
+    fireEvent.mouseEnter(targetBar as Element);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Achievement');
+    expect(tooltip).toHaveTextContent('+1.60');
+    expect(tooltip).toHaveTextContent('+0.60');
+    expect(tooltip.querySelectorAll('[aria-hidden="true"]')).toHaveLength(2);
+
+    fireEvent.mouseLeave(targetBar as Element);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows the Schwartz category ring in radar view', () => {
+    render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Radar' }));
+
+    expect(screen.getByRole('img', { name: /cluster radar chart ordered by favorability with schwartz category ring/i })).toBeInTheDocument();
+    expect(screen.getByText(/schwartz categories:/i)).toBeInTheDocument();
+    expect(screen.getByText('Self-Transcendence')).toBeInTheDocument();
+    expect(screen.getByText('Conservation')).toBeInTheDocument();
+    expect(screen.getByText('Self-Enhancement')).toBeInTheDocument();
+    expect(screen.getByText('Openness to Change')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What changed
- Updated the model groups radar chart to keep the ranked value order and add an outer Schwartz category ring.
- Added a custom hover tooltip for the bar view that shows the value name, the bar color swatches, and the corresponding logit values.
- Extended the shared tooltip primitive so absolutely positioned chart bars can use the same hover behavior.
- Added tests for the bar tooltip and the radar category ring.

## Why
- The radar view needed a clearer category structure so the outer ring matches the Schwartz grouping users already see elsewhere in the app.
- The bar view needed hover details that explain which color maps to which cluster and what score each cluster has for the hovered value.

## Validation
- `npm run test --workspace @valuerank/web -- tests/components/ModelGroupsSection.test.tsx`
- `npm run lint --workspace @valuerank/web`
- `npm run build --workspace @valuerank/web`