### PR TITLE
Refine model groups selection and radar layout

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
@@ -8,15 +8,14 @@ import {
   formatClusterScoreLabel,
   getClusterScorePosition,
   getClusterValueOrder,
+  getClusterVisualColor,
   isClusterScoreClipped,
 } from './clusterVisualizationUtils';
 
 type ClusterBarPlotProps = {
   clusters: DomainCluster[];
-  activeGroupId?: string | null;
+  activeGroupIds?: string[];
 };
-
-const CLUSTER_PALETTE = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'] as const;
 
 function ClusterValueTooltip({
   clusters,
@@ -39,7 +38,7 @@ function ClusterValueTooltip({
           const score = cluster.centroid[valueKey] ?? 0;
           const clusterIndex = clusters.findIndex((candidate) => candidate.id === cluster.id);
           const safeClusterIndex = clusterIndex >= 0 ? clusterIndex : 0;
-          const color = CLUSTER_PALETTE[safeClusterIndex % CLUSTER_PALETTE.length]!;
+          const color = getClusterVisualColor(safeClusterIndex);
 
           return (
             <div key={cluster.id} className="grid grid-cols-[auto_1fr] items-center gap-x-3">
@@ -67,8 +66,10 @@ function getClusterBarOrder(clusters: DomainCluster[], valueKey: ValueKey): Doma
   });
 }
 
-export function ClusterBarPlot({ clusters, activeGroupId = null }: ClusterBarPlotProps) {
+export function ClusterBarPlot({ clusters, activeGroupIds = [] }: ClusterBarPlotProps) {
   const sortedValues = useMemo(() => getClusterValueOrder(clusters), [clusters]);
+  const activeGroupSet = useMemo(() => new Set(activeGroupIds), [activeGroupIds]);
+  const hasActiveSelection = activeGroupIds.length > 0;
 
   if (clusters.length === 0) {
     return null;
@@ -122,10 +123,10 @@ export function ClusterBarPlot({ clusters, activeGroupId = null }: ClusterBarPlo
                     const width = Math.max(Math.abs(endPosition - midpoint), 1);
                     const clusterIndex = clusters.findIndex((candidate) => candidate.id === cluster.id);
                     const safeClusterIndex = clusterIndex >= 0 ? clusterIndex : 0;
-                    const color = CLUSTER_PALETTE[safeClusterIndex % CLUSTER_PALETTE.length]!;
+                    const color = getClusterVisualColor(safeClusterIndex);
                     const clipped = isClusterScoreClipped(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
-                    const isActive = activeGroupId == null || activeGroupId === cluster.id;
-                    const faded = activeGroupId != null && !isActive;
+                    const isActive = !hasActiveSelection || activeGroupSet.has(cluster.id);
+                    const faded = hasActiveSelection && !isActive;
 
                     return (
                       <Tooltip
@@ -141,8 +142,8 @@ export function ClusterBarPlot({ clusters, activeGroupId = null }: ClusterBarPlo
                           transform: 'translateY(-50%)',
                           height: '10px',
                           zIndex: isActive ? rankedClusters.length + 20 - index : index + 1,
-                          opacity: faded ? 0.18 : activeGroupId != null ? 1 : 0.78,
-                          filter: isActive && activeGroupId != null ? `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${color}99)` : undefined,
+                          opacity: faded ? 0.18 : hasActiveSelection ? 1 : 0.78,
+                          filter: isActive && hasActiveSelection ? `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${color}99)` : undefined,
                         }}
                       >
                         <div
@@ -151,7 +152,7 @@ export function ClusterBarPlot({ clusters, activeGroupId = null }: ClusterBarPlo
                           className="h-full w-full rounded-full"
                           style={{
                             backgroundColor: color,
-                            boxShadow: isActive && activeGroupId != null ? `0 0 0 1px rgba(255,255,255,0.7), 0 0 10px ${color}80` : undefined,
+                            boxShadow: isActive && hasActiveSelection ? `0 0 0 1px rgba(255,255,255,0.7), 0 0 10px ${color}80` : undefined,
                             border: clipped ? '1px solid rgba(15, 23, 42, 0.4)' : '1px solid rgba(255, 255, 255, 0.8)',
                           }}
                         />

--- a/cloud/apps/web/src/components/domains/ClusterDotPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterDotPlot.tsx
@@ -7,18 +7,19 @@ import {
   formatClusterScoreLabel,
   getClusterScorePosition,
   getClusterValueOrder,
+  getClusterVisualColor,
   isClusterScoreClipped,
 } from './clusterVisualizationUtils';
 
 type ClusterDotPlotProps = {
   clusters: DomainCluster[];
-  activeGroupId?: string | null;
+  activeGroupIds?: string[];
 };
 
-const DOT_COLORS = ['#3b82f6', '#f59e0b', '#10b981', '#f43f5e'] as const;
-
-export function ClusterDotPlot({ clusters, activeGroupId = null }: ClusterDotPlotProps) {
+export function ClusterDotPlot({ clusters, activeGroupIds = [] }: ClusterDotPlotProps) {
   const sortedValues = useMemo(() => getClusterValueOrder(clusters), [clusters]);
+  const activeGroupSet = useMemo(() => new Set(activeGroupIds), [activeGroupIds]);
+  const hasActiveSelection = activeGroupIds.length > 0;
 
   if (clusters.length === 0) {
     return null;
@@ -65,11 +66,11 @@ export function ClusterDotPlot({ clusters, activeGroupId = null }: ClusterDotPlo
                   {clusters.map((cluster, index) => {
                     const score = cluster.centroid[valueKey] ?? 0;
                     const xPct = getClusterScorePosition(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
-                    const color = DOT_COLORS[index % DOT_COLORS.length];
+                    const color = getClusterVisualColor(index);
                     const memberLabels = cluster.members.map((member) => member.label).join(', ');
                     const clipped = isClusterScoreClipped(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
-                    const isActive = activeGroupId == null || activeGroupId === cluster.id;
-                    const faded = activeGroupId != null && !isActive;
+                    const isActive = !hasActiveSelection || activeGroupSet.has(cluster.id);
+                    const faded = hasActiveSelection && !isActive;
 
                     return (
                       <div
@@ -81,15 +82,15 @@ export function ClusterDotPlot({ clusters, activeGroupId = null }: ClusterDotPlo
                         style={{
                           left: `${xPct}%`,
                           top: '50%',
-                          transform: `translate(-50%, -50%) scale(${isActive && activeGroupId != null ? 1.25 : 1})`,
+                          transform: `translate(-50%, -50%) scale(${isActive && hasActiveSelection ? 1.25 : 1})`,
                           backgroundColor: color,
-                          opacity: faded ? 0.2 : activeGroupId != null ? 1 : 0.78,
+                          opacity: faded ? 0.2 : hasActiveSelection ? 1 : 0.78,
                           width: '12px',
                           height: '12px',
                           borderRadius: '50%',
                           border: clipped ? '2px solid rgba(15, 23, 42, 0.45)' : '2px solid white',
                           boxShadow: clipped ? '0 0 0 1px rgba(15, 23, 42, 0.12)' : undefined,
-                          filter: isActive && activeGroupId != null ? `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${color}aa)` : undefined,
+                          filter: isActive && hasActiveSelection ? `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${color}aa)` : undefined,
                           zIndex: isActive ? index + 20 : index + 1,
                         }}
                       />

--- a/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
@@ -6,29 +6,36 @@ import {
   QUADRANT_ARCS,
   buildValueAngles,
 } from './useDominanceGraph';
+import { getClusterVisualColor } from './clusterVisualizationUtils';
 
 type ClusterRadarChartProps = {
   clusters: DomainCluster[];
-  activeGroupId?: string | null;
+  activeGroupIds?: string[];
 };
 
 const CHART_SIZE = 640;
 const VIEW_BOX_HEIGHT = 560;
 const CENTER_X = 286;
 const CENTER_Y = 276;
-const OUTER_RADIUS = 184;
+const OUTER_RADIUS = 202;
 const CATEGORY_RING_RADIUS = OUTER_RADIUS + 26;
 const CATEGORY_LABEL_RADIUS = OUTER_RADIUS + 82;
 const RADAR_SCORE_MIN = -2.5;
 const RADAR_SCORE_MAX = 2.5;
 const RADAR_SCORE_RANGE = RADAR_SCORE_MAX - RADAR_SCORE_MIN;
+const UNIVERSALISM_LABEL_OFFSET = 7;
 
-const CLUSTER_PALETTE = [
-  { stroke: '#2563eb', fill: 'rgba(37, 99, 235, 0.14)' },
-  { stroke: '#d97706', fill: 'rgba(217, 119, 6, 0.14)' },
-  { stroke: '#059669', fill: 'rgba(5, 150, 105, 0.14)' },
-  { stroke: '#e11d48', fill: 'rgba(225, 29, 72, 0.14)' },
-] as const;
+function withAlpha(hexColor: string, alpha: number): string {
+  const hex = hexColor.replace('#', '');
+  const fullHex = hex.length === 3
+    ? hex.split('').map((char) => `${char}${char}`).join('')
+    : hex;
+  const value = Number.parseInt(fullHex, 16);
+  const red = (value >> 16) & 255;
+  const green = (value >> 8) & 255;
+  const blue = value & 255;
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+}
 
 function getPoint(angle: number, radius: number) {
   return {
@@ -42,15 +49,21 @@ function scoreToRadius(score: number): number {
   return ((clamped - RADAR_SCORE_MIN) / RADAR_SCORE_RANGE) * OUTER_RADIUS;
 }
 
-export function ClusterRadarChart({ clusters, activeGroupId = null }: ClusterRadarChartProps) {
+export function ClusterRadarChart({ clusters, activeGroupIds = [] }: ClusterRadarChartProps) {
   const valueAngles = useMemo(() => buildValueAngles(), []);
+  const activeGroupSet = useMemo(() => new Set(activeGroupIds), [activeGroupIds]);
+  const hasActiveSelection = activeGroupIds.length > 0;
+  const clusterColorIndexById = useMemo(
+    () => new Map(clusters.map((cluster, index) => [cluster.id, index] as const)),
+    [clusters],
+  );
   const renderedClusters = useMemo(
     () => [...clusters].sort((left, right) => {
-      const leftActive = activeGroupId != null && left.id === activeGroupId ? 1 : 0;
-      const rightActive = activeGroupId != null && right.id === activeGroupId ? 1 : 0;
+      const leftActive = hasActiveSelection && activeGroupSet.has(left.id) ? 1 : 0;
+      const rightActive = hasActiveSelection && activeGroupSet.has(right.id) ? 1 : 0;
       return leftActive - rightActive;
     }),
-    [activeGroupId, clusters],
+    [activeGroupSet, clusters, hasActiveSelection],
   );
   const hasClippedScores = useMemo(
     () => clusters.some((cluster) => DISPLAY_VALUES.some((valueKey) => {
@@ -151,7 +164,7 @@ export function ClusterRadarChart({ clusters, activeGroupId = null }: ClusterRad
                     ? 'start'
                     : 'middle';
             const adjustedLabelPoint = valueKey === 'Universalism_Nature'
-              ? { x: labelPoint.x - 14, y: labelPoint.y }
+              ? { x: labelPoint.x - UNIVERSALISM_LABEL_OFFSET, y: labelPoint.y }
               : labelPoint;
 
             return (
@@ -173,10 +186,12 @@ export function ClusterRadarChart({ clusters, activeGroupId = null }: ClusterRad
           <circle cx={CENTER_X} cy={CENTER_Y} r="2.75" fill="#94a3b8" />
 
           {renderedClusters.map((cluster, index) => {
-            const palette = CLUSTER_PALETTE[index % CLUSTER_PALETTE.length]!;
+            const clusterColorIndex = clusterColorIndexById.get(cluster.id) ?? index;
+            const stroke = getClusterVisualColor(clusterColorIndex);
+            const fill = withAlpha(stroke, 0.14);
             const orderedValues = DISPLAY_VALUES;
-            const isActive = activeGroupId == null || activeGroupId === cluster.id;
-            const faded = activeGroupId != null && !isActive;
+            const isActive = !hasActiveSelection || activeGroupSet.has(cluster.id);
+            const faded = hasActiveSelection && !isActive;
             const points = orderedValues.map((valueKey) => {
               const angle = valueAngles.get(valueKey) ?? -Math.PI / 2;
               const score = cluster.centroid[valueKey] ?? 0;
@@ -191,11 +206,11 @@ export function ClusterRadarChart({ clusters, activeGroupId = null }: ClusterRad
               <g key={cluster.id}>
                 <path
                   d={`${path} Z`}
-                  fill={palette.fill}
-                  stroke={palette.stroke}
-                  strokeWidth={isActive && activeGroupId != null ? '3' : '2'}
-                  opacity={faded ? 0.16 : activeGroupId != null ? 1 : 0.78}
-                  style={isActive && activeGroupId != null ? { filter: `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 14px ${palette.stroke}aa)` } : undefined}
+                  fill={fill}
+                  stroke={stroke}
+                  strokeWidth={isActive && hasActiveSelection ? '3' : '2'}
+                  opacity={faded ? 0.16 : hasActiveSelection ? 1 : 0.78}
+                  style={isActive && hasActiveSelection ? { filter: `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 14px ${stroke}aa)` } : undefined}
                 />
                 {points.map((point, pointIndex) => {
                   const valueKey = orderedValues[pointIndex]!;
@@ -206,12 +221,12 @@ export function ClusterRadarChart({ clusters, activeGroupId = null }: ClusterRad
                       <circle
                         cx={point.x}
                         cy={point.y}
-                        r={isActive && activeGroupId != null ? 4 : 3.2}
-                        fill={palette.stroke}
+                        r={isActive && hasActiveSelection ? 4 : 3.2}
+                        fill={stroke}
                         stroke="#ffffff"
                         strokeWidth="1.5"
-                        opacity={faded ? 0.2 : activeGroupId != null ? 1 : 0.85}
-                        style={isActive && activeGroupId != null ? { filter: `drop-shadow(0 0 6px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${palette.stroke}aa)` } : undefined}
+                        opacity={faded ? 0.2 : hasActiveSelection ? 1 : 0.85}
+                        style={isActive && hasActiveSelection ? { filter: `drop-shadow(0 0 6px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${stroke}aa)` } : undefined}
                       />
                     </g>
                   );

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -10,10 +10,18 @@ import { ClusterRadarChart } from './ClusterRadarChart';
 import { buildIndividualClusters, getClusterMemberLabelText } from './clusterVisualizationUtils';
 
 const LEGEND_COLORS = [
-  { border: 'border-blue-500', text: 'text-blue-700', light: 'bg-blue-50', color: '#3b82f6' },
-  { border: 'border-amber-500', text: 'text-amber-700', light: 'bg-amber-50', color: '#f59e0b' },
-  { border: 'border-emerald-500', text: 'text-emerald-700', light: 'bg-emerald-50', color: '#10b981' },
-  { border: 'border-rose-500', text: 'text-rose-700', light: 'bg-rose-50', color: '#f43f5e' },
+  { border: 'border-blue-500', text: 'text-blue-700', light: 'bg-blue-50', color: '#2563eb' },
+  { border: 'border-amber-500', text: 'text-amber-700', light: 'bg-amber-50', color: '#d97706' },
+  { border: 'border-emerald-500', text: 'text-emerald-700', light: 'bg-emerald-50', color: '#059669' },
+  { border: 'border-rose-500', text: 'text-rose-700', light: 'bg-rose-50', color: '#e11d48' },
+  { border: 'border-violet-500', text: 'text-violet-700', light: 'bg-violet-50', color: '#7c3aed' },
+  { border: 'border-sky-500', text: 'text-sky-700', light: 'bg-sky-50', color: '#0ea5e9' },
+  { border: 'border-orange-500', text: 'text-orange-700', light: 'bg-orange-50', color: '#ea580c' },
+  { border: 'border-lime-500', text: 'text-lime-700', light: 'bg-lime-50', color: '#65a30d' },
+  { border: 'border-fuchsia-500', text: 'text-fuchsia-700', light: 'bg-fuchsia-50', color: '#d946ef' },
+  { border: 'border-indigo-500', text: 'text-indigo-700', light: 'bg-indigo-50', color: '#4f46e5' },
+  { border: 'border-teal-500', text: 'text-teal-700', light: 'bg-teal-50', color: '#14b8a6' },
+  { border: 'border-yellow-500', text: 'text-yellow-700', light: 'bg-yellow-50', color: '#ca8a04' },
 ] as const;
 
 type ModelGroupsSectionProps = {
@@ -53,7 +61,7 @@ export function ModelGroupsSection({
   const [showModelGroupsHelp, setShowModelGroupsHelp] = useState(false);
   const [viewMode, setViewMode] = useState<ClusterViewMode>('dot');
   const [groupDisplayMode, setGroupDisplayMode] = useState<GroupDisplayMode>('groups');
-  const [activeGroupId, setActiveGroupId] = useState<string | null>(null);
+  const [activeGroupIds, setActiveGroupIds] = useState<string[]>([]);
 
   const hasGroupedClusters = clusterAnalysis != null && !clusterAnalysis.skipped;
   const groupedClusters = useMemo(() => clusterAnalysis?.clusters ?? [], [clusterAnalysis]);
@@ -73,10 +81,26 @@ export function ModelGroupsSection({
   );
 
   useEffect(() => {
-    if (activeGroupId == null) return;
-    if (clusters.some((cluster) => cluster.id === activeGroupId)) return;
-    setActiveGroupId(null);
-  }, [activeGroupId, clusters]);
+    setActiveGroupIds((current) => {
+      const next = current.filter((id) => clusters.some((cluster) => cluster.id === id));
+      if (next.length === current.length && next.every((id, index) => id === current[index])) {
+        return current;
+      }
+      return next;
+    });
+  }, [clusters]);
+
+  const toggleGroupSelection = (clusterId: string) => {
+    setActiveGroupIds((current) => {
+      if (groupDisplayMode === 'individual') {
+        return current.includes(clusterId)
+          ? current.filter((id) => id !== clusterId)
+          : [...current, clusterId];
+      }
+
+      return current.length === 1 && current[0] === clusterId ? [] : [clusterId];
+    });
+  };
 
   const copyLabel = `${groupDisplayMode} model groups ${
     viewMode === 'dot' ? 'dot map' : viewMode === 'bar' ? 'bar chart' : 'radar chart'
@@ -217,15 +241,15 @@ export function ModelGroupsSection({
           </div>
         ) : (
           <>
-            {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} activeGroupId={activeGroupId} />}
-            {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} activeGroupId={activeGroupId} />}
-            {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} activeGroupId={activeGroupId} />}
+            {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} activeGroupIds={activeGroupIds} />}
+            {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} activeGroupIds={activeGroupIds} />}
+            {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} activeGroupIds={activeGroupIds} />}
 
             <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
               {clusters.map((cluster, index) => {
                 const style = getLegendColor(index);
                 const memberLabels = getGroupLabel(cluster);
-                const isActive = activeGroupId === cluster.id;
+                const isActive = activeGroupIds.includes(cluster.id);
 
                 return (
                   <Button
@@ -233,7 +257,7 @@ export function ModelGroupsSection({
                     type="button"
                     variant="ghost"
                     size="sm"
-                    onClick={() => setActiveGroupId((current) => (current === cluster.id ? null : cluster.id))}
+                    onClick={() => toggleGroupSelection(cluster.id)}
                     aria-pressed={isActive}
                     title={memberLabels}
                     className={`rounded-lg border p-3 text-left transition ${
@@ -252,10 +276,12 @@ export function ModelGroupsSection({
                           boxShadow: isActive ? '0 0 0 1px rgba(255,255,255,0.85), 0 0 12px rgba(45,212,191,0.55)' : undefined,
                         }}
                       />
-                      <div className="min-w-0">
-                        <p className={`truncate text-sm font-semibold ${style.text}`}>{memberLabels}</p>
-                        </div>
+                      <div className="min-w-0 flex-1">
+                        <p className={`text-sm font-semibold leading-snug ${style.text} whitespace-normal break-words`}>
+                          {memberLabels}
+                        </p>
                       </div>
+                    </div>
                   </Button>
                 );
               })}

--- a/cloud/apps/web/src/components/domains/clusterVisualizationUtils.ts
+++ b/cloud/apps/web/src/components/domains/clusterVisualizationUtils.ts
@@ -9,6 +9,21 @@ export const DOT_BAR_CLUSTER_SCORE_MIN = -2.5;
 export const DOT_BAR_CLUSTER_SCORE_MAX = 2.5;
 export const DOT_BAR_CLUSTER_SCORE_RANGE = DOT_BAR_CLUSTER_SCORE_MAX - DOT_BAR_CLUSTER_SCORE_MIN;
 
+export const CLUSTER_VISUAL_COLORS = [
+  '#2563eb',
+  '#d97706',
+  '#059669',
+  '#e11d48',
+  '#7c3aed',
+  '#0ea5e9',
+  '#ea580c',
+  '#65a30d',
+  '#d946ef',
+  '#4f46e5',
+  '#14b8a6',
+  '#ca8a04',
+] as const;
+
 const VALUE_INDEX = new Map(VALUES.map((valueKey, index) => [valueKey, index] as const));
 
 function averageScore(clusters: DomainCluster[], valueKey: ValueKey): number {
@@ -58,6 +73,10 @@ export function buildIndividualClusters(models: ModelEntry[]): DomainCluster[] {
       },
     ],
   }));
+}
+
+export function getClusterVisualColor(index: number): string {
+  return CLUSTER_VISUAL_COLORS[index % CLUSTER_VISUAL_COLORS.length]!;
 }
 
 export function formatClusterScoreLabel(score: number): string {

--- a/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
+++ b/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
@@ -104,6 +104,33 @@ describe('ModelGroupsSection', () => {
     expect(inactiveDot).toHaveStyle({ opacity: '0.2' });
   });
 
+  it('allows multi-select in individual mode', () => {
+    const { container } = render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} models={populatedModels} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Individual' }));
+
+    const firstModel = populatedModels[0];
+    const secondModel = populatedModels[1];
+    expect(firstModel).toBeDefined();
+    expect(secondModel).toBeDefined();
+
+    const firstButton = screen.getByRole('button', { name: firstModel?.label ?? '' });
+    const secondButton = screen.getByRole('button', { name: secondModel?.label ?? '' });
+
+    fireEvent.click(firstButton);
+    fireEvent.click(secondButton);
+
+    expect(firstButton).toHaveAttribute('aria-pressed', 'true');
+    expect(secondButton).toHaveAttribute('aria-pressed', 'true');
+
+    const firstDot = container.querySelector(`[data-value-key="Achievement"][data-cluster-id="${firstModel?.model}"]`);
+    const secondDot = container.querySelector(`[data-value-key="Achievement"][data-cluster-id="${secondModel?.model}"]`);
+    expect(firstDot).not.toBeNull();
+    expect(secondDot).not.toBeNull();
+    expect(firstDot as Element).toHaveStyle({ opacity: '1' });
+    expect(secondDot as Element).toHaveStyle({ opacity: '1' });
+  });
+
   it('shows a value tooltip with color rows and logit values on bar hover', () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
## Summary
- Add broader colors and multi-select legend highlighting for individual model reports
- Wrap long legend labels so they do not collide when multiple models are selected
- Tighten the radar view and adjust Universalism placement for readability

## Test plan
- [x] npm run test -- tests/components/ModelGroupsSection.test.tsx
- [x] npm run lint
- [x] npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)