### PR TITLE
fix(pressure-sensitivity): per-vignette averaging in pair-rate aggregation

### DIFF
--- a/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
@@ -598,64 +598,110 @@ export function computeDirectionBalancedPairWinRates(params: {
   cellFilter?: (ownLevel: number, opponentLevel: number) => boolean;
 }): { ownRate: number | null; opponentRate: number | null } {
   const { cells, canonicalFirstValueToken, authoredFirstTokenByDef, domainByDef, cellFilter } = params;
+  type DirectionKey = 'first' | 'second';
+  type CellRateBucket = { ownRates: number[]; opponentRates: number[] };
+  type DomainDirectionBuckets = Record<DirectionKey, CellRateBucket>;
 
-  // Per-domain direction buckets: domainKey → { first: rates[], second: rates[] }
-  const ratesByDomain = new Map<string, { first: number[]; second: number[] }>();
+  const getDirectionBuckets = (): DomainDirectionBuckets => ({
+    first: { ownRates: [], opponentRates: [] },
+    second: { ownRates: [], opponentRates: [] },
+  });
+
+  const parseCellLevels = (key: string): { ownLevel: number; opponentLevel: number } | null => {
+    const colonIdx = key.indexOf('::');
+    if (colonIdx === -1) return null;
+
+    const ownLevel = parseInt(key.slice(0, colonIdx), 10);
+    const opponentLevel = parseInt(key.slice(colonIdx + 2), 10);
+    if (!Number.isFinite(ownLevel) || !Number.isFinite(opponentLevel)) {
+      return null;
+    }
+
+    return { ownLevel, opponentLevel };
+  };
+
+  // Collect per-vignette cell rates first so each vignette gets one vote before direction pooling.
+  const cellRatesByDef = new Map<string, CellRateBucket>();
 
   for (const [key, cell] of cells) {
     if (cellFilter != null) {
-      const colonIdx = key.indexOf('::');
-      if (colonIdx === -1) continue;
-      const ownLevel = parseInt(key.slice(0, colonIdx), 10);
-      const opponentLevel = parseInt(key.slice(colonIdx + 2), 10);
-      if (!Number.isFinite(ownLevel) || !Number.isFinite(opponentLevel)) continue;
-      if (!cellFilter(ownLevel, opponentLevel)) continue;
+      const cellLevels = parseCellLevels(key);
+      if (cellLevels == null) continue;
+      if (!cellFilter(cellLevels.ownLevel, cellLevels.opponentLevel)) continue;
     }
 
     for (const [defId, observations] of cell.observationsByDefinition) {
-      const authoredFirstToken = authoredFirstTokenByDef.get(defId);
-      if (authoredFirstToken == null) continue;
-
       const metrics = buildCellMetrics([...observations]);
       if (metrics.n === 0) continue;
 
-      const domainKey = domainByDef.get(defId) ?? defId;
-      let bucket = ratesByDomain.get(domainKey);
-      if (bucket == null) {
-        bucket = { first: [], second: [] };
-        ratesByDomain.set(domainKey, bucket);
+      let defRates = cellRatesByDef.get(defId);
+      if (defRates == null) {
+        defRates = { ownRates: [], opponentRates: [] };
+        cellRatesByDef.set(defId, defRates);
       }
 
       // winRate is always the canonical own rate — assignOwnOpponent maps all outcomes
-      // to canonical own/opponent regardless of authored direction. The bucket split
-      // (first vs second) controls direction balancing; both buckets track the same value.
-      if (metrics.winRate != null) {
-        if (authoredFirstToken === canonicalFirstValueToken) {
-          bucket.first.push(metrics.winRate);
-        } else {
-          bucket.second.push(metrics.winRate);
-        }
-      }
+      // to canonical own/opponent regardless of authored direction.
+      if (metrics.winRate != null) defRates.ownRates.push(metrics.winRate);
+      if (metrics.opponentWinRate != null) defRates.opponentRates.push(metrics.opponentWinRate);
     }
+  }
+
+  // Per-domain direction buckets: domainKey → { first: vignette rates[], second: vignette rates[] }
+  const ratesByDomain = new Map<string, DomainDirectionBuckets>();
+  for (const [defId, defRates] of cellRatesByDef) {
+    const authoredFirstToken = authoredFirstTokenByDef.get(defId);
+    if (authoredFirstToken == null) continue;
+
+    const directionKey: DirectionKey =
+      authoredFirstToken === canonicalFirstValueToken ? 'first' : 'second';
+    const vignetteOwnRate = averageNonNull(defRates.ownRates);
+    const vignetteOpponentRate = averageNonNull(defRates.opponentRates);
+    if (vignetteOwnRate == null && vignetteOpponentRate == null) continue;
+
+    const domainKey = domainByDef.get(defId) ?? defId;
+    let bucket = ratesByDomain.get(domainKey);
+    if (bucket == null) {
+      bucket = getDirectionBuckets();
+      ratesByDomain.set(domainKey, bucket);
+    }
+
+    if (vignetteOwnRate != null) bucket[directionKey].ownRates.push(vignetteOwnRate);
+    if (vignetteOpponentRate != null) bucket[directionKey].opponentRates.push(vignetteOpponentRate);
   }
 
   // Per-domain: average directions, then collect domain rates.
   const domainOwnRates: number[] = [];
+  const domainOpponentRates: number[] = [];
   for (const bucket of ratesByDomain.values()) {
-    const firstMean = averageNonNull(bucket.first);
-    const secondMean = averageNonNull(bucket.second);
-    if (firstMean == null && secondMean == null) continue;
+    const firstOwnMean = averageNonNull(bucket.first.ownRates);
+    const secondOwnMean = averageNonNull(bucket.second.ownRates);
+    const firstOpponentMean = averageNonNull(bucket.first.opponentRates);
+    const secondOpponentMean = averageNonNull(bucket.second.opponentRates);
+
+    if (
+      firstOwnMean == null
+      && secondOwnMean == null
+      && firstOpponentMean == null
+      && secondOpponentMean == null
+    ) {
+      continue;
+    }
+
     // If only one direction has data, use it as the sole estimate for this domain.
-    const domainRate = averageNonNull([firstMean, secondMean]);
-    if (domainRate != null) domainOwnRates.push(domainRate);
+    const domainOwnRate = averageNonNull([firstOwnMean, secondOwnMean]);
+    const domainOpponentRate = averageNonNull([firstOpponentMean, secondOpponentMean]);
+    if (domainOwnRate != null) domainOwnRates.push(domainOwnRate);
+    if (domainOpponentRate != null) domainOpponentRates.push(domainOpponentRate);
   }
 
-  if (domainOwnRates.length === 0) {
+  const ownRate = averageNonNull(domainOwnRates);
+  const opponentRate = averageNonNull(domainOpponentRates);
+  if (ownRate == null && opponentRate == null) {
     return { ownRate: null, opponentRate: null };
   }
 
-  const ownRate = domainOwnRates.reduce((sum, r) => sum + r, 0) / domainOwnRates.length;
-  return { ownRate, opponentRate: 1 - ownRate };
+  return { ownRate, opponentRate };
 }
 
 export function summarizePressureResponse(

--- a/cloud/apps/api/tests/services/pressure-sensitivity/aggregation.test.ts
+++ b/cloud/apps/api/tests/services/pressure-sensitivity/aggregation.test.ts
@@ -639,6 +639,39 @@ describe('computeDirectionBalancedPairWinRates (second suite)', () => {
     expect(result.opponentRate).toBeCloseTo(0.4, 10);
   });
 
+  it('gives each vignette one vote within a direction instead of pooling all of its cells', () => {
+    // This regression distinguishes the PRD-correct vignette weighting from the old cell-pooling
+    // behavior. Old logic would pool six A-first cell rates as one bucket:
+    //   (1 + 1 + 1 + 1 + 1 + 0) / 6 = 0.8333...
+    // PRD logic averages per vignette first:
+    //   def-many = 1.0 across 5 cells, def-few = 0.0 across 1 cell, direction = (1 + 0) / 2 = 0.5
+    const cells = new Map([
+      makeCell('1::1', 'def-many', [makeObs('own_picked')]),
+      makeCell('1::2', 'def-many', [makeObs('own_picked')]),
+      makeCell('1::3', 'def-many', [makeObs('own_picked')]),
+      makeCell('2::1', 'def-many', [makeObs('own_picked')]),
+      makeCell('2::2', 'def-many', [makeObs('own_picked')]),
+      makeCell('3::3', 'def-few', [makeObs('opponent_picked')]),
+    ]);
+
+    const result = computeDirectionBalancedPairWinRates({
+      cells,
+      definitionsMeasured: new Set(['def-many', 'def-few']),
+      canonicalFirstValueToken: 'alpha',
+      authoredFirstTokenByDef: new Map([
+        ['def-many', 'alpha'],
+        ['def-few', 'alpha'],
+      ]),
+      domainByDef: new Map([
+        ['def-many', 'd1'],
+        ['def-few', 'd1'],
+      ]),
+    });
+
+    expect(result.ownRate).toBeCloseTo(0.5, 10);
+    expect(result.opponentRate).toBeCloseTo(0.5, 10);
+  });
+
   it('applies cellFilter to restrict which cells contribute', () => {
     // Two cells: 1::1 (balanced) and 4::1 (high pressure on own)
     // Only the balanced cell should contribute with cellFilter own===opp

--- a/cloud/scripts/file-size-allowlist.txt
+++ b/cloud/scripts/file-size-allowlist.txt
@@ -9,6 +9,10 @@ cloud/apps/web/src/components/analysis/PairedRunComparisonCard.tsx
 # fetchTranscriptsFromSourceRuns, buildEmptyResult) exported for tests.
 # Split into resolver-helpers.ts when convenient.
 cloud/apps/api/src/graphql/queries/pressure-sensitivity.ts
+# Pressure sensitivity aggregation: mixes domain aggregation logic with
+# statistical math helpers (wilsonInterval, diffProportionCI, tBasedMeanCI).
+# Extract stat helpers into stat-math.ts when convenient.
+cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
 
 # Large test files over 1200
 cloud/apps/api/tests/services/run/start.test.ts

--- a/docs/tech-debt/file-structure.json
+++ b/docs/tech-debt/file-structure.json
@@ -64,6 +64,11 @@
       "file": "cloud/apps/api/tests/graphql/queries/run.test.ts",
       "lines": 1226,
       "action": "Split by test group next time you touch it."
+    },
+    {
+      "file": "cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts",
+      "lines": 721,
+      "action": "Extract stat helpers (wilsonInterval, diffProportionCI, tBasedMeanCI) into stat-math.ts next time you touch it."
     }
   ]
 }

--- a/docs/tech-debt/file-structure.md
+++ b/docs/tech-debt/file-structure.md
@@ -37,6 +37,7 @@ Exempt from the hard line-size cap via `cloud/scripts/file-size-allowlist.txt`.
 | [start.test.ts](../../cloud/apps/api/tests/services/run/start.test.ts) | 1975 | Split by scenario group |
 | [definition.test.ts (queries)](../../cloud/apps/api/tests/graphql/queries/definition.test.ts) | 1336 | Split by test group |
 | [run.test.ts (queries)](../../cloud/apps/api/tests/graphql/queries/run.test.ts) | 1226 | Split by test group |
+| [aggregation.ts (pressure-sensitivity)](../../cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts) | 721 | Extract stat helpers (wilsonInterval, diffProportionCI, tBasedMeanCI) into stat-math.ts |
 
 ## Existing banned-suffix files (filename allowlist)
 


### PR DESCRIPTION
## Summary

`computeDirectionBalancedPairWinRates` was pooling all (cell, definition) rates within each direction bucket and averaging them as one set. This silently weighted vignettes by their count of valid cells, violating the PRD's "each vignette gets one vote" rule.

The PRD specifies (docs/valuerank_prd.yaml, Domain.Win_Rate, ~line 63):
> "Four-level aggregation — each level contributes one vote regardless of how many items it contains:
> 1. Condition → Vignette rate: average the 25 condition rates equally.
> 2. Vignette → Direction rate: average vignettes within same authored direction equally.
> 3. Direction → Pair rate: average the two direction rates equally."

The old code skipped step 1 (vignette rate), going directly from cells to a pooled direction average.

## Concrete example

- Vignette A (A-first): 25 valid cells, mean rate 0.72
- Vignette B (A-first): 5 valid cells (rest had refusals), mean rate 0.20

| Approach | A-first direction rate |
|---|---|
| PRD (per-vignette) | mean(0.72, 0.20) = **0.46** |
| Old code (pooled) | (25×0.72 + 5×0.20) / 30 = **0.633** |

In practice, when every cell has the same N (typical N=1 per cell), the two approaches give the same result. The fix matters when vignettes have unequal valid-cell counts.

## What changed

- `cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts` — refactored `computeDirectionBalancedPairWinRates` to compute per-vignette rate first, then average per direction, then average directions per domain, then cross-domain. Same input contract; same return shape (`{ ownRate, opponentRate }`); same `cellFilter` semantics.
- `cloud/apps/api/tests/services/pressure-sensitivity/aggregation.test.ts` — added a regression test that distinguishes vignette weighting from cell pooling. Old code would have produced 0.833; new code produces 0.5 (correct per PRD).

## Companion PRs

- #889 (shipped): shared value-aggregator + correct value-table aggregation order
- #891 (shipped): canonical-token fix (the headline 50%-clustering bug)
- This PR: cleans up the per-pair table to also follow the PRD's per-vignette weighting rule

## Test plan

- [x] All targeted tests pass (37 in aggregation.test.ts, 9 in pressure-sensitivity-canonical-direction.test.ts, 7 in value-win-rate-aggregation.test.ts, 1 equivalence test)
- [x] API lint clean (warnings only, all pre-existing)
- [x] API build clean
- [ ] Production smoke test post-deploy: confirm per-pair table numbers shift slightly when vignettes have unequal refusal rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)