### PR TITLE
Fix domain analysis: read dimension_values (snake_case) from production scenarios

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
@@ -17,7 +17,7 @@ export type DomainAnalysisCacheStatus =
   (typeof DOMAIN_ANALYSIS_CACHE_STATUS)[keyof typeof DOMAIN_ANALYSIS_CACHE_STATUS];
 
 export const DOMAIN_ANALYSIS_SNAPSHOT_TYPE = 'domain_overview';
-export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.7.1';
+export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.7.2';
 export const DOMAIN_ANALYSIS_ASSUMPTION_PREFIX = 'domain-analysis';
 export const DOMAIN_ANALYSIS_NONE_SIGNATURE = '__none__';
 

--- a/cloud/apps/api/src/services/analysis/transcript-cell-accumulator.ts
+++ b/cloud/apps/api/src/services/analysis/transcript-cell-accumulator.ts
@@ -173,7 +173,8 @@ export function accumulateTranscriptCells(params: {
 
     const scenarioContent = transcript.scenario.content;
     if (!isRecord(scenarioContent)) continue;
-    const dimensionValues = scenarioContent.dimensionValues;
+    // Production scenarios use snake_case `dimension_values`; test/newer data uses camelCase `dimensionValues`.
+    const dimensionValues = scenarioContent.dimensionValues ?? scenarioContent.dimension_values;
     if (!isRecord(dimensionValues)) continue;
 
     const levels = assignOwnOpponentLevels(

--- a/cloud/apps/api/tests/services/analysis/transcript-cell-accumulator.test.ts
+++ b/cloud/apps/api/tests/services/analysis/transcript-cell-accumulator.test.ts
@@ -190,6 +190,44 @@ describe('accumulateTranscriptCells', () => {
     expect(cellMap.size).toBe(0);
   });
 
+  it('reads dimension_values (snake_case) when dimensionValues is absent — production scenario format', () => {
+    const transcript = buildTranscript({
+      runId: 'run-1',
+      definitionSnapshot: buildDefinitionSnapshot(FIRST_VALUE, SECOND_VALUE),
+      scenario: {
+        id: 'scenario-1',
+        content: {
+          dimension_values: {
+            [FIRST_VALUE]: 1,
+            [SECOND_VALUE]: 2,
+          },
+        },
+        orientationFlipped: false,
+        deletedAt: null,
+      },
+    });
+    const cellMap = accumulateTranscriptCells({
+      transcripts: [transcript],
+      filteredSourceRunDefinitionById: new Map([['run-1', 'def1']]),
+    });
+
+    expect(cellMap.size).toBe(2);
+    expect(cellMap.get(encodeCellKey({
+      definitionId: 'def1',
+      modelId: 'm1',
+      valueKey: FIRST_VALUE,
+      ownLevel: 1,
+      opponentLevel: 2,
+    }))).toEqual({ wins: 1, losses: 0, neutrals: 0 });
+    expect(cellMap.get(encodeCellKey({
+      definitionId: 'def1',
+      modelId: 'm1',
+      valueKey: SECOND_VALUE,
+      ownLevel: 2,
+      opponentLevel: 1,
+    }))).toEqual({ wins: 0, losses: 1, neutrals: 0 });
+  });
+
   it('normalizes lowercase token names in definitionSnapshot to canonical PascalCase', () => {
     const lowercaseFirst = FIRST_VALUE.toLowerCase();
     const lowercaseSecond = SECOND_VALUE.toLowerCase();


### PR DESCRIPTION
## Summary
- Production scenarios store pressure levels under `dimension_values` (snake_case, string labels like `"negligible"`) not `dimensionValues` (camelCase, numeric). The transcript accumulator only checked the camelCase key, found `undefined`, and skipped every transcript — leaving all domains at `definitionsWithAnalysis: 0` regardless of how many runs existed.
- Fix: fall back to `scenarioContent.dimension_values` when `dimensionValues` is absent. `buildSafeLevelLookup` already handles string-label inputs so no further change is needed.
- Bumps `DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION` `1.7.1` → `1.7.2` to invalidate all snapshots built without this fix.
- Adds a unit test covering the production scenario format (`dimension_values` with numeric scores).

## Root cause trail
This was the third layer of the same incident:
1. **OOM** (PR #868) — paginated transcript load so the API doesn't crash on large domains
2. **Token case** (PR #870) — normalize lowercase tokens (`"achievement"`) to PascalCase (`"Achievement"`) so the value-key check passes
3. **This PR** — read `dimension_values` (snake_case) so transcripts are not silently dropped at the scenario content lookup

## Test plan
- [ ] Preflight passed (lint + tests + build)
- [ ] Unit test for `dimension_values` format passes
- [ ] National Priorities / Job Choice / Software Approach Choice flip from `definitionsWithAnalysis: 0` to non-zero after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)