### PR TITLE
fix(api): equal-weight domain pooling in pooledWinRate

### DIFF
--- a/cloud/apps/api/src/graphql/queries/models-analysis-math.ts
+++ b/cloud/apps/api/src/graphql/queries/models-analysis-math.ts
@@ -10,17 +10,17 @@ type DomainContribution = {
 export function computePooledWinRate(domains: WeightedDomainContribution[]): number | null {
   if (domains.length === 0) return null;
 
-  let weightedSum = 0;
-  let totalWeight = 0;
+  let sum = 0;
+  let count = 0;
 
   for (const domain of domains) {
     if (!Number.isFinite(domain.evidenceWeight) || domain.evidenceWeight <= 0) continue;
-    weightedSum += domain.winRate * domain.evidenceWeight;
-    totalWeight += domain.evidenceWeight;
+    sum += domain.winRate;
+    count += 1;
   }
 
-  if (totalWeight <= 0) return null;
-  return weightedSum / totalWeight;
+  if (count === 0) return null;
+  return sum / count;
 }
 
 export function computeStabilityScore(domains: DomainContribution[]): number | null {

--- a/cloud/apps/api/tests/graphql/queries/models-analysis.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/models-analysis.test.ts
@@ -48,13 +48,13 @@ describe('selectModelsAnalysisSnapshots', () => {
 });
 
 describe('models-analysis math', () => {
-  it('weights pooled win rate by vignette count instead of treating each domain equally', () => {
+  it('treats each domain equally regardless of vignette count', () => {
     const pooled = computePooledWinRate([
       { winRate: 40, evidenceWeight: 1 },
       { winRate: 80, evidenceWeight: 3 },
     ]);
 
-    expect(pooled).toBe(70);
+    expect(pooled).toBe(60);
   });
 
   it('returns null when no eligible vignette-weighted contributions are available', () => {


### PR DESCRIPTION
## Summary
- `pooledWinRate` in Domain Analysis was weighting each domain by its vignette count, so a domain with 50 vignettes at 60% would dominate a domain with 5 vignettes at 80%
- The correct principle: more trials make a domain's estimate more **certain** (narrower CI) but should not shift the **point estimate**
- Fix: each domain with at least one vignette now contributes equally to the average; `evidenceWeight > 0` remains as a validity guard but is no longer used as a multiplier

## Validation
- `npm run lint --workspace @valuerank/api` ✅ (0 errors, 27 pre-existing warnings)
- `npm run build --workspace @valuerank/api` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)