### PR TITLE
fix(analysis): weight directions and pairs equally in domain win rate

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-analysis-values.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-analysis-values.ts
@@ -16,6 +16,8 @@ export type DomainAnalysisValueKey = (typeof DOMAIN_ANALYSIS_VALUE_KEYS)[number]
 export type DomainAnalysisValuePair = {
   valueA: DomainAnalysisValueKey;
   valueB: DomainAnalysisValueKey;
+  /** Which value was authored first in the definition content (before alphabetical sort). */
+  valueFirst?: DomainAnalysisValueKey;
 };
 
 function isDomainAnalysisValueKey(value: string): value is DomainAnalysisValueKey {
@@ -46,5 +48,5 @@ export function extractValuePair(content: unknown): DomainAnalysisValuePair | nu
   const normalizedB = toPascalCaseKey(nameB);
   if (!isDomainAnalysisValueKey(normalizedA) || !isDomainAnalysisValueKey(normalizedB)) return null;
   const [first, second] = [normalizedA, normalizedB].sort() as [DomainAnalysisValueKey, DomainAnalysisValueKey];
-  return { valueA: first, valueB: second };
+  return { valueA: first, valueB: second, valueFirst: normalizedA };
 }

--- a/cloud/apps/api/src/graphql/queries/domain/shared.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/shared.ts
@@ -61,6 +61,8 @@ export type DomainAnalysisValueCounts = {
 export type DomainAnalysisValuePair = {
   valueA: DomainAnalysisValueKey;
   valueB: DomainAnalysisValueKey;
+  /** Which value was authored first in the definition content (before alphabetical sort). */
+  valueFirst?: DomainAnalysisValueKey;
 };
 
 export type DomainAnalysisValueScore = {

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
@@ -17,7 +17,7 @@ export type DomainAnalysisCacheStatus =
   (typeof DOMAIN_ANALYSIS_CACHE_STATUS)[keyof typeof DOMAIN_ANALYSIS_CACHE_STATUS];
 
 export const DOMAIN_ANALYSIS_SNAPSHOT_TYPE = 'domain_overview';
-export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.7.2';
+export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.8.0';
 export const DOMAIN_ANALYSIS_ASSUMPTION_PREFIX = 'domain-analysis';
 export const DOMAIN_ANALYSIS_NONE_SIGNATURE = '__none__';
 

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cell-win-rates.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cell-win-rates.ts
@@ -73,7 +73,7 @@ function getOrCreatePairwise(
 export function computeCellWeightedDomainRates(params: {
   cellMap: Map<string, CellCounts>;
   filteredSourceRunDefinitionById: Map<string, string>;
-  definitionValuePairById: Map<string, { valueA: DomainAnalysisValueKey; valueB: DomainAnalysisValueKey }>;
+  definitionValuePairById: Map<string, { valueA: DomainAnalysisValueKey; valueB: DomainAnalysisValueKey; valueFirst?: DomainAnalysisValueKey }>;
 }): { models: CellWeightedDomainModel[]; analyzedDefinitionIds: Set<string> } {
   const countsByModel = new Map<string, Map<DomainAnalysisValueKey, DomainAnalysisValueCounts>>();
   const pairwiseWinsByModel = new Map<string, Map<DomainAnalysisValueKey, Map<DomainAnalysisValueKey, number>>>();
@@ -126,25 +126,65 @@ export function computeCellWeightedDomainRates(params: {
     .map((modelId) => {
       const valueCounts = countsByModel.get(modelId) ?? new Map<DomainAnalysisValueKey, DomainAnalysisValueCounts>();
       const modelDefinitionRates = ratesByModelDefinitionValue.get(modelId) ?? new Map<string, Map<DomainAnalysisValueKey, number[]>>();
-      const vignetteRatesByValue = new Map<DomainAnalysisValueKey, number[]>();
 
-      for (const [, valueRatesByDefinition] of modelDefinitionRates.entries()) {
+      // Aggregation chain: conditions → vignette → direction → pair → domain.
+      // This ensures extra vignettes in one direction or for one pair do not inflate that
+      // pairing's weight in the final domain win rate.
+      //
+      // Structure: pairKey → directionKey → valueKey → [per-vignette rates]
+      const ratesByPairDirection = new Map<string, Map<DomainAnalysisValueKey, Map<DomainAnalysisValueKey, number[]>>>();
+
+      for (const [definitionId, valueRatesByDefinition] of modelDefinitionRates.entries()) {
+        const pair = params.definitionValuePairById.get(definitionId);
+        if (pair == null) continue;
+        const pairKey = `${pair.valueA}::${pair.valueB}`;
+        const directionKey: DomainAnalysisValueKey = pair.valueFirst ?? pair.valueA;
+
+        const byDirection = ratesByPairDirection.get(pairKey) ?? new Map<DomainAnalysisValueKey, Map<DomainAnalysisValueKey, number[]>>();
+        if (!ratesByPairDirection.has(pairKey)) ratesByPairDirection.set(pairKey, byDirection);
+
+        const byValue = byDirection.get(directionKey) ?? new Map<DomainAnalysisValueKey, number[]>();
+        if (!byDirection.has(directionKey)) byDirection.set(directionKey, byValue);
+
         for (const [valueKey, rates] of valueRatesByDefinition.entries()) {
           if (rates.length === 0) continue;
-          const vignetteRate = rates.reduce((sum, rate) => sum + rate, 0) / rates.length;
-          const existingRates = vignetteRatesByValue.get(valueKey) ?? [];
-          existingRates.push(vignetteRate);
-          vignetteRatesByValue.set(valueKey, existingRates);
+          const vignetteRate = rates.reduce((sum, r) => sum + r, 0) / rates.length;
+          const existing = byValue.get(valueKey) ?? [];
+          existing.push(vignetteRate);
+          byValue.set(valueKey, existing);
+        }
+      }
+
+      // Roll up: directions → pair rate, then pairs → domain rate.
+      const pairRatesByValue = new Map<DomainAnalysisValueKey, number[]>();
+      for (const [, byDirection] of ratesByPairDirection.entries()) {
+        const allValueKeys = new Set<DomainAnalysisValueKey>();
+        for (const [, byValue] of byDirection.entries()) {
+          for (const [valueKey] of byValue.entries()) allValueKeys.add(valueKey);
+        }
+
+        for (const valueKey of allValueKeys) {
+          const directionRates: number[] = [];
+          for (const [, byValue] of byDirection.entries()) {
+            const vignetteRates = byValue.get(valueKey) ?? [];
+            if (vignetteRates.length === 0) continue;
+            directionRates.push(vignetteRates.reduce((sum, r) => sum + r, 0) / vignetteRates.length);
+          }
+          if (directionRates.length === 0) continue;
+          const pairRate = directionRates.reduce((sum, r) => sum + r, 0) / directionRates.length;
+          const existing = pairRatesByValue.get(valueKey) ?? [];
+          existing.push(pairRate);
+          pairRatesByValue.set(valueKey, existing);
         }
       }
 
       const valueWinRates: Record<string, number> = {};
       const vignetteCount: Record<string, number> = {};
-      for (const [valueKey, vignetteRates] of vignetteRatesByValue.entries()) {
-        if (vignetteRates.length === 0) continue;
-        const domainRate = vignetteRates.reduce((sum, rate) => sum + rate, 0) / vignetteRates.length;
+      for (const [valueKey, pairRates] of pairRatesByValue.entries()) {
+        if (pairRates.length === 0) continue;
+        const domainRate = pairRates.reduce((sum, r) => sum + r, 0) / pairRates.length;
         valueWinRates[valueKey] = domainRate * 100;
-        vignetteCount[valueKey] = vignetteRates.length;
+        vignetteCount[valueKey] = pairRates.length;
       }
 
       return {

--- a/cloud/apps/api/tests/graphql/queries/domain-coverage.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/domain-coverage.test.ts
@@ -24,6 +24,7 @@ describe('extractValuePair', () => {
     ).toEqual({
       valueA: 'Achievement',
       valueB: 'Benevolence_Dependability',
+      valueFirst: 'Achievement',
     });
   });
 
@@ -38,6 +39,7 @@ describe('extractValuePair', () => {
     ).toEqual({
       valueA: 'Self_Direction_Action',
       valueB: 'Universalism_Nature',
+      valueFirst: 'Self_Direction_Action',
     });
   });
 
@@ -53,6 +55,7 @@ describe('extractValuePair', () => {
     ).toEqual({
       valueA: 'Achievement',
       valueB: 'Benevolence_Dependability',
+      valueFirst: 'Achievement',
     });
   });
 

--- a/cloud/apps/api/tests/services/analysis/domain-analysis-cell-win-rates.test.ts
+++ b/cloud/apps/api/tests/services/analysis/domain-analysis-cell-win-rates.test.ts
@@ -158,6 +158,33 @@ describe('computeCellWeightedDomainRates', () => {
     });
   });
 
+  it('weights directions equally when one direction has more vignettes than the other', () => {
+    // 2 vignettes with Achievement-first direction (def1 + def2), 1 with Security-first (def3).
+    // Without direction balancing, Achievement-first would get 2/3 of the weight.
+    // With direction balancing: avg(def1, def2) → direction rate; then avg(A-first, S-first) → pair rate.
+    const cellMap = new Map<string, CellCounts>([
+      [buildCellKey({ definitionId: 'def1', modelId: 'm1', valueKey: FIRST_VALUE, ownLevel: 1, opponentLevel: 1 }), buildCounts(9, 1, 0)],
+      [buildCellKey({ definitionId: 'def2', modelId: 'm1', valueKey: FIRST_VALUE, ownLevel: 1, opponentLevel: 1 }), buildCounts(7, 3, 0)],
+      [buildCellKey({ definitionId: 'def3', modelId: 'm1', valueKey: FIRST_VALUE, ownLevel: 1, opponentLevel: 1 }), buildCounts(2, 8, 0)],
+    ]);
+
+    const result = computeCellWeightedDomainRates({
+      cellMap,
+      filteredSourceRunDefinitionById: new Map([['run-1', 'def1'], ['run-2', 'def2'], ['run-3', 'def3']]),
+      definitionValuePairById: new Map([
+        ['def1', { valueA: FIRST_VALUE, valueB: SECOND_VALUE, valueFirst: FIRST_VALUE }],
+        ['def2', { valueA: FIRST_VALUE, valueB: SECOND_VALUE, valueFirst: FIRST_VALUE }],
+        ['def3', { valueA: FIRST_VALUE, valueB: SECOND_VALUE, valueFirst: SECOND_VALUE }],
+      ]),
+    });
+
+    // A-first direction rate = avg(90%, 70%) = 80%
+    // S-first direction rate = 20%
+    // pair rate = avg(80%, 20%) = 50%
+    // (old flat average would be (90+70+20)/3 ≈ 60%)
+    expect(result.models[0]?.valueWinRates[FIRST_VALUE]).toBeCloseTo(50, 5);
+  });
+
   it('maps pairwise wins by winner and opponent value key', () => {
     const cellMap = new Map<string, CellCounts>([
       [buildCellKey({ definitionId: 'def1', modelId: 'm1', valueKey: FIRST_VALUE, ownLevel: 1, opponentLevel: 2 }), buildCounts(3, 1, 0)],

--- a/docs/valuerank_prd.yaml
+++ b/docs/valuerank_prd.yaml
@@ -41,6 +41,39 @@ Methodology:
     - "Metric 2: Bradley-Terry Pairwise Ranking (derived from the full win-rate matrix with BT-implied uncertainty)."
     - "Sensitivity analysis: report Average Marginal Effect (AME) by Attribute Level to show how much a model’s chance of prioritizing an attribute changes as pressure increases."
 
+  Data_Hierarchy:
+    Overview: "Data is organized in four levels: trial → condition → vignette → domain."
+
+    Trial:
+      Definition: "One time a model is given the prompt for one condition and produces an answer (one transcript)."
+      Note: "Phase 1 runs N=1 trial per condition. N=3 is used as a fallback when non-determinism is detected."
+
+    Condition:
+      Definition: "One specific combination of attribute levels (e.g. A at level 3, B at level 4). There are 25 conditions per vignette (5×5 grid)."
+      Win_Rate: "Win rate = trials where A was picked / (picked + not picked + neutral). The orientationFlipped flag on each transcript normalizes the model's raw answer to canonical A vs B direction before counting, so trials from a flipped narrative presentation are handled correctly within a single vignette."
+
+    Vignette:
+      Definition: "The full setup for one value pairing. A vignette is authored for a specific attribute order (e.g. Universalism vs Benevolence). The mirrored ordering (Benevolence vs Universalism) is a separate vignette with its own ID, its own scenario text, and its own win rates."
+      Mirrored_Vignettes: "Because the scenario text is written from a specific framing, 'Universalism vs Benevolence' and 'Benevolence vs Universalism' are two distinct vignettes that will naturally produce different win rates. Both are valid data and both contribute equally to the domain win rate. The system normalizes both to the same canonical pair direction (alphabetical) before analysis, so results are always expressed consistently regardless of which vignette the trial came from."
+      Vignettes_Per_Domain: "10 values → C(10,2) = 45 value pairs. With both orderings authored, a domain can contain up to 90 vignettes. Each contributes one data point to the domain win rate."
+      Win_Rate: "Average of all 25 condition win rates, weighted equally."
+
+    Domain:
+      Definition: "A life context (e.g. Jobs, Neighborhoods) containing the full set of vignettes for that context."
+      Win_Rate: |
+        "Four-level aggregation — each level contributes one vote regardless of how many items it contains:
+          1. Condition → Vignette rate: average the 25 condition rates equally.
+          2. Vignette → Direction rate: for a given canonical pair (e.g. Achievement vs Universalism), average
+             all vignettes that share the same authored order (e.g. all Achievement-first vignettes). This
+             ensures that running 3 Achievement-first copies of a vignette does not outweigh a single
+             Universalism-first copy.
+          3. Direction → Pair rate: average the two direction rates equally (Achievement-first and
+             Universalism-first each count as one vote). If only one direction has been run, that direction
+             rate is the pair rate.
+          4. Pair → Domain rate: average all canonical pair rates equally. Each distinct value-pairing (e.g.
+             Achievement vs Universalism) counts as one vote, regardless of how many vignettes or directions
+             were sampled for that pairing."
+
   Project_Procedure:
     Goal: "Deterministic Grid Sampling"
     - "Phase 1 (Estimation): Run the full 25-condition grid for each vignette exactly once per domain (N=1 per condition at Temp 0). Total: 1,125 trials per domain."


### PR DESCRIPTION
## Problem

The domain analysis Value Priorities report was computing win rates by averaging all vignettes in a domain flat. This meant that if one pairing (e.g. Achievement vs Universalism) had 3 vignettes in the Achievement-first direction and only 1 in the Universalism-first direction, Achievement-first got 3× the weight. The user's requirement is that **extra vignettes should never increase a pairing's weight**.

## Fix

Replaced the flat average with a four-level aggregation chain where each level contributes exactly one vote:

| Level | Input | Output |
|---|---|---|
| 1 | 25 condition rates per vignette | vignette rate |
| 2 | All vignettes for one direction of a pair | direction rate |
| 3 | Two direction rates for a canonical pair | pair rate |
| 4 | All canonical pair rates | domain rate |

This aligns the methodology with how Pressure Sensitivity already weights data (equal-weight per vignette, then per pair).

## What changed

- **`domain-analysis-values.ts`** — added optional `valueFirst` field to `DomainAnalysisValuePair` and populated it from `extractValuePair` (the first authored dimension, before alphabetical sort). This tells the aggregator which direction a vignette was written in.
- **`domain/shared.ts`** — same optional field added to the duplicate type there.
- **`domain-analysis-cell-win-rates.ts`** — new aggregation: groups vignettes by (canonical pair, direction), averages within direction, then averages directions, then averages pairs.
- **`domain-analysis-cache-types.ts`** — version bumped `1.7.2 → 1.8.0` to bust stale cached snapshots.
- **`domain-analysis-cell-win-rates.test.ts`** — new test verifying that 2 vignettes in one direction + 1 in the other direction is treated as a 50/50 split rather than a 2/3–1/3 split.
- **`docs/valuerank_prd.yaml`** — documents the four-level aggregation chain.

## Validation

```
npm run lint --workspace @valuerank/shared   ✓ 0 errors
npm run lint --workspace @valuerank/db       ✓ 0 errors
npm run lint --workspace @valuerank/api      ✓ 0 errors, 27 warnings (pre-existing)
npm run test --workspace @valuerank/api      ✓ 2273 passed / 2 skipped (198 files)
npm run build --workspace @valuerank/api     ✓ clean
npm run lint --workspace @valuerank/web      ✓ 0 errors, 120 warnings (pre-existing)
npm run build --workspace @valuerank/web     ✓ built in 3.34s
```