### PR TITLE
fix(web): pressure sensitivity — add opponentWinRate to grid query

### DIFF
--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -3233,6 +3233,8 @@ type SensitivityCell {
   n: Int!
   netScore: Float
   opponentLevel: Int!
+  opponentSuccesses: Int!
+  opponentWinRate: Float
   ownLevel: Int!
   successes: Int!
   unscoredCount: Int!

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -3569,6 +3569,8 @@ export type SensitivityCell = {
   n: Scalars['Int']['output'];
   netScore?: Maybe<Scalars['Float']['output']>;
   opponentLevel: Scalars['Int']['output'];
+  opponentSuccesses: Scalars['Int']['output'];
+  opponentWinRate?: Maybe<Scalars['Float']['output']>;
   ownLevel: Scalars['Int']['output'];
   successes: Scalars['Int']['output'];
   unscoredCount: Scalars['Int']['output'];
@@ -7234,6 +7236,7 @@ export const PressureSensitivityDocument = gql`
           n
           unscoredCount
           winRate
+          opponentWinRate
           conviction
           netScore
           lowData


### PR DESCRIPTION
## Summary
- `Universalism_Nature` (and any value alphabetically last) showed `—` for all win rates on the Pressure Sensitivity page
- Root cause: `opponentWinRate` was missing from the `pressureSensitivity.graphql` grid fragment, so `cell.opponentWinRate` was always `undefined` on the client
- Since canonical pair keys sort values alphabetically, `Universalism_Nature` is always the **second** value in every pair, and `computePairRates` reads `cell.opponentWinRate` for the second-value perspective
- Also regenerated `schema.graphql` from the live API SDL — the API had already exposed `opponentWinRate` on `SensitivityCell` but the committed snapshot was stale

## Validation
- `npm run codegen --workspace @valuerank/web` ✅ (was failing before the schema.graphql fix)
- `npm run lint --workspace @valuerank/web` ✅ (120 warnings, 0 errors)
- `npm run test --workspace @valuerank/web` ✅ (1386 passed, 8 skipped)
- `npm run build --workspace @valuerank/web` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)