### PR TITLE
refactor(web): Pressure Response by Value averages across selected models

### DIFF
--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { PressureResponseByValueTable } from './PressureResponseByValueTable';
-import type { PressureSensitivityValueRate } from '../../api/operations/pressureSensitivity';
+import type {
+  PressureSensitivityModel,
+  PressureSensitivityValueRate,
+} from '../../api/operations/pressureSensitivity';
 
 const TEN_VALUE_LABELS = [
   'Alpha',
@@ -29,6 +32,26 @@ function createValueRate(
     highPressureOnOpposingValueWinRate: 0.5,
     pairsMeasured: 9,
     ...overrides,
+  };
+}
+
+function createModel(
+  modelId: string,
+  valueRates: PressureSensitivityValueRate[],
+): PressureSensitivityModel {
+  return {
+    modelId,
+    label: modelId,
+    providerName: 'Provider',
+    unscoredCount: 0,
+    pressureResponseSummary: {
+      mean: 0.1,
+      rangeMin: 0.05,
+      rangeMax: 0.15,
+      pairsMeasured: valueRates[0]?.pairsMeasured ?? 0,
+    },
+    valueRates,
+    valuePairs: [],
   };
 }
 
@@ -84,8 +107,8 @@ function createMathFixture(): PressureSensitivityValueRate[] {
 }
 
 describe('PressureResponseByValueTable', () => {
-  it('renders 10 rows when the model has 10 values', () => {
-    render(<PressureResponseByValueTable valueRates={createTenValueRates()} />);
+  it('renders 10 rows when the filtered model set has 10 values', () => {
+    render(<PressureResponseByValueTable models={[createModel('Model A', createTenValueRates())]} />);
 
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(12);
@@ -93,7 +116,7 @@ describe('PressureResponseByValueTable', () => {
   });
 
   it('sorts by responsiveness by default and re-sorts when a header is clicked', () => {
-    render(<PressureResponseByValueTable valueRates={createSortFixture()} />);
+    render(<PressureResponseByValueTable models={[createModel('Model A', createSortFixture())]} />);
 
     const rows = screen.getAllByRole('row');
     expect(rows[2]?.textContent ?? '').toContain('Alpha');
@@ -105,7 +128,7 @@ describe('PressureResponseByValueTable', () => {
   });
 
   it('toggles sort direction when the same header is clicked twice', () => {
-    render(<PressureResponseByValueTable valueRates={createSortFixture()} />);
+    render(<PressureResponseByValueTable models={[createModel('Model A', createSortFixture())]} />);
 
     const averageHeader = screen.getByRole('button', { name: /sort by average win rate/i });
     fireEvent.click(averageHeader);
@@ -116,15 +139,15 @@ describe('PressureResponseByValueTable', () => {
   });
 
   it('renders the snapshot button with the correct label', () => {
-    render(<PressureResponseByValueTable valueRates={createSortFixture()} />);
+    render(<PressureResponseByValueTable models={[createModel('Model A', createSortFixture())]} />);
 
     expect(
       screen.getByRole('button', { name: /copy pressure response by value as image/i }),
     ).toBeDefined();
   });
 
-  it('renders the direct value-rate inputs and responsiveness math', () => {
-    render(<PressureResponseByValueTable valueRates={createMathFixture()} />);
+  it('renders the averaged value-rate inputs and responsiveness math', () => {
+    render(<PressureResponseByValueTable models={[createModel('Model A', createMathFixture())]} />);
 
     const row = screen.getByText('Alpha').closest('tr');
     if (row == null) {
@@ -141,13 +164,15 @@ describe('PressureResponseByValueTable', () => {
   it('shows dashes for null rates instead of a numeric value', () => {
     render(
       <PressureResponseByValueTable
-        valueRates={[
-          createValueRate('Alpha', {
-            averageWinRate: null,
-            balancedWinRate: 0.4,
-            highPressureOnThisValueWinRate: null,
-            highPressureOnOpposingValueWinRate: 0.3,
-          }),
+        models={[
+          createModel('Model A', [
+            createValueRate('Alpha', {
+              averageWinRate: null,
+              balancedWinRate: 0.4,
+              highPressureOnThisValueWinRate: null,
+              highPressureOnOpposingValueWinRate: 0.3,
+            }),
+          ]),
         ]}
       />,
     );
@@ -162,5 +187,42 @@ describe('PressureResponseByValueTable', () => {
     expect(cells[2]?.textContent ?? '').toBe('40.0%');
     expect(cells[3]?.textContent ?? '').toBe('—');
     expect(cells[4]?.textContent ?? '').toBe('30.0%');
+  });
+
+  it('averages rates across all selected models', () => {
+    render(
+      <PressureResponseByValueTable
+        models={[
+          createModel('Model A', [
+            createValueRate('Alpha', {
+              averageWinRate: 0.4,
+              balancedWinRate: 0.2,
+              highPressureOnThisValueWinRate: 0.6,
+              highPressureOnOpposingValueWinRate: 0.1,
+            }),
+          ]),
+          createModel('Model B', [
+            createValueRate('Alpha', {
+              averageWinRate: 0.8,
+              balancedWinRate: 0.4,
+              highPressureOnThisValueWinRate: 1,
+              highPressureOnOpposingValueWinRate: 0.3,
+            }),
+          ]),
+        ]}
+      />,
+    );
+
+    const row = screen.getByText('Alpha').closest('tr');
+    if (row == null) {
+      throw new Error('Missing Alpha row');
+    }
+
+    const cells = within(row).getAllByRole('cell');
+    expect(screen.getByText(/Averaged across 2 selected models/)).toBeDefined();
+    expect(cells[1]?.textContent ?? '').toBe('60.0%');
+    expect(cells[2]?.textContent ?? '').toBe('30.0%');
+    expect(cells[3]?.textContent ?? '').toBe('80.0%');
+    expect(cells[4]?.textContent ?? '').toBe('20.0%');
   });
 });

--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
@@ -3,11 +3,12 @@ import type { ReactNode } from 'react';
 import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { TooltipIcon } from '../ui/TooltipIcon';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/Table';
-import type { PressureSensitivityValueRate } from '../../api/operations/pressureSensitivity';
+import type { PressureSensitivityModel } from '../../api/operations/pressureSensitivity';
 import { formatPercent } from './pressureSensitivityFormatting';
+import { averageValueRatesAcrossModels } from './pressureResponseAggregation';
 
 type Props = {
-  valueRates: PressureSensitivityValueRate[];
+  models: PressureSensitivityModel[];
 };
 
 type SortDirection = 'asc' | 'desc';
@@ -203,10 +204,11 @@ function RateCell({ value }: { value: number | null }) {
   return <TableCell className="text-right text-sm">{formatRate(value)}</TableCell>;
 }
 
-export function PressureResponseByValueTable({ valueRates }: Props) {
+export function PressureResponseByValueTable({ models }: Props) {
   const tableRef = useRef<HTMLDivElement>(null);
   const [sortKey, setSortKey] = useState<SortKey>('responsiveness');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const valueRates = useMemo(() => averageValueRatesAcrossModels(models), [models]);
 
   const rows = useMemo(
     () =>
@@ -239,13 +241,27 @@ export function PressureResponseByValueTable({ valueRates }: Props) {
     setSortDirection(defaultDirectionForKey(key));
   };
 
+  if (models.length === 0) {
+    return (
+      <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-gray-900">Pressure Response by Value</h2>
+          <p className="text-sm text-gray-600">No by-value data is available for the selected models.</p>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
       <div className="mb-3 flex items-start justify-between gap-3">
         <div className="space-y-1">
           <h2 className="text-lg font-semibold text-gray-900">Pressure Response by Value</h2>
           <p className="text-sm text-gray-600">
-            Each row is one of the model&apos;s values. The columns show how often the model picks that value across
+            Averaged across {models.length} selected model{models.length === 1 ? '' : 's'} in the page filter.
+          </p>
+          <p className="text-sm text-gray-600">
+            Each row is one value. The columns show how often the selected model set picks that value across
             its 9 pairings, broken down by what the prompt was doing.
           </p>
           <p className="text-xs text-gray-500">
@@ -362,8 +378,8 @@ export function PressureResponseByValueTable({ valueRates }: Props) {
       <div className="mt-4 space-y-3 text-sm text-gray-600">
         <h3 className="text-sm font-semibold text-gray-900">Reading this table</h3>
         <p>
-          Each row is one of the model&apos;s values. The columns show how often the model picks that value across
-          its 9 pairings, broken down by what the prompt was doing.
+          Each row is one value. The columns show how often the selected model set picks that value across its
+          9 pairings, broken down by what the prompt was doing.
         </p>
         <p>
           The two push columns are most informative when compared against the balanced rate. If &quot;high pressure on
@@ -375,17 +391,17 @@ export function PressureResponseByValueTable({ valueRates }: Props) {
           <p className="font-semibold text-gray-900">Patterns to look for:</p>
           <ul className="mt-2 list-disc space-y-2 pl-5">
             <li>
-              <strong>Moral attractor.</strong> Both push columns are higher than balanced. The model leans toward
-              this value regardless of which way the prompt steers. Unusual - most values move in opposite directions
-              under push and pull pressure.
+              <strong>Moral attractor.</strong> Both push columns are higher than balanced. The selected models lean
+              toward this value regardless of which way the prompt steers. Unusual - most values move in opposite
+              directions under push and pull pressure.
             </li>
             <li>
               <strong>Push-resistant.</strong> &quot;High pressure on value&quot; is at or below balanced.
-              Pressure to make the model pick this value does not work; sometimes it actively backfires.
+              Pressure to make the selected models pick this value does not work; sometimes it actively backfires.
             </li>
             <li>
-              <strong>Inert.</strong> All four columns are within a few points of each other. The model&apos;s choice
-              on pairs involving this value does not shift much based on prompt pressure.
+              <strong>Inert.</strong> All four columns are within a few points of each other. The selected models&apos;
+              choices on pairs involving this value do not shift much based on prompt pressure.
             </li>
           </ul>
         </div>

--- a/cloud/apps/web/src/components/models/PressureSensitivityGridSection.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityGridSection.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { PressureSensitivityModel } from '../../api/operations/pressureSensitivity';
+import { Select } from '../ui/Select';
+import { PressureSensitivityDetail } from './PressureSensitivityDetail';
+
+type Props = {
+  models: PressureSensitivityModel[];
+  children?: (selection: {
+    selectedModelId: string | null;
+    onSelectModel: (modelId: string) => void;
+  }) => ReactNode;
+};
+
+export function PressureSensitivityGridSection({ models, children }: Props) {
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (models.length === 0) {
+      setSelectedModelId(null);
+      return;
+    }
+
+    setSelectedModelId((current) => {
+      if (current != null && models.some((model) => model.modelId === current)) {
+        return current;
+      }
+      return models[0]?.modelId ?? null;
+    });
+  }, [models]);
+
+  const selectedModel = useMemo(
+    () => (selectedModelId != null ? models.find((model) => model.modelId === selectedModelId) ?? null : null),
+    [models, selectedModelId],
+  );
+
+  const modelOptions = useMemo(
+    () => models.map((model) => ({ value: model.modelId, label: model.label })),
+    [models],
+  );
+
+  if (selectedModel == null) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-xl border border-gray-200 bg-white p-4">
+        <div className="max-w-sm">
+          <Select
+            label="Show grids for"
+            value={selectedModel.modelId}
+            onChange={(value) => setSelectedModelId(value)}
+            options={modelOptions}
+          />
+        </div>
+        <p className="mt-2 text-xs text-gray-500">
+          The per-pair grid stays model-specific, so this picker only changes the detail section below.
+        </p>
+      </div>
+
+      <PressureSensitivityDetail model={selectedModel} />
+
+      {children?.({
+        selectedModelId: selectedModel.modelId,
+        onSelectModel: setSelectedModelId,
+      })}
+    </div>
+  );
+}

--- a/cloud/apps/web/src/components/models/pressureResponseAggregation.test.ts
+++ b/cloud/apps/web/src/components/models/pressureResponseAggregation.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  PressureSensitivityModel,
+  PressureSensitivityValueRate,
+} from '../../api/operations/pressureSensitivity';
+import { averageValueRatesAcrossModels } from './pressureResponseAggregation';
+
+function createValueRate(
+  valueLabel: string,
+  overrides: Partial<PressureSensitivityValueRate> = {},
+): PressureSensitivityValueRate {
+  return {
+    valueToken: valueLabel.toLowerCase(),
+    valueLabel,
+    averageWinRate: 0.5,
+    balancedWinRate: 0.5,
+    highPressureOnThisValueWinRate: 0.5,
+    highPressureOnOpposingValueWinRate: 0.5,
+    pairsMeasured: 9,
+    ...overrides,
+  };
+}
+
+function createModel(modelId: string, valueRates: PressureSensitivityValueRate[]): PressureSensitivityModel {
+  return {
+    modelId,
+    label: modelId,
+    providerName: 'Provider',
+    unscoredCount: 0,
+    pressureResponseSummary: {
+      mean: 0.1,
+      rangeMin: 0.05,
+      rangeMax: 0.15,
+      pairsMeasured: valueRates[0]?.pairsMeasured ?? 0,
+    },
+    valueRates,
+    valuePairs: [],
+  };
+}
+
+describe('averageValueRatesAcrossModels', () => {
+  it('returns an empty array for no models', () => {
+    expect(averageValueRatesAcrossModels([])).toEqual([]);
+  });
+
+  it('returns the single model rates unchanged', () => {
+    const model = createModel('Model A', [
+      createValueRate('Alpha', {
+        averageWinRate: 0.6,
+        balancedWinRate: 0.4,
+        highPressureOnThisValueWinRate: 0.8,
+        highPressureOnOpposingValueWinRate: 0.3,
+      }),
+    ]);
+
+    expect(averageValueRatesAcrossModels([model])).toEqual(model.valueRates);
+  });
+
+  it('averages full data across two models and keeps the max pairsMeasured', () => {
+    const averaged = averageValueRatesAcrossModels([
+      createModel('Model A', [
+        createValueRate('Alpha', {
+          averageWinRate: 0.4,
+          balancedWinRate: 0.2,
+          highPressureOnThisValueWinRate: 0.6,
+          highPressureOnOpposingValueWinRate: 0.1,
+          pairsMeasured: 7,
+        }),
+      ]),
+      createModel('Model B', [
+        createValueRate('Alpha', {
+          averageWinRate: 0.8,
+          balancedWinRate: 0.4,
+          highPressureOnThisValueWinRate: 1,
+          highPressureOnOpposingValueWinRate: 0.3,
+          pairsMeasured: 9,
+        }),
+      ]),
+    ]);
+
+    expect(averaged).toHaveLength(1);
+    expect(averaged[0]?.valueToken).toBe('alpha');
+    expect(averaged[0]?.valueLabel).toBe('Alpha');
+    expect(averaged[0]?.pairsMeasured).toBe(9);
+    expect(averaged[0]?.averageWinRate).toBeCloseTo(0.6);
+    expect(averaged[0]?.balancedWinRate).toBeCloseTo(0.3);
+    expect(averaged[0]?.highPressureOnThisValueWinRate).toBeCloseTo(0.8);
+    expect(averaged[0]?.highPressureOnOpposingValueWinRate).toBeCloseTo(0.2);
+  });
+
+  it('skips nulls when averaging and returns null when every model is null', () => {
+    const averaged = averageValueRatesAcrossModels([
+      createModel('Model A', [
+        createValueRate('Alpha', {
+          averageWinRate: null,
+          balancedWinRate: 0.4,
+          highPressureOnThisValueWinRate: null,
+          highPressureOnOpposingValueWinRate: 0.1,
+        }),
+      ]),
+      createModel('Model B', [
+        createValueRate('Alpha', {
+          averageWinRate: 0.8,
+          balancedWinRate: null,
+          highPressureOnThisValueWinRate: null,
+          highPressureOnOpposingValueWinRate: 0.3,
+        }),
+      ]),
+    ]);
+
+    expect(averaged).toEqual([
+      {
+        valueToken: 'alpha',
+        valueLabel: 'Alpha',
+        averageWinRate: 0.8,
+        balancedWinRate: 0.4,
+        highPressureOnThisValueWinRate: null,
+        highPressureOnOpposingValueWinRate: 0.2,
+        pairsMeasured: 9,
+      },
+    ]);
+  });
+});

--- a/cloud/apps/web/src/components/models/pressureResponseAggregation.ts
+++ b/cloud/apps/web/src/components/models/pressureResponseAggregation.ts
@@ -1,0 +1,94 @@
+import type {
+  PressureSensitivityModel,
+  PressureSensitivityValueRate,
+} from '../../api/operations/pressureSensitivity';
+
+type RateField =
+  | 'averageWinRate'
+  | 'balancedWinRate'
+  | 'highPressureOnThisValueWinRate'
+  | 'highPressureOnOpposingValueWinRate';
+
+type MutableRateAccumulator = {
+  pairsMeasured: number;
+  sums: Record<RateField, number>;
+  counts: Record<RateField, number>;
+  valueLabel: string;
+  valueToken: string;
+};
+
+const RATE_FIELDS: RateField[] = [
+  'averageWinRate',
+  'balancedWinRate',
+  'highPressureOnThisValueWinRate',
+  'highPressureOnOpposingValueWinRate',
+];
+
+function averageRate(sum: number, count: number): number | null {
+  return count > 0 ? sum / count : null;
+}
+
+export function averageValueRatesAcrossModels(
+  models: PressureSensitivityModel[],
+): PressureSensitivityValueRate[] {
+  if (models.length === 0) {
+    return [];
+  }
+
+  const ratesByValue = new Map<string, MutableRateAccumulator>();
+
+  for (const model of models) {
+    for (const valueRate of model.valueRates) {
+      const existing = ratesByValue.get(valueRate.valueToken);
+      const accumulator = existing ?? {
+        pairsMeasured: valueRate.pairsMeasured,
+        sums: {
+          averageWinRate: 0,
+          balancedWinRate: 0,
+          highPressureOnThisValueWinRate: 0,
+          highPressureOnOpposingValueWinRate: 0,
+        },
+        counts: {
+          averageWinRate: 0,
+          balancedWinRate: 0,
+          highPressureOnThisValueWinRate: 0,
+          highPressureOnOpposingValueWinRate: 0,
+        },
+        valueLabel: valueRate.valueLabel,
+        valueToken: valueRate.valueToken,
+      };
+
+      // pairsMeasured should be structural per value, but keep the max if older data varies.
+      accumulator.pairsMeasured = Math.max(accumulator.pairsMeasured, valueRate.pairsMeasured);
+
+      for (const field of RATE_FIELDS) {
+        const rate = valueRate[field];
+        if (rate == null) {
+          continue;
+        }
+        accumulator.sums[field] += rate;
+        accumulator.counts[field] += 1;
+      }
+
+      if (existing == null) {
+        ratesByValue.set(valueRate.valueToken, accumulator);
+      }
+    }
+  }
+
+  return Array.from(ratesByValue.values()).map((rate) => ({
+    valueToken: rate.valueToken,
+    valueLabel: rate.valueLabel,
+    averageWinRate: averageRate(rate.sums.averageWinRate, rate.counts.averageWinRate),
+    balancedWinRate: averageRate(rate.sums.balancedWinRate, rate.counts.balancedWinRate),
+    highPressureOnThisValueWinRate: averageRate(
+      rate.sums.highPressureOnThisValueWinRate,
+      rate.counts.highPressureOnThisValueWinRate,
+    ),
+    highPressureOnOpposingValueWinRate: averageRate(
+      rate.sums.highPressureOnOpposingValueWinRate,
+      rate.counts.highPressureOnOpposingValueWinRate,
+    ),
+    pairsMeasured: rate.pairsMeasured,
+  }));
+}

--- a/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { PressureSensitivity } from './PressureSensitivity';
 import { DOMAIN_AVAILABLE_SIGNATURES_QUERY } from '../api/operations/domainAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
@@ -45,9 +45,9 @@ function createPressureData(
             {
               valueToken: 'alpha',
               valueLabel: 'Alpha',
-              averageWinRate: 0.6,
-              balancedWinRate: 0.5,
-              highPressureOnThisValueWinRate: 0.7,
+              averageWinRate: 0.4,
+              balancedWinRate: 0.3,
+              highPressureOnThisValueWinRate: 0.6,
               highPressureOnOpposingValueWinRate: 0.3,
               pairsMeasured: 1,
             },
@@ -70,6 +70,52 @@ function createPressureData(
                 qualifyingTrials: 12,
                 ciLow: 0.1,
                 ciHigh: 0.7,
+                reason: null,
+              },
+              grid: [],
+            },
+          ],
+        },
+        {
+          modelId: 'model-b',
+          label: 'Model B',
+          providerName: 'Provider',
+          unscoredCount: 0,
+          pressureResponseSummary: {
+            mean: 0.2,
+            rangeMin: 0.1,
+            rangeMax: 0.3,
+            pairsMeasured: 1,
+          },
+          valueRates: [
+            {
+              valueToken: 'alpha',
+              valueLabel: 'Alpha',
+              averageWinRate: 0.8,
+              balancedWinRate: 0.5,
+              highPressureOnThisValueWinRate: 0.9,
+              highPressureOnOpposingValueWinRate: 0.2,
+              pairsMeasured: 1,
+            },
+          ],
+          valuePairs: [
+            {
+              pairKey: 'gamma::delta',
+              firstValueToken: 'gamma',
+              firstValueLabel: 'Gamma',
+              secondValueToken: 'delta',
+              secondValueLabel: 'Delta',
+              n: 8,
+              unscoredCount: 0,
+              definitionsMeasured: 1,
+              pressureResponse: {
+                value: -0.2,
+                baselineRate: 0.4,
+                pushTowardFirstRate: 0.3,
+                pushTowardSecondRate: 0.5,
+                qualifyingTrials: 8,
+                ciLow: -0.4,
+                ciHigh: 0,
                 reason: null,
               },
               grid: [],
@@ -280,6 +326,7 @@ describe('PressureSensitivity page', () => {
     );
 
     expect(screen.getByText('Pressure Response by Value')).toBeDefined();
+    expect(screen.getByText(/Averaged across 2 selected models/)).toBeDefined();
   });
 
   it('defaults to the model picker and removes the provider filter copy', () => {
@@ -313,5 +360,42 @@ describe('PressureSensitivity page', () => {
     );
 
     expect(screen.getByText(/lower bound on pressure sensitivity/)).toBeDefined();
+  });
+
+  it('switches the grid model picker without changing the averaged by-value table', () => {
+    mockDomainsOnce();
+    mockQuery(createPressureData(false));
+
+    render(
+      <MemoryRouter initialEntries={['/models/pressure-sensitivity?domainId=domain-a&signature=vnewtd']}>
+        <PressureSensitivity />
+      </MemoryRouter>,
+    );
+
+    const valueRow = screen.getByText('Alpha').closest('tr');
+    if (valueRow == null) {
+      throw new Error('Missing Alpha row');
+    }
+
+    let valueCells = within(valueRow).getAllByRole('cell');
+    expect(valueCells[1]?.textContent ?? '').toBe('60.0%');
+    expect(screen.getByText('Alpha ↔ Beta')).toBeDefined();
+    expect(screen.queryByText('Gamma ↔ Delta')).toBeNull();
+
+    const gridLabel = screen.getByText('Show grids for');
+    const gridPickerButton = gridLabel.nextElementSibling;
+    if (!(gridPickerButton instanceof HTMLButtonElement)) {
+      throw new Error('Missing grid picker button');
+    }
+
+    fireEvent.click(gridPickerButton);
+    fireEvent.click(screen.getByRole('option', { name: 'Model B' }));
+
+    expect(screen.queryByText('Alpha ↔ Beta')).toBeNull();
+    expect(screen.getByText('Gamma ↔ Delta')).toBeDefined();
+
+    valueCells = within(valueRow).getAllByRole('cell');
+    expect(valueCells[1]?.textContent ?? '').toBe('60.0%');
+    expect(screen.getByText(/Averaged across 2 selected models/)).toBeDefined();
   });
 });

--- a/cloud/apps/web/src/pages/PressureSensitivity.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.tsx
@@ -18,7 +18,7 @@ import {
 import { PressureDirectionalBreakdown } from '../components/models/PressureDirectionalBreakdown';
 import { PressureSensitivitySummary } from '../components/models/PressureSensitivitySummary';
 import { PressureResponseByValueTable } from '../components/models/PressureResponseByValueTable';
-import { PressureSensitivityDetail } from '../components/models/PressureSensitivityDetail';
+import { PressureSensitivityGridSection } from '../components/models/PressureSensitivityGridSection';
 import { PressureSensitivityCrossValueMap } from '../components/models/PressureSensitivityCrossValueMap';
 import { PressureSensitivitySanityCheck } from '../components/models/PressureSensitivitySanityCheck';
 import { PressureSensitivityLimitations } from '../components/models/PressureSensitivityLimitations';
@@ -38,7 +38,6 @@ export function PressureSensitivity() {
   const hasDomainParam = domainParam != null;
   const domainFilter = domainParam === 'all' ? null : domainParam;
   const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
-  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
 
   const defaultDomainId = domains[0]?.id ?? null;
   const urlDomainId = hasDomainParam ? domainFilter : defaultDomainId;
@@ -162,20 +161,6 @@ export function PressureSensitivity() {
   const transcriptCapHit = data?.pressureSensitivity.transcriptCapHit ?? false;
   const pressureConditionExcludedCount = data?.pressureSensitivity.pressureConditionExcludedCount ?? 0;
 
-  useEffect(() => {
-    if (selectedModelId == null && models.length > 0) {
-      setSelectedModelId(models[0]!.modelId);
-      return;
-    }
-    if (selectedModelId != null && !models.some((m) => m.modelId === selectedModelId)) {
-      setSelectedModelId(models[0]?.modelId ?? null);
-    }
-  }, [models, selectedModelId]);
-
-  const selectedModel = selectedModelId != null
-    ? models.find((m) => m.modelId === selectedModelId) ?? null
-    : models[0] ?? null;
-
   const loading =
     (domainsLoading && domains.length === 0)
     || llmModelsLoading
@@ -297,21 +282,25 @@ export function PressureSensitivity() {
       ) : (
         <>
           <PressureDirectionalBreakdown models={models} />
-          {selectedModel && <PressureResponseByValueTable valueRates={selectedModel.valueRates} />}
+          <PressureResponseByValueTable models={models} />
 
-          {selectedModel && <PressureSensitivityDetail model={selectedModel} />}
+          <PressureSensitivityGridSection models={models}>
+            {({ selectedModelId, onSelectModel }) => (
+              <>
+                <PressureSensitivityCrossValueMap models={models} />
 
-          <PressureSensitivityCrossValueMap models={models} />
+                {directionalSanityCheck && <PressureSensitivitySanityCheck data={directionalSanityCheck} />}
 
-          {directionalSanityCheck && <PressureSensitivitySanityCheck data={directionalSanityCheck} />}
+                <PressureSensitivityLimitations />
 
-          <PressureSensitivityLimitations />
-
-          <PressureSensitivitySummary
-            models={models}
-            selectedModelId={selectedModel?.modelId ?? null}
-            onSelectModel={setSelectedModelId}
-          />
+                <PressureSensitivitySummary
+                  models={models}
+                  selectedModelId={selectedModelId}
+                  onSelectModel={onSelectModel}
+                />
+              </>
+            )}
+          </PressureSensitivityGridSection>
         </>
       )}
 


### PR DESCRIPTION
## Summary

The Pressure Sensitivity page had a hidden singular model picker (`selectedModelId`) that silently controlled both the value table and the per-pair grids. This created a confusing scope mismatch:

- **Domain Analysis "Value Priorities"**: averages across all selected models
- **Pressure Response by Value (before)**: showed one model's data, defaulted to first in list

Users compared 37.1% (DA, all-models avg) to 42.3% (PS, single Gemini model) and thought the pipelines disagreed. They didn't — the UI was just showing different scopes.

## What changed

**Pressure Response by Value table:** now averages `valueRates` across all models selected in the page-level filter. Mirrors Domain Analysis exactly. Same data shape, same comparison.

**Per-pair grids:** kept per-model (averaging cell-level data across models doesn't make physical sense). Moved the model picker out of the page header and into a new `PressureSensitivityGridSection` component, co-located with the grid view, labeled "Show grids for:". Now users can clearly see the picker only affects the grids.

**Hidden state removed:** `selectedModelId` is no longer a page-level concern. The averaged value table is fed by `models[]` directly.

## Files changed

- `cloud/apps/web/src/pages/PressureSensitivity.tsx` — removed `selectedModelId` state; passes `models[]` to value table; uses new `PressureSensitivityGridSection`
- `cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx` — accepts `models[]` instead of `valueRates`; renders averaged data
- `cloud/apps/web/src/components/models/pressureResponseAggregation.ts` (new) — pure helper that averages `valueRates` across models, handling nulls correctly
- `cloud/apps/web/src/components/models/PressureSensitivityGridSection.tsx` (new) — owns the grid model picker locally
- Tests added for the aggregator and updated for the new prop shapes

## Test plan

- [x] `npm run lint --workspace @valuerank/web` — clean (warnings are pre-existing)
- [x] `npm run test --workspace @valuerank/web` — passing
- [x] `npm run build --workspace @valuerank/web` — clean
- [ ] After deploy, verify Pressure Response by Value matches Domain Analysis Value Priorities at the all-models scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)