### PR TITLE
fix(pressure-sensitivity): query source runs directly, drop Aggregate gate

### DIFF
--- a/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
@@ -290,15 +290,14 @@ builder.queryField('pressureSensitivity', (t) =>
         return matchesModelIds && matchesProvider;
       });
 
-      // 2. Aggregate runs
-      // orderBy id:asc makes sourceRunToDefId Map.set "last write wins" deterministic
-      // across queries; without it the collision warning would point to a different
-      // winner each run (Slice A diff review finding).
+      // 2. Source runs (direct — same selection logic as domain analysis)
+      // Exclude Aggregate-tagged runs; those are pooling views with no transcripts of
+      // their own. orderBy id:asc keeps the defId mapping deterministic.
       const runs = (await db.run.findMany({
         where: {
           status: 'COMPLETED',
           deletedAt: null,
-          tags: { some: { tag: { name: 'Aggregate' } } },
+          tags: { none: { tag: { name: 'Aggregate' } } },
           ...(domainId != null ? { definition: { domainId } } : {}),
         },
         include: {
@@ -417,12 +416,16 @@ builder.queryField('pressureSensitivity', (t) =>
         [...definitionMeta.entries()].map(([id, meta]) => [id, meta.valueFirstToken]),
       );
 
-      // 5. Stream transcripts from the SOURCE runs of each Aggregate-tagged run.
-      // Aggregate runs are pooling views — they own metadata (perScenario summaries) but
-      // the raw transcripts live on the runs listed in `config.sourceRunIds`. Fetching
-      // transcripts WHERE runId IN aggregateRunIds returns 0 rows; the production smoke
-      // test on PR #770 caught this.
-      const sourceRunToDefId = buildSourceRunToDefIdMap(eligibleRuns, definitionMeta, log);
+      // 5. Build a direct run → definition map and stream transcripts.
+      // Eligible runs are source runs with real transcripts; map each run.id to its
+      // definition so transcript rows can be routed without a join.
+      const sourceRunToDefId = new Map<string, string>();
+      for (const run of eligibleRuns) {
+        const defId = run.definition?.id ?? run.definitionId;
+        if (definitionMeta.has(defId)) {
+          sourceRunToDefId.set(run.id, defId);
+        }
+      }
       const sourceRunIds = [...sourceRunToDefId.keys()];
       const rosterModelIds = models.map((m) => m.modelId);
       const pressureConditionExclusionBreakdown = emptyPressureConditionExclusionBreakdown();


### PR DESCRIPTION
## Summary
- Removes the Aggregate-tag requirement from the pressure sensitivity run query
- Pressure sensitivity now queries source runs directly (same as domain analysis), applying only the signature filter
- Replaces the `buildSourceRunToDefIdMap` indirection (which extracted `sourceRunIds` from Aggregate configs) with a direct `run.id → definitionId` mapping

## Why
Pressure sensitivity was filtering to Aggregate-tagged runs, then reading their `sourceRunIds` to find transcripts. Domain analysis queries source runs directly. This asymmetry caused win rates to diverge whenever a source run had completed after the last Aggregate job fired (the Aggregate hadn't yet claimed the new run).

Investigation confirmed: no mismatched preamble versions or failed/unsummarized transcripts in production — the Aggregate gate was not actually protecting against bad data.

## What stays the same
- `availableSignatures` query still uses Aggregate runs — the dropdown remains a curated, Aggregate-validated list
- `buildSourceRunToDefIdMap` export is preserved (it has unit tests)
- Signature filter applies identically to before

## Validation
- `npm run build --workspace @valuerank/api` — clean (verified against main which includes PRs #877/#878)
- Logic change is a direct parallel to the existing `modelsConfidence` query which already excludes Aggregate runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)