### PR TITLE
perf(api): parallelize definition validation in pressure sensitivity resolver

### DIFF
--- a/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
@@ -333,7 +333,7 @@ builder.queryField('pressureSensitivity', (t) =>
       const validationResults = await Promise.all(
         [...distinctDefIds].map(async (defId) => ({
           defId,
-          validation: await validateDefinitionForPressureSensitivity(defId) as ValidationResult,
+          validation: await validateDefinitionForPressureSensitivity(defId),
         })),
       );
 

--- a/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
@@ -330,8 +330,14 @@ builder.queryField('pressureSensitivity', (t) =>
       const definitionMeta = new Map<string, DefinitionMetadata>();
       const excludedDefinitions: ExcludedDefinitionShape[] = [];
 
-      for (const defId of distinctDefIds) {
-        const validation: ValidationResult = await validateDefinitionForPressureSensitivity(defId);
+      const validationResults = await Promise.all(
+        [...distinctDefIds].map(async (defId) => ({
+          defId,
+          validation: await validateDefinitionForPressureSensitivity(defId) as ValidationResult,
+        })),
+      );
+
+      for (const { defId, validation } of validationResults) {
         if (validation.status === 'excluded') {
           excludedDefinitions.push({
             definitionId: defId,

--- a/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
@@ -23,10 +23,7 @@ import {
   FLAT_DELTA_THRESHOLD,
   type Observation,
 } from '../../services/pressure-sensitivity/aggregation.js';
-import {
-  validateDefinitionForPressureSensitivity,
-  type ValidationResult,
-} from '../../services/pressure-sensitivity/definition-validation.js';
+import { validateDefinitionForPressureSensitivity } from '../../services/pressure-sensitivity/definition-validation.js';
 import {
   assignOwnOpponent,
   assignOwnOpponentLevels,


### PR DESCRIPTION
## Summary
- Definition validation in the pressure sensitivity resolver was sequential — one `await` per definition in a `for` loop
- Each call hits `resolveDefinitionContent` (1–2 DB queries per definition), so 90 definitions = 90–180 sequential round trips before transcript loading starts
- Changed to `Promise.all` so all validations fire concurrently, bound only by the Prisma connection pool

## Validation
- `npm run build --workspace @valuerank/api` — clean build
- No logic changes — only the scheduling of the async calls changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)