### PR TITLE
Fix token case normalization: lowercase vignette tokens now produce analysis

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
@@ -17,7 +17,7 @@ export type DomainAnalysisCacheStatus =
   (typeof DOMAIN_ANALYSIS_CACHE_STATUS)[keyof typeof DOMAIN_ANALYSIS_CACHE_STATUS];
 
 export const DOMAIN_ANALYSIS_SNAPSHOT_TYPE = 'domain_overview';
-export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.7.0';
+export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.7.1';
 export const DOMAIN_ANALYSIS_ASSUMPTION_PREFIX = 'domain-analysis';
 export const DOMAIN_ANALYSIS_NONE_SIGNATURE = '__none__';
 

--- a/cloud/apps/api/src/services/analysis/transcript-cell-accumulator.ts
+++ b/cloud/apps/api/src/services/analysis/transcript-cell-accumulator.ts
@@ -82,6 +82,12 @@ function isDomainAnalysisValueKey(value: string): value is DomainAnalysisValueKe
   return (DOMAIN_ANALYSIS_VALUE_KEYS as readonly string[]).includes(value);
 }
 
+function normalizeToDomainAnalysisValueKey(rawToken: string): DomainAnalysisValueKey | null {
+  const lower = rawToken.trim().toLowerCase();
+  const match = (DOMAIN_ANALYSIS_VALUE_KEYS as readonly string[]).find((key) => key.toLowerCase() === lower);
+  return match !== undefined ? (match as DomainAnalysisValueKey) : null;
+}
+
 function getStringToken(value: unknown): string | null {
   return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
 }
@@ -92,14 +98,17 @@ function getSnapshotValuePair(definitionSnapshot: unknown): [string, string] | n
   if (!isRecord(components)) return null;
   const valueFirstComponent = components.value_first;
   const valueSecondComponent = components.value_second;
