### PR TITLE
Fix bar chart z-order: shortest bar renders on top

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
@@ -141,7 +141,7 @@ export function ClusterBarPlot({ clusters, activeGroupIds = [] }: ClusterBarPlot
                           width: `${width}%`,
                           transform: 'translateY(-50%)',
                           height: '10px',
-                          zIndex: isActive ? rankedClusters.length + 20 - index : index + 1,
+                          zIndex: isActive ? index + 20 : index + 1,
                           opacity: faded ? 0.18 : hasActiveSelection ? 1 : 0.78,
                           filter: isActive && hasActiveSelection ? `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${color}99)` : undefined,
                         }}


### PR DESCRIPTION
## Summary
- When a group legend item is active (highlighted), the z-index formula was inverted — the longest bar got the highest z-index, covering all shorter bars underneath
- Changed `rankedClusters.length + 20 - index` → `index + 20` so shortest bars (highest index in the longest-first sort) always render on top, matching the already-correct inactive formula

## Validation
- `npm run build --workspace @valuerank/web` ✅
- `ModelGroupsSection` test suite (6/6) ✅

## Test plan
- [ ] In Bar view, click a legend item to activate it — all 4 cluster colors should remain visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)