### PR TITLE
feat(coverage): replace run-based batch counting with trial-based batch equivalents

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-coverage-gql-types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-coverage-gql-types.ts
@@ -13,30 +13,33 @@ import {
 } from '@valuerank/shared/trial-signature';
 import { parseDefinitionVersion } from '../../utils/definition-version.js';
 import { parseTemperature } from '../../utils/temperature.js';
-import type { CoverageModelBreakdown } from './domain-coverage-utils.js';
 
 // ─── TypeScript types ─────────────────────────────────────────────────────────
+
+export type CoverageModelCount = {
+  modelId: string;
+  label: string;
+  trialCount: number;
+};
+
+export type CoverageWeakestCondition = {
+  conditionLabel: string;
+  modelCounts: CoverageModelCount[];
+  otherConditionsCount: number | null;
+};
 
 export type DomainValueCoverageCell = {
   valueA: string;
   valueB: string;
-  batchCount: number;
-  pairedBatchCount: number;
-  orphanedBatchCount: number;
-  aFirstBatchCount: number;
-  bFirstBatchCount: number;
-  pairedConditionCount: number;
-  orphanedConditionCount: number;
-  directionalCoverage: DirectionalCoverage[];
+  batchEquivalent: number;
+  aFirstBatchEquivalent: number;
+  bFirstBatchEquivalent: number;
+  aFirstDefinitionName: string | null;
+  bFirstDefinitionName: string | null;
+  weakestCondition: CoverageWeakestCondition | null;
   contributingDefinitionIds: string[];
-  /** Number of non-aggregate runs whose transcript count is less than expected. */
-  incompleteBatchCount: number;
   definitionId: string | null;
-  definitionName: string | null;
   aggregateRunId: string | null;
-  minTrialCount: number | null;
-  maxTrialCount: number | null;
-  modelBreakdown: CoverageModelBreakdown[] | null;
 };
 
 export type CoverageModelOption = {
@@ -70,8 +73,8 @@ const CoverageModelOptionRef = builder
     }),
   });
 
-const CoverageModelBreakdownRef = builder
-  .objectRef<CoverageModelBreakdown>('CoverageModelBreakdown')
+const CoverageModelCountRef = builder
+  .objectRef<CoverageModelCount>('CoverageModelCount')
   .implement({
     fields: (t) => ({
       modelId: t.exposeString('modelId'),
@@ -80,15 +83,16 @@ const CoverageModelBreakdownRef = builder
     }),
   });
 
-const DirectionalCoverageRef = builder
-  .objectRef<DirectionalCoverage>('DirectionalCoverage')
+const CoverageWeakestConditionRef = builder
+  .objectRef<CoverageWeakestCondition>('CoverageWeakestCondition')
   .implement({
     fields: (t) => ({
-      direction: t.exposeString('direction'),
-      completeBatches: t.exposeInt('completeBatches'),
-      filledSlots: t.exposeInt('filledSlots'),
-      leftoverConditions: t.exposeInt('leftoverConditions'),
-      definitionIds: t.exposeStringList('definitionIds'),
+      conditionLabel: t.exposeString('conditionLabel'),
+      modelCounts: t.field({
+        type: [CoverageModelCountRef],
+        resolve: (parent) => parent.modelCounts,
+      }),
+      otherConditionsCount: t.exposeInt('otherConditionsCount', { nullable: true }),
     }),
   });
 
@@ -98,80 +102,22 @@ const DomainValueCoverageCellRef = builder
     fields: (t) => ({
       valueA: t.exposeString('valueA'),
       valueB: t.exposeString('valueB'),
-      batchCount: t.exposeInt('batchCount', {
-        description:
-          'Count of fully-complete non-aggregate runs for this value pair. ' +
-          'A run is complete when every selected model has at least one ' +
-          'transcript at every (scenario × sampleIndex) slot. samplesPerScenario ' +
-          'does not multiply this count -- a complete run contributes 1 ' +
-          'regardless of how many samples per scenario were planned. ' +
-          'Aggregate runs are excluded.',
-      }),
-      pairedBatchCount: t.exposeInt('pairedBatchCount', {
-        description:
-          'Count of pairable analysis-ready batches for this value pair, ' +
-          'computed as min(complete A-first non-aggregate runs, ' +
-          'complete B-first non-aggregate runs) where direction is read from ' +
-          'config.jobChoiceValueFirst. A launch where only one direction completed ' +
-          'contributes 0 here (the surviving complete run still appears in batchCount). ' +
-          'Runs without a recognizable direction token are excluded from both sides. ' +
-          'See docs/canonical-glossary.md "Paired Batch" for full semantic.',
-      }),
-      orphanedBatchCount: t.exposeInt('orphanedBatchCount', {
-        description:
-          'Count of unmatched directional runs for this value pair, computed as ' +
-          'max(complete A-first runs, complete B-first runs) - ' +
-          'min(complete A-first runs, complete B-first runs). When both directions ' +
-          'are equal this is 0; when only one direction has runs this is the count ' +
-          'of that side. Runs without a recognizable direction token are excluded.',
-      }),
-      aFirstBatchCount: t.exposeInt('aFirstBatchCount', {
-        description:
-          'Count of complete A-first runs for this value pair after model-set filtering. ' +
-          'This is the filtered directional count for the first value in the pair.',
-      }),
-      bFirstBatchCount: t.exposeInt('bFirstBatchCount', {
-        description:
-          'Count of complete B-first runs for this value pair after model-set filtering. ' +
-          'This is the filtered directional count for the second value in the pair.',
-      }),
-      pairedConditionCount: t.exposeInt('pairedConditionCount', {
-        description:
-          'Count of matched condition slots across both directions, computed as the ' +
-          'size of the intersection of filled (scenarioId, modelId, sampleIndex) slots.',
-      }),
-      orphanedConditionCount: t.exposeInt('orphanedConditionCount', {
-        description:
-          'Count of unmatched condition slots across both directions, computed as the ' +
-          'size of the symmetric difference of filled (scenarioId, modelId, sampleIndex) slots.',
-      }),
-      directionalCoverage: t.field({
-        type: [DirectionalCoverageRef],
-        resolve: (parent) => parent.directionalCoverage,
-        description:
-          'Per-direction condition coverage for this value pair, including complete batches, ' +
-          'filled slots, leftover conditions from incomplete runs, and contributing definition IDs.',
+      batchEquivalent: t.exposeInt('batchEquivalent'),
+      aFirstBatchEquivalent: t.exposeInt('aFirstBatchEquivalent'),
+      bFirstBatchEquivalent: t.exposeInt('bFirstBatchEquivalent'),
+      aFirstDefinitionName: t.exposeString('aFirstDefinitionName', { nullable: true }),
+      bFirstDefinitionName: t.exposeString('bFirstDefinitionName', { nullable: true }),
+      weakestCondition: t.field({
+        type: CoverageWeakestConditionRef,
+        nullable: true,
+        resolve: (parent) => parent.weakestCondition,
       }),
       contributingDefinitionIds: t.exposeStringList('contributingDefinitionIds', {
         description:
           'Union of definition IDs that contribute data to this coverage cell, sorted alphabetically.',
       }),
-      incompleteBatchCount: t.exposeInt('incompleteBatchCount', {
-        description:
-          'Count of non-aggregate runs that expect transcripts but are ' +
-          'missing one or more (model × scenario × sampleIndex) slots. ' +
-          'Per-run; samplesPerScenario does not multiply this count. ' +
-          'Aggregate runs and runs with zero expected slots are excluded.',
-      }),
       definitionId: t.exposeString('definitionId', { nullable: true }),
-      definitionName: t.exposeString('definitionName', { nullable: true }),
       aggregateRunId: t.exposeString('aggregateRunId', { nullable: true }),
-      minTrialCount: t.exposeInt('minTrialCount', { nullable: true }),
-      maxTrialCount: t.exposeInt('maxTrialCount', { nullable: true }),
-      modelBreakdown: t.expose('modelBreakdown', {
-        type: [CoverageModelBreakdownRef],
-        nullable: true,
-      }),
     }),
   });
 

--- a/cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts
@@ -1,4 +1,5 @@
 import { DOMAIN_ANALYSIS_VALUE_KEYS, extractValuePair, toPascalCaseKey, type DomainAnalysisValueKey } from './domain-analysis-values.js';
+import type { CoverageWeakestCondition } from './domain-coverage-gql-types.js';
 
 export const COVERAGE_VALUE_KEYS = DOMAIN_ANALYSIS_VALUE_KEYS;
 export type CoverageValueKey = DomainAnalysisValueKey;
