### PR TITLE
refactor(api): consolidate pairwise win rate into computePairwiseWinRate

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/analysis/value-detail-types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/analysis/value-detail-types.ts
@@ -1,5 +1,6 @@
 import type { DomainAnalysisConditionDetail, DomainAnalysisVignetteDetail } from '../shared.js';
 import type { DomainAnalysisValueKey } from '../../domain-analysis-values.js';
+import { computePairwiseWinRate } from '../../../../utils/pairwise-math.js';
 
 export type MutableCondition = {
   scenarioId: string | null;
@@ -30,8 +31,6 @@ export type MutableVignette = {
 };
 
 export function mapCondition(condition: MutableCondition): DomainAnalysisConditionDetail {
-  const comparisonDenominator =
-    condition.prioritized + condition.deprioritized + condition.neutral;
   return {
     scenarioId: condition.scenarioId,
     conditionName: condition.conditionName,
@@ -40,7 +39,7 @@ export function mapCondition(condition: MutableCondition): DomainAnalysisConditi
     deprioritized: condition.deprioritized,
     neutral: condition.neutral,
     totalTrials: condition.totalTrials,
-    selectedValueWinRate: comparisonDenominator === 0 ? null : condition.prioritized / comparisonDenominator,
+    selectedValueWinRate: computePairwiseWinRate(condition.prioritized, condition.deprioritized, condition.neutral),
     strongly: condition.strongly,
     somewhat: condition.somewhat,
     opponentSomewhat: condition.opponentSomewhat,
@@ -53,8 +52,6 @@ export function mapVignette(vignette: MutableVignette): DomainAnalysisVignetteDe
   const conditions: DomainAnalysisConditionDetail[] = Array.from(vignette.conditions.values())
     .sort((left, right) => left.conditionName.localeCompare(right.conditionName))
     .map(mapCondition);
-  const comparisonDenominator =
-    vignette.prioritized + vignette.deprioritized + vignette.neutral;
   return {
     definitionId: vignette.definitionId,
     definitionName: vignette.definitionName,
@@ -65,7 +62,7 @@ export function mapVignette(vignette: MutableVignette): DomainAnalysisVignetteDe
     deprioritized: vignette.deprioritized,
     neutral: vignette.neutral,
     totalTrials: vignette.totalTrials,
-    selectedValueWinRate: comparisonDenominator === 0 ? null : vignette.prioritized / comparisonDenominator,
+    selectedValueWinRate: computePairwiseWinRate(vignette.prioritized, vignette.deprioritized, vignette.neutral),
     conditions,
   };
 }

--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-aggregator.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-aggregator.ts
@@ -11,6 +11,7 @@ import {
 } from '../../graphql/queries/domain-analysis-values.js';
 import type { DomainAnalysisValueCounts } from '../../graphql/queries/domain/shared.js';
 import type { AnalysisOutputRow } from './domain-analysis-cache-types.js';
+import { computePairwiseWinRate } from '../../utils/pairwise-math.js';
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -174,14 +175,10 @@ export function aggregateAnalysisRows(params: {
       acc.second.deprioritized += secondCounts.deprioritized;
       acc.second.neutral += secondCounts.neutral;
 
-      const totalFirst = firstCounts.prioritized + firstCounts.deprioritized + firstCounts.neutral;
-      if (totalFirst > 0) {
-        acc.firstRates.push(firstCounts.prioritized / totalFirst);
-      }
-      const totalSecond = secondCounts.prioritized + secondCounts.deprioritized + secondCounts.neutral;
-      if (totalSecond > 0) {
-        acc.secondRates.push(secondCounts.prioritized / totalSecond);
-      }
+      const firstRate = computePairwiseWinRate(firstCounts.prioritized, firstCounts.deprioritized, firstCounts.neutral);
+      if (firstRate !== null) acc.firstRates.push(firstRate);
+      const secondRate = computePairwiseWinRate(secondCounts.prioritized, secondCounts.deprioritized, secondCounts.neutral);
+      if (secondRate !== null) acc.secondRates.push(secondRate);
 
       acc.runCount += 1;
     }

--- a/cloud/apps/api/src/services/circumplex/aggregation.ts
+++ b/cloud/apps/api/src/services/circumplex/aggregation.ts
@@ -3,6 +3,7 @@ import { SCHWARTZ_CIRCULAR_ORDER, type ValueKey } from '@valuerank/shared/schwar
 import { extractValuePair, type DomainAnalysisValuePair } from '../../graphql/queries/domain-analysis-values.js';
 import { runMatchesSignature } from '../../graphql/queries/domain-coverage-gql-types.js';
 import { resolveTranscriptDecisionModel } from '../../graphql/queries/domain/decision-model.js';
+import { computePairwiseWinRate } from '../../utils/pairwise-math.js';
 
 export type CircumplexPairCell = {
   winRate: number | null;
@@ -64,15 +65,13 @@ function buildOrderedCell(stats: PairStats | undefined, left: ValueKey): Circump
     return createEmptyCell();
   }
 
-  const total = stats.prioritizedA + stats.prioritizedB + stats.neutrals;
-  if (total <= 0) {
-    return createEmptyCell();
-  }
-
-  const winCount = left === stats.pair.valueA ? stats.prioritizedA : stats.prioritizedB;
+  const wins = left === stats.pair.valueA ? stats.prioritizedA : stats.prioritizedB;
+  const losses = left === stats.pair.valueA ? stats.prioritizedB : stats.prioritizedA;
+  const winRate = computePairwiseWinRate(wins, losses, stats.neutrals);
+  if (winRate === null) return createEmptyCell();
   return {
-    winRate: winCount / total,
-    trials: total,
+    winRate,
+    trials: wins + losses + stats.neutrals,
     neutrals: stats.neutrals,
   };
 }

--- a/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
@@ -8,6 +8,7 @@
  */
 
 import type { AssignedOutcome } from './value-pair.js';
+import { computePairwiseWinRate } from '../../utils/pairwise-math.js';
 
 export type DecisionStrength = 'strong' | 'lean' | null;
 
@@ -178,8 +179,8 @@ export function buildCellMetrics(observations: ReadonlyArray<Observation>): Cell
     };
   }
 
