### PR TITLE
Add group mode and legend highlighting to model groups

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
@@ -6,7 +6,6 @@ import {
   DOT_BAR_CLUSTER_SCORE_MAX,
   DOT_BAR_CLUSTER_SCORE_MIN,
   formatClusterScoreLabel,
-  getClusterMemberLabelText,
   getClusterScorePosition,
   getClusterValueOrder,
   isClusterScoreClipped,
@@ -14,6 +13,7 @@ import {
 
 type ClusterBarPlotProps = {
   clusters: DomainCluster[];
+  activeGroupId?: string | null;
 };
 
 const CLUSTER_PALETTE = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'] as const;
@@ -67,7 +67,7 @@ function getClusterBarOrder(clusters: DomainCluster[], valueKey: ValueKey): Doma
   });
 }
 
-export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
+export function ClusterBarPlot({ clusters, activeGroupId = null }: ClusterBarPlotProps) {
   const sortedValues = useMemo(() => getClusterValueOrder(clusters), [clusters]);
 
   if (clusters.length === 0) {
@@ -122,8 +122,10 @@ export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
                     const width = Math.max(Math.abs(endPosition - midpoint), 1);
                     const clusterIndex = clusters.findIndex((candidate) => candidate.id === cluster.id);
                     const safeClusterIndex = clusterIndex >= 0 ? clusterIndex : 0;
-                    const color = CLUSTER_PALETTE[safeClusterIndex % CLUSTER_PALETTE.length];
+                    const color = CLUSTER_PALETTE[safeClusterIndex % CLUSTER_PALETTE.length]!;
                     const clipped = isClusterScoreClipped(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
+                    const isActive = activeGroupId == null || activeGroupId === cluster.id;
+                    const faded = activeGroupId != null && !isActive;
 
                     return (
                       <Tooltip
@@ -138,7 +140,9 @@ export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
                           width: `${width}%`,
                           transform: 'translateY(-50%)',
                           height: '10px',
-                          zIndex: index + 1,
+                          zIndex: isActive ? rankedClusters.length + 20 - index : index + 1,
+                          opacity: faded ? 0.18 : activeGroupId != null ? 1 : 0.78,
+                          filter: isActive && activeGroupId != null ? `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${color}99)` : undefined,
                         }}
                       >
                         <div
@@ -147,8 +151,7 @@ export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
                           className="h-full w-full rounded-full"
                           style={{
                             backgroundColor: color,
-                            opacity: 0.78,
-                            boxShadow: clipped ? '0 0 0 1px rgba(15, 23, 42, 0.12)' : undefined,
+                            boxShadow: isActive && activeGroupId != null ? `0 0 0 1px rgba(255,255,255,0.7), 0 0 10px ${color}80` : undefined,
                             border: clipped ? '1px solid rgba(15, 23, 42, 0.4)' : '1px solid rgba(255, 255, 255, 0.8)',
                           }}
                         />
@@ -183,23 +186,6 @@ export function ClusterBarPlot({ clusters }: ClusterBarPlotProps) {
             </p>
           )}
         </div>
-      </div>
-
-      <div className="flex flex-wrap gap-3">
-        {clusters.map((cluster, index) => {
-          const color = CLUSTER_PALETTE[index % CLUSTER_PALETTE.length]!;
-          const memberList = getClusterMemberLabelText(cluster);
-
-          return (
-            <div key={cluster.id} className="flex items-center gap-1 text-xs text-gray-600" title={memberList}>
-              <span
-                className="h-2.5 w-2.5 shrink-0 rounded-full"
-                style={{ backgroundColor: color }}
-              />
-              <span>Models: {memberList}</span>
-            </div>
-          );
-        })}
       </div>
     </div>
   );

