### PR TITLE
Restore header dropdowns

### DIFF
--- a/cloud/apps/web/src/components/layout/Header.tsx
+++ b/cloud/apps/web/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ComponentType, type RefObject } from 'react';
+import { type FocusEvent, useEffect, useRef, useState, type ComponentType, type RefObject } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import {
   Activity,
@@ -140,6 +140,20 @@ export function Header() {
       : isTabActive(item.path, item.aliases ?? [], item.match ?? 'prefix')
   );
 
+  const handleMenuFocus = (setOpen: (value: boolean) => void) => () => {
+    setOpen(true);
+  };
+
+  const handleMenuBlur =
+    (menuRef: RefObject<HTMLDivElement>, setOpen: (value: boolean) => void) =>
+      (event: FocusEvent<HTMLDivElement>) => {
+        const nextFocused = event.relatedTarget as Node | null;
+        if (menuRef.current && nextFocused && menuRef.current.contains(nextFocused)) {
+          return;
+        }
+        setOpen(false);
+      };
+
   const visibleDomainMenuItems = isAdmin
     ? domainMenuItems
     : domainMenuItems.filter((item) => !isMenuGroupItem(item) && item.path !== '/domains/manage');
@@ -167,6 +181,8 @@ export function Header() {
         className="relative group"
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}
+        onFocus={handleMenuFocus((value) => setOpen(value))}
+        onBlur={handleMenuBlur(ref, (value) => setOpen(value))}
       >
         <div
           className={cn(
@@ -252,7 +268,7 @@ export function Header() {
           </span>
         </div>
 
-        <nav className="hidden min-w-0 flex-1 sm:flex items-stretch gap-1 overflow-x-auto">
+        <nav className="hidden min-w-0 flex-1 sm:flex items-stretch gap-1">
           {renderMenu(modelsMenuRef, 'Models', '/domains/analysis', Cpu, modelsMenuItems, isModelsActive, isModelsMenuOpen, setIsModelsMenuOpen)}
           {renderMenu(domainsMenuRef, 'Domains', '/domains', FolderTree, visibleDomainMenuItems, isDomainsActive, isDomainsMenuOpen, setIsDomainsMenuOpen)}
           {renderMenu(vignettesMenuRef, 'Vignettes', '/definitions', Library, vignettesMenuItems, isVignettesActive, isVignettesMenuOpen, setIsVignettesMenuOpen)}

--- a/cloud/apps/web/tests/components/layout/Header.test.tsx
+++ b/cloud/apps/web/tests/components/layout/Header.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import { Header } from '../../../src/components/layout/Header';
@@ -87,5 +87,20 @@ describe('Header Component', () => {
     await waitFor(() => {
       expect(screen.queryByText('Sign out')).not.toBeInTheDocument();
     });
+  });
+
+  it('should open the navigation dropdown and show submenu links', async () => {
+    renderHeader();
+
+    const navToggle = screen.getByRole('button', { name: 'Toggle Vignettes menu' });
+    const menuRoot = navToggle.closest('.relative');
+    expect(menuRoot).toBeTruthy();
+    fireEvent.mouseEnter(menuRoot!);
+
+    await waitFor(() => {
+      expect(navToggle).toHaveAttribute('aria-expanded', 'true');
+    });
+    expect(within(menuRoot!).getByRole('link', { name: 'Runs' })).toBeInTheDocument();
+    expect(within(menuRoot!).getByRole('link', { name: 'Analysis' })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Restore the desktop navigation dropdowns that were clipped by the compact header layout.
- Keep the title and nav on the same row while preserving the old focus and blur behavior.
- Add a regression test for the dropdown interaction.

## Test plan
- [x] Preflight passed (`npm run lint --workspace @valuerank/shared && npm run lint --workspace @valuerank/db && npm run lint --workspace @valuerank/api && npm run build --workspace @valuerank/api && npm run lint --workspace @valuerank/web && npm run build --workspace @valuerank/web`)
- [x] Manual smoke test done in the local app

🤖 Generated with [Claude Code](https://claude.com/claude-code)