### PR TITLE
refactor(coverage): remove jobChoicePresentationOrder fallback

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts
@@ -286,33 +286,10 @@ export function getCoverageBatchGroupId(runConfig: unknown): string | null {
  */
 export function getCoverageDirection(runConfig: unknown): string | null {
   if (typeof runConfig !== 'object' || runConfig === null) return null;
-  const config = runConfig as {
-    jobChoiceValueFirst?: unknown;
-    jobChoicePresentationOrder?: unknown;
-    definitionSnapshot?: {
-      components?: {
-        value_first?: { token?: unknown };
-        value_second?: { token?: unknown };
-      };
-    };
-  };
-
-  // Primary: explicit direction token present on newer runs.
-  if (typeof config.jobChoiceValueFirst === 'string') {
-    const trimmed = config.jobChoiceValueFirst.trim();
-    if (trimmed.length > 0) return toPascalCaseKey(trimmed);
-  }
-
-  // Fallback: older runs use jobChoicePresentationOrder + definition snapshot tokens.
-  const order = config.jobChoicePresentationOrder;
-  if (order !== 'A_first' && order !== 'B_first') return null;
-  const components = config.definitionSnapshot?.components;
-  const token = order === 'A_first'
-    ? components?.value_first?.token
-    : components?.value_second?.token;
-  if (typeof token !== 'string' || token.trim().length === 0) return null;
-  // Normalize to PascalCase_Underscore to match COVERAGE_VALUE_KEYS.
-  return toPascalCaseKey(token.trim());
+  const config = runConfig as { jobChoiceValueFirst?: unknown };
+  if (typeof config.jobChoiceValueFirst !== 'string') return null;
+  const trimmed = config.jobChoiceValueFirst.trim();
+  return trimmed.length > 0 ? toPascalCaseKey(trimmed) : null;
 }
 
 /**

--- a/cloud/apps/web/src/components/domains/CoverageCell.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageCell.tsx
@@ -86,7 +86,6 @@ export function CoverageCell(props: CoverageCellProps) {
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
-        {/* eslint-disable-next-line react/forbid-elements */}
         <button
           type="button"
           disabled={isDiagonal}

--- a/cloud/apps/web/src/components/domains/CoverageCell.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageCell.tsx
@@ -86,6 +86,7 @@ export function CoverageCell(props: CoverageCellProps) {
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
+        {/* eslint-disable-next-line react/forbid-elements */}
         <button
           type="button"
           disabled={isDiagonal}


### PR DESCRIPTION
## Summary
- Removes the `jobChoicePresentationOrder` fallback from `getCoverageDirection` in `domain-coverage-utils.ts`
- `getCoverageDirection` now only reads `jobChoiceValueFirst` (the canonical field)

## Why it's safe now
All 116 production runs that had `jobChoicePresentationOrder` but no `jobChoiceValueFirst` were backfilled by PR #888 (`backfill-job-choice-value-first` script). Verified via production GraphQL query — Job Choice domain coverage matrix now shows non-zero batch equivalents across all value pairs.

The 102 runs that were skipped by the backfill (missing snapshot components) return `null` from `getCoverageDirection` with or without the fallback — no regression.

## Validation
- `npm run build --workspace @valuerank/api` ✅
- Production smoke test: Job Choice domain cells all non-zero after backfill ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)