### PR TITLE
docs(prd): add direction-balancing worked example

### DIFF
--- a/docs/valuerank_prd.yaml
+++ b/docs/valuerank_prd.yaml
@@ -74,6 +74,27 @@ Methodology:
              Achievement vs Universalism) counts as one vote, regardless of how many vignettes or directions
              were sampled for that pairing."
 
+      Direction_Balancing_Example: |
+        "Why direction balancing matters — concrete example:
+
+        Suppose we have 4 vignettes for the Security vs Privacy pair:
+          V1 (Security-first): model picks Security 70% of the time
+          V2 (Security-first): model picks Security 80% of the time
+          V3 (Security-first): model picks Security 90% of the time
+          V4 (Privacy-first):  model picks Security 40% of the time
+
+        Flat average (wrong): (70 + 80 + 90 + 40) / 4 = 70%
+        This overstates Security preference because we happened to author 3 Security-first vignettes.
+
+        Direction-balanced (correct):
+          Security-first direction rate: (70 + 80 + 90) / 3 = 80%
+          Privacy-first direction rate: 40%
+          Final pair rate: (80 + 40) / 2 = 60%
+
+        The 60% is a more honest estimate of how often the model favors Security. It treats each
+        authored direction as one vote regardless of how many vignettes were written in that direction.
+        This same logic applies to all win rate columns in the pressure sensitivity analysis."
+
   Project_Procedure:
     Goal: "Deterministic Grid Sampling"
     - "Phase 1 (Estimation): Run the full 25-condition grid for each vignette exactly once per domain (N=1 per condition at Temp 0). Total: 1,125 trials per domain."


### PR DESCRIPTION
## Summary
- Adds a concrete Security vs Privacy example under `Domain > Direction_Balancing_Example`
- Illustrates why flat averaging overstates preference when one authored direction has more vignettes
- Shows flat-average result (70%) vs direction-balanced result (60%) and explains the difference

## Validation
Docs-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)