@@ -38,6 +39,126 @@ export function getCoverageBatchIncrement(samplesPerScenario: unknown): number {
 
 export type CoverageModelBreakdown = { modelId: string; label: string; trialCount: number };
 export type CoverageConditionBreakdown = { filledSlots: number; definitionIds: string[] };
+
+/**
+ * Compute batch equivalent from a trial count map.
+ *
+ * trialMap: scenarioId -> modelId -> trialCount
+ * selectedModelIds: models to require (all must have trials for a scenario to count)
+ *
+ * Returns min across all scenarios of (min per model across selectedModelIds).
+ * A scenario with 0 trials for any selected model contributes 0.
+ * Returns 0 if trialMap is empty or selectedModelIds is empty.
+ */
+export function computeBatchEquivalent(
+  trialMap: ReadonlyMap<string, ReadonlyMap<string, number>>,
+  selectedModelIds: readonly string[],
+): number {
+  if (trialMap.size === 0 || selectedModelIds.length === 0) {
+    return 0;
+  }
+
+  let weakestScenarioCount = Number.POSITIVE_INFINITY;
+  for (const scenarioMap of trialMap.values()) {
+    let perScenarioCount = Number.POSITIVE_INFINITY;
+    for (const modelId of selectedModelIds) {
+      perScenarioCount = Math.min(perScenarioCount, scenarioMap.get(modelId) ?? 0);
+    }
+    weakestScenarioCount = Math.min(weakestScenarioCount, perScenarioCount);
+  }
+
+  return Number.isFinite(weakestScenarioCount) ? weakestScenarioCount : 0;
+}
+
+function countTrialsForScenario(
+  scenarioMap: ReadonlyMap<string, number>,
+  selectedModelIds: readonly string[],
+): number {
+  let count = Number.POSITIVE_INFINITY;
+  for (const modelId of selectedModelIds) {
+    count = Math.min(count, scenarioMap.get(modelId) ?? 0);
+  }
+  return Number.isFinite(count) ? count : 0;
+}
+
+function buildCoverageWeakestCondition(
+  scenarioId: string,
+  scenarioMap: ReadonlyMap<string, number>,
+  selectedModelIds: readonly string[],
+  scenarioLabelMap: ReadonlyMap<string, string>,
+  modelLabelById: ReadonlyMap<string, string>,
+): {
+  scenarioId: string;
+  conditionLabel: string;
+  minCount: number;
+  modelCounts: { modelId: string; label: string; trialCount: number }[];
+} {
+  const modelCounts = selectedModelIds.map((modelId) => ({
+    modelId,
+    label: modelLabelById.get(modelId) ?? modelId,
+    trialCount: scenarioMap.get(modelId) ?? 0,
+  }));
+  return {
+    scenarioId,
+    conditionLabel: scenarioLabelMap.get(scenarioId) ?? scenarioId.slice(0, 6),
+    minCount: countTrialsForScenario(scenarioMap, selectedModelIds),
+    modelCounts,
+  };
+}
+
+/**
+ * Find the weakest condition: the scenario with the lowest min-per-model count.
+ * Returns null if all scenarios have equal coverage (no variation), or trialMap is empty.
+ *
+ * scenarioLabelMap: scenarioId -> human-readable label (e.g. "5×1")
+ * modelLabelById: modelId -> display name
+ */
+export function findWeakestCondition(
+  trialMap: ReadonlyMap<string, ReadonlyMap<string, number>>,
+  selectedModelIds: readonly string[],
+  scenarioLabelMap: ReadonlyMap<string, string>,
+  modelLabelById: ReadonlyMap<string, string>,
+): CoverageWeakestCondition | null {
+  if (trialMap.size === 0 || selectedModelIds.length === 0) {
+    return null;
+  }
+
+  const scenarioCounts = Array.from(trialMap.entries())
+    .map(([scenarioId, scenarioMap]) =>
+      buildCoverageWeakestCondition(scenarioId, scenarioMap, selectedModelIds, scenarioLabelMap, modelLabelById))
+    .sort((left, right) => {
+      if (left.minCount !== right.minCount) return left.minCount - right.minCount;
+      return left.scenarioId.localeCompare(right.scenarioId);
+    });
+
+  if (scenarioCounts.length <= 1) {
+    return null;
+  }
+
+  const firstCount = scenarioCounts[0]?.minCount ?? 0;
+  const allEqual = scenarioCounts.every((entry) => entry.minCount === firstCount);
+  if (allEqual) {
+    return null;
+  }
+
+  const weakest = scenarioCounts[0];
+  if (weakest == null) {
+    return null;
+  }
+
+  const otherCounts = scenarioCounts.slice(1).map((entry) => entry.minCount);
+  let otherConditionsCount: number | null = null;
+  if (otherCounts.length > 0) {
+    const uniformOtherCount = otherCounts.every((count) => count === otherCounts[0]);
+    otherConditionsCount = uniformOtherCount ? otherCounts[0] ?? null : otherCounts[0] ?? null;
+  }
+
+  return {
+    conditionLabel: weakest.conditionLabel,
+    modelCounts: weakest.modelCounts,
+    otherConditionsCount,
+  };
+}
 
 /**
  * Deduplicate a list of runs by their paired-batch group ID.

--- a/cloud/apps/api/src/graphql/queries/domain-coverage.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-coverage.ts
@@ -9,19 +9,14 @@
 import { builder } from '../builder.js';
 import { db, resolveDefinitionContent } from '@valuerank/db';
 import { AppError } from '@valuerank/shared';
-
 import {
   COVERAGE_VALUE_KEYS,
   type CoverageValueKey,
-  computeConditionCounts,
+  computeBatchEquivalent,
   extractValuePair,
-  getCoverageBatchGroupId,
+  findWeakestCondition,
   getCoverageDirection,
-  selectPrimaryDefinitionCounts,
-  computePerModelTrialCounts,
-  deduplicateRunsByGroupId,
 } from './domain-coverage-utils.js';
-import { isRunComplete } from '../../services/run/coverage-completeness.js';
 import { resolveEffectiveDefaultModelIds } from './domain/shared.js';
 import {
   DomainValueCoverageResultRef,
@@ -31,6 +26,110 @@ import {
 } from './domain-coverage-gql-types.js';
 
 const VALUE_PAIR_RESOLVE_CHUNK_SIZE = 20;
+
+type CoverageTranscript = {
+  modelId: string;
+  scenarioId: string | null;
+  sampleIndex: number;
+};
+
+type ScopedRun = {
+  id: string;
+  definitionId: string;
+  config: unknown;
+  transcripts: CoverageTranscript[];
+};
+
+type TrialMap = Map<string, Map<string, Map<string, Map<string, number>>>>;
+
+function incrementTrialCount(
+  trialsByDefAndDirection: TrialMap,
+  definitionId: string,
+  direction: string,
+  scenarioId: string,
+  modelId: string,
+): void {
+  const directionMap = trialsByDefAndDirection.get(definitionId) ?? new Map<string, Map<string, Map<string, number>>>();
+  const scenarioMap = directionMap.get(direction) ?? new Map<string, Map<string, number>>();
+  const modelMap = scenarioMap.get(scenarioId) ?? new Map<string, number>();
+
+  modelMap.set(modelId, (modelMap.get(modelId) ?? 0) + 1);
+  scenarioMap.set(scenarioId, modelMap);
+  directionMap.set(direction, scenarioMap);
+  trialsByDefAndDirection.set(definitionId, directionMap);
+}
+
+function mergeTrialMapsForDirection(
+  defIdsForPair: readonly string[],
+  direction: string,
+  trialsByDefAndDirection: TrialMap,
+): Map<string, Map<string, number>> {
+  const merged = new Map<string, Map<string, number>>();
+
+  for (const defId of defIdsForPair) {
+    const directionMap = trialsByDefAndDirection.get(defId)?.get(direction);
+    if (directionMap == null) continue;
+
+    for (const [scenarioId, modelMap] of directionMap) {
+      const mergedScenarioMap = merged.get(scenarioId) ?? new Map<string, number>();
+      for (const [modelId, trialCount] of modelMap) {
+        mergedScenarioMap.set(modelId, (mergedScenarioMap.get(modelId) ?? 0) + trialCount);
+      }
+      merged.set(scenarioId, mergedScenarioMap);
+    }
+  }
+
+  return merged;
+}
+
+function sumTrialsForDefinition(
+  definitionId: string,
+  trialsByDefAndDirection: TrialMap,
+): number {
+  const directionMap = trialsByDefAndDirection.get(definitionId);
+  if (directionMap == null) return 0;
+
+  let total = 0;
+  for (const scenarioMap of directionMap.values()) {
+    for (const modelMap of scenarioMap.values()) {
+      for (const trialCount of modelMap.values()) {
+        total += trialCount;
+      }
+    }
+  }
+  return total;
+}
+
+function findDirectionalDefinitionName(
+  defIdsForPair: readonly string[],
+  direction: string,
+  trialsByDefAndDirection: TrialMap,
+  pairByDefinitionId: ReadonlyMap<string, { name: string }>,
+): string | null {
+  for (const defId of defIdsForPair) {
+    const directionMap = trialsByDefAndDirection.get(defId)?.get(direction);
+    if (directionMap != null && directionMap.size > 0) {
+      return pairByDefinitionId.get(defId)?.name ?? null;
+    }
+  }
+  return null;
+}
+
+function formatScenarioLabel(content: unknown, fallbackId: string): string {
+  if (content === null || typeof content !== 'object' || Array.isArray(content)) {
+    return fallbackId.slice(0, 6);
+  }
+
+  const dimensionValues = (content as { dimension_values?: unknown }).dimension_values;
+  if (dimensionValues === null || typeof dimensionValues !== 'object' || Array.isArray(dimensionValues)) {
+    return fallbackId.slice(0, 6);
+  }
+
+  const entries = Object.entries(dimensionValues as Record<string, unknown>)
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
+  const label = entries.map(([, value]) => String(value)).join('×');
+  return label.length > 0 ? label : fallbackId.slice(0, 6);
+}
 
 builder.queryField('domainValueCoverage', (t) =>
   t.field({
@@ -69,24 +168,16 @@ builder.queryField('domainValueCoverage', (t) =>
 
       ctx.log.debug({ domainId, filterModelIds, selectedSignature }, 'Computing domain value coverage');
 
-      const domain = await db.domain.findUnique({ where: { id: domainId }, select: { id: true, defaultModelIds: true } });
+      const domain = await db.domain.findUnique({
+        where: { id: domainId },
+        select: { id: true, defaultModelIds: true },
+      });
       if (!domain) return null;
 
       // Resolve effective model IDs: use domain-specific list if set, otherwise fall back
       // to globally defaulted models (isDefault=true, ACTIVE) from the Models settings page.
       const effectiveModelIds = await resolveEffectiveDefaultModelIds(domain.defaultModelIds);
-
-      // Pre-fetch labels for effective models so we can populate model breakdown
-      const defaultModelLabelById = new Map<string, string>();
-      if (effectiveModelIds.length > 0) {
-        const defaultModelRows = await db.llmModel.findMany({
-          where: { modelId: { in: effectiveModelIds } },
-          select: { modelId: true, displayName: true },
-        });
-        for (const row of defaultModelRows) {
-          defaultModelLabelById.set(row.modelId, row.displayName);
-        }
-      }
+      const activeModelFilter = filterModelIds.length > 0 ? filterModelIds : effectiveModelIds;
 
       // Fetch all non-deleted definitions (need IDs to resolve content)
       const definitions = await db.definition.findMany({
@@ -98,7 +189,6 @@ builder.queryField('domainValueCoverage', (t) =>
       // Map definition ID -> value pair (only those with recognized canonical pair)
       type DefValuePair = { valueA: CoverageValueKey; valueB: CoverageValueKey; name: string };
       const pairByDefinitionId = new Map<string, DefValuePair>();
-      // Map directional pair key -> definition IDs (to detect multi-vignette cells)
       const definitionsByPairKey = new Map<string, string[]>();
 
       // Resolve definition contents in chunks to handle inheritance
@@ -115,47 +205,23 @@ builder.queryField('domainValueCoverage', (t) =>
             const existing = definitionsByPairKey.get(key) ?? [];
             existing.push(def.id);
             definitionsByPairKey.set(key, existing);
-          })
+          }),
         );
         settled.forEach((result, idx) => {
           if (result.status === 'rejected') {
             ctx.log.error(
               { err: result.reason as unknown, definitionId: batch[idx]?.id },
-              'Failed to resolve definition content for coverage grid'
+              'Failed to resolve definition content for coverage grid',
             );
           }
         });
       }
 
-      // Count completed runs per definition, optionally filtered by signature and model
       const definitionIds = Array.from(pairByDefinitionId.keys());
-      const batchCountByDefinitionId = new Map<string, number>();
-      // Per-definition map: direction token -> Set<groupKey> where groupKey is
-      // the run's jobChoiceBatchGroupId (collapses retry duplicates within a
-      // launch group) or "__ungrouped__:<runId>" so each ungrouped run still
-      // counts once. Drives the new pairedBatchCount = min(A-first, B-first).
-      const directionalGroupsByDefinitionId =
-        new Map<string, Map<string, Set<string>>>();
-      const directionalSlotsByDefinitionId =
-        new Map<string, Map<string, Set<string>>>();
-      const directionalLeftoverSlotsByDefinitionId =
-        new Map<string, Map<string, Set<string>>>();
+      const trialsByDefAndDirection: TrialMap = new Map();
       const latestMatchingRunIdByDefinitionId = new Map<string, string>();
       const latestAggregateRunIdByDefinitionId = new Map<string, string>();
-      const incompleteBatchCountByDefinitionId = new Map<string, number>();
-      const signatureScopedRunsByDefinitionId = new Map<string, Array<{
-        id: string;
-        definitionId: string;
-        config: unknown;
-        transcripts: Array<{ modelId: string; scenarioId: string | null; sampleIndex: number }>;
-        scenarioIds: string[];
-      }>>();
-      // Non-aggregate runs per definition (for per-model trial count computation)
-      const nonAggregateRunsByDefinitionId = new Map<string, Array<{
-        config: unknown;
-        transcripts: Array<{ modelId: string; scenarioId: string | null; sampleIndex: number }>;
-        scenarioIds: string[];
-      }>>();
+      const signatureScopedRunsByDefinitionId = new Map<string, ScopedRun[]>();
 
       if (definitionIds.length > 0) {
         const completedRuns = await db.run.findMany({
@@ -185,15 +251,6 @@ builder.queryField('domainValueCoverage', (t) =>
           : completedRuns.filter((run) => runMatchesSignature(run.config, selectedSignature));
 
         for (const run of signatureScopedRuns) {
-          // Per the canonical glossary (docs/canonical-glossary.md), a `Batch` is
-          // one fully-complete run -- every selected model has a transcript at
-          // every (scenarioId × sampleIndex) slot. samplesPerScenario does not
-          // multiply the count. Aggregate runs are excluded from both batch
-          // and incomplete-batch counts (they are rollup records, not data).
-          //
-          // A COMPLETED run with null/malformed `config` or no `models` array
-          // is a data corruption signal; surface it instead of silently
-          // skipping. `samplesPerScenario` and `isAggregate` remain optional.
           if (run.config === null || typeof run.config !== 'object') {
             throw new AppError(
               `Run ${run.id} has null or non-object config; cannot compute coverage`,
@@ -202,25 +259,22 @@ builder.queryField('domainValueCoverage', (t) =>
               { runId: run.id },
             );
           }
+
           const config = run.config as {
             isAggregate?: boolean;
             models?: unknown;
-            samplesPerScenario?: unknown;
           };
-          const scenarioIds = run.scenarioSelections.map((s) => s.scenarioId);
-          const runWithScenarios = {
+          const scopedRun: ScopedRun = {
             id: run.id,
             definitionId: run.definitionId,
             config: run.config,
             transcripts: run.transcripts,
-            scenarioIds,
           };
           const existingRuns = signatureScopedRunsByDefinitionId.get(run.definitionId) ?? [];
-          existingRuns.push(runWithScenarios);
+          existingRuns.push(scopedRun);
           signatureScopedRunsByDefinitionId.set(run.definitionId, existingRuns);
 
-          const isAggregateRun = config.isAggregate === true;
-          if (isAggregateRun) {
+          if (config.isAggregate === true) {
             if (!latestAggregateRunIdByDefinitionId.has(run.definitionId)) {
               latestAggregateRunIdByDefinitionId.set(run.definitionId, run.id);
             }
@@ -228,119 +282,37 @@ builder.queryField('domainValueCoverage', (t) =>
           }
 
           const models = Array.isArray(config.models)
-            ? config.models.filter((m): m is string => typeof m === 'string' && m.length > 0)
+            ? config.models.filter((model): model is string => typeof model === 'string' && model.length > 0)
             : null;
-          // When the caller provides explicit modelIds, those replace the effective
-          // model set filter so counts reflect runs planned for exactly those models.
-          // When no explicit modelIds, fall back to the domain's effective defaults.
-          const activeModelFilter = filterModelIds.length > 0 ? filterModelIds : effectiveModelIds;
           const matchesEffectiveModelSet = activeModelFilter.length === 0
             || (models !== null && activeModelFilter.every((id) => models.includes(id)));
           if (!matchesEffectiveModelSet) {
             continue;
           }
 
-          const matchingTranscripts = run.transcripts.filter((transcript): transcript is {
-            modelId: string;
-            scenarioId: string;
-            sampleIndex: number;
-          } => transcript.scenarioId !== null
-            && transcript.sampleIndex !== null
-            && (filterModelIds.length === 0 || filterModelIds.includes(transcript.modelId)));
-
           const direction = getCoverageDirection(run.config);
-          if (direction !== null && matchingTranscripts.length > 0) {
-            const defMap = directionalSlotsByDefinitionId.get(run.definitionId)
-              ?? new Map<string, Set<string>>();
-            const slotSet = defMap.get(direction) ?? new Set<string>();
-            for (const transcript of matchingTranscripts) {
-              slotSet.add(`${transcript.scenarioId}|${transcript.modelId}|${transcript.sampleIndex}`);
-            }
-            defMap.set(direction, slotSet);
-            directionalSlotsByDefinitionId.set(run.definitionId, defMap);
+          if (direction === null) {
+            continue;
           }
 
           if (!latestMatchingRunIdByDefinitionId.has(run.definitionId)) {
             latestMatchingRunIdByDefinitionId.set(run.definitionId, run.id);
           }
 
-          // Track non-aggregate runs for per-model trial count computation.
-          const nonAggregateRuns = nonAggregateRunsByDefinitionId.get(run.definitionId) ?? [];
-          nonAggregateRuns.push({ config: run.config, transcripts: run.transcripts, scenarioIds });
-          nonAggregateRunsByDefinitionId.set(run.definitionId, nonAggregateRuns);
-
-          // Determine completeness using the existing helper. A run is complete
-          // iff every (scenarioId × modelId × sampleIndex) slot has at least
-          // one transcript. Extra transcripts in a slot do NOT break
-          // completeness; only missing slots do.
-          if (models === null) {
-            throw new AppError(
-              `Run ${run.id} config has no models array; cannot compute coverage`,
-              'RUN_CONFIG_INVALID',
-              500,
-              { runId: run.id },
-            );
-          }
-          if (models.length === 0) {
-            throw new AppError(
-              `Run ${run.id} has empty or invalid models array`,
-              'RUN_CONFIG_INVALID',
-              500,
-              { runId: run.id },
-            );
-          }
-          const rawSamples = config.samplesPerScenario;
-          const samplesPerScenario = typeof rawSamples === 'number' ? rawSamples : null;
-          const existingTranscripts = run.transcripts
-            .filter((t): t is { scenarioId: string; modelId: string; sampleIndex: number } => t.scenarioId !== null && t.sampleIndex !== null);
-          const complete = isRunComplete({
-            scenarioIds,
-            models,
-            samplesPerScenario,
-            existingTranscripts,
-          });
-
-          if (!complete) {
-            incompleteBatchCountByDefinitionId.set(
-              run.definitionId,
-              (incompleteBatchCountByDefinitionId.get(run.definitionId) ?? 0) + 1,
-            );
-
-            if (direction !== null && matchingTranscripts.length > 0) {
-              const defMap = directionalLeftoverSlotsByDefinitionId.get(run.definitionId)
-                ?? new Map<string, Set<string>>();
-              const slotSet = defMap.get(direction) ?? new Set<string>();
-              for (const transcript of matchingTranscripts) {
-                slotSet.add(`${transcript.scenarioId}|${transcript.modelId}|${transcript.sampleIndex}`);
-              }
-              defMap.set(direction, slotSet);
-              directionalLeftoverSlotsByDefinitionId.set(run.definitionId, defMap);
+          for (const transcript of run.transcripts) {
+            if (transcript.scenarioId === null) {
+              continue;
             }
-            continue;
-          }
-
-          // Run is complete: contribute exactly 1 to batchCount regardless of
-          // samplesPerScenario.
-          batchCountByDefinitionId.set(
-            run.definitionId,
-            (batchCountByDefinitionId.get(run.definitionId) ?? 0) + 1,
-          );
-
-          // pairedBatchCount semantic: count complete A-first vs B-first runs
-          // independently per the direction token in config.jobChoiceValueFirst.
-          // The Set<groupKey> collapses retry duplicates that share the same
-          // launch group; ungrouped runs use a unique sentinel so they each
-          // count once. Runs with no recognizable direction token are skipped
-          // here (they still count toward batchCount above).
-          if (direction !== null) {
-            const launchGroupId = getCoverageBatchGroupId(run.config);
-            const groupKey = launchGroupId ?? `__ungrouped__:${run.id}`;
-            const defMap = directionalGroupsByDefinitionId.get(run.definitionId)
-              ?? new Map<string, Set<string>>();
-            const dirSet = defMap.get(direction) ?? new Set<string>();
-            dirSet.add(groupKey);
-            defMap.set(direction, dirSet);
-            directionalGroupsByDefinitionId.set(run.definitionId, defMap);
+            if (activeModelFilter.length > 0 && !activeModelFilter.includes(transcript.modelId)) {
+              continue;
+            }
+            incrementTrialCount(
+              trialsByDefAndDirection,
+              run.definitionId,
+              direction,
+              transcript.scenarioId,
+              transcript.modelId,
+            );
           }
         }
       }
@@ -354,27 +326,48 @@ builder.queryField('domainValueCoverage', (t) =>
         }
       }
 
-      const modelDetailRows =
-        availableModelIds.size > 0
-          ? await db.llmModel.findMany({
-            where: { modelId: { in: Array.from(availableModelIds) } },
-            select: { modelId: true, displayName: true },
-            orderBy: { displayName: 'asc' },
-          })
-          : [];
+      const modelDetailRows = availableModelIds.size > 0
+        ? await db.llmModel.findMany({
+          where: { modelId: { in: Array.from(availableModelIds) } },
+          select: { modelId: true, displayName: true },
+          orderBy: { displayName: 'asc' },
+        })
+        : [];
 
-      const availableModels: CoverageModelOption[] = modelDetailRows.map((m) => ({
-        modelId: m.modelId,
-        label: m.displayName,
+      const availableModels: CoverageModelOption[] = modelDetailRows.map((model) => ({
+        modelId: model.modelId,
+        label: model.displayName,
       }));
+      const modelLabelById = new Map<string, string>(
+        availableModels.map((model) => [model.modelId, model.label] as const),
+      );
 
-      // Build the symmetric 45-cell matrix (one cell per unique sorted pair)
+      const allScenarioIds = new Set<string>();
+      for (const directionMap of trialsByDefAndDirection.values()) {
+        for (const scenarioMap of directionMap.values()) {
+          for (const scenarioId of scenarioMap.keys()) {
+            allScenarioIds.add(scenarioId);
+          }
+        }
+      }
+
+      const scenarioLabelMap = new Map<string, string>();
+      if (allScenarioIds.size > 0) {
+        const scenarioRows = await db.scenario.findMany({
+          where: { id: { in: [...allScenarioIds] } },
+          select: { id: true, content: true },
+        });
+
+        for (const scenarioRow of scenarioRows) {
+          scenarioLabelMap.set(scenarioRow.id, formatScenarioLabel(scenarioRow.content, scenarioRow.id));
+        }
+      }
+
       const values = [...COVERAGE_VALUE_KEYS] as string[];
       const cells: DomainValueCoverageCell[] = [];
 
       for (const valueA of COVERAGE_VALUE_KEYS) {
         for (const valueB of COVERAGE_VALUE_KEYS) {
-          // Only emit sorted pairs: skip diagonal and reversed pairs
           if (valueA.localeCompare(valueB) >= 0) continue;
 
           const key = `${valueA}::${valueB}`;
@@ -384,154 +377,71 @@ builder.queryField('domainValueCoverage', (t) =>
             cells.push({
               valueA,
               valueB,
-              batchCount: 0,
-              pairedBatchCount: 0,
-              orphanedBatchCount: 0,
-              aFirstBatchCount: 0,
-              bFirstBatchCount: 0,
-              pairedConditionCount: 0,
-              orphanedConditionCount: 0,
-              directionalCoverage: [],
+              batchEquivalent: 0,
+              aFirstBatchEquivalent: 0,
+              bFirstBatchEquivalent: 0,
+              aFirstDefinitionName: null,
+              bFirstDefinitionName: null,
+              weakestCondition: null,
               contributingDefinitionIds: [],
-              incompleteBatchCount: 0,
               definitionId: null,
-              definitionName: null,
               aggregateRunId: null,
-              minTrialCount: null,
-              maxTrialCount: null,
-              modelBreakdown: null,
             });
-          } else {
-            // Use the total counts across all definitions for the visible cell, but
-            // still choose one stable definition for the analysis link target.
-            const {
-              primaryDefinitionId,
-              batchCount,
-              pairedBatchCount,
-              orphanedBatchCount,
-              aFirstBatchCount,
-              bFirstBatchCount,
-            } = selectPrimaryDefinitionCounts(
-              defIdsForPair,
-              batchCountByDefinitionId,
-              directionalGroupsByDefinitionId,
-              valueA,
-              valueB,
-              ctx.log,
-              `${valueA}::${valueB}`,
-            );
-            const conditionCounts = computeConditionCounts(defIdsForPair, directionalSlotsByDefinitionId);
-            const primaryDefId = primaryDefinitionId ?? '';
-            const primaryPair = pairByDefinitionId.get(primaryDefId);
-            const aggregateRunId = primaryDefId === ''
-              ? null
-              : (latestAggregateRunIdByDefinitionId.get(primaryDefId)
-                ?? latestMatchingRunIdByDefinitionId.get(primaryDefId)
-                ?? null);
-
-            // Sum incompleteBatchCount across all definitions for this pair
-            const incompleteBatchCount = defIdsForPair.reduce(
-              (sum, defId) => sum + (incompleteBatchCountByDefinitionId.get(defId) ?? 0),
-              0,
-            );
-
-            // Compute per-model trial counts across all definitions for this pair.
-            // Deduplicate by group ID first: A-first and B-first companion definitions
-            // share the same jobChoiceBatchGroupId, so flatMapping across both would
-            // double-count each paired batch.
-            //
-            // When companions have different completeness, prefer the complete one
-            // for the trial-count computation. This is read-time consistency with
-            // batchCount: the surviving run is the one whose data feeds analysis.
-            //
-            // Intentionally unchanged by the directional-pairedBatchCount refactor:
-            // the trial-count path keeps the surviving-companion semantic so that
-            // healthy paired batches do not double their displayed trial counts.
-            // See spec §5.7 ("Per-model trial counts — intentionally unchanged").
-            const allNonAggregateRunsForPair = deduplicateRunsByGroupId(
-              defIdsForPair.flatMap((defId) => nonAggregateRunsByDefinitionId.get(defId) ?? []),
-              (run) => {
-                const configModels = (run.config as { models?: unknown } | null)?.models;
-                const models = Array.isArray(configModels)
-                  ? configModels.filter((m): m is string => typeof m === 'string' && m.length > 0)
-                  : [];
-                const rawSamples = (run.config as { samplesPerScenario?: unknown } | null)?.samplesPerScenario;
-                const existing = run.transcripts
-                  .filter((t): t is { scenarioId: string; modelId: string; sampleIndex: number } => t.scenarioId !== null);
-                return isRunComplete({
-                  scenarioIds: run.scenarioIds,
-                  models,
-                  samplesPerScenario: typeof rawSamples === 'number' ? rawSamples : null,
-                  existingTranscripts: existing,
-                });
-              },
-            );
-            const { minTrialCount, maxTrialCount, modelBreakdown } = computePerModelTrialCounts(
-              allNonAggregateRunsForPair,
-              effectiveModelIds,
-              defaultModelLabelById,
-            );
-
-            const mergedDirectionalGroups = new Map<string, Set<string>>();
-            const mergedDirectionalLeftovers = new Map<string, Set<string>>();
-            for (const defId of new Set(defIdsForPair)) {
-              const defMap = directionalGroupsByDefinitionId.get(defId);
-              if (defMap == null) continue;
-              for (const [direction, groupKeys] of defMap) {
-                const existing = mergedDirectionalGroups.get(direction) ?? new Set<string>();
-                for (const groupKey of groupKeys) {
-                  existing.add(groupKey);
-                }
-                mergedDirectionalGroups.set(direction, existing);
-              }
-
-              const leftoverMap = directionalLeftoverSlotsByDefinitionId.get(defId);
-              if (leftoverMap == null) continue;
-              for (const [direction, slotKeys] of leftoverMap) {
-                const existing = mergedDirectionalLeftovers.get(direction) ?? new Set<string>();
-                for (const slotKey of slotKeys) {
-                  existing.add(slotKey);
-                }
-                mergedDirectionalLeftovers.set(direction, existing);
-              }
-            }
-
-            const orderedDirections = [
-              valueA,
-              valueB,
-              ...Array.from(conditionCounts.perDirection.keys())
-                .filter((direction) => direction !== valueA && direction !== valueB)
-                .sort((left, right) => left.localeCompare(right)),
-            ].filter((direction, index, array) => array.indexOf(direction) === index);
-            const directionalCoverage = orderedDirections.map((direction) => ({
-              direction,
-              completeBatches: mergedDirectionalGroups.get(direction)?.size ?? 0,
-              filledSlots: conditionCounts.perDirection.get(direction)?.filledSlots ?? 0,
-              leftoverConditions: mergedDirectionalLeftovers.get(direction)?.size ?? 0,
-              definitionIds: conditionCounts.perDirection.get(direction)?.definitionIds ?? [],
-            }));
-
-            cells.push({
-              valueA,
-              valueB,
-              batchCount,
-              pairedBatchCount,
-              orphanedBatchCount,
-              aFirstBatchCount,
-              bFirstBatchCount,
-              pairedConditionCount: conditionCounts.pairedConditionCount,
-              orphanedConditionCount: conditionCounts.orphanedConditionCount,
-              directionalCoverage,
-              contributingDefinitionIds: Array.from(new Set(defIdsForPair)).sort((left, right) => left.localeCompare(right)),
-              incompleteBatchCount,
-              definitionId: primaryDefId !== '' ? primaryDefId : null,
-              definitionName: primaryPair?.name ?? null,
-              aggregateRunId,
-              minTrialCount,
-              maxTrialCount,
-              modelBreakdown,
-            });
+            continue;
           }
+
+          const uniqueDefIdsForPair = Array.from(new Set(defIdsForPair)).sort((left, right) => left.localeCompare(right));
+          const primaryDefinitionId = uniqueDefIdsForPair.reduce((best, defId) => {
+            const bestCount = sumTrialsForDefinition(best, trialsByDefAndDirection);
+            const thisCount = sumTrialsForDefinition(defId, trialsByDefAndDirection);
+            if (thisCount > bestCount) return defId;
+            if (thisCount < bestCount) return best;
+            return defId.localeCompare(best) < 0 ? defId : best;
+          }, uniqueDefIdsForPair[0] ?? '');
+          const primaryDefinitionName = pairByDefinitionId.get(primaryDefinitionId)?.name ?? null;
+
+          const mergedAFirstTrialMap = mergeTrialMapsForDirection(uniqueDefIdsForPair, valueA, trialsByDefAndDirection);
+          const mergedBFirstTrialMap = mergeTrialMapsForDirection(uniqueDefIdsForPair, valueB, trialsByDefAndDirection);
+          const aFirstBatchEquivalent = computeBatchEquivalent(mergedAFirstTrialMap, activeModelFilter);
+          const bFirstBatchEquivalent = computeBatchEquivalent(mergedBFirstTrialMap, activeModelFilter);
+          const batchEquivalent = Math.min(aFirstBatchEquivalent, bFirstBatchEquivalent);
+          const aFirstDefinitionName = findDirectionalDefinitionName(
+            uniqueDefIdsForPair,
+            valueA,
+            trialsByDefAndDirection,
+            pairByDefinitionId,
+          ) ?? primaryDefinitionName;
+          const bFirstDefinitionName = findDirectionalDefinitionName(
+            uniqueDefIdsForPair,
+            valueB,
+            trialsByDefAndDirection,
+            pairByDefinitionId,
+          ) ?? primaryDefinitionName;
+          const weakestCondition = aFirstBatchEquivalent === bFirstBatchEquivalent
+            ? null
+            : findWeakestCondition(
+              aFirstBatchEquivalent < bFirstBatchEquivalent ? mergedAFirstTrialMap : mergedBFirstTrialMap,
+              activeModelFilter,
+              scenarioLabelMap,
+              modelLabelById,
+            );
+          const aggregateRunId = latestAggregateRunIdByDefinitionId.get(primaryDefinitionId)
+            ?? latestMatchingRunIdByDefinitionId.get(primaryDefinitionId)
+            ?? null;
+
+          cells.push({
+            valueA,
+            valueB,
+            batchEquivalent,
+            aFirstBatchEquivalent,
+            bFirstBatchEquivalent,
+            aFirstDefinitionName,
+            bFirstDefinitionName,
+            weakestCondition,
+            contributingDefinitionIds: uniqueDefIdsForPair,
+            definitionId: primaryDefinitionId === '' ? null : primaryDefinitionId,
+            aggregateRunId,
+          });
         }
       }
 
@@ -540,3 +450,4 @@ builder.queryField('domainValueCoverage', (t) =>
     },
   })
 );
+

--- a/cloud/apps/web/src/api/operations/domainCoverage.graphql
+++ b/cloud/apps/web/src/api/operations/domainCoverage.graphql
@@ -5,32 +5,23 @@ query DomainValueCoverage($domainId: ID!, $modelIds: [String!], $signature: Stri
     cells {
       valueA
       valueB
-      batchCount
-      pairedBatchCount
-      orphanedBatchCount
-      aFirstBatchCount
-      bFirstBatchCount
-      pairedConditionCount
-      orphanedConditionCount
-      directionalCoverage {
-        direction
-        completeBatches
-        filledSlots
-        leftoverConditions
-        definitionIds
+      batchEquivalent
+      aFirstBatchEquivalent
+      bFirstBatchEquivalent
+      aFirstDefinitionName
+      bFirstDefinitionName
+      weakestCondition {
+        conditionLabel
+        modelCounts {
+          modelId
+          label
+          trialCount
+        }
+        otherConditionsCount
       }
       contributingDefinitionIds
-      incompleteBatchCount
       definitionId
-      definitionName
       aggregateRunId
-      minTrialCount
-      maxTrialCount
-      modelBreakdown {
-        modelId
-        label
-        trialCount
-      }
     }
     availableModels {
       modelId
@@ -46,23 +37,22 @@ query DomainValueCoverageLegacy($domainId: ID!, $modelIds: [String!]) {
     cells {
       valueA
       valueB
-      batchCount
-      pairedBatchCount
-      orphanedBatchCount
-      aFirstBatchCount
-      bFirstBatchCount
-      pairedConditionCount
-      orphanedConditionCount
-      directionalCoverage {
-        direction
-        completeBatches
-        filledSlots
-        leftoverConditions
-        definitionIds
+      batchEquivalent
+      aFirstBatchEquivalent
+      bFirstBatchEquivalent
+      aFirstDefinitionName
+      bFirstDefinitionName
+      weakestCondition {
+        conditionLabel
+        modelCounts {
+          modelId
+          label
+          trialCount
+        }
+        otherConditionsCount
       }
       contributingDefinitionIds
       definitionId
-      definitionName
       aggregateRunId
     }
     availableModels {

--- a/cloud/apps/web/src/api/operations/domainCoverage.ts
+++ b/cloud/apps/web/src/api/operations/domainCoverage.ts
@@ -15,39 +15,30 @@ export { DomainValueCoverageLegacyDocument as DOMAIN_VALUE_COVERAGE_QUERY_LEGACY
 // TYPES
 // ============================================================================
 
-export type CoverageModelBreakdownItem = {
+export type CoverageModelCountItem = {
   modelId: string;
   label: string;
   trialCount: number;
 };
 
-export type DirectionalCoverageItem = {
-  direction: string;
-  completeBatches: number;
-  filledSlots: number;
-  leftoverConditions: number;
-  definitionIds: string[];
+export type CoverageWeakestConditionItem = {
+  conditionLabel: string;
+  modelCounts: CoverageModelCountItem[];
+  otherConditionsCount: number | null;
 };
 
 export type DomainValueCoverageCell = {
   valueA: string;
   valueB: string;
-  batchCount: number;
-  pairedBatchCount: number;
-  orphanedBatchCount: number;
-  aFirstBatchCount: number;
-  bFirstBatchCount: number;
-  pairedConditionCount: number;
-  orphanedConditionCount: number;
-  directionalCoverage: DirectionalCoverageItem[];
+  batchEquivalent: number;
+  aFirstBatchEquivalent: number;
+  bFirstBatchEquivalent: number;
+  aFirstDefinitionName: string | null;
+  bFirstDefinitionName: string | null;
+  weakestCondition: CoverageWeakestConditionItem | null;
   contributingDefinitionIds: string[];
-  incompleteBatchCount: number;
   definitionId: string | null;
-  definitionName: string | null;
   aggregateRunId: string | null;
-  minTrialCount: number | null;
-  maxTrialCount: number | null;
-  modelBreakdown: CoverageModelBreakdownItem[] | null;
 };
 
 export type CoverageModelOption = {

--- a/cloud/apps/web/src/components/domains/CoverageCell.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageCell.tsx
@@ -4,100 +4,56 @@ import { ChevronRight, FileSearch } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/Popover';
 import { cn } from '../../lib/utils';
 import { VALUE_LABELS } from './domainAnalysisData';
-import { computeLaggingDirection } from '../../utils/coverageGap';
-
-type CoverageModelBreakdownItem = {
-  modelId: string;
-  label: string;
-  trialCount: number;
-};
 
 type CoverageCellProps = {
   valueA: string;
   valueB: string;
-  batchCount: number;
-  pairedBatchCount: number;
-  orphanedBatchCount: number;
-  aFirstBatchCount: number;
-  bFirstBatchCount: number;
-  pairedConditionCount: number;
-  orphanedConditionCount: number;
-  directionalCoverage: Array<{
-    direction: string;
-    completeBatches: number;
-    filledSlots: number;
-    leftoverConditions: number;
-    definitionIds: string[];
-  }>;
+  batchEquivalent: number;
+  aFirstBatchEquivalent: number;
+  bFirstBatchEquivalent: number;
+  aFirstDefinitionName: string | null;
+  bFirstDefinitionName: string | null;
+  weakestCondition: {
+    conditionLabel: string;
+    modelCounts: Array<{ modelId: string; label: string; trialCount: number }>;
+    otherConditionsCount: number | null;
+  } | null;
   contributingDefinitionIds: string[];
-  incompleteBatchCount?: number | null;
   definitionId: string | null;
   aggregateRunId: string | null;
-  modelBreakdown?: CoverageModelBreakdownItem[] | null;
 };
 
-function formatDirectionLabel(direction: string): string {
-  const label = VALUE_LABELS[direction as keyof typeof VALUE_LABELS] ?? direction;
-  return `${label}-first`;
-}
-
-function formatCountWord(count: number, singular: string, plural = `${singular}s`): string {
-  return `${count} ${count === 1 ? singular : plural}`;
+function renderBar(count: number, maxCount: number): string {
+  if (maxCount <= 0) return '0%';
+  return `${Math.max(0, Math.min(100, (count / maxCount) * 100))}%`;
 }
 
 export function CoverageCell(props: CoverageCellProps) {
   const {
     valueA,
     valueB,
-    batchCount,
-    pairedBatchCount,
-    orphanedBatchCount,
-    aFirstBatchCount,
-    bFirstBatchCount,
-    pairedConditionCount: _pairedConditionCount,
-    orphanedConditionCount,
-    directionalCoverage,
+    batchEquivalent,
+    aFirstBatchEquivalent,
+    bFirstBatchEquivalent,
+    aFirstDefinitionName,
+    bFirstDefinitionName,
+    weakestCondition,
     contributingDefinitionIds,
-    incompleteBatchCount,
     definitionId,
     aggregateRunId,
-    modelBreakdown,
   } = props;
+
   const [isOpen, setIsOpen] = useState(false);
   const isDiagonal = valueA === valueB;
   const hasVignette = definitionId !== null;
-  const hasIncompleteBatches = (incompleteBatchCount ?? 0) > 0;
-  const displayCount = pairedBatchCount > 0 ? pairedBatchCount : batchCount;
-  const coverageByDirection = new Map(
-    directionalCoverage.map((coverage) => [coverage.direction, coverage] as const),
-  );
-  const directionA = coverageByDirection.get(valueA);
-  const directionB = coverageByDirection.get(valueB);
-  const filledSlotsA = directionA?.filledSlots ?? 0;
-  const filledSlotsB = directionB?.filledSlots ?? 0;
-  const hasImbalance =
-    aFirstBatchCount !== bFirstBatchCount ||
-    filledSlotsA !== filledSlotsB ||
-    orphanedBatchCount > 0;
-  const laggingDirection = hasImbalance
-    ? computeLaggingDirection({
-        valueA,
-        valueB,
-        definitionId,
-        directionalCoverage,
-      })
-    : null;
-  const launchDefinitionId = laggingDirection?.definitionId ?? definitionId;
-  const directionALabel = formatDirectionLabel(valueA);
-  const directionBLabel = formatDirectionLabel(valueB);
-  const visibleLabel = isDiagonal || !hasVignette ? '—' : displayCount.toLocaleString();
+  const hasImbalance = aFirstBatchEquivalent !== bFirstBatchEquivalent;
+  const visibleLabel = isDiagonal || !hasVignette ? '—' : batchEquivalent.toLocaleString();
   const xLabel = VALUE_LABELS[valueB as keyof typeof VALUE_LABELS] ?? valueB;
   const yLabel = VALUE_LABELS[valueA as keyof typeof VALUE_LABELS] ?? valueA;
-  const batchLabel = pairedBatchCount > 0
-    ? (displayCount === 1 ? 'paired batch' : 'paired batches')
-    : (displayCount === 1 ? 'batch' : 'batches');
-
-  const countForColor = displayCount;
+  const directionALabel = aFirstDefinitionName ?? valueA;
+  const directionBLabel = bFirstDefinitionName ?? valueB;
+  const maxDirectionCount = Math.max(aFirstBatchEquivalent, bFirstBatchEquivalent, 1);
+  const countForColor = batchEquivalent;
 
   let bgColorClass = 'bg-gray-50';
   if (isDiagonal) {
@@ -113,41 +69,35 @@ export function CoverageCell(props: CoverageCellProps) {
     bgColorClass = 'bg-emerald-500 hover:bg-emerald-600 transition-colors text-white';
   }
 
-  let tooltipBreakdown: string | undefined;
-  if (hasImbalance) {
-    const directionLines = [
-      `${directionALabel}: ${formatCountWord(aFirstBatchCount, 'batch', 'batches')}, ${formatCountWord(filledSlotsA, 'condition', 'conditions')}`,
-      `${directionBLabel}: ${formatCountWord(bFirstBatchCount, 'batch', 'batches')}, ${formatCountWord(filledSlotsB, 'condition', 'conditions')}`,
-    ];
-    if (orphanedBatchCount > 0) {
-      directionLines.push(formatCountWord(orphanedBatchCount, 'unpaired directional batch', 'unpaired directional batches'));
-    }
-    if (orphanedConditionCount > 0) {
-      directionLines.push(formatCountWord(orphanedConditionCount, 'unpaired condition', 'unpaired conditions'));
-    }
-    tooltipBreakdown = directionLines.join('\n');
-  } else if (modelBreakdown != null && modelBreakdown.length > 0) {
-    tooltipBreakdown = modelBreakdown
-      .map((b) => `${b.label}: ${b.trialCount} trial${b.trialCount === 1 ? '' : 's'}`)
-      .join('\n');
-  }
+  const weakestDirectionName = aFirstBatchEquivalent < bFirstBatchEquivalent
+    ? (aFirstDefinitionName ?? valueA)
+    : (bFirstDefinitionName ?? valueB);
+  const showWeakestCondition = hasVignette && weakestCondition !== null && aFirstBatchEquivalent !== bFirstBatchEquivalent;
+  const batchEquivalentLabel = `${batchEquivalent} batch equivalent${batchEquivalent === 1 ? '' : 's'}`;
+  const visibleTitle = isDiagonal
+    ? 'Not applicable'
+    : !hasVignette
+      ? `${xLabel} versus ${yLabel}: no vignette`
+      : `${xLabel} versus ${yLabel}: ${batchEquivalentLabel}`;
+
+  const aFirstBarWidth = renderBar(aFirstBatchEquivalent, maxDirectionCount);
+  const bFirstBarWidth = renderBar(bFirstBatchEquivalent, maxDirectionCount);
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
-        {/* eslint-disable-next-line react/forbid-elements */}
         <button
           type="button"
           disabled={isDiagonal}
