### PR TITLE
fix(pressure-sensitivity): average per-domain win rates equally across domains

### DIFF
--- a/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
@@ -75,6 +75,7 @@ type ScenarioRow = {
 type DefinitionMetadata = {
   id: string;
   name: string;
+  domainId: string | null;
   /** Definition's stored value_first.token (used to remap canonical direction). */
   valueFirstToken: string;
   /** Definition's stored value_second.token (used to remap canonical direction). */
@@ -315,10 +316,12 @@ builder.queryField('pressureSensitivity', (t) =>
       // 4. Distinct definitions → validation
       const distinctDefIds = new Set<string>();
       const defNames = new Map<string, string>();
+      const defDomainId = new Map<string, string>();
       for (const r of eligibleRuns) {
         if (r.definition?.id != null) {
           distinctDefIds.add(r.definition.id);
           defNames.set(r.definition.id, r.definition.name);
+          if (r.definition.domainId != null) defDomainId.set(r.definition.id, r.definition.domainId);
         } else {
           distinctDefIds.add(r.definitionId);
         }
@@ -399,6 +402,7 @@ builder.queryField('pressureSensitivity', (t) =>
         definitionMeta.set(defId, {
           id: defId,
           name: defNames.get(defId) ?? defId,
+          domainId: defDomainId.get(defId) ?? null,
           valueFirstToken: components.value_first.token,
           valueSecondToken: components.value_second.token,
           firstValueToken,
@@ -415,6 +419,12 @@ builder.queryField('pressureSensitivity', (t) =>
       const authoredFirstTokenByDef = new Map<string, string>(
         [...definitionMeta.entries()].map(([id, meta]) => [id, meta.valueFirstToken]),
       );
+
+      // Build a lookup from definitionId → domainId for per-domain equal-weight averaging.
+      const domainByDef = new Map<string, string>();
+      for (const [defId, meta] of definitionMeta.entries()) {
+        if (meta.domainId != null) domainByDef.set(defId, meta.domainId);
+      }
 
       // 5. Build a direct run → definition map and stream transcripts.
       // Eligible runs are source runs with real transcripts; map each run.id to its
@@ -609,6 +619,7 @@ builder.queryField('pressureSensitivity', (t) =>
             definitionsMeasured: acc.definitionsMeasured,
             canonicalFirstValueToken: acc.firstValueToken,
             authoredFirstTokenByDef,
+            domainByDef,
           };
 
           const dbAll = computeDirectionBalancedPairWinRates(directionBalancedCommonParams);

--- a/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
@@ -569,36 +569,38 @@ export function pooledDirectionalReduction(
 /**
  * Compute direction-balanced win rates for a canonical value pair.
  *
- * Each vignette contributes equally regardless of which direction it was authored.
+ * Each vignette contributes equally regardless of which direction it was authored,
+ * and each domain contributes equally regardless of how many vignettes it has.
  * Optionally restricts to a subset of cells via `cellFilter`.
  *
  * The `cells` Map key format is `${ownLevel}::${opponentLevel}`.
  * `canonicalFirstValueToken` is the alphabetically-first value token.
  * `authoredFirstTokenByDef` maps definitionId to the token that was value_first in that definition.
+ * `domainByDef` maps definitionId to its domain ID; definitions absent from this map fall back
+ * to using their defId as the domain key (treated as a singleton domain).
  *
  * Algorithm:
- * 1. For each cell (filtered by `cellFilter` if provided), split observations into two direction buckets:
- *    - authored-first: definitions where value_first === canonicalFirstValueToken
- *    - authored-second: definitions where value_first !== canonicalFirstValueToken
- * 2. Compute a per-vignette win rate within each direction bucket.
- * 3. Average the per-vignette rates within each direction bucket.
- * 4. Return the mean of the two direction averages (equally weighted regardless of vignette count).
+ * 1. For each cell (filtered by `cellFilter` if provided), split observations by domain and
+ *    authoring direction into per-domain direction buckets.
+ * 2. Within each domain, average the per-vignette rates in each direction bucket.
+ * 3. Average the two direction means within each domain (equally weighted).
+ * 4. Average the per-domain rates equally (one vote per domain).
  *
- * Prevents a direction with more vignettes from outweighing the other, consistent
- * with how domain analysis aggregates across directions.
+ * This matches domain analysis's aggregation order: conditions → vignette → direction → pair → domain.
+ * Prevents a domain with more vignettes or runs from outweighing a smaller domain.
  */
 export function computeDirectionBalancedPairWinRates(params: {
   cells: ReadonlyMap<string, Readonly<{ observationsByDefinition: ReadonlyMap<string, ReadonlyArray<Observation>> }>>;
   definitionsMeasured: ReadonlySet<string>;
   canonicalFirstValueToken: string;
   authoredFirstTokenByDef: ReadonlyMap<string, string>;
+  domainByDef: ReadonlyMap<string, string>;
   cellFilter?: (ownLevel: number, opponentLevel: number) => boolean;
 }): { ownRate: number | null; opponentRate: number | null } {
-  const { cells, canonicalFirstValueToken, authoredFirstTokenByDef, cellFilter } = params;
+  const { cells, canonicalFirstValueToken, authoredFirstTokenByDef, domainByDef, cellFilter } = params;
 
-  // Per-vignette rates for each authoring direction.
-  const firstDirectionOwnRates: number[] = [];   // defs where authored value_first === canonical first
-  const secondDirectionOwnRates: number[] = [];  // defs where authored value_first !== canonical first
+  // Per-domain direction buckets: domainKey → { first: rates[], second: rates[] }
+  const ratesByDomain = new Map<string, { first: number[]; second: number[] }>();
 
   for (const [key, cell] of cells) {
     if (cellFilter != null) {
@@ -617,28 +619,40 @@ export function computeDirectionBalancedPairWinRates(params: {
       const metrics = buildCellMetrics([...observations]);
       if (metrics.n === 0) continue;
 
+      const domainKey = domainByDef.get(defId) ?? defId;
+      let bucket = ratesByDomain.get(domainKey);
+      if (bucket == null) {
+        bucket = { first: [], second: [] };
+        ratesByDomain.set(domainKey, bucket);
+      }
+
       if (authoredFirstToken === canonicalFirstValueToken) {
         // Authored first = canonical first: winRate is the canonical own rate.
-        if (metrics.winRate != null) firstDirectionOwnRates.push(metrics.winRate);
+        if (metrics.winRate != null) bucket.first.push(metrics.winRate);
       } else {
         // Authored first = canonical second: opponentWinRate is the canonical own rate.
-        if (metrics.opponentWinRate != null) secondDirectionOwnRates.push(metrics.opponentWinRate);
+        if (metrics.opponentWinRate != null) bucket.second.push(metrics.opponentWinRate);
       }
     }
   }
 
-  const firstMean = averageNonNull(firstDirectionOwnRates);
-  const secondMean = averageNonNull(secondDirectionOwnRates);
+  // Per-domain: average directions, then collect domain rates.
+  const domainOwnRates: number[] = [];
+  for (const bucket of ratesByDomain.values()) {
+    const firstMean = averageNonNull(bucket.first);
+    const secondMean = averageNonNull(bucket.second);
+    if (firstMean == null && secondMean == null) continue;
+    // If only one direction has data, use it as the sole estimate for this domain.
+    const domainRate = averageNonNull([firstMean, secondMean]);
+    if (domainRate != null) domainOwnRates.push(domainRate);
+  }
 
-  if (firstMean == null && secondMean == null) {
+  if (domainOwnRates.length === 0) {
     return { ownRate: null, opponentRate: null };
   }
 
-  // If only one direction has data, use it as the sole estimate.
-  const ownRate = averageNonNull([firstMean, secondMean]);
-  const opponentRate = ownRate == null ? null : 1 - ownRate;
-
-  return { ownRate, opponentRate };
+  const ownRate = domainOwnRates.reduce((sum, r) => sum + r, 0) / domainOwnRates.length;
+  return { ownRate, opponentRate: 1 - ownRate };
 }
 
 export function summarizePressureResponse(

--- a/cloud/apps/api/tests/services/pressure-sensitivity/aggregation.test.ts
+++ b/cloud/apps/api/tests/services/pressure-sensitivity/aggregation.test.ts
@@ -385,6 +385,12 @@ describe('computeDirectionBalancedPairWinRates', () => {
         ['def3', 'A'],
         ['def4', 'B'],
       ]),
+      domainByDef: new Map([
+        ['def1', 'd1'],
+        ['def2', 'd1'],
+        ['def3', 'd1'],
+        ['def4', 'd1'],
+      ]),
     });
 
     expect(result.ownRate).toBeCloseTo(0.5, 10);
@@ -413,6 +419,10 @@ describe('computeDirectionBalancedPairWinRates', () => {
         ['defA', 'X'],
         ['defB', 'Y'],
       ]),
+      domainByDef: new Map([
+        ['defA', 'd1'],
+        ['defB', 'd1'],
+      ]),
     });
 
     expect(result.ownRate).toBeCloseTo(0.25, 10);
@@ -430,6 +440,7 @@ describe('computeDirectionBalancedPairWinRates', () => {
       definitionsMeasured: new Set(['def1']),
       canonicalFirstValueToken: 'A',
       authoredFirstTokenByDef: new Map([['def1', 'A']]),
+      domainByDef: new Map([['def1', 'd1']]),
     });
 
     expect(result.ownRate).toBeNull();
@@ -442,6 +453,7 @@ describe('computeDirectionBalancedPairWinRates', () => {
       definitionsMeasured: new Set(),
       canonicalFirstValueToken: 'A',
       authoredFirstTokenByDef: new Map(),
+      domainByDef: new Map(),
     });
 
     expect(result.ownRate).toBeNull();
@@ -460,34 +472,86 @@ describe('computeDirectionBalancedPairWinRates', () => {
       definitionsMeasured: new Set(['defA']),
       canonicalFirstValueToken: 'A',
       authoredFirstTokenByDef: new Map([['defA', 'A']]),
+      domainByDef: new Map([['defA', 'd1']]),
     });
 
     expect(result.ownRate).toBeCloseTo(1.0, 10);
     expect(result.opponentRate).toBeCloseTo(0.0, 10);
   });
-});
 
-describe('summarizePressureResponse', () => {
-  it('computes an equal-weight mean and range across measured pairs', () => {
-    const summary = summarizePressureResponse([0.019, 0.021, 0.05]);
+  it('weights domains equally regardless of how many vignettes each domain has', () => {
+    // Domain A has 2 A-first vignettes both winning 100%.
+    // Domain B has 1 A-first vignette winning 0%.
+    // Flat pool: (1 + 1 + 0) / 3 = 0.667
+    // Per-domain equal weighting: avg(domainA=1.0, domainB=0.0) = 0.5
+    const cells = new Map([
+      makeCell('cell1', {
+        defA1: [{ outcome: 'own_picked', strength: 'strong' }],
+        defA2: [{ outcome: 'own_picked', strength: 'strong' }],
+        defB1: [{ outcome: 'opponent_picked', strength: 'strong' }],
+      }),
+    ]);
 
-    expect(summary.pairsMeasured).toBe(3);
-    expect(summary.mean).toBeCloseTo(0.03, 10);
-    expect(summary.rangeMin).toBe(0.019);
-    expect(summary.rangeMax).toBe(0.05);
-  });
-
-  it('returns null summary fields when no pairs are measured', () => {
-    expect(summarizePressureResponse([])).toEqual({
-      mean: null,
-      rangeMin: null,
-      rangeMax: null,
-      pairsMeasured: 0,
+    const result = computeDirectionBalancedPairWinRates({
+      cells,
+      definitionsMeasured: new Set(['defA1', 'defA2', 'defB1']),
+      canonicalFirstValueToken: 'A',
+      authoredFirstTokenByDef: new Map([
+        ['defA1', 'A'],
+        ['defA2', 'A'],
+        ['defB1', 'A'],
+      ]),
+      domainByDef: new Map([
+        ['defA1', 'domain-alpha'],
+        ['defA2', 'domain-alpha'],
+        ['defB1', 'domain-beta'],
+      ]),
     });
+
+    expect(result.ownRate).toBeCloseTo(0.5, 10);
+    expect(result.opponentRate).toBeCloseTo(0.5, 10);
+  });
+
+  it('combines direction balancing and domain equal-weighting independently', () => {
+    // Domain A: defA1 authored A-first wins 100%; defA2 authored B-first canonical-own=0%
+    //   → firstMean=1.0, secondMean=0.0 → domainRate=0.5
+    // Domain B: defB1 authored A-first wins 0%
+    //   → firstMean=0.0, secondMean=null → domainRate=0.0
+    // ownRate = avg(0.5, 0.0) = 0.25
+    const cells = new Map([
+      makeCell('cell1', {
+        defA1: [{ outcome: 'own_picked', strength: 'strong' }],
+        defA2: [{ outcome: 'own_picked', strength: 'strong' }],
+        defB1: [{ outcome: 'opponent_picked', strength: 'strong' }],
+      }),
+    ]);
+
+    const result = computeDirectionBalancedPairWinRates({
+      cells,
+      definitionsMeasured: new Set(['defA1', 'defA2', 'defB1']),
+      canonicalFirstValueToken: 'A',
+      authoredFirstTokenByDef: new Map([
+        ['defA1', 'A'],
+        ['defA2', 'B'],
+        ['defB1', 'A'],
+      ]),
+      domainByDef: new Map([
+        ['defA1', 'domain-alpha'],
+        ['defA2', 'domain-alpha'],
+        ['defB1', 'domain-beta'],
+      ]),
+    });
+
+    // defA2 is authored B-first and own_picked → B won → canonical own (A) lost → opponentWinRate=0
+    // Domain alpha: firstMean=avg(1.0)=1.0, secondMean=avg(0.0)=0.0 → domainRate=0.5
+    // Domain beta:  firstMean=avg(0.0)=0.0, secondMean=null           → domainRate=0.0
+    // ownRate = avg(0.5, 0.0) = 0.25
+    expect(result.ownRate).toBeCloseTo(0.25, 10);
+    expect(result.opponentRate).toBeCloseTo(0.75, 10);
   });
 });
 
-describe('computeDirectionBalancedPairWinRates', () => {
+describe('computeDirectionBalancedPairWinRates (second suite)', () => {
   function makeObs(outcome: 'own_picked' | 'opponent_picked' | 'neutral'): Observation {
     return { outcome, strength: null };
   }
@@ -506,6 +570,7 @@ describe('computeDirectionBalancedPairWinRates', () => {
       definitionsMeasured: new Set(['def-a']),
       canonicalFirstValueToken: 'alpha',
       authoredFirstTokenByDef: new Map([['def-a', 'alpha']]),
+      domainByDef: new Map([['def-a', 'd1']]),
     });
 
     expect(result.ownRate).toBeNull();
@@ -523,6 +588,7 @@ describe('computeDirectionBalancedPairWinRates', () => {
       definitionsMeasured: new Set(['def-a']),
       canonicalFirstValueToken: 'alpha',
       authoredFirstTokenByDef: new Map([['def-a', 'alpha']]),
+      domainByDef: new Map([['def-a', 'd1']]),
     });
 
     expect(result.ownRate).toBeCloseTo(0.75, 10);
@@ -541,6 +607,7 @@ describe('computeDirectionBalancedPairWinRates', () => {
       definitionsMeasured: new Set(['def-b']),
       canonicalFirstValueToken: 'alpha',
       authoredFirstTokenByDef: new Map([['def-b', 'beta']]),
+      domainByDef: new Map([['def-b', 'd1']]),
     });
 
     // opponentWinRate of the cell = 0.75, which is the canonical own rate
@@ -562,6 +629,7 @@ describe('computeDirectionBalancedPairWinRates', () => {
       definitionsMeasured: new Set(['def-a', 'def-b']),
       canonicalFirstValueToken: 'alpha',
       authoredFirstTokenByDef: new Map([['def-a', 'alpha'], ['def-b', 'beta']]),
+      domainByDef: new Map([['def-a', 'd1'], ['def-b', 'd1']]),
     });
 
     // def-a cell: winRate = 4/5 = 0.8 (authored first → canonical own)
@@ -584,6 +652,7 @@ describe('computeDirectionBalancedPairWinRates', () => {
       definitionsMeasured: new Set(['def-a']),
       canonicalFirstValueToken: 'alpha',
       authoredFirstTokenByDef: new Map([['def-a', 'alpha']]),
+      domainByDef: new Map([['def-a', 'd1']]),
       cellFilter: (own, opp) => own === opp,
     });
 
@@ -595,6 +664,7 @@ describe('computeDirectionBalancedPairWinRates', () => {
       definitionsMeasured: new Set(['def-a']),
       canonicalFirstValueToken: 'alpha',
       authoredFirstTokenByDef: new Map([['def-a', 'alpha']]),
+      domainByDef: new Map([['def-a', 'd1']]),
       cellFilter: (own, opp) => own >= 4 && opp <= 3,
     });
 
@@ -612,6 +682,7 @@ describe('computeDirectionBalancedPairWinRates', () => {
       definitionsMeasured: new Set(['def-a']),
       canonicalFirstValueToken: 'alpha',
       authoredFirstTokenByDef: new Map([['def-a', 'alpha']]),
+      domainByDef: new Map([['def-a', 'd1']]),
       cellFilter: (own, opp) => own >= 4 && opp <= 3,
     });
 


### PR DESCRIPTION
## Summary
- All four directional rate columns (Average, Balanced, HighPressureOnValue, HighPressureOnOpposingValue) now group observations by domain first, compute a direction-balanced rate within each domain, then average those domain rates with equal weight.
- This matches the same methodology used by Domain Analysis ("Value Priorities" column), which was the source of the mismatch.
- Previously, all definitions from all domains were pooled into shared direction buckets, implicitly weighting domains by their run count — a domain with 3× as many vignettes had 3× the influence.

## How it works
`computeDirectionBalancedPairWinRates` now takes a `domainByDef` map (definitionId → domainId). For each value pair:
1. Collect per-definition rates into per-domain buckets, grouped by authored direction (first vs second).
2. For each domain: average the first-direction rates, average the second-direction rates, then average those two direction means equally (direction balancing).
3. Average the resulting per-domain rates equally (one vote per domain).

Definitions without a known domain fall back to using their `definitionId` as a singleton domain key, so they're never silently dropped.

## Test plan
- [ ] Preflight passed (lint + tests + build)
  - `npm run lint --workspace @valuerank/shared` ✅
  - `npm run lint --workspace @valuerank/db` ✅
  - `npm run lint --workspace @valuerank/api` ✅ (0 errors)
  - `npm run test --workspace @valuerank/api` ✅ (2306 passed, 2 skipped)
  - `npm run build --workspace @valuerank/api` ✅
  - `npm run lint --workspace @valuerank/web` ✅ (0 errors)
  - `npm run build --workspace @valuerank/web` ✅
- [ ] Two new unit tests added:
  - "weights domains equally regardless of how many vignettes each domain has" — verifies a domain with 2 vignettes at 100% doesn't outweigh a domain with 1 vignette at 0%.
  - "combines direction balancing and domain equal-weighting independently" — verifies both mechanisms apply correctly together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)