--- a/cloud/apps/web/src/components/domains/ClusterDotPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterDotPlot.tsx
@@ -5,7 +5,6 @@ import {
   DOT_BAR_CLUSTER_SCORE_MAX,
   DOT_BAR_CLUSTER_SCORE_MIN,
   formatClusterScoreLabel,
-  getClusterMemberLabelText,
   getClusterScorePosition,
   getClusterValueOrder,
   isClusterScoreClipped,
@@ -13,9 +12,12 @@ import {
 
 type ClusterDotPlotProps = {
   clusters: DomainCluster[];
+  activeGroupId?: string | null;
 };
 
-export function ClusterDotPlot({ clusters }: ClusterDotPlotProps) {
+const DOT_COLORS = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'] as const;
+
+export function ClusterDotPlot({ clusters, activeGroupId = null }: ClusterDotPlotProps) {
   const sortedValues = useMemo(() => getClusterValueOrder(clusters), [clusters]);
 
   if (clusters.length === 0) {
@@ -63,25 +65,32 @@ export function ClusterDotPlot({ clusters }: ClusterDotPlotProps) {
                   {clusters.map((cluster, index) => {
                     const score = cluster.centroid[valueKey] ?? 0;
                     const xPct = getClusterScorePosition(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
-                    const color = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'][index % 4];
+                    const color = DOT_COLORS[index % DOT_COLORS.length];
                     const memberLabels = cluster.members.map((member) => member.label).join(', ');
                     const clipped = isClusterScoreClipped(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
+                    const isActive = activeGroupId == null || activeGroupId === cluster.id;
+                    const faded = activeGroupId != null && !isActive;
 
                     return (
                       <div
                         key={cluster.id}
                         title={`${memberLabels}: ${score.toFixed(2)}`}
+                        data-cluster-id={cluster.id}
+                        data-value-key={valueKey}
                         className="absolute"
                         style={{
                           left: `${xPct}%`,
                           top: '50%',
-                          transform: 'translate(-50%, -50%)',
+                          transform: `translate(-50%, -50%) scale(${isActive && activeGroupId != null ? 1.25 : 1})`,
                           backgroundColor: color,
+                          opacity: faded ? 0.2 : activeGroupId != null ? 1 : 0.78,
                           width: '12px',
                           height: '12px',
                           borderRadius: '50%',
                           border: clipped ? '2px solid rgba(15, 23, 42, 0.45)' : '2px solid white',
                           boxShadow: clipped ? '0 0 0 1px rgba(15, 23, 42, 0.12)' : undefined,
+                          filter: isActive && activeGroupId != null ? `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${color}aa)` : undefined,
+                          zIndex: isActive ? index + 20 : index + 1,
                         }}
                       />
                     );
@@ -114,23 +123,6 @@ export function ClusterDotPlot({ clusters }: ClusterDotPlotProps) {
             </p>
           )}
         </div>
-      </div>
-
-      <div className="flex flex-wrap gap-3">
-        {clusters.map((cluster, index) => {
-          const color = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'][index % 4];
-          const memberList = getClusterMemberLabelText(cluster);
-
-          return (
-            <div key={cluster.id} className="flex items-center gap-1 text-xs text-gray-600" title={memberList}>
-              <span
-                className="h-2.5 w-2.5 shrink-0 rounded-full"
-                style={{ backgroundColor: color }}
-              />
-              <span>Models: {memberList}</span>
-            </div>
-          );
-        })}
       </div>
     </div>
   );

--- a/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
@@ -2,9 +2,6 @@ import { useMemo } from 'react';
 import { type DomainCluster } from '../../api/operations/domainAnalysis';
 import { VALUE_LABELS } from '../../data/domainAnalysisData';
 import {
-  getClusterMemberLabelText,
-} from './clusterVisualizationUtils';
-import {
   DISPLAY_VALUES,
   QUADRANT_ARCS,
   buildValueAngles,
@@ -12,6 +9,7 @@ import {
 
 type ClusterRadarChartProps = {
   clusters: DomainCluster[];
+  activeGroupId?: string | null;
 };
 
 const CHART_SIZE = 640;
@@ -44,8 +42,16 @@ function scoreToRadius(score: number): number {
   return ((clamped - RADAR_SCORE_MIN) / RADAR_SCORE_RANGE) * OUTER_RADIUS;
 }
 
-export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
+export function ClusterRadarChart({ clusters, activeGroupId = null }: ClusterRadarChartProps) {
   const valueAngles = useMemo(() => buildValueAngles(), []);
+  const renderedClusters = useMemo(
+    () => [...clusters].sort((left, right) => {
+      const leftActive = activeGroupId != null && left.id === activeGroupId ? 1 : 0;
+      const rightActive = activeGroupId != null && right.id === activeGroupId ? 1 : 0;
+      return leftActive - rightActive;
+    }),
+    [activeGroupId, clusters],
+  );
   const hasClippedScores = useMemo(
     () => clusters.some((cluster) => DISPLAY_VALUES.some((valueKey) => {
       const score = cluster.centroid[valueKey] ?? 0;
@@ -137,14 +143,23 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
             const labelPoint = getPoint(angle, OUTER_RADIUS + 18);
             const label = VALUE_LABELS[valueKey];
             const anchor =
-              labelPoint.x < CENTER_X - 8 ? 'end' : labelPoint.x > CENTER_X + 8 ? 'start' : 'middle';
+              valueKey === 'Universalism_Nature'
+                ? 'end'
+                : labelPoint.x < CENTER_X - 8
+                  ? 'end'
+                  : labelPoint.x > CENTER_X + 8
+                    ? 'start'
+                    : 'middle';
+            const adjustedLabelPoint = valueKey === 'Universalism_Nature'
+              ? { x: labelPoint.x - 14, y: labelPoint.y }
+              : labelPoint;
 
             return (
               <g key={valueKey}>
                 <line x1={CENTER_X} y1={CENTER_Y} x2={outer.x} y2={outer.y} stroke="#e5e7eb" strokeWidth="1" />
                 <text
-                  x={labelPoint.x}
-                  y={labelPoint.y}
+                  x={adjustedLabelPoint.x}
+                  y={adjustedLabelPoint.y}
                   textAnchor={anchor}
                   dominantBaseline="middle"
                   className="fill-gray-700 text-[10px] font-medium"
@@ -157,9 +172,11 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
 
           <circle cx={CENTER_X} cy={CENTER_Y} r="2.75" fill="#94a3b8" />
 
-          {clusters.map((cluster, index) => {
+          {renderedClusters.map((cluster, index) => {
             const palette = CLUSTER_PALETTE[index % CLUSTER_PALETTE.length]!;
             const orderedValues = DISPLAY_VALUES;
+            const isActive = activeGroupId == null || activeGroupId === cluster.id;
+            const faded = activeGroupId != null && !isActive;
             const points = orderedValues.map((valueKey) => {
               const angle = valueAngles.get(valueKey) ?? -Math.PI / 2;
               const score = cluster.centroid[valueKey] ?? 0;
@@ -172,7 +189,14 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
 
             return (
               <g key={cluster.id}>
-                <path d={`${path} Z`} fill={palette.fill} stroke={palette.stroke} strokeWidth="2" />
+                <path
+                  d={`${path} Z`}
+                  fill={palette.fill}
+                  stroke={palette.stroke}
+                  strokeWidth={isActive && activeGroupId != null ? '3' : '2'}
+                  opacity={faded ? 0.16 : activeGroupId != null ? 1 : 0.78}
+                  style={isActive && activeGroupId != null ? { filter: `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 14px ${palette.stroke}aa)` } : undefined}
+                />
                 {points.map((point, pointIndex) => {
                   const valueKey = orderedValues[pointIndex]!;
                   const score = cluster.centroid[valueKey] ?? 0;
@@ -182,10 +206,12 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
                       <circle
                         cx={point.x}
                         cy={point.y}
-                        r="3.2"
+                        r={isActive && activeGroupId != null ? 4 : 3.2}
                         fill={palette.stroke}
                         stroke="#ffffff"
                         strokeWidth="1.5"
+                        opacity={faded ? 0.2 : activeGroupId != null ? 1 : 0.85}
+                        style={isActive && activeGroupId != null ? { filter: `drop-shadow(0 0 6px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${palette.stroke}aa)` } : undefined}
                       />
                     </g>
                   );
@@ -219,25 +245,6 @@ export function ClusterRadarChart({ clusters }: ClusterRadarChartProps) {
           Some scores fall outside the fixed range and are shown at the edge of the chart.
         </p>
       )}
-
-      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
-        {clusters.map((cluster, index) => {
-          const palette = CLUSTER_PALETTE[index % CLUSTER_PALETTE.length]!;
-          const memberLabels = getClusterMemberLabelText(cluster);
-          const title = cluster.name.length > 0 ? cluster.name : memberLabels;
-          return (
-            <div key={cluster.id} className="rounded-lg border border-gray-200 bg-white p-3">
-              <div className="flex items-start gap-2">
-                <span className="mt-1 h-3 w-3 shrink-0 rounded-full" style={{ backgroundColor: palette.stroke }} />
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-semibold text-gray-900">Models: {memberLabels}</p>
-                  <p className="text-xs text-gray-500">Cluster: {title}</p>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-      </div>
     </div>
   );
 }

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -1,109 +1,86 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { HelpCircle, X } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { type ClusterAnalysis, type DomainCluster } from '../../api/operations/domainAnalysis';
-import { VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
-import { formatDisplayLabel } from '../../utils/displayLabels';
-import { getClusterMemberLabelText } from './clusterVisualizationUtils';
+import { type ModelEntry } from '../../data/domainAnalysisData';
 import { ClusterBarPlot } from './ClusterBarPlot';
 import { ClusterDotPlot } from './ClusterDotPlot';
-import { ClusterHeatmap } from './ClusterHeatmap';
 import { ClusterRadarChart } from './ClusterRadarChart';
+import { buildIndividualClusters, getClusterMemberLabelText } from './clusterVisualizationUtils';
 
-const CLUSTER_COLORS = [
-  { border: 'border-blue-500', text: 'text-blue-700', light: 'bg-blue-50' },
-  { border: 'border-amber-500', text: 'text-amber-700', light: 'bg-amber-50' },
-  { border: 'border-emerald-500', text: 'text-emerald-700', light: 'bg-emerald-50' },
-  { border: 'border-rose-500', text: 'text-rose-700', light: 'bg-rose-50' },
+const LEGEND_COLORS = [
+  { border: 'border-blue-500', text: 'text-blue-700', light: 'bg-blue-50', color: '#3b82f6' },
+  { border: 'border-amber-500', text: 'text-amber-700', light: 'bg-amber-50', color: '#f59e0b' },
+  { border: 'border-emerald-500', text: 'text-emerald-700', light: 'bg-emerald-50', color: '#10b981' },
+  { border: 'border-rose-500', text: 'text-rose-700', light: 'bg-rose-50', color: '#f43f5e' },
 ] as const;
-
-type ClusterPersonality = {
-  title: string;
-  tendency: string;
-  topValues: string[];
-  bottomValues: string[];
-};
-
-function getClusterColor(index: number) {
-  return CLUSTER_COLORS[index % CLUSTER_COLORS.length]!;
-}
-
-function getClusterPersonality(cluster: DomainCluster): ClusterPersonality {
-  const sortedKeys = Object.entries(cluster.centroid)
-    .sort((a, b) => b[1] - a[1])
-    .map(([valueKey]) => valueKey);
-  const topKeys = sortedKeys.slice(0, 3);
-  const bottomKeys = sortedKeys.slice(-3);
-
-  const hasTop = (valueKey: string) => topKeys.includes(valueKey);
-  const hasBottom = (valueKey: string) => bottomKeys.includes(valueKey);
-
-  let title = 'Values-Driven Advisors';
-  let tendency = 'Recommend paths that align with core priorities over generic prestige paths.';
-
-  if (hasTop('Universalism_Nature') && hasTop('Achievement')) {
-    title = 'Ambition-and-Impact';
-    tendency = 'Recommend high-upside roles where visible outcomes and momentum matter more than comfort.';
-  } else if (hasTop('Self_Direction_Action') && hasTop('Power_Dominance')) {
-    title = 'Practical Independence';
-    tendency = 'Recommend autonomous roles with decision latitude and execution authority over comfort or conformity.';
-  } else if (hasTop('Self_Direction_Action') && hasTop('Tradition') && hasTop('Universalism_Nature')) {
-    if (hasBottom('Conformity_Interpersonal') && hasBottom('Power_Dominance')) {
-      title = 'Purpose-and-Values';
-      tendency = 'Recommend principled work that feels meaningful and socially positive, not status-first ladder climbing.';
-    } else if (hasBottom('Achievement') || hasBottom('Hedonism') || hasBottom('Security_Personal')) {
-      title = 'Stability-with-Principles';
-      tendency = 'Recommend steady, values-aligned paths that preserve long-term fit over short-term rewards.';
-    }
-  } else if (hasTop('Universalism_Nature') && hasTop('Self_Direction_Action')) {
-    title = 'Purpose-and-Values';
-    tendency = 'Recommend values-aligned, self-directed paths with strong emphasis on meaning and contribution.';
-  }
-
-  return {
-    title,
-    tendency,
-    topValues: topKeys.map((key) => VALUE_LABELS[key as ValueKey] ?? formatDisplayLabel(key)),
-    bottomValues: bottomKeys.map((key) => VALUE_LABELS[key as ValueKey] ?? formatDisplayLabel(key)),
-  };
-}
 
 type ModelGroupsSectionProps = {
   clusterAnalysis?: ClusterAnalysis;
+  models: ModelEntry[];
   selectedModelId?: string | null;
 };
 
-type ClusterViewMode = 'dot' | 'bar' | 'radar' | 'heatmap';
+type ClusterViewMode = 'dot' | 'bar' | 'radar';
+type GroupDisplayMode = 'groups' | 'individual';
 
 const CLUSTER_VIEW_OPTIONS: Array<{ value: ClusterViewMode; label: string }> = [
   { value: 'radar', label: 'Radar' },
   { value: 'dot', label: 'Dot map' },
   { value: 'bar', label: 'Bar' },
-  { value: 'heatmap', label: 'Heatmap' },
 ];
 
-export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: ModelGroupsSectionProps) {
+const GROUP_DISPLAY_OPTIONS: Array<{ value: GroupDisplayMode; label: string }> = [
+  { value: 'groups', label: 'Groups' },
+  { value: 'individual', label: 'Individual' },
+];
+
+function getLegendColor(index: number) {
+  return LEGEND_COLORS[index % LEGEND_COLORS.length]!;
+}
+
+function getGroupLabel(cluster: DomainCluster): string {
+  return getClusterMemberLabelText(cluster);
+}
+
+export function ModelGroupsSection({
+  clusterAnalysis,
+  models,
+  selectedModelId = null,
+}: ModelGroupsSectionProps) {
   const summaryTableRef = useRef<HTMLDivElement>(null);
   const [showModelGroupsHelp, setShowModelGroupsHelp] = useState(false);
   const [viewMode, setViewMode] = useState<ClusterViewMode>('dot');
+  const [groupDisplayMode, setGroupDisplayMode] = useState<GroupDisplayMode>('groups');
+  const [activeGroupId, setActiveGroupId] = useState<string | null>(null);
+
+  const hasGroupedClusters = clusterAnalysis != null && !clusterAnalysis.skipped;
+  const groupedClusters = useMemo(() => clusterAnalysis?.clusters ?? [], [clusterAnalysis]);
+  const individualClusters = useMemo(() => buildIndividualClusters(models), [models]);
+
+  const sourceClusters = useMemo(
+    () => (groupDisplayMode === 'individual' ? individualClusters : groupedClusters),
+    [groupDisplayMode, groupedClusters, individualClusters],
+  );
 
   const clusters = useMemo(
     () => {
-      if (clusterAnalysis == null || clusterAnalysis.skipped) return [];
-      if (selectedModelId == null) return clusterAnalysis.clusters;
-      return clusterAnalysis.clusters.filter((cluster) => cluster.members.some((member) => member.model === selectedModelId));
+      if (selectedModelId == null) return sourceClusters;
+      return sourceClusters.filter((cluster) => cluster.members.some((member) => member.model === selectedModelId));
     },
-    [clusterAnalysis, selectedModelId],
+    [selectedModelId, sourceClusters],
   );
 
-  const copyLabel = viewMode === 'dot'
-    ? 'model groups dot map'
-    : viewMode === 'bar'
-      ? 'model groups bar chart'
-      : viewMode === 'radar'
-        ? 'model groups radar chart'
-        : 'model groups heatmap';
+  useEffect(() => {
+    if (activeGroupId == null) return;
+    if (clusters.some((cluster) => cluster.id === activeGroupId)) return;
+    setActiveGroupId(null);
+  }, [activeGroupId, clusters]);
+
+  const copyLabel = `${groupDisplayMode} model groups ${
+    viewMode === 'dot' ? 'dot map' : viewMode === 'bar' ? 'bar chart' : 'radar chart'
+  }`;
 
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-4">
@@ -120,7 +97,28 @@ export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: 
             {showModelGroupsHelp ? <X className="h-8 w-8" /> : <HelpCircle className="h-8 w-8" />}
           </Button>
         </div>
+
         <div className="flex flex-wrap items-center gap-2">
+          <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+            {GROUP_DISPLAY_OPTIONS.map((option) => {
+              const active = groupDisplayMode === option.value;
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  variant={active ? 'primary' : 'ghost'}
+                  size="sm"
+                  onClick={() => setGroupDisplayMode(option.value)}
+                  className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
+                    active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-white hover:text-gray-900'
+                  }`}
+                >
+                  {option.label}
+                </Button>
+              );
+            })}
+          </div>
+
           <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
             {CLUSTER_VIEW_OPTIONS.map((option) => {
               const active = viewMode === option.value;
@@ -140,20 +138,22 @@ export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: 
               );
             })}
           </div>
+
           <CopyVisualButton targetRef={summaryTableRef} label={copyLabel} />
         </div>
       </div>
+
       {showModelGroupsHelp && (
         <div className="mb-4 space-y-3 rounded-lg border border-blue-100 bg-blue-50 p-3 text-xs text-gray-700">
           <div>
             <p className="mb-1 font-semibold text-gray-800">What is a log-odds score?</p>
             <p>
-              When we compare two values — like Achievement vs. Hedonism — a model has to pick one. We count
+              When we compare two values - like Achievement vs. Hedonism - a model has to pick one. We count
               how many times it picks each, then compute: score = log((wins + 1) / (losses + 1)).
             </p>
             <p className="mt-1">
-              <strong>Zero</strong> means the model chose each value equally often.{' '}
-              <strong>Positive</strong> means it chose this value more often than not.{' '}
+              <strong>Zero</strong> means the model chose each value equally often. {' '}
+              <strong>Positive</strong> means it chose this value more often than not. {' '}
               <strong>Negative</strong> means it avoided this value.
             </p>
             <p className="mt-1">
@@ -172,12 +172,12 @@ export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: 
             <p className="mt-1">
               Some models have higher scores across many values simply because they have strong preferences
               in general. We don&apos;t want that to drive the grouping. After mean-centering, a positive
-              score means &ldquo;this value is above this model&apos;s own average&rdquo; — not just
+              score means &ldquo;this value is above this model&apos;s own average&rdquo; - not just
               &ldquo;this model scores high overall.&rdquo;
             </p>
             <p className="mt-1">
               Steps: (1) compute log-odds for all 10 values, (2) average those 10 numbers, (3) subtract the
-              average from each score. Now we&apos;re comparing the shape of each model&apos;s profile —
+              average from each score. Now we&apos;re comparing the shape of each model&apos;s profile -
               which values it ranks above or below its own typical level.
             </p>
           </div>
@@ -191,48 +191,72 @@ export function ModelGroupsSection({ clusterAnalysis, selectedModelId = null }: 
             <p className="mt-1">
               Similarity is measured using cosine distance on the mean-centered scores. Think of each
               model&apos;s 10 scores as an arrow pointing in a direction. Two models that rank values in a
-              similar order point in nearly the same direction — small distance. Models that disagree on
-              priorities point in different directions — large distance.
+              similar order point in nearly the same direction - small distance. Models that disagree on
+              priorities point in different directions - large distance.
             </p>
             <p className="mt-1">
-              The default dot map shows each value on a fixed scale from -2.5 to +2.5, with 0 in the
-              middle. Values are sorted from the ones the groups favor most on average to the ones they
-              favor least. The bar view shows the same scores as bars instead of dots, with shorter bars
-              rendered on top so they stay visible. Use the toggle above to compare the radar chart, dot
-              map, bar chart, and heatmap views of the same cluster data.
+              Use the group toggle above to compare clustered groups against individual models. The dot map
+              and bar chart show each value on a fixed scale from -2.5 to +2.5, with 0 in the middle.
+              Values are sorted from the ones the groups favor most on average to the ones they favor least.
+              The bar view shows the same scores as bars instead of dots, with shorter bars rendered on top
+              so they stay visible.
             </p>
           </div>
         </div>
       )}
+
       <div ref={summaryTableRef}>
-        {clusterAnalysis == null || clusterAnalysis.skipped ? (
+        {groupDisplayMode === 'groups' && !hasGroupedClusters ? (
           <div className="space-y-1 text-xs text-gray-500 italic">
             <p>Cluster analysis not available.</p>
             {clusterAnalysis?.skipReason && <p>{clusterAnalysis.skipReason}</p>}
           </div>
+        ) : groupDisplayMode === 'individual' && models.length === 0 ? (
+          <div className="space-y-1 text-xs text-gray-500 italic">
+            <p>No model data available.</p>
+          </div>
         ) : (
           <>
-            {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} />}
-            {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} />}
-            {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} />}
-            {viewMode === 'heatmap' && <ClusterHeatmap clusters={clusters} />}
-            <div className="flex flex-wrap gap-4">
+            {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} activeGroupId={activeGroupId} />}
+            {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} activeGroupId={activeGroupId} />}
+            {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} activeGroupId={activeGroupId} />}
+
+            <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
               {clusters.map((cluster, index) => {
-                const style = getClusterColor(index);
-                const personality = getClusterPersonality(cluster);
-                const memberLabels = getClusterMemberLabelText(cluster);
+                const style = getLegendColor(index);
+                const memberLabels = getGroupLabel(cluster);
+                const isActive = activeGroupId === cluster.id;
+
                 return (
-                  <div key={cluster.id} className={`min-w-[280px] max-w-[520px] rounded-lg border ${style.border} ${style.light} p-3`}>
-                    <p className={`text-sm font-semibold ${style.text}`}>
-                      <span className="font-medium">Models:</span> {memberLabels}
-                    </p>
-                    <p className="mt-2 text-xs text-gray-700">
-                      <span className="font-medium">Prioritizes:</span> {personality.topValues.join(', ')}
-                    </p>
-                    <p className="mt-1 text-xs text-gray-700">
-                      <span className="font-medium">Sacrifices:</span> {personality.bottomValues.join(', ')}
-                    </p>
-                  </div>
+                  <Button
+                    key={cluster.id}
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setActiveGroupId((current) => (current === cluster.id ? null : cluster.id))}
+                    aria-pressed={isActive}
+                    title={memberLabels}
+                    className={`rounded-lg border p-3 text-left transition ${
+                      isActive
+                        ? `${style.border} ${style.light} ring-2 ring-teal-400 shadow-[0_0_0_1px_rgba(13,148,136,0.25),0_0_16px_rgba(45,212,191,0.35)]`
+                        : 'border-gray-200 bg-white hover:border-teal-300 hover:shadow-sm'
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      <span
+                        className={`mt-1 h-3 w-3 shrink-0 rounded-full transition ${
+                          isActive ? 'scale-125' : ''
+                        }`}
+                        style={{
+                          backgroundColor: style.color,
+                          boxShadow: isActive ? '0 0 0 1px rgba(255,255,255,0.85), 0 0 12px rgba(45,212,191,0.55)' : undefined,
+                        }}
+                      />
+                      <div className="min-w-0">
+                        <p className={`truncate text-sm font-semibold ${style.text}`}>{memberLabels}</p>
+                        </div>
+                      </div>
+                  </Button>
                 );
               })}
             </div>

--- a/cloud/apps/web/src/components/domains/clusterVisualizationUtils.ts
+++ b/cloud/apps/web/src/components/domains/clusterVisualizationUtils.ts
@@ -1,5 +1,5 @@
 import { type DomainCluster } from '../../api/operations/domainAnalysis';
-import { VALUE_LABELS, VALUES, type ValueKey } from '../../data/domainAnalysisData';
+import { VALUE_LABELS, VALUES, type ModelEntry, type ValueKey } from '../../data/domainAnalysisData';
 
 export const CLUSTER_SCORE_MIN = -3.25;
 export const CLUSTER_SCORE_MAX = 3.25;
@@ -39,6 +39,25 @@ export function getClusterMemberLabels(cluster: DomainCluster): string[] {
 
 export function getClusterMemberLabelText(cluster: DomainCluster): string {
   return getClusterMemberLabels(cluster).join(', ');
+}
+
+export function buildIndividualClusters(models: ModelEntry[]): DomainCluster[] {
+  return models.map((model) => ({
+    id: model.model,
+    name: model.label,
+    definingValues: [],
+    centroid: model.values,
+    members: [
+      {
+        model: model.model,
+        label: model.label,
+        silhouetteScore: 1,
+        isOutlier: false,
+        nearestClusterIds: null,
+        distancesToNearestClusters: null,
+      },
+    ],
+  }));
 }
 
 export function formatClusterScoreLabel(score: number): string {

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -502,7 +502,11 @@ export function DomainAnalysis() {
         <Loading size="lg" text="Loading domain analysis..." />
       ) : (
         <>
-          <ModelGroupsSection clusterAnalysis={data?.domainAnalysis.clusterAnalysis} selectedModelId={singleSelectedModelId} />
+          <ModelGroupsSection
+            clusterAnalysis={data?.domainAnalysis.clusterAnalysis}
+            models={models}
+            selectedModelId={singleSelectedModelId}
+          />
           <ValuePrioritiesSection
             models={visibleModels}
             selectedDomainId={selectedDomainId}

--- a/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
+++ b/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ModelGroupsSection } from '../../src/components/domains/ModelGroupsSection';
 import type { ClusterAnalysis } from '../../src/api/operations/domainAnalysis';
+import { DOMAIN_ANALYSIS_MODELS } from '../../src/data/domainAnalysisData';
 
 const skippedClusterAnalysis: ClusterAnalysis = {
   skipped: true,
@@ -60,37 +61,53 @@ const populatedClusterAnalysis: ClusterAnalysis = {
   faultLinesByPair: {},
 };
 
+const populatedModels = DOMAIN_ANALYSIS_MODELS.slice(0, 2);
+
 describe('ModelGroupsSection', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it('renders the plain model groups heading without numbering', () => {
-    render(<ModelGroupsSection clusterAnalysis={skippedClusterAnalysis} />);
+    render(<ModelGroupsSection clusterAnalysis={skippedClusterAnalysis} models={populatedModels} />);
 
     expect(screen.getByRole('heading', { name: 'Model Groups' })).toBeInTheDocument();
     expect(screen.getByText(/cluster analysis not available/i)).toBeInTheDocument();
     expect(screen.queryByText(/^1\./i)).not.toBeInTheDocument();
   });
 
-  it('offers a bar view and keeps the legend focused on model names', () => {
-    render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} />);
+  it('offers group and individual views without heatmap', () => {
+    render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} models={populatedModels} />);
 
+    expect(screen.getByRole('button', { name: 'Groups' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Individual' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Bar' })).toBeInTheDocument();
-    expect(screen.getByText('-2.50')).toBeInTheDocument();
-    expect(screen.getByText('+2.50')).toBeInTheDocument();
-    expect(screen.getByText(/Models: Model A/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Heatmap' })).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Bar' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Individual' }));
 
-    expect(screen.getByText(/Models: Model A/i)).toBeInTheDocument();
-    expect(screen.getByText(/Models: Model B/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Claude Sonnet 4.5' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'DeepSeek Chat' })).toBeInTheDocument();
+  });
+
+  it('lights up the selected legend item and fades the others', () => {
+    const { container } = render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} models={populatedModels} />);
+
+    const legendButton = screen.getByRole('button', { name: 'Model A' });
+    fireEvent.click(legendButton);
+
+    const activeDot = container.querySelector('[data-value-key="Achievement"][data-cluster-id="cluster-1"]');
+    const inactiveDot = container.querySelector('[data-value-key="Achievement"][data-cluster-id="cluster-2"]');
+    expect(activeDot).not.toBeNull();
+    expect(inactiveDot).not.toBeNull();
+    expect(activeDot).toHaveStyle({ opacity: '1' });
+    expect(inactiveDot).toHaveStyle({ opacity: '0.2' });
   });
 
   it('shows a value tooltip with color rows and logit values on bar hover', () => {
     vi.useFakeTimers();
 
-    const { container } = render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} />);
+    const { container } = render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} models={populatedModels} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Bar' }));
 
@@ -113,15 +130,16 @@ describe('ModelGroupsSection', () => {
   });
 
   it('shows the Schwartz category ring in radar view', () => {
-    render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} />);
+    render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} models={populatedModels} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Radar' }));
 
     expect(screen.getByRole('img', { name: /cluster radar chart ordered by favorability with schwartz category ring/i })).toBeInTheDocument();
-    expect(screen.queryByText(/ordered to match ranking and cycles/i)).not.toBeInTheDocument();
     expect(screen.getByText('Self-Transcendence')).toBeInTheDocument();
     expect(screen.getByText('Conservation')).toBeInTheDocument();
     expect(screen.getByText('Self-Enhancement')).toBeInTheDocument();
     expect(screen.getByText('Openness to Change')).toBeInTheDocument();
+    expect(screen.getByText('Universalism')).toHaveAttribute('text-anchor', 'end');
+    expect(screen.queryByText(/Cluster:/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Add a Groups vs Individual mode for model groups reports
- Make legend clicks highlight the matching group across dot, bar, and radar charts
- Remove the heatmap option and keep radar labels aligned with Ranking and Cycles

## Test plan
- [x] npm run test -- tests/components/ModelGroupsSection.test.tsx
- [x] npm run lint
- [x] npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)