### PR TITLE
Radar chart: zoom in, fix Universalism label, remove scale legend

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
@@ -17,13 +17,12 @@ const CHART_SIZE = 640;
 const VIEW_BOX_HEIGHT = 560;
 const CENTER_X = 286;
 const CENTER_Y = 276;
-const OUTER_RADIUS = 202;
+const OUTER_RADIUS = 228;
 const CATEGORY_RING_RADIUS = OUTER_RADIUS + 26;
 const CATEGORY_LABEL_RADIUS = OUTER_RADIUS + 82;
 const RADAR_SCORE_MIN = -2.5;
 const RADAR_SCORE_MAX = 2.5;
 const RADAR_SCORE_RANGE = RADAR_SCORE_MAX - RADAR_SCORE_MIN;
-const UNIVERSALISM_LABEL_OFFSET = 7;
 
 function withAlpha(hexColor: string, alpha: number): string {
   const hex = hexColor.replace('#', '');
@@ -156,23 +155,18 @@ export function ClusterRadarChart({ clusters, activeGroupIds = [] }: ClusterRada
             const labelPoint = getPoint(angle, OUTER_RADIUS + 18);
             const label = VALUE_LABELS[valueKey];
             const anchor =
-              valueKey === 'Universalism_Nature'
+              labelPoint.x < CENTER_X - 8
                 ? 'end'
-                : labelPoint.x < CENTER_X - 8
-                  ? 'end'
-                  : labelPoint.x > CENTER_X + 8
-                    ? 'start'
-                    : 'middle';
-            const adjustedLabelPoint = valueKey === 'Universalism_Nature'
-              ? { x: labelPoint.x - UNIVERSALISM_LABEL_OFFSET, y: labelPoint.y }
-              : labelPoint;
+                : labelPoint.x > CENTER_X + 8
+                  ? 'start'
+                  : 'middle';
 
             return (
               <g key={valueKey}>
                 <line x1={CENTER_X} y1={CENTER_Y} x2={outer.x} y2={outer.y} stroke="#e5e7eb" strokeWidth="1" />
                 <text
-                  x={adjustedLabelPoint.x}
-                  y={adjustedLabelPoint.y}
+                  x={labelPoint.x}
+                  y={labelPoint.y}
                   textAnchor={anchor}
                   dominantBaseline="middle"
                   className="fill-gray-700 text-[10px] font-medium"
@@ -235,23 +229,6 @@ export function ClusterRadarChart({ clusters, activeGroupIds = [] }: ClusterRada
             );
           })}
 
-          <g>
-            <line x1={24} y1={512} x2={132} y2={512} stroke="#d1d5db" strokeWidth="1.5" />
-            <line x1={78} y1={502} x2={78} y2={522} stroke="#d1d5db" strokeWidth="1.5" />
-            <text x={24} y={500} className="fill-gray-400 text-[10px]">
-              -2.5
-            </text>
-            <text x={71} y={500} className="fill-gray-500 text-[10px] font-semibold">
-              0
-            </text>
-            <text x={116} y={500} className="fill-gray-400 text-[10px]">
-              +2.5
-            </text>
-          </g>
-
-          <text x={24} y={534} className="fill-gray-500 text-[10px]">
-            Mid-ring = neutral, outer ring = strongest favoring.
-          </text>
         </svg>
       </div>
 

--- a/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
+++ b/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
@@ -166,7 +166,7 @@ describe('ModelGroupsSection', () => {
     expect(screen.getByText('Conservation')).toBeInTheDocument();
     expect(screen.getByText('Self-Enhancement')).toBeInTheDocument();
     expect(screen.getByText('Openness to Change')).toBeInTheDocument();
-    expect(screen.getByText('Universalism')).toHaveAttribute('text-anchor', 'end');
+    expect(screen.getByText('Universalism')).toHaveAttribute('text-anchor', 'start');
     expect(screen.queryByText(/Cluster:/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Increase \`OUTER_RADIUS\` from 202 to 228 so the 2.5 score ring aligns with the outer edge of the colored quadrant fill (zooms in the data polygon)
- Remove the forced \`'end'\` text anchor and offset on the Universalism label — it now uses the standard position-based anchor and appears to the right
- Remove the \`-2.5 0 +2.5\` axis mini-legend and "Mid-ring = neutral, outer ring = strongest favoring" text

## Validation
- \`npm run build --workspace @valuerank/web\` ✅

## Test plan
- [ ] Radar chart in Model Groups section shows larger data polygon filling more of the colored circle
- [ ] Universalism label appears to the right of its ring point
- [ ] No scale legend text below the chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)