### PR TITLE
refactor: share value-aggregation between domain-analysis and pressure-sensitivity

### DIFF
--- a/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
@@ -12,11 +12,13 @@ import {
   type PressureSensitivityModelShape,
   type PressureSensitivityResultShape,
   type PressureSensitivityValuePairShape,
+  type PressureSensitivityValueRateShape,
   type SensitivityCellShape,
 } from '../types/pressure-sensitivity.js';
 import { buildSafeLevelLookup, type DefinitionDimension } from './scenarios-utils.js';
 import { normalizeScenarioAnalysisMetadata } from '../../services/analysis/scenario-metadata.js';
 import {
+  buildCellMetrics,
   buildVignetteWeightedCellMetrics,
   computeDirectionBalancedPairWinRates,
   pooledDirectionalReduction,
@@ -36,6 +38,7 @@ import {
   buildPressureSensitivityDecisionSnapshot,
   type PressureSensitivityDecisionSnapshot,
 } from '../../services/pressure-sensitivity/decision-snapshot.js';
+import { aggregateValueWinRates } from '../../services/analysis/value-win-rate-aggregation.js';
 
 const log = createLogger('pressure-sensitivity');
 const MIN_N = 3;
@@ -113,6 +116,21 @@ type PressureConditionExclusionBreakdown = {
   levelAssignment: number;
 };
 
+type ValueRateFilter =
+  | 'all'
+  | 'balanced'
+  | 'highPressureOnValue'
+  | 'highPressureOnOpposingValue';
+
+type ValueRateCellAccumulator = {
+  valueKey: string;
+  definitionId: string;
+  domainId: string;
+  pairKey: string;
+  directionKey: string;
+  cellRates: number[];
+};
+
 function cellKey(ownLevel: number, opponentLevel: number): string {
   return `${ownLevel}::${opponentLevel}`;
 }
@@ -177,6 +195,78 @@ export function buildSourceRunToDefIdMap(
 
 function formatValueLabel(token: string): string {
   return token.replaceAll('_', ' ').trim();
+}
+
+function shouldIncludeValueRateCell(
+  filter: ValueRateFilter,
+  isCanonicalFirst: boolean,
+  ownLevel: number,
+  opponentLevel: number,
+): boolean {
+  if (filter === 'all') return true;
+  if (filter === 'balanced') return ownLevel === opponentLevel;
+
+  if (isCanonicalFirst) {
+    if (filter === 'highPressureOnValue') {
+      return ownLevel >= 4 && opponentLevel <= 3;
+    }
+    return opponentLevel >= 4 && ownLevel <= 3;
+  }
+
+  if (filter === 'highPressureOnValue') {
+    return opponentLevel >= 4 && ownLevel <= 3;
+  }
+  return ownLevel >= 4 && opponentLevel <= 3;
+}
+
+function addValueRateCell(
+  groups: Map<string, ValueRateCellAccumulator>,
+  params: {
+    valueKey: string;
+    definitionId: string;
+    domainId: string;
+    pairKey: string;
+    directionKey: string;
+    cellRate: number;
+  },
+): void {
+  const key = [
+    params.valueKey,
+    params.definitionId,
+    params.domainId,
+    params.pairKey,
+    params.directionKey,
+  ].join('||');
+  const existing = groups.get(key) ?? {
+    valueKey: params.valueKey,
+    definitionId: params.definitionId,
+    domainId: params.domainId,
+    pairKey: params.pairKey,
+    directionKey: params.directionKey,
+    cellRates: [],
+  };
+  existing.cellRates.push(params.cellRate);
+  groups.set(key, existing);
+}
+
+function toValueRateInputs(groups: Map<string, ValueRateCellAccumulator>) {
+  const inputs = [];
+
+  for (const group of groups.values()) {
+    if (group.cellRates.length === 0) continue;
+    const vignetteRate =
+      group.cellRates.reduce((sum, rate) => sum + rate, 0) / group.cellRates.length;
+    inputs.push({
+      domainId: group.domainId,
+      definitionId: group.definitionId,
+      valueKey: group.valueKey,
+      pairKey: group.pairKey,
+      directionKey: group.directionKey,
+      vignetteRate,
+    });
+  }
+
+  return inputs;
 }
 
 function emptyPressureConditionExclusionBreakdown(): PressureConditionExclusionBreakdown {
@@ -581,6 +671,7 @@ builder.queryField('pressureSensitivity', (t) =>
       for (const model of models) {
         const pairs = perModel.get(model.modelId) ?? new Map<string, PairAccumulator>();
         const valuePairs: PressureSensitivityValuePairShape[] = [];
+        const pairKeysByValue = new Map<string, Set<string>>();
         let modelUnscored = 0;
         const perPairPressureResponses: number[] = [];
 
@@ -667,6 +758,14 @@ builder.queryField('pressureSensitivity', (t) =>
             directionBalancedHighPressureOpponentOpponentWinRate: dbHighOpponent.opponentRate,
           });
 
+          const firstPairKeys = pairKeysByValue.get(acc.firstValueToken) ?? new Set<string>();
+          firstPairKeys.add(acc.pairKey);
+          pairKeysByValue.set(acc.firstValueToken, firstPairKeys);
+
+          const secondPairKeys = pairKeysByValue.get(acc.secondValueToken) ?? new Set<string>();
+          secondPairKeys.add(acc.pairKey);
+          pairKeysByValue.set(acc.secondValueToken, secondPairKeys);
+
           if (pressureResponse.value !== null) {
             perPairPressureResponses.push(pressureResponse.value);
 
@@ -690,6 +789,95 @@ builder.queryField('pressureSensitivity', (t) =>
           }
         }
 
+        const valueRateGroupsByFilter: Record<ValueRateFilter, Map<string, ValueRateCellAccumulator>> = {
+          all: new Map(),
+          balanced: new Map(),
+          highPressureOnValue: new Map(),
+          highPressureOnOpposingValue: new Map(),
+        };
+
+        for (const acc of pairs.values()) {
+          for (const [, cellAcc] of acc.cells) {
+            for (const [defId, observations] of cellAcc.observationsByDefinition.entries()) {
+              const authoredFirstToken = authoredFirstTokenByDef.get(defId);
+              if (authoredFirstToken == null) continue;
+
+              const metrics = buildCellMetrics([...observations]);
+              if (
+                metrics.n === 0
+                || metrics.winRate == null
+                || metrics.opponentWinRate == null
+              ) {
+                continue;
+              }
+
+              const domainForDefinition = domainByDef.get(defId) ?? defId;
+              const sides = [
+                {
+                  valueToken: acc.firstValueToken,
+                  cellRate: metrics.winRate,
+                  isCanonicalFirst: true,
+                },
+                {
+                  valueToken: acc.secondValueToken,
+                  cellRate: metrics.opponentWinRate,
+                  isCanonicalFirst: false,
+                },
+              ] as const;
+
+              for (const side of sides) {
+                if (side.cellRate == null) continue;
+
+                for (const filter of Object.keys(valueRateGroupsByFilter) as ValueRateFilter[]) {
+                  if (
+                    !shouldIncludeValueRateCell(
+                      filter,
+                      side.isCanonicalFirst,
+                      cellAcc.ownLevel,
+                      cellAcc.opponentLevel,
+                    )
+                  ) {
+                    continue;
+                  }
+
+                  addValueRateCell(valueRateGroupsByFilter[filter], {
+                    valueKey: side.valueToken,
+                    definitionId: defId,
+                    domainId: domainForDefinition,
+                    pairKey: acc.pairKey,
+                    directionKey: authoredFirstToken,
+                    cellRate: side.cellRate,
+                  });
+                }
+              }
+            }
+          }
+        }
+
+        const allValueRates = aggregateValueWinRates(toValueRateInputs(valueRateGroupsByFilter.all));
+        const balancedValueRates = aggregateValueWinRates(
+          toValueRateInputs(valueRateGroupsByFilter.balanced),
+        );
+        const highPressureOnValueRates = aggregateValueWinRates(
+          toValueRateInputs(valueRateGroupsByFilter.highPressureOnValue),
+        );
+        const highPressureOnOpposingValueRates = aggregateValueWinRates(
+          toValueRateInputs(valueRateGroupsByFilter.highPressureOnOpposingValue),
+        );
+
+        const valueTokens = [...pairKeysByValue.keys()].sort((left, right) => left.localeCompare(right));
+        const valueRates: PressureSensitivityValueRateShape[] = valueTokens.map((valueToken) => ({
+          valueToken,
+          valueLabel: formatValueLabel(valueToken),
+          averageWinRate: allValueRates.get(valueToken)?.crossDomainRate ?? null,
+          balancedWinRate: balancedValueRates.get(valueToken)?.crossDomainRate ?? null,
+          highPressureOnThisValueWinRate:
+            highPressureOnValueRates.get(valueToken)?.crossDomainRate ?? null,
+          highPressureOnOpposingValueWinRate:
+            highPressureOnOpposingValueRates.get(valueToken)?.crossDomainRate ?? null,
+          pairsMeasured: pairKeysByValue.get(valueToken)?.size ?? 0,
+        }));
+
         const pressureResponseSummary = summarizePressureResponse(perPairPressureResponses);
 
         if (valuePairs.length === 0 || pressureResponseSummary.pairsMeasured === 0) {
@@ -708,6 +896,7 @@ builder.queryField('pressureSensitivity', (t) =>
           providerName: model.provider.displayName ?? model.provider.name,
           pressureResponseSummary,
           valuePairs: valuePairs.sort((a, b) => a.pairKey.localeCompare(b.pairKey)),
+          valueRates,
           unscoredCount: modelUnscored,
         });
       }

--- a/cloud/apps/api/src/graphql/types/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/types/pressure-sensitivity.ts
@@ -58,12 +58,23 @@ export type PressureSensitivityValuePairShape = {
   directionBalancedHighPressureOpponentOpponentWinRate: number | null;
 };
 
+export type PressureSensitivityValueRateShape = {
+  valueToken: string;
+  valueLabel: string;
+  averageWinRate: number | null;
+  balancedWinRate: number | null;
+  highPressureOnThisValueWinRate: number | null;
+  highPressureOnOpposingValueWinRate: number | null;
+  pairsMeasured: number;
+};
+
 export type PressureSensitivityModelShape = {
   modelId: string;
   label: string;
   providerName: string;
   pressureResponseSummary: PressureResponseSummaryShape;
   valuePairs: PressureSensitivityValuePairShape[];
+  valueRates: PressureSensitivityValueRateShape[];
   unscoredCount: number;
 };
 
@@ -121,6 +132,9 @@ const PressureResponseSummaryRef = builder.objectRef<PressureResponseSummaryShap
 );
 const PressureSensitivityValuePairRef = builder.objectRef<PressureSensitivityValuePairShape>(
   'PressureSensitivityValuePair',
+);
+const PressureSensitivityValueRateRef = builder.objectRef<PressureSensitivityValueRateShape>(
+  'PressureSensitivityValueRate',
 );
 const PressureSensitivityModelRef = builder.objectRef<PressureSensitivityModelShape>(
   'PressureSensitivityModel',
@@ -204,6 +218,23 @@ builder.objectType(PressureSensitivityValuePairRef, {
   }),
 });
 
+builder.objectType(PressureSensitivityValueRateRef, {
+  fields: (t) => ({
+    valueToken: t.exposeString('valueToken'),
+    valueLabel: t.exposeString('valueLabel'),
+    averageWinRate: t.exposeFloat('averageWinRate', { nullable: true }),
+    balancedWinRate: t.exposeFloat('balancedWinRate', { nullable: true }),
+    highPressureOnThisValueWinRate: t.exposeFloat('highPressureOnThisValueWinRate', {
+      nullable: true,
+    }),
+    highPressureOnOpposingValueWinRate: t.exposeFloat(
+      'highPressureOnOpposingValueWinRate',
+      { nullable: true },
+    ),
+    pairsMeasured: t.exposeInt('pairsMeasured'),
+  }),
+});
+
 builder.objectType(PressureSensitivityModelRef, {
   fields: (t) => ({
     modelId: t.exposeString('modelId'),
@@ -213,6 +244,7 @@ builder.objectType(PressureSensitivityModelRef, {
       type: PressureResponseSummaryRef,
     }),
     valuePairs: t.expose('valuePairs', { type: [PressureSensitivityValuePairRef] }),
+    valueRates: t.expose('valueRates', { type: [PressureSensitivityValueRateRef] }),
     unscoredCount: t.exposeInt('unscoredCount'),
   }),
 });

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cell-win-rates.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cell-win-rates.ts
@@ -5,6 +5,9 @@ import {
 } from '../../graphql/queries/domain-analysis-values.js';
 import type { DomainAnalysisValueCounts } from '../../graphql/queries/domain/shared.js';
 import { decodeCellKey, type CellCounts } from './transcript-cell-accumulator.js';
+import { aggregateValueWinRates } from './value-win-rate-aggregation.js';
+
+const SNAPSHOT_DOMAIN_ID = '__snapshot_domain__';
 
 export type CellWeightedDomainModel = {
   model: string;
@@ -126,13 +129,7 @@ export function computeCellWeightedDomainRates(params: {
     .map((modelId) => {
       const valueCounts = countsByModel.get(modelId) ?? new Map<DomainAnalysisValueKey, DomainAnalysisValueCounts>();
       const modelDefinitionRates = ratesByModelDefinitionValue.get(modelId) ?? new Map<string, Map<DomainAnalysisValueKey, number[]>>();
-
-      // Aggregation chain: conditions → vignette → direction → pair → domain.
-      // This ensures extra vignettes in one direction or for one pair do not inflate that
-      // pairing's weight in the final domain win rate.
-      //
-      // Structure: pairKey → directionKey → valueKey → [per-vignette rates]
-      const ratesByPairDirection = new Map<string, Map<DomainAnalysisValueKey, Map<DomainAnalysisValueKey, number[]>>>();
+      const inputs = [];
 
       for (const [definitionId, valueRatesByDefinition] of modelDefinitionRates.entries()) {
         const pair = params.definitionValuePairById.get(definitionId);
@@ -140,51 +137,30 @@ export function computeCellWeightedDomainRates(params: {
         const pairKey = `${pair.valueA}::${pair.valueB}`;
         const directionKey: DomainAnalysisValueKey = pair.valueFirst ?? pair.valueA;
 
-        const byDirection = ratesByPairDirection.get(pairKey) ?? new Map<DomainAnalysisValueKey, Map<DomainAnalysisValueKey, number[]>>();
-        if (!ratesByPairDirection.has(pairKey)) ratesByPairDirection.set(pairKey, byDirection);
-
-        const byValue = byDirection.get(directionKey) ?? new Map<DomainAnalysisValueKey, number[]>();
-        if (!byDirection.has(directionKey)) byDirection.set(directionKey, byValue);
-
         for (const [valueKey, rates] of valueRatesByDefinition.entries()) {
           if (rates.length === 0) continue;
           const vignetteRate = rates.reduce((sum, r) => sum + r, 0) / rates.length;
-          const existing = byValue.get(valueKey) ?? [];
-          existing.push(vignetteRate);
-          byValue.set(valueKey, existing);
+          inputs.push({
+            domainId: SNAPSHOT_DOMAIN_ID,
+            definitionId,
+            valueKey,
+            pairKey,
+            directionKey,
+            vignetteRate,
+          });
         }
       }
-
-      // Roll up: directions → pair rate, then pairs → domain rate.
-      const pairRatesByValue = new Map<DomainAnalysisValueKey, number[]>();
-      for (const [, byDirection] of ratesByPairDirection.entries()) {
-        const allValueKeys = new Set<DomainAnalysisValueKey>();
-        for (const [, byValue] of byDirection.entries()) {
-          for (const [valueKey] of byValue.entries()) allValueKeys.add(valueKey);
-        }
-
-        for (const valueKey of allValueKeys) {
-          const directionRates: number[] = [];
-          for (const [, byValue] of byDirection.entries()) {
-            const vignetteRates = byValue.get(valueKey) ?? [];
-            if (vignetteRates.length === 0) continue;
-            directionRates.push(vignetteRates.reduce((sum, r) => sum + r, 0) / vignetteRates.length);
-          }
-          if (directionRates.length === 0) continue;
-          const pairRate = directionRates.reduce((sum, r) => sum + r, 0) / directionRates.length;
-          const existing = pairRatesByValue.get(valueKey) ?? [];
-          existing.push(pairRate);
-          pairRatesByValue.set(valueKey, existing);
-        }
-      }
+      const aggregatedValueRates = aggregateValueWinRates(inputs);
 
       const valueWinRates: Record<string, number> = {};
       const vignetteCount: Record<string, number> = {};
-      for (const [valueKey, pairRates] of pairRatesByValue.entries()) {
-        if (pairRates.length === 0) continue;
-        const domainRate = pairRates.reduce((sum, r) => sum + r, 0) / pairRates.length;
-        valueWinRates[valueKey] = domainRate * 100;
-        vignetteCount[valueKey] = pairRates.length;
+      for (const [valueKey, result] of aggregatedValueRates.entries()) {
+        if (result.crossDomainRate == null) continue;
+        valueWinRates[valueKey] = result.crossDomainRate * 100;
+        vignetteCount[valueKey] = result.domainRates.reduce(
+          (sum, domainRate) => sum + domainRate.pairsCounted,
+          0,
+        );
       }
 
       return {

--- a/cloud/apps/api/src/services/analysis/value-win-rate-aggregation.ts
+++ b/cloud/apps/api/src/services/analysis/value-win-rate-aggregation.ts
@@ -1,0 +1,133 @@
+export type ValueRateInput = {
+  domainId: string;
+  definitionId: string;
+  valueKey: string;
+  pairKey: string;
+  directionKey: string;
+  vignetteRate: number;
+};
+
+export type ValueRateResult = {
+  valueKey: string;
+  domainRates: Array<{ domainId: string; rate: number; pairsCounted: number }>;
+  crossDomainRate: number | null;
+};
+
+function mean(values: Iterable<number>): number | null {
+  let sum = 0;
+  let count = 0;
+
+  for (const value of values) {
+    if (!Number.isFinite(value)) continue;
+    sum += value;
+    count += 1;
+  }
+
+  return count === 0 ? null : sum / count;
+}
+
+export function aggregateValueWinRates(
+  inputs: Iterable<ValueRateInput>,
+): Map<string, ValueRateResult> {
+  const vignetteRatesByGroup = new Map<string, ValueRateInput[]>();
+
+  for (const input of inputs) {
+    if (!Number.isFinite(input.vignetteRate)) continue;
+
+    const groupKey = [
+      input.valueKey,
+      input.domainId,
+      input.pairKey,
+      input.directionKey,
+    ].join('||');
+    const group = vignetteRatesByGroup.get(groupKey) ?? [];
+    group.push(input);
+    vignetteRatesByGroup.set(groupKey, group);
+  }
+
+  const directionRatesByPair = new Map<
+    string,
+    { valueKey: string; domainId: string; pairKey: string; directionRate: number }
+  >();
+
+  for (const group of vignetteRatesByGroup.values()) {
+    const first = group[0];
+    if (first == null) continue;
+    const directionRate = mean(group.map((item) => item.vignetteRate));
+    if (directionRate == null) continue;
+
+    const key = [first.valueKey, first.domainId, first.pairKey, first.directionKey].join('||');
+    directionRatesByPair.set(key, {
+      valueKey: first.valueKey,
+      domainId: first.domainId,
+      pairKey: first.pairKey,
+      directionRate,
+    });
+  }
+
+  const directionRatesByValueDomainPair = new Map<
+    string,
+    { valueKey: string; domainId: string; pairKey: string; directionRates: number[] }
+  >();
+
+  for (const directionGroup of directionRatesByPair.values()) {
+    const key = [directionGroup.valueKey, directionGroup.domainId, directionGroup.pairKey].join(
+      '||',
+    );
+    const existing = directionRatesByValueDomainPair.get(key) ?? {
+      valueKey: directionGroup.valueKey,
+      domainId: directionGroup.domainId,
+      pairKey: directionGroup.pairKey,
+      directionRates: [],
+    };
+    existing.directionRates.push(directionGroup.directionRate);
+    directionRatesByValueDomainPair.set(key, existing);
+  }
+
+  const pairRatesByValueDomain = new Map<
+    string,
+    { valueKey: string; domainId: string; pairRates: number[]; pairsCounted: number }
+  >();
+
+  for (const pairGroup of directionRatesByValueDomainPair.values()) {
+    const pairRate = mean(pairGroup.directionRates);
+    if (pairRate == null) continue;
+
+    const key = [pairGroup.valueKey, pairGroup.domainId].join('||');
+    const existing = pairRatesByValueDomain.get(key) ?? {
+      valueKey: pairGroup.valueKey,
+      domainId: pairGroup.domainId,
+      pairRates: [],
+      pairsCounted: 0,
+    };
+    existing.pairRates.push(pairRate);
+    existing.pairsCounted += 1;
+    pairRatesByValueDomain.set(key, existing);
+  }
+
+  const domainRatesByValue = new Map<string, ValueRateResult>();
+
+  for (const domainGroup of pairRatesByValueDomain.values()) {
+    const domainRate = mean(domainGroup.pairRates);
+    if (domainRate == null) continue;
+
+    const existing = domainRatesByValue.get(domainGroup.valueKey) ?? {
+      valueKey: domainGroup.valueKey,
+      domainRates: [],
+      crossDomainRate: null,
+    };
+    existing.domainRates.push({
+      domainId: domainGroup.domainId,
+      rate: domainRate,
+      pairsCounted: domainGroup.pairsCounted,
+    });
+    domainRatesByValue.set(domainGroup.valueKey, existing);
+  }
+
+  for (const result of domainRatesByValue.values()) {
+    result.domainRates.sort((left, right) => left.domainId.localeCompare(right.domainId));
+    result.crossDomainRate = mean(result.domainRates.map((domainRate) => domainRate.rate));
+  }
+
+  return domainRatesByValue;
+}

--- a/cloud/apps/api/tests/services/analysis/domain-analysis-vs-pressure-equivalence.test.ts
+++ b/cloud/apps/api/tests/services/analysis/domain-analysis-vs-pressure-equivalence.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from 'vitest';
+import type { DomainAnalysisValueKey } from '../../../src/graphql/queries/domain-analysis-values.js';
+import { computePooledWinRate } from '../../../src/graphql/queries/models-analysis-math.js';
+import { computePairwiseWinRate } from '../../../src/utils/pairwise-math.js';
+import { computeCellWeightedDomainRates } from '../../../src/services/analysis/domain-analysis-cell-win-rates.js';
+import { encodeCellKey, type CellCounts } from '../../../src/services/analysis/transcript-cell-accumulator.js';
+import { aggregateValueWinRates } from '../../../src/services/analysis/value-win-rate-aggregation.js';
+
+type DefinitionFixture = {
+  id: string;
+  domainId: string;
+  valueA: DomainAnalysisValueKey;
+  valueB: DomainAnalysisValueKey;
+  valueFirst: DomainAnalysisValueKey;
+};
+
+type CanonicalCellFixture = {
+  definitionId: string;
+  modelId: string;
+  ownLevel: number;
+  opponentLevel: number;
+  wins: number;
+  losses: number;
+  neutrals: number;
+};
+
+function buildDefinitionFixture(
+  id: string,
+  domainId: string,
+  valueA: DomainAnalysisValueKey,
+  valueB: DomainAnalysisValueKey,
+  valueFirst: DomainAnalysisValueKey,
+): DefinitionFixture {
+  return { id, domainId, valueA, valueB, valueFirst };
+}
+
+function buildSeededCells(seed: number): Array<Omit<CanonicalCellFixture, 'definitionId' | 'modelId'>> {
+  const winsA = (seed % 5) + 1;
+  const lossesA = ((seed * 2) % 4) + 1;
+  const winsB = ((seed * 3) % 5) + 1;
+  const lossesB = ((seed * 5) % 4) + 1;
+
+  return [
+    {
+      ownLevel: 5,
+      opponentLevel: 1,
+      wins: winsA,
+      losses: lossesA,
+      neutrals: 10 - winsA - lossesA,
+    },
+    {
+      ownLevel: 2,
+      opponentLevel: 4,
+      wins: winsB,
+      losses: lossesB,
+      neutrals: 10 - winsB - lossesB,
+    },
+  ];
+}
+
+function addMirroredCellCounts(
+  cellMap: Map<string, CellCounts>,
+  definition: DefinitionFixture,
+  cell: CanonicalCellFixture,
+): void {
+  cellMap.set(
+    encodeCellKey({
+      definitionId: cell.definitionId,
+      modelId: cell.modelId,
+      valueKey: definition.valueA,
+      ownLevel: cell.ownLevel,
+      opponentLevel: cell.opponentLevel,
+    }),
+    { wins: cell.wins, losses: cell.losses, neutrals: cell.neutrals },
+  );
+  cellMap.set(
+    encodeCellKey({
+      definitionId: cell.definitionId,
+      modelId: cell.modelId,
+      valueKey: definition.valueB,
+      ownLevel: cell.opponentLevel,
+      opponentLevel: cell.ownLevel,
+    }),
+    { wins: cell.losses, losses: cell.wins, neutrals: cell.neutrals },
+  );
+}
+
+describe('domain analysis vs pressure value aggregation', () => {
+  it('matches per-(model,value) pooled win rates even with uneven domain coverage', () => {
+    const definitions: DefinitionFixture[] = [
+      buildDefinitionFixture(
+        'domain-a-p1-achievement-first',
+        'domain-a',
+        'Achievement',
+        'Security_Personal',
+        'Achievement',
+      ),
+      buildDefinitionFixture(
+        'domain-a-p1-security-first',
+        'domain-a',
+        'Achievement',
+        'Security_Personal',
+        'Security_Personal',
+      ),
+      buildDefinitionFixture(
+        'domain-a-p2-achievement-first',
+        'domain-a',
+        'Achievement',
+        'Hedonism',
+        'Achievement',
+      ),
+      buildDefinitionFixture(
+        'domain-a-p2-hedonism-first',
+        'domain-a',
+        'Achievement',
+        'Hedonism',
+        'Hedonism',
+      ),
+      buildDefinitionFixture(
+        'domain-a-p3-security-first',
+        'domain-a',
+        'Hedonism',
+        'Security_Personal',
+        'Security_Personal',
+      ),
+      buildDefinitionFixture(
+        'domain-a-p4-achievement-first',
+        'domain-a',
+        'Achievement',
+        'Stimulation',
+        'Achievement',
+      ),
+      buildDefinitionFixture(
+        'domain-b-p1-achievement-first',
+        'domain-b',
+        'Achievement',
+        'Security_Personal',
+        'Achievement',
+      ),
+      buildDefinitionFixture(
+        'domain-b-p2-hedonism-first',
+        'domain-b',
+        'Achievement',
+        'Hedonism',
+        'Hedonism',
+      ),
+      buildDefinitionFixture(
+        'domain-b-p3-hedonism-first',
+        'domain-b',
+        'Hedonism',
+        'Security_Personal',
+        'Hedonism',
+      ),
+      buildDefinitionFixture(
+        'domain-b-p4-stimulation-first',
+        'domain-b',
+        'Achievement',
+        'Stimulation',
+        'Stimulation',
+      ),
+      buildDefinitionFixture(
+        'domain-c-p1-security-first',
+        'domain-c',
+        'Achievement',
+        'Security_Personal',
+        'Security_Personal',
+      ),
+      buildDefinitionFixture(
+        'domain-c-p2-achievement-first',
+        'domain-c',
+        'Achievement',
+        'Hedonism',
+        'Achievement',
+      ),
+      buildDefinitionFixture(
+        'domain-c-p3-security-first',
+        'domain-c',
+        'Hedonism',
+        'Security_Personal',
+        'Security_Personal',
+      ),
+    ];
+
+    const definitionById = new Map(definitions.map((definition) => [definition.id, definition]));
+    const canonicalCells: CanonicalCellFixture[] = [];
+    const modelIds = ['model-a', 'model-b'];
+
+    definitions.forEach((definition, definitionIndex) => {
+      modelIds.forEach((modelId, modelIndex) => {
+        const seed = definitionIndex * 11 + modelIndex * 17 + 3;
+        buildSeededCells(seed).forEach((cell) => {
+          canonicalCells.push({
+            definitionId: definition.id,
+            modelId,
+            ...cell,
+          });
+        });
+      });
+    });
+
+    const domainIds = [...new Set(definitions.map((definition) => definition.domainId))];
+    const snapshotContributions = new Map<
+      string,
+      Array<{ evidenceWeight: number; winRate: number }>
+    >();
+
+    for (const domainId of domainIds) {
+      const domainDefinitions = definitions.filter((definition) => definition.domainId === domainId);
+      const domainDefinitionMap = new Map(
+        domainDefinitions.map((definition) => [
+          definition.id,
+          {
+            valueA: definition.valueA,
+            valueB: definition.valueB,
+            valueFirst: definition.valueFirst,
+          },
+        ]),
+      );
+      const domainCellMap = new Map<string, CellCounts>();
+
+      for (const cell of canonicalCells) {
+        const definition = definitionById.get(cell.definitionId);
+        if (definition == null || definition.domainId !== domainId) continue;
+        addMirroredCellCounts(domainCellMap, definition, cell);
+      }
+
+      const result = computeCellWeightedDomainRates({
+        cellMap: domainCellMap,
+        filteredSourceRunDefinitionById: new Map(),
+        definitionValuePairById: domainDefinitionMap,
+      });
+
+      for (const model of result.models) {
+        for (const [valueKey, winRate] of Object.entries(model.valueWinRates)) {
+          const contributionKey = `${model.model}||${valueKey}`;
+          const contributions = snapshotContributions.get(contributionKey) ?? [];
+          contributions.push({
+            evidenceWeight: model.vignetteCount[valueKey] ?? 0,
+            winRate,
+          });
+          snapshotContributions.set(contributionKey, contributions);
+        }
+      }
+    }
+
+    const pooledSnapshotRates = new Map(
+      Array.from(snapshotContributions.entries()).map(([key, contributions]) => [
+        key,
+        computePooledWinRate(contributions),
+      ]),
+    );
+
+    const groupedByModel = new Map<
+      string,
+      Map<
+        string,
+        {
+          domainId: string;
+          definitionId: string;
+          valueKey: string;
+          pairKey: string;
+          directionKey: string;
+          cellRates: number[];
+        }
+      >
+    >();
+
+    for (const cell of canonicalCells) {
+      const definition = definitionById.get(cell.definitionId);
+      if (definition == null) continue;
+
+      const firstRate = computePairwiseWinRate(cell.wins, cell.losses, cell.neutrals);
+      const secondRate = computePairwiseWinRate(cell.losses, cell.wins, cell.neutrals);
+      const pairKey = `${definition.valueA}::${definition.valueB}`;
+      const modelGroups = groupedByModel.get(cell.modelId) ?? new Map();
+      groupedByModel.set(cell.modelId, modelGroups);
+
+      if (firstRate != null) {
+        const key = [
+          definition.valueA,
+          definition.domainId,
+          definition.id,
+          pairKey,
+          definition.valueFirst,
+        ].join('||');
+        const existing = modelGroups.get(key) ?? {
+          domainId: definition.domainId,
+          definitionId: definition.id,
+          valueKey: definition.valueA,
+          pairKey,
+          directionKey: definition.valueFirst,
+          cellRates: [],
+        };
+        existing.cellRates.push(firstRate);
+        modelGroups.set(key, existing);
+      }
+
+      if (secondRate != null) {
+        const key = [
+          definition.valueB,
+          definition.domainId,
+          definition.id,
+          pairKey,
+          definition.valueFirst,
+        ].join('||');
+        const existing = modelGroups.get(key) ?? {
+          domainId: definition.domainId,
+          definitionId: definition.id,
+          valueKey: definition.valueB,
+          pairKey,
+          directionKey: definition.valueFirst,
+          cellRates: [],
+        };
+        existing.cellRates.push(secondRate);
+        modelGroups.set(key, existing);
+      }
+    }
+
+    const aggregatedPressureRates = new Map<string, Map<string, number | null>>();
+    for (const [modelId, groups] of groupedByModel.entries()) {
+      const inputs = Array.from(groups.values()).map((group) => ({
+        domainId: group.domainId,
+        definitionId: group.definitionId,
+        valueKey: group.valueKey,
+        pairKey: group.pairKey,
+        directionKey: group.directionKey,
+        vignetteRate: group.cellRates.reduce((sum, rate) => sum + rate, 0) / group.cellRates.length,
+      }));
+      const aggregated = aggregateValueWinRates(inputs);
+      aggregatedPressureRates.set(
+        modelId,
+        new Map(
+          Array.from(aggregated.entries()).map(([valueKey, result]) => [
+            valueKey,
+            result.crossDomainRate == null ? null : result.crossDomainRate * 100,
+          ]),
+        ),
+      );
+    }
+
+    const allModelValueKeys = new Set<string>([
+      ...pooledSnapshotRates.keys(),
+      ...Array.from(aggregatedPressureRates.entries()).flatMap(([modelId, values]) =>
+        Array.from(values.keys()).map((valueKey) => `${modelId}||${valueKey}`),
+      ),
+    ]);
+
+    for (const modelValueKey of allModelValueKeys) {
+      const [modelId, valueKey] = modelValueKey.split('||');
+      if (modelId == null || valueKey == null) {
+        throw new Error(`Invalid model/value key: ${modelValueKey}`);
+      }
+
+      const snapshotRate = pooledSnapshotRates.get(modelValueKey) ?? null;
+      const pressureRate = aggregatedPressureRates.get(modelId)?.get(valueKey) ?? null;
+
+      expect(snapshotRate).not.toBeNull();
+      expect(pressureRate).not.toBeNull();
+      expect(pressureRate).toBeCloseTo(snapshotRate, 9);
+    }
+  });
+});

--- a/cloud/apps/api/tests/services/analysis/value-win-rate-aggregation.test.ts
+++ b/cloud/apps/api/tests/services/analysis/value-win-rate-aggregation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateValueWinRates,
+  type ValueRateInput,
+} from '../../../src/services/analysis/value-win-rate-aggregation.js';
+
+function buildInput(overrides: Partial<ValueRateInput> = {}): ValueRateInput {
+  return {
+    domainId: 'domain-a',
+    definitionId: 'def-1',
+    valueKey: 'Achievement',
+    pairKey: 'achievement::security_personal',
+    directionKey: 'Achievement',
+    vignetteRate: 0.5,
+    ...overrides,
+  };
+}
+
+describe('aggregateValueWinRates', () => {
+  it('returns the vignette rate for a single-domain single-pair single-direction input', () => {
+    const result = aggregateValueWinRates([buildInput({ vignetteRate: 0.8 })]);
+
+    expect(result.get('Achievement')).toEqual({
+      valueKey: 'Achievement',
+      domainRates: [{ domainId: 'domain-a', rate: 0.8, pairsCounted: 1 }],
+      crossDomainRate: 0.8,
+    });
+  });
+
+  it('averages direction means before the pair rate', () => {
+    const result = aggregateValueWinRates([
+      buildInput({ definitionId: 'def-a-1', directionKey: 'Achievement', vignetteRate: 0.8 }),
+      buildInput({ definitionId: 'def-a-2', directionKey: 'Achievement', vignetteRate: 0.6 }),
+      buildInput({ definitionId: 'def-b-1', directionKey: 'Security_Personal', vignetteRate: 0.2 }),
+    ]);
+
+    expect(result.get('Achievement')?.crossDomainRate).toBeCloseTo(0.45, 10);
+  });
+
+  it('averages pair rates equally within a domain', () => {
+    const result = aggregateValueWinRates([
+      buildInput({ pairKey: 'achievement::security_personal', vignetteRate: 0.6 }),
+      buildInput({
+        definitionId: 'def-2',
+        pairKey: 'achievement::hedonism',
+        vignetteRate: 0.2,
+      }),
+    ]);
+
+    expect(result.get('Achievement')).toEqual({
+      valueKey: 'Achievement',
+      domainRates: [{ domainId: 'domain-a', rate: 0.4, pairsCounted: 2 }],
+      crossDomainRate: 0.4,
+    });
+  });
+
+  it('equal-weights domains when both domains contain the same value pairs', () => {
+    const result = aggregateValueWinRates([
+      buildInput({ domainId: 'domain-a', pairKey: 'achievement::security_personal', vignetteRate: 0.8 }),
+      buildInput({ domainId: 'domain-a', definitionId: 'def-a-2', pairKey: 'achievement::hedonism', vignetteRate: 0.4 }),
+      buildInput({ domainId: 'domain-b', definitionId: 'def-b-1', pairKey: 'achievement::security_personal', vignetteRate: 0.2 }),
+      buildInput({ domainId: 'domain-b', definitionId: 'def-b-2', pairKey: 'achievement::hedonism', vignetteRate: 0.4 }),
+    ]);
+
+    expect(result.get('Achievement')?.domainRates).toHaveLength(2);
+    expect(result.get('Achievement')?.domainRates[0]).toEqual({
+      domainId: 'domain-a',
+      rate: expect.closeTo(0.6, 10),
+      pairsCounted: 2,
+    });
+    expect(result.get('Achievement')?.domainRates[1]).toEqual({
+      domainId: 'domain-b',
+      rate: expect.closeTo(0.3, 10),
+      pairsCounted: 2,
+    });
+    expect(result.get('Achievement')?.crossDomainRate).toBeCloseTo(0.45, 10);
+  });
+
+  it('does not match pair-first cross-domain averaging when domain coverage is uneven', () => {
+    const result = aggregateValueWinRates([
+      buildInput({ domainId: 'domain-a', pairKey: 'achievement::security_personal', vignetteRate: 1 }),
+      buildInput({ domainId: 'domain-a', definitionId: 'def-a-2', pairKey: 'achievement::hedonism', vignetteRate: 0 }),
+      buildInput({ domainId: 'domain-b', definitionId: 'def-b-1', pairKey: 'achievement::hedonism', vignetteRate: 0 }),
+    ]);
+
+    const canonicalRate = result.get('Achievement')?.crossDomainRate;
+    const wrongPairFirstRate = (1 + 0) / 2;
+
+    expect(canonicalRate).toBeCloseTo(0.25, 10);
+    expect(canonicalRate).not.toBeCloseTo(wrongPairFirstRate, 10);
+  });
+
+  it('returns an empty map for empty inputs', () => {
+    expect(aggregateValueWinRates([]).size).toBe(0);
+  });
+
+  it('ignores NaN and Infinity vignette rates', () => {
+    const result = aggregateValueWinRates([
+      buildInput({ definitionId: 'def-valid', vignetteRate: 0.6 }),
+      buildInput({ definitionId: 'def-nan', pairKey: 'achievement::hedonism', vignetteRate: Number.NaN }),
+      buildInput({
+        definitionId: 'def-inf',
+        pairKey: 'achievement::stimulation',
+        vignetteRate: Number.POSITIVE_INFINITY,
+      }),
+    ]);
+
+    expect(result.get('Achievement')).toEqual({
+      valueKey: 'Achievement',
+      domainRates: [{ domainId: 'domain-a', rate: 0.6, pairsCounted: 1 }],
+      crossDomainRate: 0.6,
+    });
+  });
+});

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1196,17 +1196,34 @@ type DomainTrialRunStatus {
   updatedAt: DateTime!
 }
 
+type CoverageModelCount {
+  label: String!
+  modelId: String!
+  trialCount: Int!
+}
+
+type CoverageWeakestCondition {
+  conditionLabel: String!
+  modelCounts: [CoverageModelCount!]!
+  otherConditionsCount: Int
+}
+
 type DomainValueCoverageCell {
+  aFirstBatchEquivalent: Int!
   """
   Count of complete A-first runs for this value pair after model-set filtering. This is the filtered directional count for the first value in the pair.
   """
   aFirstBatchCount: Int!
+  aFirstDefinitionName: String
   aggregateRunId: String
 
+  batchEquivalent: Int!
   """
   Count of complete B-first runs for this value pair after model-set filtering. This is the filtered directional count for the second value in the pair.
   """
   bFirstBatchCount: Int!
+  bFirstBatchEquivalent: Int!
+  bFirstDefinitionName: String
 
   """
   Count of fully-complete non-aggregate runs for this value pair. A run is complete when every selected model has at least one transcript at every (scenario × sampleIndex) slot. samplesPerScenario does not multiply this count -- a complete run contributes 1 regardless of how many samples per scenario were planned. Aggregate runs are excluded.
@@ -1232,6 +1249,7 @@ type DomainValueCoverageCell {
   maxTrialCount: Int
   minTrialCount: Int
   modelBreakdown: [CoverageModelBreakdown!]
+  weakestCondition: CoverageWeakestCondition
 
   """
   Count of unmatched directional runs for this value pair, computed as max(complete A-first runs, complete B-first runs) - min(complete A-first runs, complete B-first runs). When both directions are equal this is 0; when only one direction has runs this is the count of that side. Runs without a recognizable direction token are excluded.
@@ -2099,6 +2117,7 @@ type PressureSensitivityModel {
   providerName: String!
   unscoredCount: Int!
   valuePairs: [PressureSensitivityValuePair!]!
+  valueRates: [PressureSensitivityValueRate!]!
 }
 
 type PressureSensitivityResult {
@@ -2130,6 +2149,16 @@ type PressureSensitivityValuePair {
   secondValueLabel: String!
   secondValueToken: String!
   unscoredCount: Int!
+}
+
+type PressureSensitivityValueRate {
+  averageWinRate: Float
+  balancedWinRate: Float
+  highPressureOnOpposingValueWinRate: Float
+  highPressureOnThisValueWinRate: Float
+  pairsMeasured: Int!
+  valueLabel: String!
+  valueToken: String!
 }
 
 """Result of a probe job execution"""

--- a/cloud/apps/web/src/api/operations/pressureSensitivity.graphql
+++ b/cloud/apps/web/src/api/operations/pressureSensitivity.graphql
@@ -19,6 +19,15 @@ query PressureSensitivity(
         rangeMax
         pairsMeasured
       }
+      valueRates {
+        valueToken
+        valueLabel
+        averageWinRate
+        balancedWinRate
+        highPressureOnThisValueWinRate
+        highPressureOnOpposingValueWinRate
+        pairsMeasured
+      }
       valuePairs {
         pairKey
         firstValueToken

--- a/cloud/apps/web/src/api/operations/pressureSensitivity.ts
+++ b/cloud/apps/web/src/api/operations/pressureSensitivity.ts
@@ -23,6 +23,7 @@ export type PressureSensitivityExcludedDefinition =
   PressureSensitivityResult['excludedDefinitions'][number];
 
 export type PressureSensitivityValuePair = PressureSensitivityModel['valuePairs'][number];
+export type PressureSensitivityValueRate = PressureSensitivityModel['valueRates'][number];
 export type PressureSensitivityCell = PressureSensitivityValuePair['grid'][number];
 export type PressureResponse = NonNullable<PressureSensitivityValuePair['pressureResponse']>;
 export type PressureResponseSummary =

--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
@@ -1,11 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { PressureResponseByValueTable } from './PressureResponseByValueTable';
-import type {
-  PressureSensitivityCell,
-  PressureSensitivityModel,
-  PressureSensitivityValuePair,
-} from '../../api/operations/pressureSensitivity';
+import type { PressureSensitivityValueRate } from '../../api/operations/pressureSensitivity';
 
 const TEN_VALUE_LABELS = [
   'Alpha',
@@ -20,255 +16,76 @@ const TEN_VALUE_LABELS = [
   'Juliet',
 ];
 
-function createCell(
-  ownLevel: number,
-  opponentLevel: number,
-  n: number,
-  winRate: number,
-  opponentWinRate: number = 1 - winRate,
-): PressureSensitivityCell {
+function createValueRate(
+  valueLabel: string,
+  overrides: Partial<PressureSensitivityValueRate> = {},
+): PressureSensitivityValueRate {
   return {
-    ownLevel,
-    opponentLevel,
-    n,
-    unscoredCount: 0,
-    winRate,
-    opponentWinRate,
-    conviction: null,
-    netScore: null,
-    lowData: false,
+    valueToken: valueLabel.toLowerCase(),
+    valueLabel,
+    averageWinRate: 0.5,
+    balancedWinRate: 0.5,
+    highPressureOnThisValueWinRate: 0.5,
+    highPressureOnOpposingValueWinRate: 0.5,
+    pairsMeasured: 9,
+    ...overrides,
   };
 }
 
-type DirectionBalancedFields = {
-  directionBalancedWinRate?: number | null;
-  directionBalancedOpponentWinRate?: number | null;
-  directionBalancedBalancedWinRate?: number | null;
-  directionBalancedBalancedOpponentWinRate?: number | null;
-  directionBalancedHighPressureOwnWinRate?: number | null;
-  directionBalancedHighPressureOwnOpponentWinRate?: number | null;
-  directionBalancedHighPressureOpponentWinRate?: number | null;
-  directionBalancedHighPressureOpponentOpponentWinRate?: number | null;
-};
-
-function createPair(
-  pairKey: string,
-  firstValueLabel: string,
-  secondValueLabel: string,
-  grid: PressureSensitivityCell[],
-  directionBalanced: DirectionBalancedFields = {},
-): PressureSensitivityValuePair {
-  const n = grid.reduce((sum, cell) => sum + cell.n, 0);
-
-  return {
-    pairKey,
-    firstValueToken: firstValueLabel.toLowerCase(),
-    firstValueLabel,
-    secondValueToken: secondValueLabel.toLowerCase(),
-    secondValueLabel,
-    n,
-    unscoredCount: 0,
-    definitionsMeasured: 1,
-    pressureResponse: {
-      value: null,
-      baselineRate: null,
-      pushTowardFirstRate: null,
-      pushTowardSecondRate: null,
-      qualifyingTrials: n,
-      ciLow: null,
-      ciHigh: null,
-      reason: null,
-    },
-    grid,
-    directionBalancedWinRate: directionBalanced.directionBalancedWinRate ?? null,
-    directionBalancedOpponentWinRate: directionBalanced.directionBalancedOpponentWinRate ?? null,
-    directionBalancedBalancedWinRate: directionBalanced.directionBalancedBalancedWinRate ?? null,
-    directionBalancedBalancedOpponentWinRate: directionBalanced.directionBalancedBalancedOpponentWinRate ?? null,
-    directionBalancedHighPressureOwnWinRate: directionBalanced.directionBalancedHighPressureOwnWinRate ?? null,
-    directionBalancedHighPressureOwnOpponentWinRate: directionBalanced.directionBalancedHighPressureOwnOpponentWinRate ?? null,
-    directionBalancedHighPressureOpponentWinRate: directionBalanced.directionBalancedHighPressureOpponentWinRate ?? null,
-    directionBalancedHighPressureOpponentOpponentWinRate: directionBalanced.directionBalancedHighPressureOpponentOpponentWinRate ?? null,
-  };
+function createTenValueRates(): PressureSensitivityValueRate[] {
+  return TEN_VALUE_LABELS.map((valueLabel, index) =>
+    createValueRate(valueLabel, {
+      averageWinRate: 0.4 + index * 0.01,
+      balancedWinRate: 0.35 + index * 0.01,
+      highPressureOnThisValueWinRate: 0.45 + index * 0.01,
+      highPressureOnOpposingValueWinRate: 0.3 + index * 0.01,
+    }),
+  );
 }
 
-function createModel(valuePairs: PressureSensitivityValuePair[]): PressureSensitivityModel {
-  return {
-    modelId: 'model-a',
-    label: 'Model A',
-    providerName: 'Provider',
-    unscoredCount: 0,
-    pressureResponseSummary: { mean: 0.1, rangeMin: 0.05, rangeMax: 0.15, pairsMeasured: valuePairs.length },
-    valuePairs,
-  };
-}
-
-function createUniformGrid(): PressureSensitivityCell[] {
+function createSortFixture(): PressureSensitivityValueRate[] {
   return [
-    createCell(1, 1, 5, 0.6),
-    createCell(4, 1, 5, 0.8),
-    createCell(1, 4, 5, 0.4),
-    createCell(2, 3, 5, 0.6),
+    createValueRate('Alpha', {
+      averageWinRate: 0.3,
+      balancedWinRate: 0.3,
+      highPressureOnThisValueWinRate: 0.9,
+      highPressureOnOpposingValueWinRate: 0,
+    }),
+    createValueRate('Beta', {
+      averageWinRate: 0.8,
+      balancedWinRate: 0.75,
+      highPressureOnThisValueWinRate: 0.9,
+      highPressureOnOpposingValueWinRate: 0.1,
+    }),
+    createValueRate('Charlie', {
+      averageWinRate: 0.7,
+      balancedWinRate: 0.45,
+      highPressureOnThisValueWinRate: 0.7,
+      highPressureOnOpposingValueWinRate: 0.4,
+    }),
   ];
 }
 
-function createTenValueModel(): PressureSensitivityModel {
-  const pairs: PressureSensitivityValuePair[] = [];
-
-  for (let i = 0; i < TEN_VALUE_LABELS.length; i += 1) {
-    const firstValueLabel = TEN_VALUE_LABELS[i];
-    if (firstValueLabel == null) continue;
-
-    for (let j = i + 1; j < TEN_VALUE_LABELS.length; j += 1) {
-      const secondValueLabel = TEN_VALUE_LABELS[j];
-      if (secondValueLabel == null) continue;
-
-      pairs.push(
-        createPair(
-          `${firstValueLabel.toLowerCase()}::${secondValueLabel.toLowerCase()}`,
-          firstValueLabel,
-          secondValueLabel,
-          createUniformGrid(),
-        ),
-      );
-    }
-  }
-
-  return createModel(pairs);
-}
-
-function createSortFixture(): PressureSensitivityModel {
-  // alpha::beta / alpha::charlie: Alpha average = 0.3 (via directionBalancedWinRate)
-  // beta::charlie: Beta average = 0.8 (via directionBalancedWinRate)
-  // Sorted by responsiveness (highPressureOnValue - balanced):
-  //   Alpha: highOwn(0.9) - balanced(0.3) = 0.6
-  //   Beta: highOwn(0.9) - balanced(mean[0.7,0.8]=0.75) = 0.15
-  //   Charlie: highOwn(mean[1,0.4]=0.7) - balanced(mean[0.7,0.2]=0.45) = 0.25
-  //   → Alpha (0.6) > Charlie (0.25) > Beta (0.15)
-  return createModel([
-    createPair(
-      'alpha::beta',
-      'Alpha',
-      'Beta',
-      [
-        createCell(1, 1, 10, 0.3),
-        createCell(4, 1, 10, 0.9),
-        createCell(1, 4, 10, 0),
-        createCell(2, 3, 10, 0),
-      ],
-      {
-        directionBalancedWinRate: 0.3,
-        directionBalancedOpponentWinRate: 0.7,
-        directionBalancedBalancedWinRate: 0.3,
-        directionBalancedBalancedOpponentWinRate: 0.7,
-        directionBalancedHighPressureOwnWinRate: 0.9,
-        directionBalancedHighPressureOwnOpponentWinRate: 0.1,
-        directionBalancedHighPressureOpponentWinRate: 0,
-        directionBalancedHighPressureOpponentOpponentWinRate: 1,
-      },
-    ),
-    createPair(
-      'alpha::charlie',
-      'Alpha',
-      'Charlie',
-      [
-        createCell(1, 1, 10, 0.3),
-        createCell(4, 1, 10, 0.9),
-        createCell(1, 4, 10, 0),
-        createCell(2, 3, 10, 0),
-      ],
-      {
-        directionBalancedWinRate: 0.3,
-        directionBalancedOpponentWinRate: 0.7,
-        directionBalancedBalancedWinRate: 0.3,
-        directionBalancedBalancedOpponentWinRate: 0.7,
-        directionBalancedHighPressureOwnWinRate: 0.9,
-        directionBalancedHighPressureOwnOpponentWinRate: 0.1,
-        directionBalancedHighPressureOpponentWinRate: 0,
-        directionBalancedHighPressureOpponentOpponentWinRate: 1,
-      },
-    ),
-    createPair(
-      'beta::charlie',
-      'Beta',
-      'Charlie',
-      [
-        createCell(1, 1, 10, 0.8),
-        createCell(4, 1, 10, 0.9),
-        createCell(1, 4, 10, 0.6),
-        createCell(2, 3, 10, 0.9),
-      ],
-      {
-        directionBalancedWinRate: 0.8,
-        directionBalancedOpponentWinRate: 0.2,
-        directionBalancedBalancedWinRate: 0.8,
-        directionBalancedBalancedOpponentWinRate: 0.2,
-        directionBalancedHighPressureOwnWinRate: 0.9,
-        directionBalancedHighPressureOwnOpponentWinRate: 0.1,
-        directionBalancedHighPressureOpponentWinRate: 0.6,
-        directionBalancedHighPressureOpponentOpponentWinRate: 0.4,
-      },
-    ),
-  ]);
-}
-
-function createMathFixture(): PressureSensitivityModel {
-  // alpha::beta: Alpha direction-balanced average = 0.6 (directionBalancedWinRate)
-  // gamma::alpha: Alpha direction-balanced average (as second) = 0.6 (directionBalancedOpponentWinRate)
-  // Alpha average = mean([0.6, 0.6]) = 0.6
-  // Alpha balanced = mean([0.4, 0.4]) = 0.4
-  // Alpha highOwn = mean([0.8, 0.8]) = 0.8
-  // Alpha highOpp = mean([0.3, 0.3]) = 0.3
-  return createModel([
-    createPair(
-      'alpha::beta',
-      'Alpha',
-      'Beta',
-      [
-        createCell(1, 1, 5, 0.4),
-        createCell(4, 1, 5, 0.8),
-        createCell(1, 4, 10, 0.3),
-        createCell(2, 3, 10, 0.9),
-      ],
-      {
-        // Alpha is first
-        directionBalancedWinRate: 0.6,
-        directionBalancedOpponentWinRate: 0.4,
-        directionBalancedBalancedWinRate: 0.4,
-        directionBalancedBalancedOpponentWinRate: 0.6,
-        directionBalancedHighPressureOwnWinRate: 0.8,
-        directionBalancedHighPressureOwnOpponentWinRate: 0.2,
-        directionBalancedHighPressureOpponentWinRate: 0.3,
-        directionBalancedHighPressureOpponentOpponentWinRate: 0.7,
-      },
-    ),
-    createPair(
-      'gamma::alpha',
-      'Gamma',
-      'Alpha',
-      [
-        createCell(1, 1, 10, 0.6),
-        createCell(4, 1, 10, 0.7),
-        createCell(1, 4, 10, 0.2),
-        createCell(2, 3, 10, 0.1),
-      ],
-      {
-        // Alpha is second
-        directionBalancedWinRate: 0.4,
-        directionBalancedOpponentWinRate: 0.6,
-        directionBalancedBalancedWinRate: 0.6,
-        directionBalancedBalancedOpponentWinRate: 0.4,
-        directionBalancedHighPressureOwnWinRate: 0.7,
-        directionBalancedHighPressureOwnOpponentWinRate: 0.3,
-        directionBalancedHighPressureOpponentWinRate: 0.2,
-        directionBalancedHighPressureOpponentOpponentWinRate: 0.8,
-      },
-    ),
-  ]);
+function createMathFixture(): PressureSensitivityValueRate[] {
+  return [
+    createValueRate('Alpha', {
+      averageWinRate: 0.6,
+      balancedWinRate: 0.4,
+      highPressureOnThisValueWinRate: 0.8,
+      highPressureOnOpposingValueWinRate: 0.3,
+    }),
+    createValueRate('Beta', {
+      averageWinRate: 0.4,
+      balancedWinRate: 0.6,
+      highPressureOnThisValueWinRate: 0.2,
+      highPressureOnOpposingValueWinRate: 0.7,
+    }),
+  ];
 }
 
 describe('PressureResponseByValueTable', () => {
-  it('renders 10 rows when the model has 10 values across 9 pairs each', () => {
-    render(<PressureResponseByValueTable valuePairs={createTenValueModel().valuePairs} />);
+  it('renders 10 rows when the model has 10 values', () => {
+    render(<PressureResponseByValueTable valueRates={createTenValueRates()} />);
 
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(12);
@@ -276,7 +93,7 @@ describe('PressureResponseByValueTable', () => {
   });
 
   it('sorts by responsiveness by default and re-sorts when a header is clicked', () => {
-    render(<PressureResponseByValueTable valuePairs={createSortFixture().valuePairs} />);
+    render(<PressureResponseByValueTable valueRates={createSortFixture()} />);
 
     const rows = screen.getAllByRole('row');
     expect(rows[2]?.textContent ?? '').toContain('Alpha');
@@ -287,16 +104,27 @@ describe('PressureResponseByValueTable', () => {
     expect(resortedRows[2]?.textContent ?? '').toContain('Beta');
   });
 
+  it('toggles sort direction when the same header is clicked twice', () => {
+    render(<PressureResponseByValueTable valueRates={createSortFixture()} />);
+
+    const averageHeader = screen.getByRole('button', { name: /sort by average win rate/i });
+    fireEvent.click(averageHeader);
+    fireEvent.click(averageHeader);
+
+    const rows = screen.getAllByRole('row');
+    expect(rows[2]?.textContent ?? '').toContain('Alpha');
+  });
+
   it('renders the snapshot button with the correct label', () => {
-    render(<PressureResponseByValueTable valuePairs={createSortFixture().valuePairs} />);
+    render(<PressureResponseByValueTable valueRates={createSortFixture()} />);
 
     expect(
       screen.getByRole('button', { name: /copy pressure response by value as image/i }),
     ).toBeDefined();
   });
 
-  it('aggregates pooled win rates across multiple pairs', () => {
-    render(<PressureResponseByValueTable valuePairs={createMathFixture().valuePairs} />);
+  it('renders the direct value-rate inputs and responsiveness math', () => {
+    render(<PressureResponseByValueTable valueRates={createMathFixture()} />);
 
     const row = screen.getByText('Alpha').closest('tr');
     if (row == null) {
@@ -310,27 +138,16 @@ describe('PressureResponseByValueTable', () => {
     expect(cells[4]?.textContent ?? '').toBe('30.0%');
   });
 
-  it('treats each pooled condition cell equally instead of weighting by cell size', () => {
+  it('shows dashes for null rates instead of a numeric value', () => {
     render(
       <PressureResponseByValueTable
-        valuePairs={[
-          createPair(
-            'alpha::beta',
-            'Alpha',
-            'Beta',
-            [
-              createCell(1, 1, 1, 0),
-              createCell(4, 1, 100, 1),
-              createCell(1, 4, 1, 0),
-              createCell(2, 3, 100, 1),
-            ],
-            {
-              directionBalancedWinRate: 0.5,
-              directionBalancedBalancedWinRate: 0,
-              directionBalancedHighPressureOwnWinRate: 1,
-              directionBalancedHighPressureOpponentWinRate: 0,
-            },
-          ),
+        valueRates={[
+          createValueRate('Alpha', {
+            averageWinRate: null,
+            balancedWinRate: 0.4,
+            highPressureOnThisValueWinRate: null,
+            highPressureOnOpposingValueWinRate: 0.3,
+          }),
         ]}
       />,
     );
@@ -341,46 +158,9 @@ describe('PressureResponseByValueTable', () => {
     }
 
     const cells = within(row).getAllByRole('cell');
-    expect(cells[1]?.textContent ?? '').toBe('50.0%');
-    expect(cells[2]?.textContent ?? '').toBe('0.0%');
-    expect(cells[3]?.textContent ?? '').toBe('100.0%');
-    expect(cells[4]?.textContent ?? '').toBe('0.0%');
-  });
-
-  it('keeps sparse vignette cells in the pooled rates instead of showing dashes', () => {
-    render(
-      <PressureResponseByValueTable
-        valuePairs={[
-          createPair(
-            'alpha::beta',
-            'Alpha',
-            'Beta',
-            [
-              createCell(1, 1, 1, 0.4),
-              createCell(4, 1, 1, 0.8),
-              createCell(1, 4, 2, 0.3),
-              createCell(2, 3, 2, 0.9),
-            ],
-            {
-              directionBalancedWinRate: 0.6,
-              directionBalancedBalancedWinRate: 0.4,
-              directionBalancedHighPressureOwnWinRate: 0.8,
-              directionBalancedHighPressureOpponentWinRate: 0.3,
-            },
-          ),
-        ]}
-      />,
-    );
-
-    const row = screen.getByText('Alpha').closest('tr');
-    if (row == null) {
-      throw new Error('Missing Alpha row');
-    }
-
-    const cells = within(row).getAllByRole('cell');
-    expect(cells[1]?.textContent ?? '').toBe('60.0%');
+    expect(cells[1]?.textContent ?? '').toBe('—');
     expect(cells[2]?.textContent ?? '').toBe('40.0%');
-    expect(cells[3]?.textContent ?? '').toBe('80.0%');
+    expect(cells[3]?.textContent ?? '').toBe('—');
     expect(cells[4]?.textContent ?? '').toBe('30.0%');
   });
 });

--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
@@ -3,11 +3,11 @@ import type { ReactNode } from 'react';
 import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { TooltipIcon } from '../ui/TooltipIcon';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/Table';
-import type { PressureSensitivityValuePair } from '../../api/operations/pressureSensitivity';
+import type { PressureSensitivityValueRate } from '../../api/operations/pressureSensitivity';
 import { formatPercent } from './pressureSensitivityFormatting';
 
 type Props = {
-  valuePairs: PressureSensitivityValuePair[];
+  valueRates: PressureSensitivityValueRate[];
 };
 
 type SortDirection = 'asc' | 'desc';
@@ -32,13 +32,6 @@ type ValueRow = {
   highPressureOnThisValue: number | null;
   highPressureOnOpposingValue: number | null;
   responsiveness: number | null;
-};
-
-type PairPerspectiveRates = {
-  averageWinRate: number | null;
-  balancedWinRate: number | null;
-  highPressureOnThisValue: number | null;
-  highPressureOnOpposingValue: number | null;
 };
 
 const GRID_LABELS = [5, 4, 3, 2, 1];
@@ -103,73 +96,6 @@ function formatRate(value: number | null): ReactNode {
   }
 
   return <span className="font-mono text-gray-900">{formatPercent(value)}</span>;
-}
-
-
-function computePairRates(pair: PressureSensitivityValuePair, valueLabel: string): PairPerspectiveRates {
-  if (pair.firstValueLabel === valueLabel) {
-    return {
-      averageWinRate: pair.directionBalancedWinRate ?? null,
-      balancedWinRate: pair.directionBalancedBalancedWinRate ?? null,
-      highPressureOnThisValue: pair.directionBalancedHighPressureOwnWinRate ?? null,
-      highPressureOnOpposingValue: pair.directionBalancedHighPressureOpponentWinRate ?? null,
-    };
-  }
-
-  return {
-    averageWinRate: pair.directionBalancedOpponentWinRate ?? null,
-    balancedWinRate: pair.directionBalancedBalancedOpponentWinRate ?? null,
-    highPressureOnThisValue: pair.directionBalancedHighPressureOpponentOpponentWinRate ?? null,
-    highPressureOnOpposingValue: pair.directionBalancedHighPressureOwnOpponentWinRate ?? null,
-  };
-}
-
-function mean(values: Array<number | null>): number | null {
-  let sum = 0;
-  let count = 0;
-
-  for (const value of values) {
-    if (value == null) {
-      continue;
-    }
-    sum += value;
-    count += 1;
-  }
-
-  if (count === 0) {
-    return null;
-  }
-
-  return sum / count;
-}
-
-function buildValueRows(valuePairs: PressureSensitivityValuePair[]): ValueRow[] {
-  const valueLabels = [...new Set(valuePairs.flatMap((pair) => [pair.firstValueLabel, pair.secondValueLabel]))].sort((a, b) =>
-    a.localeCompare(b),
-  );
-
-  return valueLabels.map((valueLabel) => {
-    const pairRates = valuePairs
-      .filter((pair) => pair.firstValueLabel === valueLabel || pair.secondValueLabel === valueLabel)
-      .map((pair) => computePairRates(pair, valueLabel));
-
-    const averageWinRate = mean(pairRates.map((rates) => rates.averageWinRate));
-    const balancedWinRate = mean(pairRates.map((rates) => rates.balancedWinRate));
-    const highPressureOnThisValue = mean(pairRates.map((rates) => rates.highPressureOnThisValue));
-    const highPressureOnOpposingValue = mean(pairRates.map((rates) => rates.highPressureOnOpposingValue));
-
-    return {
-      valueLabel,
-      averageWinRate,
-      balancedWinRate,
-      highPressureOnThisValue,
-      highPressureOnOpposingValue,
-      responsiveness:
-        highPressureOnThisValue != null && balancedWinRate != null
-          ? highPressureOnThisValue - balancedWinRate
-          : null,
-    };
-  });
 }
 
 function defaultDirectionForKey(key: SortKey): SortDirection {
@@ -277,12 +203,26 @@ function RateCell({ value }: { value: number | null }) {
   return <TableCell className="text-right text-sm">{formatRate(value)}</TableCell>;
 }
 
-export function PressureResponseByValueTable({ valuePairs }: Props) {
+export function PressureResponseByValueTable({ valueRates }: Props) {
   const tableRef = useRef<HTMLDivElement>(null);
   const [sortKey, setSortKey] = useState<SortKey>('responsiveness');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
 
-  const rows = useMemo(() => buildValueRows(valuePairs), [valuePairs]);
+  const rows = useMemo(
+    () =>
+      valueRates.map((vr) => ({
+        valueLabel: vr.valueLabel,
+        averageWinRate: vr.averageWinRate ?? null,
+        balancedWinRate: vr.balancedWinRate ?? null,
+        highPressureOnThisValue: vr.highPressureOnThisValueWinRate ?? null,
+        highPressureOnOpposingValue: vr.highPressureOnOpposingValueWinRate ?? null,
+        responsiveness:
+          vr.highPressureOnThisValueWinRate != null && vr.balancedWinRate != null
+            ? vr.highPressureOnThisValueWinRate - vr.balancedWinRate
+            : null,
+      })),
+    [valueRates],
+  );
 
   const sortedRows = useMemo(
     () => sortRows(rows, sortKey, sortDirection),

--- a/cloud/apps/web/src/components/models/PressureSensitivityCrossValueMap.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityCrossValueMap.test.tsx
@@ -10,6 +10,7 @@ function createModel(value: number | null = 0.4): PressureSensitivityModel {
     providerName: 'Provider',
     unscoredCount: 0,
     pressureResponseSummary: { mean: 0.1, rangeMin: 0.05, rangeMax: 0.15, pairsMeasured: 1 },
+    valueRates: [],
     valuePairs: [
       {
         pairKey: 'alpha::beta',

--- a/cloud/apps/web/src/components/models/PressureSensitivityDetail.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityDetail.test.tsx
@@ -46,6 +46,7 @@ function createModel(valuePairs: PressureSensitivityValuePair[]): PressureSensit
     providerName: 'Provider',
     unscoredCount: 0,
     pressureResponseSummary: { mean: 0.1, rangeMin: 0.05, rangeMax: 0.15, pairsMeasured: 2 },
+    valueRates: [],
     valuePairs,
   };
 }

--- a/cloud/apps/web/src/components/models/PressureSensitivitySummary.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivitySummary.test.tsx
@@ -16,6 +16,7 @@ function createModel(
     label,
     providerName: 'Provider',
     unscoredCount: 0,
+    valueRates: [],
     valuePairs: [],
     pressureResponseSummary: { mean, rangeMin, rangeMax, pairsMeasured },
   };

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1182,17 +1182,40 @@ export type DomainTrialRunStatus = {
 
 export type DomainValueCoverageCell = {
   __typename?: 'DomainValueCoverageCell';
+  /** Count of complete A-first runs for this value pair after model-set filtering. This is the filtered directional count for the first value in the pair. */
+  aFirstBatchCount: Scalars['Int']['output'];
   aFirstBatchEquivalent: Scalars['Int']['output'];
   aFirstDefinitionName?: Maybe<Scalars['String']['output']>;
   aggregateRunId?: Maybe<Scalars['String']['output']>;
+  /** Count of complete B-first runs for this value pair after model-set filtering. This is the filtered directional count for the second value in the pair. */
+  bFirstBatchCount: Scalars['Int']['output'];
   bFirstBatchEquivalent: Scalars['Int']['output'];
   bFirstDefinitionName?: Maybe<Scalars['String']['output']>;
+  /** Count of fully-complete non-aggregate runs for this value pair. A run is complete when every selected model has at least one transcript at every (scenario × sampleIndex) slot. samplesPerScenario does not multiply this count -- a complete run contributes 1 regardless of how many samples per scenario were planned. Aggregate runs are excluded. */
+  batchCount: Scalars['Int']['output'];
   batchEquivalent: Scalars['Int']['output'];
+  /** Union of definition IDs that contribute data to this coverage cell, sorted alphabetically. */
   contributingDefinitionIds: Array<Scalars['String']['output']>;
   definitionId?: Maybe<Scalars['String']['output']>;
-  weakestCondition?: Maybe<CoverageWeakestCondition>;
+  definitionName?: Maybe<Scalars['String']['output']>;
+  /** Per-direction condition coverage for this value pair, including complete batches, filled slots, leftover conditions from incomplete runs, and contributing definition IDs. */
+  directionalCoverage: Array<DirectionalCoverage>;
+  /** Count of non-aggregate runs that expect transcripts but are missing one or more (model × scenario × sampleIndex) slots. Per-run; samplesPerScenario does not multiply this count. Aggregate runs and runs with zero expected slots are excluded. */
+  incompleteBatchCount: Scalars['Int']['output'];
+  maxTrialCount?: Maybe<Scalars['Int']['output']>;
+  minTrialCount?: Maybe<Scalars['Int']['output']>;
+  modelBreakdown?: Maybe<Array<CoverageModelBreakdown>>;
+  /** Count of unmatched directional runs for this value pair, computed as max(complete A-first runs, complete B-first runs) - min(complete A-first runs, complete B-first runs). When both directions are equal this is 0; when only one direction has runs this is the count of that side. Runs without a recognizable direction token are excluded. */
+  orphanedBatchCount: Scalars['Int']['output'];
+  /** Count of unmatched condition slots across both directions, computed as the size of the symmetric difference of filled (scenarioId, modelId, sampleIndex) slots. */
+  orphanedConditionCount: Scalars['Int']['output'];
+  /** Count of pairable analysis-ready batches for this value pair, computed as min(complete A-first non-aggregate runs, complete B-first non-aggregate runs) where direction is read from config.jobChoiceValueFirst. A launch where only one direction completed contributes 0 here (the surviving complete run still appears in batchCount). Runs without a recognizable direction token are excluded from both sides. See docs/canonical-glossary.md "Paired Batch" for full semantic. */
+  pairedBatchCount: Scalars['Int']['output'];
+  /** Count of matched condition slots across both directions, computed as the size of the intersection of filled (scenarioId, modelId, sampleIndex) slots. */
+  pairedConditionCount: Scalars['Int']['output'];
   valueA: Scalars['String']['output'];
   valueB: Scalars['String']['output'];
+  weakestCondition?: Maybe<CoverageWeakestCondition>;
 };
 
 export type DomainValueCoverageResult = {
@@ -2378,6 +2401,7 @@ export type PressureSensitivityModel = {
   providerName: Scalars['String']['output'];
   unscoredCount: Scalars['Int']['output'];
   valuePairs: Array<PressureSensitivityValuePair>;
+  valueRates: Array<PressureSensitivityValueRate>;
 };
 
 export type PressureSensitivityResult = {
@@ -2411,6 +2435,17 @@ export type PressureSensitivityValuePair = {
   secondValueLabel: Scalars['String']['output'];
   secondValueToken: Scalars['String']['output'];
   unscoredCount: Scalars['Int']['output'];
+};
+
+export type PressureSensitivityValueRate = {
+  __typename?: 'PressureSensitivityValueRate';
+  averageWinRate?: Maybe<Scalars['Float']['output']>;
+  balancedWinRate?: Maybe<Scalars['Float']['output']>;
+  highPressureOnOpposingValueWinRate?: Maybe<Scalars['Float']['output']>;
+  highPressureOnThisValueWinRate?: Maybe<Scalars['Float']['output']>;
+  pairsMeasured: Scalars['Int']['output'];
+  valueLabel: Scalars['String']['output'];
+  valueToken: Scalars['String']['output'];
 };
 
 /** Result of a probe job execution */
@@ -4283,7 +4318,7 @@ export type DomainValueCoverageQueryVariables = Exact<{
 }>;
 
 
-export type DomainValueCoverageQuery = { __typename?: 'Query', domainValueCoverage?: { __typename?: 'DomainValueCoverageResult', domainId: string, values: Array<string>, cells: Array<{ __typename?: 'DomainValueCoverageCell', valueA: string, valueB: string, batchEquivalent: number, aFirstBatchEquivalent: number, bFirstBatchEquivalent: number, aFirstDefinitionName?: string | null, bFirstDefinitionName?: string | null, weakestCondition?: { __typename?: 'CoverageWeakestCondition', conditionLabel: string, otherConditionsCount?: number | null, modelCounts: Array<{ __typename?: 'CoverageModelCount', modelId: string, label: string, trialCount: number }> } | null, contributingDefinitionIds: Array<string>, definitionId?: string | null, aggregateRunId?: string | null }>, availableModels: Array<{ __typename?: 'CoverageModelOption', modelId: string, label: string }> } | null };
+export type DomainValueCoverageQuery = { __typename?: 'Query', domainValueCoverage?: { __typename?: 'DomainValueCoverageResult', domainId: string, values: Array<string>, cells: Array<{ __typename?: 'DomainValueCoverageCell', valueA: string, valueB: string, batchEquivalent: number, aFirstBatchEquivalent: number, bFirstBatchEquivalent: number, aFirstDefinitionName?: string | null, bFirstDefinitionName?: string | null, contributingDefinitionIds: Array<string>, definitionId?: string | null, aggregateRunId?: string | null, weakestCondition?: { __typename?: 'CoverageWeakestCondition', conditionLabel: string, otherConditionsCount?: number | null, modelCounts: Array<{ __typename?: 'CoverageModelCount', modelId: string, label: string, trialCount: number }> } | null }>, availableModels: Array<{ __typename?: 'CoverageModelOption', modelId: string, label: string }> } | null };
 
 export type DomainValueCoverageLegacyQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -4291,7 +4326,7 @@ export type DomainValueCoverageLegacyQueryVariables = Exact<{
 }>;
 
 
-export type DomainValueCoverageLegacyQuery = { __typename?: 'Query', domainValueCoverage?: { __typename?: 'DomainValueCoverageResult', domainId: string, values: Array<string>, cells: Array<{ __typename?: 'DomainValueCoverageCell', valueA: string, valueB: string, batchEquivalent: number, aFirstBatchEquivalent: number, bFirstBatchEquivalent: number, aFirstDefinitionName?: string | null, bFirstDefinitionName?: string | null, weakestCondition?: { __typename?: 'CoverageWeakestCondition', conditionLabel: string, otherConditionsCount?: number | null, modelCounts: Array<{ __typename?: 'CoverageModelCount', modelId: string, label: string, trialCount: number }> } | null, contributingDefinitionIds: Array<string>, definitionId?: string | null, aggregateRunId?: string | null }>, availableModels: Array<{ __typename?: 'CoverageModelOption', modelId: string, label: string }> } | null };
+export type DomainValueCoverageLegacyQuery = { __typename?: 'Query', domainValueCoverage?: { __typename?: 'DomainValueCoverageResult', domainId: string, values: Array<string>, cells: Array<{ __typename?: 'DomainValueCoverageCell', valueA: string, valueB: string, batchEquivalent: number, aFirstBatchEquivalent: number, bFirstBatchEquivalent: number, aFirstDefinitionName?: string | null, bFirstDefinitionName?: string | null, contributingDefinitionIds: Array<string>, definitionId?: string | null, aggregateRunId?: string | null, weakestCondition?: { __typename?: 'CoverageWeakestCondition', conditionLabel: string, otherConditionsCount?: number | null, modelCounts: Array<{ __typename?: 'CoverageModelCount', modelId: string, label: string, trialCount: number }> } | null }>, availableModels: Array<{ __typename?: 'CoverageModelOption', modelId: string, label: string }> } | null };
 
 export type DomainsQueryVariables = Exact<{
   search?: InputMaybe<Scalars['String']['input']>;
@@ -4655,7 +4690,7 @@ export type PressureSensitivityQueryVariables = Exact<{
 }>;
 
 
-export type PressureSensitivityQuery = { __typename?: 'Query', pressureSensitivity: { __typename?: 'PressureSensitivityResult', pressureConditionExcludedCount: number, transcriptCapHit: boolean, models: Array<{ __typename?: 'PressureSensitivityModel', modelId: string, label: string, providerName: string, unscoredCount: number, pressureResponseSummary: { __typename?: 'PressureResponseSummary', mean?: number | null, rangeMin?: number | null, rangeMax?: number | null, pairsMeasured: number }, valuePairs: Array<{ __typename?: 'PressureSensitivityValuePair', pairKey: string, firstValueToken: string, firstValueLabel: string, secondValueToken: string, secondValueLabel: string, n: number, unscoredCount: number, definitionsMeasured: number, directionBalancedWinRate?: number | null, directionBalancedOpponentWinRate?: number | null, directionBalancedBalancedWinRate?: number | null, directionBalancedBalancedOpponentWinRate?: number | null, directionBalancedHighPressureOwnWinRate?: number | null, directionBalancedHighPressureOwnOpponentWinRate?: number | null, directionBalancedHighPressureOpponentWinRate?: number | null, directionBalancedHighPressureOpponentOpponentWinRate?: number | null, pressureResponse: { __typename?: 'PressureResponse', value?: number | null, baselineRate?: number | null, pushTowardFirstRate?: number | null, pushTowardSecondRate?: number | null, qualifyingTrials: number, ciLow?: number | null, ciHigh?: number | null, reason?: string | null }, grid: Array<{ __typename?: 'SensitivityCell', ownLevel: number, opponentLevel: number, n: number, unscoredCount: number, winRate?: number | null, opponentWinRate?: number | null, conviction?: number | null, netScore?: number | null, lowData: boolean }> }> }>, insufficient: Array<{ __typename?: 'InsufficientPressureSensitivityModel', modelId: string, label: string, providerName: string, reason: string }>, excludedDefinitions: Array<{ __typename?: 'ExcludedDefinition', definitionId: string, name: string, reason: string }>, pressureConditionExclusionBreakdown: { __typename?: 'PressureConditionExclusionBreakdown', sourceRunMapping: number, definitionMetadata: number, missingScenario: number, invalidMetadata: number, levelAssignment: number }, directionalSanityCheck: { __typename?: 'DirectionalSanityCheck', positivePct: number, flatPct: number, negativePct: number, measuredCount: number, unmeasurableCount: number, breakdown: Array<{ __typename?: 'DirectionalSanityCheckEntry', modelId: string, pairKey: string, pressureResponse: number, classification: string }> } } };
+export type PressureSensitivityQuery = { __typename?: 'Query', pressureSensitivity: { __typename?: 'PressureSensitivityResult', pressureConditionExcludedCount: number, transcriptCapHit: boolean, models: Array<{ __typename?: 'PressureSensitivityModel', modelId: string, label: string, providerName: string, unscoredCount: number, pressureResponseSummary: { __typename?: 'PressureResponseSummary', mean?: number | null, rangeMin?: number | null, rangeMax?: number | null, pairsMeasured: number }, valueRates: Array<{ __typename?: 'PressureSensitivityValueRate', valueToken: string, valueLabel: string, averageWinRate?: number | null, balancedWinRate?: number | null, highPressureOnThisValueWinRate?: number | null, highPressureOnOpposingValueWinRate?: number | null, pairsMeasured: number }>, valuePairs: Array<{ __typename?: 'PressureSensitivityValuePair', pairKey: string, firstValueToken: string, firstValueLabel: string, secondValueToken: string, secondValueLabel: string, n: number, unscoredCount: number, definitionsMeasured: number, directionBalancedWinRate?: number | null, directionBalancedOpponentWinRate?: number | null, directionBalancedBalancedWinRate?: number | null, directionBalancedBalancedOpponentWinRate?: number | null, directionBalancedHighPressureOwnWinRate?: number | null, directionBalancedHighPressureOwnOpponentWinRate?: number | null, directionBalancedHighPressureOpponentWinRate?: number | null, directionBalancedHighPressureOpponentOpponentWinRate?: number | null, pressureResponse: { __typename?: 'PressureResponse', value?: number | null, baselineRate?: number | null, pushTowardFirstRate?: number | null, pushTowardSecondRate?: number | null, qualifyingTrials: number, ciLow?: number | null, ciHigh?: number | null, reason?: string | null }, grid: Array<{ __typename?: 'SensitivityCell', ownLevel: number, opponentLevel: number, n: number, unscoredCount: number, winRate?: number | null, opponentWinRate?: number | null, conviction?: number | null, netScore?: number | null, lowData: boolean }> }> }>, insufficient: Array<{ __typename?: 'InsufficientPressureSensitivityModel', modelId: string, label: string, providerName: string, reason: string }>, excludedDefinitions: Array<{ __typename?: 'ExcludedDefinition', definitionId: string, name: string, reason: string }>, pressureConditionExclusionBreakdown: { __typename?: 'PressureConditionExclusionBreakdown', sourceRunMapping: number, definitionMetadata: number, missingScenario: number, invalidMetadata: number, levelAssignment: number }, directionalSanityCheck: { __typename?: 'DirectionalSanityCheck', positivePct: number, flatPct: number, negativePct: number, measuredCount: number, unmeasurableCount: number, breakdown: Array<{ __typename?: 'DirectionalSanityCheckEntry', modelId: string, pairKey: string, pressureResponse: number, classification: string }> } } };
 
 export type OpenRunAnomaliesQueryVariables = Exact<{
   domainId?: InputMaybe<Scalars['ID']['input']>;
@@ -7204,6 +7239,15 @@ export const PressureSensitivityDocument = gql`
         mean
         rangeMin
         rangeMax
+        pairsMeasured
+      }
+      valueRates {
+        valueToken
+        valueLabel
+        averageWinRate
+        balancedWinRate
+        highPressureOnThisValueWinRate
+        highPressureOnOpposingValueWinRate
         pairsMeasured
       }
       valuePairs {

--- a/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
@@ -41,6 +41,17 @@ function createPressureData(
             rangeMax: 0.15,
             pairsMeasured: 1,
           },
+          valueRates: [
+            {
+              valueToken: 'alpha',
+              valueLabel: 'Alpha',
+              averageWinRate: 0.6,
+              balancedWinRate: 0.5,
+              highPressureOnThisValueWinRate: 0.7,
+              highPressureOnOpposingValueWinRate: 0.3,
+              pairsMeasured: 1,
+            },
+          ],
           valuePairs: [
             {
               pairKey: 'alpha::beta',

--- a/cloud/apps/web/src/pages/PressureSensitivity.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.tsx
@@ -297,7 +297,7 @@ export function PressureSensitivity() {
       ) : (
         <>
           <PressureDirectionalBreakdown models={models} />
-          {selectedModel && <PressureResponseByValueTable valuePairs={selectedModel.valuePairs} />}
+          {selectedModel && <PressureResponseByValueTable valueRates={selectedModel.valueRates} />}
 
           {selectedModel && <PressureSensitivityDetail model={selectedModel} />}
 


### PR DESCRIPTION
## Summary

Both pipelines now use a single `aggregateValueWinRates` function that implements the canonical 5-level aggregation (cells → vignette → direction → pair → domain → cross-domain). This fixes the value-table mismatch on the Pressure Sensitivity page when value pairs have unequal domain coverage.

This is the structural fix described in [#886](https://github.com/chrislawcodes/valuerank/pull/886). After PRs #881, #883, #884, the value-table column on Pressure Sensitivity still didn't match the Value Priorities column on the Models page because the two sides averaged in different orders. They now share the function that computes the value rate, so equivalence is structural — not a coincidence.

## What changed

- **New shared file:** `cloud/apps/api/src/services/analysis/value-win-rate-aggregation.ts` — pure aggregator that takes per-(domain, def, value, pair, direction, vignetteRate) inputs and returns per-value cross-domain rates.
- **Domain analysis:** `computeCellWeightedDomainRates` now calls the shared aggregator. Snapshot output schema unchanged (same `valueWinRates`, same `vignetteCount` semantics).
- **Pressure sensitivity resolver:** new `valueRates` field on `PressureSensitivityModel`, populated by the shared aggregator (called 4× for the 4 cell-filter views).
- **Frontend:** `PressureResponseByValueTable` reads the new `valueRates` field directly. The cross-pair averaging in `buildValueRows` is gone — that was the bug.
- **Per-pair table is unchanged.** `computeDirectionBalancedPairWinRates` and all `directionBalanced*` fields stay — pair-level metrics don't have the coverage problem and are correct as-is.

## Equivalence test

`tests/services/analysis/domain-analysis-vs-pressure-equivalence.test.ts` builds a fixture with 3 domains, 4 value pairs, uneven domain coverage (one domain missing one pair), and asserts that both pipelines produce identical per-(model, value) rates to 9 decimal places. This is the regression guard.

## Test plan

- [x] All 2314 API tests pass
- [x] All 1386 web tests pass
- [x] API lint + build clean
- [x] Web lint + build clean
- [x] Equivalence test passes
- [ ] Production smoke test against a known model (run before squash-merge per data-resolver rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)