-          title={tooltipBreakdown}
+          title={visibleTitle}
           aria-label={
             isDiagonal
               ? 'Not applicable'
               : !hasVignette
                 ? `${xLabel} versus ${yLabel}: no vignette`
                 : hasImbalance
-                  ? `${xLabel} versus ${yLabel}: ${displayCount} ${batchLabel}; ${directionALabel} ${aFirstBatchCount} batches, ${filledSlotsA} conditions; ${directionBLabel} ${bFirstBatchCount} batches, ${filledSlotsB} conditions`
-                  : `${xLabel} versus ${yLabel}: ${displayCount} ${batchLabel}`
+                  ? `${xLabel} versus ${yLabel}: ${batchEquivalentLabel}; ${directionALabel} ${aFirstBatchEquivalent} batches; ${directionBLabel} ${bFirstBatchEquivalent} batches`
+                  : `${xLabel} versus ${yLabel}: ${batchEquivalentLabel}`
           }
           className={cn(
             'relative w-full h-full min-h-[48px] p-2 flex flex-col items-center justify-center text-sm font-medium border rounded-none focus:ring-0 focus:ring-offset-0',
@@ -156,103 +106,98 @@ export function CoverageCell(props: CoverageCellProps) {
             isDiagonal && 'cursor-not-allowed text-transparent font-normal',
             !isDiagonal && !hasVignette && 'text-gray-500 cursor-pointer hover:bg-gray-100',
             hasVignette && countForColor < 3 && 'text-rose-900',
-            hasVignette && countForColor >= 3 && countForColor < 10 && 'text-amber-900'
+            hasVignette && countForColor >= 3 && countForColor < 10 && 'text-amber-900',
           )}
         >
           {visibleLabel}
-          {hasImbalance && (
-            <span
-              className="text-[10px] text-orange-600 font-normal leading-none mt-0.5"
-              aria-label="direction imbalance across batches"
-            >
-              ⚠
-            </span>
-          )}
-          {hasIncompleteBatches && (
-            <span
-              className="absolute top-1 right-1 w-2 h-2 rounded-full bg-amber-400"
-              aria-label={`${incompleteBatchCount ?? 0} incomplete batch${(incompleteBatchCount ?? 0) === 1 ? '' : 'es'}`}
-            />
-          )}
         </button>
       </PopoverTrigger>
       {!isDiagonal && (
-        <PopoverContent
-          className="w-72 p-0 shadow-lg border-gray-200"
-          align="center"
-          sideOffset={5}
-        >
+        <PopoverContent className="w-80 p-0 shadow-lg border-gray-200" align="center" sideOffset={5}>
           <div className="p-3 border-b border-gray-100 bg-gray-50/50 rounded-t-md">
             {hasVignette ? (
-              <>
-                <div className="mt-2 text-xs text-gray-600 flex items-center">
-                  <span
-                    className={cn(
-                      'inline-block w-2 h-2 rounded-full mr-1.5',
-                      countForColor < 3
-                        ? 'bg-rose-500'
-                        : countForColor < 10
-                          ? 'bg-amber-500'
-                          : 'bg-emerald-500'
-                    )}
-                  />
-                  {displayCount} {batchLabel}
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-medium text-gray-900">
+                  <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-teal-100 text-teal-700 text-xs">
+                    ●
+                  </span>
+                  <span>{batchEquivalentLabel}</span>
                 </div>
-                {hasImbalance && (
-                  <div className="mt-2 rounded border border-orange-200 bg-orange-50 px-2 py-1.5 text-xs text-orange-900">
-                    <div className="font-medium text-orange-800">Direction imbalance</div>
-                    <div className="mt-2 grid grid-cols-[1fr_auto_auto] gap-x-3 gap-y-1">
-                      <div />
-                      <div className="text-right font-medium text-orange-700">Batches</div>
-                      <div className="text-right font-medium text-orange-700">Conditions</div>
-                      <div className="font-medium text-orange-900">{directionALabel}</div>
-                      <div className="text-right font-medium">{aFirstBatchCount}</div>
-                      <div className="text-right font-medium">{filledSlotsA}</div>
-                      <div className="font-medium text-orange-900">{directionBLabel}</div>
-                      <div className="text-right font-medium">{bFirstBatchCount}</div>
-                      <div className="text-right font-medium">{filledSlotsB}</div>
+
+                <div className="space-y-2">
+                  <div className="grid grid-cols-[minmax(0,1fr)_1fr_auto] items-center gap-2 text-xs text-gray-700">
+                    <div className="truncate">{directionALabel}</div>
+                    <div className="h-2 overflow-hidden rounded bg-gray-200">
+                      <div
+                        className="h-full rounded bg-teal-500"
+                        style={{ width: aFirstBarWidth }}
+                      />
                     </div>
-                    {orphanedBatchCount > 0 && (
-                      <div className="mt-2 text-[11px] text-orange-700">
-                        {orphanedBatchCount} unpaired directional batch{orphanedBatchCount === 1 ? '' : 'es'}
+                    <div className="font-medium tabular-nums text-gray-900">
+                      {aFirstBatchEquivalent}
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-[minmax(0,1fr)_1fr_auto] items-center gap-2 text-xs text-gray-700">
+                    <div className="truncate">{directionBLabel}</div>
+                    <div className="h-2 overflow-hidden rounded bg-gray-200">
+                      <div
+                        className="h-full rounded bg-teal-500"
+                        style={{ width: bFirstBarWidth }}
+                      />
+                    </div>
+                    <div className="font-medium tabular-nums text-gray-900">
+                      {bFirstBatchEquivalent}
+                    </div>
+                  </div>
+                </div>
+
+                {showWeakestCondition && (
+                  <div className="space-y-2 rounded border border-gray-200 bg-white p-3">
+                    <div>
+                      <div className="text-sm font-medium text-gray-900">Weakest condition</div>
+                      <div className="text-xs text-gray-500">({weakestDirectionName})</div>
+                    </div>
+
+                    <div className="space-y-2">
+                      {weakestCondition.modelCounts.map((model) => {
+                        const maxModelCount = Math.max(
+                          ...weakestCondition.modelCounts.map((entry) => entry.trialCount),
+                          1,
+                        );
+                        return (
+                          <div key={model.modelId} className="grid grid-cols-[minmax(0,1fr)_1fr_auto] items-center gap-2 text-xs text-gray-700">
+                            <div className="truncate">{model.label}</div>
+                            <div className="h-2 overflow-hidden rounded bg-gray-200">
+                              <div
+                                className="h-full rounded bg-teal-500"
+                                style={{ width: renderBar(model.trialCount, maxModelCount) }}
+                              />
+                            </div>
+                            <div className="font-medium tabular-nums text-gray-900">
+                              {model.trialCount}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+
+                    {weakestCondition.otherConditionsCount !== null && (
+                      <div className="text-xs text-gray-500">
+                        All other conditions: {weakestCondition.otherConditionsCount} per model
                       </div>
                     )}
-                    {orphanedConditionCount > 0 && (
-                      <div className="mt-1 text-[11px] text-orange-700">
-                        {orphanedConditionCount} unpaired condition{orphanedConditionCount === 1 ? '' : 's'}
-                      </div>
-                    )}
                   </div>
                 )}
-                {modelBreakdown != null && modelBreakdown.length > 0 && (
-                  <div className="mt-2 space-y-0.5">
-                    <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-gray-500">
-                      Transcripts
-                    </div>
-                    {modelBreakdown.map((b) => (
-                      <div key={b.modelId} className="flex items-center justify-between text-xs text-gray-600">
-                        <span className="truncate mr-2">{b.label}</span>
-                        <span className="font-medium">{b.trialCount}</span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {hasIncompleteBatches && (
-                  <div className="mt-2 flex items-center gap-1.5 text-xs text-amber-700">
-                    <span className="inline-block w-2 h-2 rounded-full bg-amber-400 flex-shrink-0" />
-                    {incompleteBatchCount ?? 0} incomplete batch{(incompleteBatchCount ?? 0) === 1 ? '' : 'es'} — not all transcripts generated
-                  </div>
-                )}
-              </>
+              </div>
             ) : (
-              <div className="mt-2 text-xs text-gray-500">No batch for this value pair</div>
+              <div className="text-xs text-gray-500">No batch for this value pair</div>
             )}
           </div>
 
           <div className="p-1 flex flex-col">
             {hasVignette && aggregateRunId !== null && (
               <Link
-                to={`/analysis/${aggregateRunId}?tab=overview&mode=single&coverageBatchCount=${batchCount}&coveragePairedBatchCount=${pairedBatchCount}`}
+                to={`/analysis/${aggregateRunId}?tab=overview&mode=single&coverageBatchCount=${batchEquivalent}&coveragePairedBatchCount=${batchEquivalent}`}
                 className="flex items-center justify-between px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-sm w-full text-left"
                 onClick={() => setIsOpen(false)}
               >
@@ -264,19 +209,9 @@ export function CoverageCell(props: CoverageCellProps) {
               </Link>
             )}
 
-            {/*
-              Match Pair Counts gate: `hasImbalance` already excludes cells whose
-              data is purely aggregate (aggregate runs do not contribute to
-              orphanedBatchCount or orphanedConditionCount per the resolver).
-              An earlier draft also gated on `aggregateRunId === null`, but the
-              resolver sets that field from `latestAggregateRunIdByDefinitionId
-              ?? latestMatchingRunIdByDefinitionId`, so it is non-null on every
-              cell that has any completed run — making the gate hide the CTA
-              on virtually every cell with real data. The gate is removed.
-            */}
-            {hasVignette && hasImbalance && launchDefinitionId !== null && (
+            {hasVignette && hasImbalance && definitionId !== null && (
               <Link
-                to={`/definitions/${launchDefinitionId}/start-paired-batch`}
+                to={`/definitions/${definitionId}/start-paired-batch`}
                 state={{
                   returnLabel: 'Back to Value coverage',
                   returnTo: `${window.location.pathname}${window.location.search}`,
@@ -285,18 +220,18 @@ export function CoverageCell(props: CoverageCellProps) {
                     valueA,
                     valueB,
                     contributingDefinitionIds: contributingDefinitionIds.slice().sort((left, right) => left.localeCompare(right)),
-                    launchDefinitionId,
-                    laggingDirection: laggingDirection?.direction ?? (filledSlotsA <= filledSlotsB ? valueA : valueB),
+                    launchDefinitionId: definitionId,
+                    laggingDirection: aFirstBatchEquivalent <= bFirstBatchEquivalent ? valueA : valueB,
                     before: {
                       directionA: {
                         name: valueA,
-                        batches: aFirstBatchCount,
-                        conditions: filledSlotsA,
+                        batches: aFirstBatchEquivalent,
+                        conditions: aFirstBatchEquivalent,
                       },
                       directionB: {
                         name: valueB,
-                        batches: bFirstBatchCount,
-                        conditions: filledSlotsB,
+                        batches: bFirstBatchEquivalent,
+                        conditions: bFirstBatchEquivalent,
                       },
                     },
                   },
@@ -312,7 +247,7 @@ export function CoverageCell(props: CoverageCellProps) {
               </Link>
             )}
 
-            {hasVignette && (
+            {hasVignette && definitionId !== null && (
               <Link
                 to={`/definitions/${definitionId}/start-paired-batch`}
                 state={{

--- a/cloud/apps/web/src/components/domains/CoverageCell.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageCell.tsx
@@ -86,6 +86,7 @@ export function CoverageCell(props: CoverageCellProps) {
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
+        {/* eslint-disable-next-line react/forbid-elements */}
         <button
           type="button"
           disabled={isDiagonal}

--- a/cloud/apps/web/src/components/domains/CoverageMatrix.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageMatrix.tsx
@@ -393,19 +393,19 @@ export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
                           <CoverageCell
                             valueA={rowVal}
                             valueB={colVal}
-                            batchCount={cell?.batchCount ?? 0}
-                            pairedBatchCount={cell?.pairedBatchCount ?? 0}
-                            orphanedBatchCount={cell?.orphanedBatchCount ?? 0}
-                            aFirstBatchCount={cell?.aFirstBatchCount ?? 0}
-                            bFirstBatchCount={cell?.bFirstBatchCount ?? 0}
-                            pairedConditionCount={cell?.pairedConditionCount ?? 0}
-                            orphanedConditionCount={cell?.orphanedConditionCount ?? 0}
-                            directionalCoverage={cell?.directionalCoverage ?? []}
+                            batchEquivalent={cell?.batchEquivalent ?? 0}
+                            aFirstBatchEquivalent={cell?.aFirstBatchEquivalent ?? 0}
+                            bFirstBatchEquivalent={cell?.bFirstBatchEquivalent ?? 0}
+                            aFirstDefinitionName={cell?.aFirstDefinitionName ?? null}
+                            bFirstDefinitionName={cell?.bFirstDefinitionName ?? null}
+                            weakestCondition={cell?.weakestCondition != null ? {
+                              conditionLabel: cell.weakestCondition.conditionLabel,
+                              modelCounts: cell.weakestCondition.modelCounts,
+                              otherConditionsCount: cell.weakestCondition.otherConditionsCount ?? null,
+                            } : null}
                             contributingDefinitionIds={cell?.contributingDefinitionIds ?? []}
-                            incompleteBatchCount={cell?.incompleteBatchCount ?? 0}
                             definitionId={cell?.definitionId ?? null}
                             aggregateRunId={cell?.aggregateRunId ?? null}
-                            modelBreakdown={cell?.modelBreakdown ?? null}
                           />
                         </td>
                       );

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -438,10 +438,24 @@ export type CoverageModelBreakdown = {
   trialCount: Scalars['Int']['output'];
 };
 
+export type CoverageModelCount = {
+  __typename?: 'CoverageModelCount';
+  label: Scalars['String']['output'];
+  modelId: Scalars['String']['output'];
+  trialCount: Scalars['Int']['output'];
+};
+
 export type CoverageModelOption = {
   __typename?: 'CoverageModelOption';
   label: Scalars['String']['output'];
   modelId: Scalars['String']['output'];
+};
+
+export type CoverageWeakestCondition = {
+  __typename?: 'CoverageWeakestCondition';
+  conditionLabel: Scalars['String']['output'];
+  modelCounts: Array<CoverageModelCount>;
+  otherConditionsCount?: Maybe<Scalars['Int']['output']>;
 };
 
 export type CreateApiKeyInput = {
@@ -1168,32 +1182,15 @@ export type DomainTrialRunStatus = {
 
 export type DomainValueCoverageCell = {
   __typename?: 'DomainValueCoverageCell';
-  /** Count of complete A-first runs for this value pair after model-set filtering. This is the filtered directional count for the first value in the pair. */
-  aFirstBatchCount: Scalars['Int']['output'];
+  aFirstBatchEquivalent: Scalars['Int']['output'];
+  aFirstDefinitionName?: Maybe<Scalars['String']['output']>;
   aggregateRunId?: Maybe<Scalars['String']['output']>;
-  /** Count of complete B-first runs for this value pair after model-set filtering. This is the filtered directional count for the second value in the pair. */
-  bFirstBatchCount: Scalars['Int']['output'];
-  /** Count of fully-complete non-aggregate runs for this value pair. A run is complete when every selected model has at least one transcript at every (scenario × sampleIndex) slot. samplesPerScenario does not multiply this count -- a complete run contributes 1 regardless of how many samples per scenario were planned. Aggregate runs are excluded. */
-  batchCount: Scalars['Int']['output'];
-  /** Union of definition IDs that contribute data to this coverage cell, sorted alphabetically. */
+  bFirstBatchEquivalent: Scalars['Int']['output'];
+  bFirstDefinitionName?: Maybe<Scalars['String']['output']>;
+  batchEquivalent: Scalars['Int']['output'];
   contributingDefinitionIds: Array<Scalars['String']['output']>;
   definitionId?: Maybe<Scalars['String']['output']>;
-  definitionName?: Maybe<Scalars['String']['output']>;
-  /** Per-direction condition coverage for this value pair, including complete batches, filled slots, leftover conditions from incomplete runs, and contributing definition IDs. */
-  directionalCoverage: Array<DirectionalCoverage>;
-  /** Count of non-aggregate runs that expect transcripts but are missing one or more (model × scenario × sampleIndex) slots. Per-run; samplesPerScenario does not multiply this count. Aggregate runs and runs with zero expected slots are excluded. */
-  incompleteBatchCount: Scalars['Int']['output'];
-  maxTrialCount?: Maybe<Scalars['Int']['output']>;
-  minTrialCount?: Maybe<Scalars['Int']['output']>;
-  modelBreakdown?: Maybe<Array<CoverageModelBreakdown>>;
-  /** Count of unmatched directional runs for this value pair, computed as max(complete A-first runs, complete B-first runs) - min(complete A-first runs, complete B-first runs). When both directions are equal this is 0; when only one direction has runs this is the count of that side. Runs without a recognizable direction token are excluded. */
-  orphanedBatchCount: Scalars['Int']['output'];
-  /** Count of unmatched condition slots across both directions, computed as the size of the symmetric difference of filled (scenarioId, modelId, sampleIndex) slots. */
-  orphanedConditionCount: Scalars['Int']['output'];
-  /** Count of pairable analysis-ready batches for this value pair, computed as min(complete A-first non-aggregate runs, complete B-first non-aggregate runs) where direction is read from config.jobChoiceValueFirst. A launch where only one direction completed contributes 0 here (the surviving complete run still appears in batchCount). Runs without a recognizable direction token are excluded from both sides. See docs/canonical-glossary.md "Paired Batch" for full semantic. */
-  pairedBatchCount: Scalars['Int']['output'];
-  /** Count of matched condition slots across both directions, computed as the size of the intersection of filled (scenarioId, modelId, sampleIndex) slots. */
-  pairedConditionCount: Scalars['Int']['output'];
+  weakestCondition?: Maybe<CoverageWeakestCondition>;
   valueA: Scalars['String']['output'];
   valueB: Scalars['String']['output'];
 };
@@ -4286,7 +4283,7 @@ export type DomainValueCoverageQueryVariables = Exact<{
 }>;
 
 
-export type DomainValueCoverageQuery = { __typename?: 'Query', domainValueCoverage?: { __typename?: 'DomainValueCoverageResult', domainId: string, values: Array<string>, cells: Array<{ __typename?: 'DomainValueCoverageCell', valueA: string, valueB: string, batchCount: number, pairedBatchCount: number, orphanedBatchCount: number, aFirstBatchCount: number, bFirstBatchCount: number, pairedConditionCount: number, orphanedConditionCount: number, contributingDefinitionIds: Array<string>, incompleteBatchCount: number, definitionId?: string | null, definitionName?: string | null, aggregateRunId?: string | null, minTrialCount?: number | null, maxTrialCount?: number | null, directionalCoverage: Array<{ __typename?: 'DirectionalCoverage', direction: string, completeBatches: number, filledSlots: number, leftoverConditions: number, definitionIds: Array<string> }>, modelBreakdown?: Array<{ __typename?: 'CoverageModelBreakdown', modelId: string, label: string, trialCount: number }> | null }>, availableModels: Array<{ __typename?: 'CoverageModelOption', modelId: string, label: string }> } | null };
+export type DomainValueCoverageQuery = { __typename?: 'Query', domainValueCoverage?: { __typename?: 'DomainValueCoverageResult', domainId: string, values: Array<string>, cells: Array<{ __typename?: 'DomainValueCoverageCell', valueA: string, valueB: string, batchEquivalent: number, aFirstBatchEquivalent: number, bFirstBatchEquivalent: number, aFirstDefinitionName?: string | null, bFirstDefinitionName?: string | null, weakestCondition?: { __typename?: 'CoverageWeakestCondition', conditionLabel: string, otherConditionsCount?: number | null, modelCounts: Array<{ __typename?: 'CoverageModelCount', modelId: string, label: string, trialCount: number }> } | null, contributingDefinitionIds: Array<string>, definitionId?: string | null, aggregateRunId?: string | null }>, availableModels: Array<{ __typename?: 'CoverageModelOption', modelId: string, label: string }> } | null };
 
 export type DomainValueCoverageLegacyQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -4294,7 +4291,7 @@ export type DomainValueCoverageLegacyQueryVariables = Exact<{
 }>;
 
 
-export type DomainValueCoverageLegacyQuery = { __typename?: 'Query', domainValueCoverage?: { __typename?: 'DomainValueCoverageResult', domainId: string, values: Array<string>, cells: Array<{ __typename?: 'DomainValueCoverageCell', valueA: string, valueB: string, batchCount: number, pairedBatchCount: number, orphanedBatchCount: number, aFirstBatchCount: number, bFirstBatchCount: number, pairedConditionCount: number, orphanedConditionCount: number, contributingDefinitionIds: Array<string>, definitionId?: string | null, definitionName?: string | null, aggregateRunId?: string | null, directionalCoverage: Array<{ __typename?: 'DirectionalCoverage', direction: string, completeBatches: number, filledSlots: number, leftoverConditions: number, definitionIds: Array<string> }> }>, availableModels: Array<{ __typename?: 'CoverageModelOption', modelId: string, label: string }> } | null };
+export type DomainValueCoverageLegacyQuery = { __typename?: 'Query', domainValueCoverage?: { __typename?: 'DomainValueCoverageResult', domainId: string, values: Array<string>, cells: Array<{ __typename?: 'DomainValueCoverageCell', valueA: string, valueB: string, batchEquivalent: number, aFirstBatchEquivalent: number, bFirstBatchEquivalent: number, aFirstDefinitionName?: string | null, bFirstDefinitionName?: string | null, weakestCondition?: { __typename?: 'CoverageWeakestCondition', conditionLabel: string, otherConditionsCount?: number | null, modelCounts: Array<{ __typename?: 'CoverageModelCount', modelId: string, label: string, trialCount: number }> } | null, contributingDefinitionIds: Array<string>, definitionId?: string | null, aggregateRunId?: string | null }>, availableModels: Array<{ __typename?: 'CoverageModelOption', modelId: string, label: string }> } | null };
 
 export type DomainsQueryVariables = Exact<{
   search?: InputMaybe<Scalars['String']['input']>;
@@ -6175,32 +6172,23 @@ export const DomainValueCoverageDocument = gql`
     cells {
       valueA
       valueB
-      batchCount
-      pairedBatchCount
-      orphanedBatchCount
-      aFirstBatchCount
-      bFirstBatchCount
-      pairedConditionCount
-      orphanedConditionCount
-      directionalCoverage {
-        direction
-        completeBatches
-        filledSlots
-        leftoverConditions
-        definitionIds
+      batchEquivalent
+      aFirstBatchEquivalent
+      bFirstBatchEquivalent
+      aFirstDefinitionName
+      bFirstDefinitionName
+      weakestCondition {
+        conditionLabel
+        modelCounts {
+          modelId
+          label
+          trialCount
+        }
+        otherConditionsCount
       }
       contributingDefinitionIds
-      incompleteBatchCount
       definitionId
-      definitionName
       aggregateRunId
-      minTrialCount
-      maxTrialCount
-      modelBreakdown {
-        modelId
-        label
-        trialCount
-      }
     }
     availableModels {
       modelId
@@ -6221,23 +6209,22 @@ export const DomainValueCoverageLegacyDocument = gql`
     cells {
       valueA
       valueB
-      batchCount
-      pairedBatchCount
-      orphanedBatchCount
-      aFirstBatchCount
-      bFirstBatchCount
-      pairedConditionCount
-      orphanedConditionCount
-      directionalCoverage {
-        direction
-        completeBatches
-        filledSlots
-        leftoverConditions
-        definitionIds
+      batchEquivalent
+      aFirstBatchEquivalent
+      bFirstBatchEquivalent
+      aFirstDefinitionName
+      bFirstDefinitionName
+      weakestCondition {
+        conditionLabel
+        modelCounts {
+          modelId
+          label
+          trialCount
+        }
+        otherConditionsCount
       }
       contributingDefinitionIds
       definitionId
-      definitionName
       aggregateRunId
     }
     availableModels {

--- a/cloud/apps/web/tests/components/domains/CoverageCell.test.tsx
+++ b/cloud/apps/web/tests/components/domains/CoverageCell.test.tsx
@@ -15,36 +15,22 @@ function renderCell(overrides: Partial<Parameters<typeof CoverageCell>[0]> = {})
               <CoverageCell
                 valueA="Achievement"
                 valueB="Power_Dominance"
-                batchCount={4}
-                pairedBatchCount={2}
-                orphanedBatchCount={0}
-                aFirstBatchCount={2}
-                bFirstBatchCount={2}
-                pairedConditionCount={8}
-                orphanedConditionCount={0}
-                directionalCoverage={[
-                  {
-                    direction: 'Achievement',
-                    completeBatches: 2,
-                    filledSlots: 8,
-                    leftoverConditions: 1,
-                    definitionIds: ['def-a'],
-                  },
-                  {
-                    direction: 'Power_Dominance',
-                    completeBatches: 2,
-                    filledSlots: 10,
-                    leftoverConditions: 2,
-                    definitionIds: ['def-b'],
-                  },
-                ]}
+                batchEquivalent={2}
+                aFirstBatchEquivalent={2}
+                bFirstBatchEquivalent={3}
+                aFirstDefinitionName="Achievement-first vignette"
+                bFirstDefinitionName="Power-first vignette"
+                weakestCondition={{
+                  conditionLabel: '5×1',
+                  modelCounts: [
+                    { modelId: 'gpt-4', label: 'GPT-4', trialCount: 3 },
+                    { modelId: 'gpt-5', label: 'GPT-5', trialCount: 2 },
+                  ],
+                  otherConditionsCount: 4,
+                }}
                 contributingDefinitionIds={['def-a', 'def-b']}
-                incompleteBatchCount={1}
                 definitionId="def-1"
                 aggregateRunId={null}
-                modelBreakdown={[
-                  { modelId: 'gpt-4', label: 'GPT-4', trialCount: 3 },
-                ]}
                 {...overrides}
               />
             </div>
@@ -62,26 +48,23 @@ function LocationStateProbe() {
 }
 
 describe('CoverageCell', () => {
-  it('shows the direction table, transcripts header, and top-up action for imbalanced cells', async () => {
+  it('shows the direction breakdown, weakest condition, and top-up action for imbalanced cells', async () => {
     const user = userEvent.setup();
     renderCell();
 
     await user.click(screen.getByRole('button', { name: /power versus achievement/i }));
 
-    expect(screen.getByText('Direction imbalance')).toBeInTheDocument();
-    expect(screen.getByText('Batches')).toBeInTheDocument();
-    expect(screen.getByText('Conditions')).toBeInTheDocument();
-    expect(screen.getByText('Achievement-first')).toBeInTheDocument();
-    expect(screen.getByText('Power-first')).toBeInTheDocument();
-    expect(screen.getAllByText('2').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('8').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('10').length).toBeGreaterThan(0);
-    expect(screen.getByText('Transcripts')).toBeInTheDocument();
+    expect(screen.getByText('2 batch equivalents')).toBeInTheDocument();
+    expect(screen.getByText('Achievement-first vignette')).toBeInTheDocument();
+    expect(screen.getByText('Power-first vignette')).toBeInTheDocument();
+    expect(screen.getByText('Weakest condition')).toBeInTheDocument();
+    expect(screen.getByText('(Achievement-first vignette)')).toBeInTheDocument();
     expect(screen.getByText('GPT-4')).toBeInTheDocument();
-    expect(screen.getByText('1 incomplete batch — not all transcripts generated')).toBeInTheDocument();
+    expect(screen.getByText('GPT-5')).toBeInTheDocument();
+    expect(screen.getByText('All other conditions: 4 per model')).toBeInTheDocument();
 
     const matchPairCountsLink = screen.getByRole('link', { name: /match pair counts/i });
-    expect(matchPairCountsLink).toHaveAttribute('href', '/definitions/def-a/start-paired-batch');
+    expect(matchPairCountsLink).toHaveAttribute('href', '/definitions/def-1/start-paired-batch');
 
     await user.click(matchPairCountsLink);
 
@@ -93,15 +76,23 @@ describe('CoverageCell', () => {
         launchDefinitionId: string;
         laggingDirection: string;
         contributingDefinitionIds: string[];
+        before: {
+          directionA: { name: string; batches: number; conditions: number };
+          directionB: { name: string; batches: number; conditions: number };
+        };
       };
     };
     expect(state.matchPairCounts).toEqual(expect.objectContaining({
       pairKey: 'achievement::power_dominance',
       valueA: 'Achievement',
       valueB: 'Power_Dominance',
-      launchDefinitionId: 'def-a',
+      launchDefinitionId: 'def-1',
       laggingDirection: 'Achievement',
       contributingDefinitionIds: ['def-a', 'def-b'],
+      before: expect.objectContaining({
+        directionA: expect.objectContaining({ name: 'Achievement', batches: 2, conditions: 2 }),
+        directionB: expect.objectContaining({ name: 'Power_Dominance', batches: 3, conditions: 3 }),
+      }),
     }));
   });
 
@@ -111,22 +102,14 @@ describe('CoverageCell', () => {
     // `aggregateRunId` from `latestAggregateRunIdByDefinitionId ?? latestMatchingRunIdByDefinitionId`,
     // so it is non-null on every cell with any completed run — the gate was
     // hiding the CTA on virtually every cell with real data. The correct gate
-    // is `hasImbalance` only; cells with purely aggregate data already report
-    // `orphanedBatchCount = 0` and `orphanedConditionCount = 0` because the
-    // resolver excludes aggregate runs from those counts. So setting
-    // aggregateRunId without any imbalance signal must hide the CTA.
+    // is `hasImbalance` only. So setting aggregateRunId without any imbalance
+    // signal must hide the CTA.
     const user = userEvent.setup();
     renderCell({
       aggregateRunId: 'run-1',
-      orphanedBatchCount: 0,
-      orphanedConditionCount: 0,
-      aFirstBatchCount: 2,
-      bFirstBatchCount: 2,
-      directionalCoverage: [
-        { direction: 'Achievement', completeBatches: 2, filledSlots: 8, leftoverConditions: 0, definitionIds: ['def-a'] },
-        { direction: 'Power_Dominance', completeBatches: 2, filledSlots: 8, leftoverConditions: 0, definitionIds: ['def-b'] },
-      ],
-      incompleteBatchCount: 0,
+      aFirstBatchEquivalent: 2,
+      bFirstBatchEquivalent: 2,
+      weakestCondition: null,
     });
 
     await user.click(screen.getByRole('button', { name: /power versus achievement/i }));
@@ -137,12 +120,14 @@ describe('CoverageCell', () => {
 
   it('shows Match Pair Counts on imbalanced cells regardless of aggregateRunId', async () => {
     // Companion to the test above: when the cell has an imbalance signal
-    // (orphanedBatchCount, orphanedConditionCount, mismatched filledSlots, or
-    // mismatched a/b-first batch counts), the CTA must show even when
+    // (mismatched a/b-first batch equivalents), the CTA must show even when
     // aggregateRunId is non-null.
     const user = userEvent.setup();
     renderCell({
       aggregateRunId: 'run-1',
+      aFirstBatchEquivalent: 1,
+      bFirstBatchEquivalent: 2,
+      weakestCondition: null,
     });
 
     await user.click(screen.getByRole('button', { name: /power versus achievement/i }));

--- a/cloud/apps/web/tests/pages/DomainCoverage.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainCoverage.test.tsx
@@ -46,10 +46,14 @@ const coverageByDomain = {
       {
         valueA: 'Achievement',
         valueB: 'Self_Direction_Action',
-        batchCount: 3,
-        pairedBatchCount: 2,
+        batchEquivalent: 2,
+        aFirstBatchEquivalent: 2,
+        bFirstBatchEquivalent: 3,
+        aFirstDefinitionName: 'A vs B',
+        bFirstDefinitionName: 'B vs A',
+        weakestCondition: null,
+        contributingDefinitionIds: ['def-1'],
         definitionId: 'def-1',
-        definitionName: 'A vs B',
         aggregateRunId: 'run-1',
       },
     ],
@@ -65,10 +69,14 @@ const coverageByDomain = {
       {
         valueA: 'Achievement',
         valueB: 'Self_Direction_Action',
-        batchCount: 4,
-        pairedBatchCount: 3,
+        batchEquivalent: 3,
+        aFirstBatchEquivalent: 3,
+        bFirstBatchEquivalent: 4,
+        aFirstDefinitionName: 'B vs A',
+        bFirstDefinitionName: 'A vs B',
+        weakestCondition: null,
+        contributingDefinitionIds: ['def-2'],
         definitionId: 'def-2',
-        definitionName: 'B vs A',
         aggregateRunId: 'run-2',
       },
     ],
@@ -250,7 +258,7 @@ describe('DomainCoverage Page', () => {
 
     await act(async () => {
       await user.click(
-        screen.getByRole('button', { name: /self-direction versus achievement.*2 paired batch/i })
+        screen.getByRole('button', { name: /self-direction versus achievement.*2 batch equivalent/i })
       );
     });
 
@@ -264,7 +272,7 @@ describe('DomainCoverage Page', () => {
     expect(url.pathname).toBe('/analysis/run-1');
     expect(url.searchParams.get('tab')).toBe('overview');
     expect(url.searchParams.get('mode')).toBe('single');
-    expect(url.searchParams.get('coverageBatchCount')).toBe('3');
+    expect(url.searchParams.get('coverageBatchCount')).toBe('2');
     expect(url.searchParams.get('coveragePairedBatchCount')).toBe('2');
     expect(screen.queryByRole('link', { name: /view domain analysis/i })).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Replaces run-completeness counting with direct trial aggregation per condition per model
- A **batch equivalent** = min across all conditions of (min trials per selected model); two companion vignettes produce a cell value of min(A-first batch equiv, B-first batch equiv)
- New popover UI shows direction breakdown (vignette names + proportional progress bars) and a weakest-condition panel that appears only when coverage is uneven
- Removes orphaned-batch, incomplete-batch, and per-model-transcript-breakdown concepts

## How it works
For each value-pair cell, transcripts from completed runs are aggregated into a nested map: `definition → direction → scenario → model → count`. The batch equivalent for a direction is `min(min per model across all scenarios)`. The weakest-condition panel shows the single scenario with the lowest per-model count (hidden when all conditions are equal).

## Test plan
- [ ] All 1333 web tests pass (verified locally)
- [ ] API type-checks clean (0 TS errors)
- [ ] Web type-checks clean (0 TS errors)
- [ ] CI green

## Validation
```
api: tsc --noEmit → 0 errors
web: tsc --noEmit → 0 errors
web: vitest run → 1333 passed, 8 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)