### PR TITLE
feat(web): add model filter to coverage matrix

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-coverage.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-coverage.ts
@@ -230,19 +230,15 @@ builder.queryField('domainValueCoverage', (t) =>
           const models = Array.isArray(config.models)
             ? config.models.filter((m): m is string => typeof m === 'string' && m.length > 0)
             : null;
-          const matchesEffectiveModelSet = effectiveModelIds.length === 0
-            || (models !== null && effectiveModelIds.every((id) => models.includes(id)));
+          // When the caller provides explicit modelIds, those replace the effective
+          // model set filter so counts reflect runs planned for exactly those models.
+          // When no explicit modelIds, fall back to the domain's effective defaults.
+          const activeModelFilter = filterModelIds.length > 0 ? filterModelIds : effectiveModelIds;
+          const matchesEffectiveModelSet = activeModelFilter.length === 0
+            || (models !== null && activeModelFilter.every((id) => models.includes(id)));
           if (!matchesEffectiveModelSet) {
             continue;
           }
-
-          // Apply the explicit model-ID filter symmetrically: a run that doesn't
-          // match contributes to neither bucket. Without this, incompleteBatchCount
-          // would mention runs that batchCount cannot, breaking the "exactly one
-          // bucket" invariant.
-          const matchesModelFilter = filterModelIds.length === 0
-            || run.transcripts.some((transcript) => filterModelIds.includes(transcript.modelId));
-          if (!matchesModelFilter) continue;
 
           const matchingTranscripts = run.transcripts.filter((transcript): transcript is {
             modelId: string;

--- a/cloud/apps/web/src/components/domains/CoverageMatrix.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageMatrix.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useMemo, useState } from 'react';
+import { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'urql';
 import { ErrorMessage } from '../ui/ErrorMessage';
 import { Loading } from '../ui/Loading';
@@ -19,6 +19,8 @@ import { cn } from '../../lib/utils';
 import { getCanonicalDimension } from '@valuerank/shared';
 import { CoverageCell } from './CoverageCell';
 import { selectPreferredSignature } from './coverageMatrixHelpers';
+import { Button } from '../ui/Button';
+import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../../api/operations/llm';
 
 type CategoryGroup = {
   name: string;
@@ -37,6 +39,8 @@ export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
   const [selectedSignature, setSelectedSignature] = useState<string>('');
   const [allowAllSignatures, setAllowAllSignatures] = useState(false);
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
+  const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
+  const initializedModelSelection = useRef(false);
 
   const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
     DomainAvailableSignaturesQueryResult,
@@ -65,11 +69,19 @@ export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
     && hasValidSelectedSignature
     && (selectedSignature !== '' || allowAllSignatures || signatureOptions.length === 0);
 
+  const [{ data: llmModelsData }] = useQuery<LlmModelsQueryResult>({
+    query: LLM_MODELS_QUERY,
+    variables: { status: 'ACTIVE' },
+    requestPolicy: 'cache-and-network',
+  });
+
   // Reset state when domainId changes
   useEffect(() => {
     setSelectedSignature('');
     setAllowAllSignatures(false);
     setUseLegacyQuery(false);
+    setSelectedModelIds([]);
+    initializedModelSelection.current = false;
   }, [domainId]);
 
   useEffect(() => {
@@ -91,6 +103,7 @@ export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
     variables: {
       domainId,
       signature: selectedSignature === '' ? undefined : selectedSignature,
+      modelIds: selectedModelIds.length === 0 ? undefined : selectedModelIds,
     },
     pause: domainId === '' || !signatureSelectionReady || useLegacyQuery,
     requestPolicy: 'network-only',
@@ -122,6 +135,48 @@ export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
   const error = useLegacyQuery ? legacyError : scoredError;
 
   const canonicalValues = data?.domainValueCoverage?.values ?? [];
+  const availableModels = data?.domainValueCoverage?.availableModels ?? [];
+
+  const defaultModelIds = useMemo(
+    () => new Set((llmModelsData?.llmModels ?? []).filter((m) => m.isDefault).map((m) => m.modelId)),
+    [llmModelsData],
+  );
+
+  const defaultSelection = useMemo(() => {
+    const availableIds = availableModels.map((m) => m.modelId);
+    const defaults = availableIds.filter((id) => defaultModelIds.has(id));
+    return defaults.length > 0 ? defaults : availableIds;
+  }, [availableModels, defaultModelIds]);
+
+  useEffect(() => {
+    if (initializedModelSelection.current) return;
+    if (availableModels.length === 0) return;
+    if (llmModelsData == null) return;
+    setSelectedModelIds(defaultSelection);
+    initializedModelSelection.current = true;
+  }, [availableModels, llmModelsData, defaultSelection]);
+
+  const isDefaultSelection = useMemo(() => {
+    if (selectedModelIds.length !== defaultSelection.length) return false;
+    const defaultSet = new Set(defaultSelection);
+    return selectedModelIds.every((id) => defaultSet.has(id));
+  }, [selectedModelIds, defaultSelection]);
+
+  const modelSetSummary = availableModels.length === 0
+    ? 'Loading...'
+    : isDefaultSelection
+      ? `Default — ${selectedModelIds.length} model${selectedModelIds.length === 1 ? '' : 's'}`
+      : selectedModelIds.length === availableModels.length
+        ? 'All models'
+        : `${selectedModelIds.length} of ${availableModels.length} selected`;
+
+  const toggleModelId = (modelId: string) => {
+    setSelectedModelIds((current) => (
+      current.includes(modelId)
+        ? current.filter((id) => id !== modelId)
+        : [...current, modelId]
+    ));
+  };
 
   const cellLookup = useMemo(() => {
     const defaultCells = data?.domainValueCoverage?.cells ?? [];
@@ -210,6 +265,54 @@ export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
             ))}
           </select>
         </div>
+        {availableModels.length > 0 && (
+          <details className="min-w-[210px]">
+            <summary className="cursor-pointer list-none">
+              <p className="mb-1 text-sm font-medium text-gray-700">Model filter</p>
+              <div className="inline-flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm min-h-[44px] hover:border-gray-400 sm:min-h-0">
+                <span>{modelSetSummary}</span>
+                <span className="ml-2 text-gray-400">▾</span>
+              </div>
+            </summary>
+            <div className="mt-1 space-y-2 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+              <div className="flex flex-wrap gap-1.5">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setSelectedModelIds(defaultSelection)}
+                  className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
+                    isDefaultSelection
+                      ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
+                      : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
+                  }`}
+                >
+                  Default Models
+                </Button>
+                {availableModels.map((model) => {
+                  const isSelected = selectedModelIds.includes(model.modelId);
+                  return (
+                    <Button
+                      key={model.modelId}
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => toggleModelId(model.modelId)}
+                      className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
+                        isSelected
+                          ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
+                          : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
+                      }`}
+                      title={model.label}
+                    >
+                      {model.label}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+          </details>
+        )}
       </div>
 
       {/* Matrix */}

--- a/cloud/apps/web/tests/pages/DomainCoverage.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainCoverage.test.tsx
@@ -128,6 +128,9 @@ describe('DomainCoverage Page', () => {
           error: undefined,
         }];
       }
+      if (operationName === 'LlmModels') {
+        return [{ data: { llmModels: [] }, fetching: false, error: undefined }];
+      }
       if (operationName === 'DomainValueCoverageLegacy') {
         const legacyCoverage = coverageByDomain[args.variables.domainId];
         return [{ data: { domainValueCoverage: legacyCoverage }, fetching: false, error: undefined }];
@@ -145,8 +148,8 @@ describe('DomainCoverage Page', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /copy coverage table as image/i })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Model A' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Model B' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Model A' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Model B' })).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a model filter pill UI to the coverage matrix page, matching the same pill-based dropdown pattern used in Domain Analysis
- When explicit model IDs are selected, they now **replace** the domain's effective model set filter (instead of stacking a second `some`-based filter on top) — this means selecting gpt-4.1 correctly counts the gpt-4.1-only run rather than being excluded by the 10-model `every()` gate
- Model selection is initialized to the domain's default models on first load and resets when the domain changes
- The filter is hidden until `availableModels` loads (avoids flash of empty state)

## Details
**Server (`domain-coverage.ts`):** When `filterModelIds` are provided, they become `activeModelFilter` and completely replace `effectiveModelIds`. The `every()` check runs against the caller's selection rather than the domain's default set.

**Client (`CoverageMatrix.tsx`):** Queries `LLM_MODELS_QUERY` for `isDefault` flags; intersects those with `availableModels` from the coverage query to determine the default selection. Pill toggle + "Default Models" reset button — same UX as DomainAnalysis.

## Validation
- `npm run lint --workspace @valuerank/web` — 0 errors
- `npm run build --workspace @valuerank/web` — clean build
- `npm run lint --workspace @valuerank/api` — 0 errors
- API TypeScript: checked only changed files (`domain-coverage.ts`) — no new errors
- CI passes on current `origin/main` (confirmed via `gh run list`)

## Production smoke test
N/A — UI filter change. No new resolver fields; existing `domainValueCoverage` query with `modelIds` argument was already wired end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)