-  const valueFirstToken = getStringToken(isRecord(valueFirstComponent) ? valueFirstComponent.token : undefined);
-  const valueSecondToken = getStringToken(isRecord(valueSecondComponent) ? valueSecondComponent.token : undefined);
+  const valueFirstRaw = getStringToken(isRecord(valueFirstComponent) ? valueFirstComponent.token : undefined);
+  const valueSecondRaw = getStringToken(isRecord(valueSecondComponent) ? valueSecondComponent.token : undefined);
+  if (valueFirstRaw === null || valueSecondRaw === null) return null;
+  const valueFirstToken = normalizeToDomainAnalysisValueKey(valueFirstRaw);
+  const valueSecondToken = normalizeToDomainAnalysisValueKey(valueSecondRaw);
   if (valueFirstToken === null || valueSecondToken === null) return null;
   return canonicalOwnOpponent(valueFirstToken, valueSecondToken);
 }
 
 function isDimensionMatch(dimension: unknown, token: string): dimension is DefinitionDimension {
-  return isRecord(dimension) && typeof dimension.name === 'string' && dimension.name.trim() === token;
+  return isRecord(dimension) && typeof dimension.name === 'string' && dimension.name.trim().toLowerCase() === token.toLowerCase();
 }
 
 function getDefinitionDimensions(definitionSnapshot: unknown, firstValueToken: string, secondValueToken: string): {

--- a/cloud/apps/api/src/services/pressure-sensitivity/value-pair.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/value-pair.ts
@@ -94,15 +94,17 @@ export function assignOwnOpponentLevels(
   const opponentTrimmed = secondValueToken.trim();
 
   const ownDim = definitionDimensions.find(
-    (d) => typeof d.name === 'string' && d.name.trim() === ownTrimmed,
+    (d) => typeof d.name === 'string' && d.name.trim().toLowerCase() === ownTrimmed.toLowerCase(),
   );
   const opponentDim = definitionDimensions.find(
-    (d) => typeof d.name === 'string' && d.name.trim() === opponentTrimmed,
+    (d) => typeof d.name === 'string' && d.name.trim().toLowerCase() === opponentTrimmed.toLowerCase(),
   );
   if (!ownDim || !opponentDim) return null;
 
-  const ownRaw = scenarioDimensionValues[ownTrimmed];
-  const opponentRaw = scenarioDimensionValues[opponentTrimmed];
+  const ownStoredName = (ownDim.name as string).trim();
+  const opponentStoredName = (opponentDim.name as string).trim();
+  const ownRaw = scenarioDimensionValues[ownStoredName];
+  const opponentRaw = scenarioDimensionValues[opponentStoredName];
   if (ownRaw === undefined || opponentRaw === undefined) return null;
 
   const ownLevel = ownLookup(ownRaw);

--- a/cloud/apps/api/tests/services/analysis/transcript-cell-accumulator.test.ts
+++ b/cloud/apps/api/tests/services/analysis/transcript-cell-accumulator.test.ts
@@ -189,4 +189,44 @@ describe('accumulateTranscriptCells', () => {
 
     expect(cellMap.size).toBe(0);
   });
+
+  it('normalizes lowercase token names in definitionSnapshot to canonical PascalCase', () => {
+    const lowercaseFirst = FIRST_VALUE.toLowerCase();
+    const lowercaseSecond = SECOND_VALUE.toLowerCase();
+    const transcript = buildTranscript({
+      runId: 'run-1',
+      definitionSnapshot: buildDefinitionSnapshot(lowercaseFirst, lowercaseSecond),
+      scenario: {
+        id: 'scenario-1',
+        content: {
+          dimensionValues: {
+            [lowercaseFirst]: 1,
+            [lowercaseSecond]: 2,
+          },
+        },
+        orientationFlipped: false,
+        deletedAt: null,
+      },
+    });
+    const cellMap = accumulateTranscriptCells({
+      transcripts: [transcript],
+      filteredSourceRunDefinitionById: new Map([['run-1', 'def1']]),
+    });
+
+    expect(cellMap.size).toBe(2);
+    expect(cellMap.get(encodeCellKey({
+      definitionId: 'def1',
+      modelId: 'm1',
+      valueKey: FIRST_VALUE,
+      ownLevel: 1,
+      opponentLevel: 2,
+    }))).toEqual({ wins: 1, losses: 0, neutrals: 0 });
+    expect(cellMap.get(encodeCellKey({
+      definitionId: 'def1',
+      modelId: 'm1',
+      valueKey: SECOND_VALUE,
+      ownLevel: 2,
+      opponentLevel: 1,
+    }))).toEqual({ wins: 0, losses: 1, neutrals: 0 });
+  });
 });


### PR DESCRIPTION
## Summary
- Definitions like National Priorities store value tokens in lowercase (`achievement` instead of `Achievement`). Three code paths did exact-case comparisons against `DOMAIN_ANALYSIS_VALUE_KEYS` (PascalCase), so every transcript for those domains was silently skipped → all definitions showed `NO_ANALYSIS`.
- Added `normalizeToDomainAnalysisValueKey` helper in `transcript-cell-accumulator.ts` that maps any case to the canonical PascalCase key; applied it in `getSnapshotValuePair` and made `isDimensionMatch` case-insensitive.
- Made `assignOwnOpponentLevels` in `value-pair.ts` find dimensions case-insensitively; use the stored dimension name (not the normalized token) for `scenarioDimensionValues` lookup so keys always match.
- Bumped `DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION` `1.7.0` → `1.7.1` to invalidate already-built snapshots that dropped the lowercase transcripts.
- Added a unit test covering the lowercase-token path end-to-end.

## Test plan
- [ ] Preflight passed (lint + tests + build)
- [ ] `transcript-cell-accumulator` unit tests pass including new lowercase-token case
- [ ] National Priorities domain analysis flips from `NO_ANALYSIS` → real counts after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)