### PR TITLE
fix(web): remove false-positive direction imbalance warning

### DIFF
--- a/cloud/apps/web/src/components/domains/CoverageCell.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageCell.tsx
@@ -78,8 +78,7 @@ export function CoverageCell(props: CoverageCellProps) {
   const hasImbalance =
     aFirstBatchCount !== bFirstBatchCount ||
     filledSlotsA !== filledSlotsB ||
-    orphanedBatchCount > 0 ||
-    orphanedConditionCount > 0;
+    orphanedBatchCount > 0;
   const laggingDirection = hasImbalance
     ? computeLaggingDirection({
         valueA,


### PR DESCRIPTION
## Summary

- Removes `orphanedConditionCount > 0` from the `hasImbalance` check in `CoverageCell.tsx`
- Condition slot IDs are always direction-specific (unique per transcript), so the set intersection across A-first and B-first directions is structurally always zero
- This made `orphanedConditionCount` always equal the total of all filled slots, firing the orange imbalance warning on every cell with any data
- The batch-count checks that remain (`aFirstBatchCount !== bFirstBatchCount`, `filledSlotsA !== filledSlotsB`, `orphanedBatchCount > 0`) correctly flag the ~6 genuinely unbalanced cells

## Validation

- Lint: `eslint CoverageCell.tsx` — 0 errors (13 pre-existing warnings, unchanged)
- `orphanedConditionCount` is still referenced in the popover detail section so no unused-variable warning
- CI will run full test + build suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)