### PR TITLE
Shrink radar chart to 512px and align data ring to category ring edge

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
@@ -18,7 +18,7 @@ const VIEW_BOX_HEIGHT = 560;
 const CENTER_X = 286;
 const CENTER_Y = 276;
 const OUTER_RADIUS = 228;
-const CATEGORY_RING_RADIUS = OUTER_RADIUS + 26;
+const CATEGORY_RING_RADIUS = OUTER_RADIUS + 9;
 const CATEGORY_LABEL_RADIUS = OUTER_RADIUS + 82;
 const RADAR_SCORE_MIN = -2.5;
 const RADAR_SCORE_MAX = 2.5;
@@ -81,7 +81,7 @@ export function ClusterRadarChart({ clusters, activeGroupIds = [] }: ClusterRada
       <div className="overflow-x-auto rounded-lg border border-gray-100 bg-white p-2">
         <svg
           viewBox={`0 0 ${CHART_SIZE} ${VIEW_BOX_HEIGHT}`}
-          className="h-auto min-w-[640px] w-full"
+          className="h-auto min-w-[512px] max-w-[512px] w-full"
           role="img"
           aria-label="Cluster radar chart ordered by favorability with Schwartz category ring"
         >


### PR DESCRIPTION
## Summary
- Cap radar chart SVG at `max-w-[512px]` (80% of previous 640px min) so it fits on a single screen
- Change `CATEGORY_RING_RADIUS` from `OUTER_RADIUS + 26` to `OUTER_RADIUS + 9` so the outermost data point (score 2.5) lands exactly on the inner edge of the colored ring arcs — tighter zoom on actual data

## Validation
- `npm run lint --workspace @valuerank/web` — 0 errors
- `npm run test --workspace @valuerank/web` — 147 files, 1385 tests passed
- `npm run build --workspace @valuerank/web` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)