-  const winRate = ownPicked / n;
-  const opponentWinRate = opponentPicked / n;
+  const winRate = computePairwiseWinRate(ownPicked, opponentPicked, neutral);
+  const opponentWinRate = computePairwiseWinRate(opponentPicked, ownPicked, neutral);
   const ownPicksWithStrength = ownStrong + ownLean;
   const conviction =
     ownPicksWithStrength === 0 ? null : (2 * ownStrong + ownLean) / ownPicksWithStrength;

--- a/cloud/apps/api/src/utils/pairwise-math.ts
+++ b/cloud/apps/api/src/utils/pairwise-math.ts
@@ -1,0 +1,14 @@
+/**
+ * Computes the win rate for one side of a pairwise comparison, including
+ * neutral outcomes in the denominator. Returns null when there are no
+ * observations.
+ */
+export function computePairwiseWinRate(
+  wins: number,
+  losses: number,
+  neutral: number,
+): number | null {
+  const total = wins + losses + neutral;
+  if (total <= 0) return null;
+  return wins / total;
+}


### PR DESCRIPTION
## Summary
- Four separate sites were each computing `wins / (wins + losses + neutral)` inline with slightly different variable names (`ownPicked/opponentPicked`, `prioritized/deprioritized`, `winCount/total`)
- Extracted to a single `computePairwiseWinRate(wins, losses, neutral)` in `utils/pairwise-math.ts`
- No behavior change — pure deduplication

## Files changed
- **new** `utils/pairwise-math.ts` — shared function
- `services/pressure-sensitivity/aggregation.ts`
- `services/analysis/domain-analysis-snapshot-aggregator.ts`
- `graphql/queries/domain/analysis/value-detail-types.ts`
- `services/circumplex/aggregation.ts`

## Validation
- `npm run build --workspace @valuerank/api` ✅
- `npm run lint --workspace @valuerank/api` ✅ (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)