### PR TITLE
fix(coverage): derive direction from definitionSnapshot.components.value_first.token

### DIFF
--- a/cloud/apps/api/src/cli/backfill-job-choice-value-first.ts
+++ b/cloud/apps/api/src/cli/backfill-job-choice-value-first.ts
@@ -1,17 +1,17 @@
 #!/usr/bin/env tsx
 
 /**
- * Backfills `jobChoiceValueFirst` onto runs that were created before this field
- * existed. Those runs carry `jobChoicePresentationOrder` ("A_first"/"B_first")
- * together with a `definitionSnapshot.components.value_first/second.token` that
- * holds the actual value name.
+ * @deprecated Do not run this script. The backfill logic here is incorrect for
+ * runs on B-first definitions: it reads `components.value_second.token` for
+ * `B_first` runs, but the correct value is always `components.value_first.token`
+ * (the slot assembleTemplate renders first is always value_first, regardless of
+ * presentation order).
  *
- * After this backfill confirms clean, the `jobChoicePresentationOrder` fallback
- * in `getCoverageDirection` can be removed.
+ * `getCoverageDirection` now reads `definitionSnapshot.components.value_first.token`
+ * directly as its primary signal, making `jobChoiceValueFirst` unnecessary.
  *
- * Usage:
- *   npx tsx src/cli/backfill-job-choice-value-first.ts --dry-run
- *   npx tsx src/cli/backfill-job-choice-value-first.ts
+ * Original intent: backfill `jobChoiceValueFirst` onto runs that were created
+ * before this field existed, using `jobChoicePresentationOrder` as the source.
  */
 
 import { fileURLToPath } from 'url';

--- a/cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts
@@ -278,18 +278,45 @@ export function getCoverageBatchGroupId(runConfig: unknown): string | null {
 }
 
 /**
- * Read the direction token off a Run's config. Returns null for missing,
- * blank, or non-string `jobChoiceValueFirst`. Trimmed.
+ * Read the direction token off a Run's config.
  *
- * Defensive against any non-object input (number, boolean, etc.); returns
- * null without touching the value.
+ * Primary source: `definitionSnapshot.components.value_first.token` — the
+ * value that assembleTemplate always renders first, set at definition-creation
+ * time and immutable thereafter.
+ *
+ * Fallback: deprecated `jobChoiceValueFirst` field. This field was backfilled
+ * with incorrect logic for older runs on B-first definitions and must not be
+ * trusted as the primary signal.
+ *
+ * Returns null when neither source yields a non-blank string. Defensive
+ * against any non-object input.
  */
 export function getCoverageDirection(runConfig: unknown): string | null {
   if (typeof runConfig !== 'object' || runConfig === null) return null;
-  const config = runConfig as { jobChoiceValueFirst?: unknown };
-  if (typeof config.jobChoiceValueFirst !== 'string') return null;
-  const trimmed = config.jobChoiceValueFirst.trim();
-  return trimmed.length > 0 ? toPascalCaseKey(trimmed) : null;
+  const config = runConfig as Record<string, unknown>;
+
+  const snapshot = config.definitionSnapshot;
+  if (typeof snapshot === 'object' && snapshot !== null) {
+    const components = (snapshot as Record<string, unknown>).components;
+    if (typeof components === 'object' && components !== null) {
+      const valueFirst = (components as Record<string, unknown>).value_first;
+      if (typeof valueFirst === 'object' && valueFirst !== null) {
+        const token = (valueFirst as Record<string, unknown>).token;
+        if (typeof token === 'string' && token.trim().length > 0) {
+          return toPascalCaseKey(token.trim());
+        }
+      }
+    }
+  }
+
+  // Deprecated fallback — may be incorrect for runs backfilled before 2026-05.
+  const jcvf = config.jobChoiceValueFirst;
+  if (typeof jcvf === 'string') {
+    const trimmed = jcvf.trim();
+    return trimmed.length > 0 ? toPascalCaseKey(trimmed) : null;
+  }
+
+  return null;
 }
 
 /**
@@ -397,7 +424,7 @@ export function selectPrimaryDefinitionCounts(
     if (log != null) {
       log.warn(
         { cellKey, directions: Array.from(merged.keys()), definitionIds: uniqueDefinitionIds },
-        '>2 distinct jobChoiceValueFirst tokens in single coverage cell; using min of two largest',
+        '>2 distinct direction tokens in single coverage cell; using min of two largest',
       );
     }
   }

--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -28,6 +28,7 @@ type RunConfig = {
   estimatedCosts?: CostEstimateShape;
   companionRunId?: string | null;
   jobChoiceBatchGroupId?: string | null;
+  /** @deprecated Use definitionSnapshot.components.value_first.token instead. */
   jobChoiceValueFirst?: string | null;
   isAggregate?: boolean;
   sourceRunIds?: string[];

--- a/cloud/apps/api/tests/graphql/queries/domain-coverage.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/domain-coverage.test.ts
@@ -369,47 +369,79 @@ describe('deduplicateRunsByGroupId', () => {
 });
 
 describe('getCoverageDirection', () => {
-  it('returns the trimmed string for a normal direction token', () => {
-    // Normalizes to PascalCase_Underscore to match COVERAGE_VALUE_KEYS.
-    // Prod tokens are lowercase (e.g. "career"); keys are "Career".
-    expect(getCoverageDirection({ jobChoiceValueFirst: 'career' })).toBe('Career');
+  function makeConfig(valueFirstToken: string) {
+    return {
+      definitionSnapshot: {
+        components: {
+          value_first: { token: valueFirstToken },
+        },
+      },
+    };
+  }
+
+  describe('primary path — definitionSnapshot.components.value_first.token', () => {
+    it('returns the token from the snapshot', () => {
+      expect(getCoverageDirection(makeConfig('career'))).toBe('Career');
+    });
+
+    it('trims whitespace from the snapshot token', () => {
+      expect(getCoverageDirection(makeConfig('  career  '))).toBe('Career');
+    });
+
+    it('normalizes multi-word snake_case tokens', () => {
+      expect(getCoverageDirection(makeConfig('conformity_interpersonal'))).toBe('Conformity_Interpersonal');
+    });
+
+    it('snapshot takes priority over a conflicting jobChoiceValueFirst', () => {
+      // Reproduces the backfill bug: old C→A runs have jobChoiceValueFirst='achievement'
+      // but value_first.token='conformity_interpersonal'. Snapshot must win.
+      expect(getCoverageDirection({
+        ...makeConfig('conformity_interpersonal'),
+        jobChoiceValueFirst: 'achievement',
+      })).toBe('Conformity_Interpersonal');
+    });
+
+    it('returns null when snapshot token is empty', () => {
+      expect(getCoverageDirection(makeConfig(''))).toBeNull();
+    });
+
+    it('returns null when snapshot token is whitespace-only', () => {
+      expect(getCoverageDirection(makeConfig('   '))).toBeNull();
+    });
   });
 
-  it('trims whitespace', () => {
-    expect(getCoverageDirection({ jobChoiceValueFirst: '  career  ' })).toBe('Career');
+  describe('fallback path — deprecated jobChoiceValueFirst', () => {
+    it('returns the trimmed string when no snapshot is present', () => {
+      expect(getCoverageDirection({ jobChoiceValueFirst: 'career' })).toBe('Career');
+    });
+
+    it('trims whitespace', () => {
+      expect(getCoverageDirection({ jobChoiceValueFirst: '  career  ' })).toBe('Career');
+    });
+
+    it('returns null for an empty string', () => {
+      expect(getCoverageDirection({ jobChoiceValueFirst: '' })).toBeNull();
+    });
+
+    it('returns null for whitespace-only', () => {
+      expect(getCoverageDirection({ jobChoiceValueFirst: '   ' })).toBeNull();
+    });
+
+    it('returns null for a non-string number value', () => {
+      expect(getCoverageDirection({ jobChoiceValueFirst: 42 })).toBeNull();
+    });
+
+    it('returns null for a non-string boolean value', () => {
+      expect(getCoverageDirection({ jobChoiceValueFirst: true })).toBeNull();
+    });
   });
 
-  it('returns null for an empty string', () => {
-    expect(getCoverageDirection({ jobChoiceValueFirst: '' })).toBeNull();
-  });
-
-  it('returns null for whitespace-only', () => {
-    expect(getCoverageDirection({ jobChoiceValueFirst: '   ' })).toBeNull();
-  });
-
-  it('returns null when the field is missing', () => {
+  it('returns null when neither source is present', () => {
     expect(getCoverageDirection({})).toBeNull();
-  });
-
-  it('returns null for a non-string number value', () => {
-    expect(getCoverageDirection({ jobChoiceValueFirst: 42 })).toBeNull();
-  });
-
-  it('returns null for a non-string boolean value', () => {
-    expect(getCoverageDirection({ jobChoiceValueFirst: true })).toBeNull();
   });
 
   it('returns null for null config', () => {
     expect(getCoverageDirection(null)).toBeNull();
-  });
-
-  it('returns the value even when launch mode is not PAIRED_BATCH (trust-but-do-not-validate tripwire)', () => {
-    // The algorithm trusts jobChoiceValueFirst regardless of launch mode.
-    // If a future change adds a launch-mode guard, this test should fail
-    // and force a deliberate update.
-    expect(
-      getCoverageDirection({ jobChoiceLaunchMode: 'AD_HOC_BATCH', jobChoiceValueFirst: 'career' }),
-    ).toBe('Career');
   });
 });
 

--- a/cloud/apps/web/src/api/run-json-types.ts
+++ b/cloud/apps/web/src/api/run-json-types.ts
@@ -16,6 +16,7 @@ export type RunConfig = {
   companionRunId?: string | null;
   jobChoiceLaunchMode?: 'PAIRED_BATCH' | 'PAIRED_BATCH_TOPUP' | 'AD_HOC_BATCH' | 'STANDARD' | null;
   jobChoiceBatchGroupId?: string | null;
+  /** @deprecated Use definitionSnapshot.components.value_first.token instead. */
   jobChoiceValueFirst?: string | null;
   isAggregate?: boolean;
   sourceRunIds?: string[];

--- a/cloud/apps/web/src/components/domains/CoverageCell.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageCell.tsx
@@ -86,7 +86,6 @@ export function CoverageCell(props: CoverageCellProps) {
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
-        {/* eslint-disable-next-line react/forbid-elements */}
         <button
           type="button"
           disabled={isDiagonal}

--- a/cloud/apps/web/src/components/domains/CoverageCell.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageCell.tsx
@@ -86,6 +86,7 @@ export function CoverageCell(props: CoverageCellProps) {
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
+        {/* eslint-disable-next-line react/forbid-elements */}
         <button
           type="button"
           disabled={isDiagonal}

--- a/docs/coverage-investigations/achievement-conformity-coverage.md
+++ b/docs/coverage-investigations/achievement-conformity-coverage.md
@@ -1,0 +1,123 @@
+# Coverage Investigation: Achievement vs Conformity (Job Choice Domain)
+
+**Date:** 2026-05-03
+**Domain:** Job Choice (`cmmqi1urq0000e4y3ot8sfm06`)
+**Pair:** Achievement × Conformity Interpersonal
+
+---
+
+## The Two Values
+
+**Achievement** — *"Success according to social standards"* (Schwartz et al., 2012)
+Valuing success and competence by social standards. Desire to demonstrate ability and effectiveness. Emphasis on performance, excellence, and results.
+
+**Conformity – Interpersonal** — *"Avoidance of upsetting or harming other people"* (Schwartz et al., 2012)
+Valuing harmony and avoiding upsetting others. Restraint of behavior to keep peace in relationships. Preference for smooth social interactions.
+
+These sit on opposite sides of the Schwartz circle: Achievement is Self-Enhancement; Conformity is Conservation. They are a genuine motivational tension.
+
+---
+
+## The Two Vignettes
+
+| ID | Name | Definition |
+|---|---|---|
+| `cmmz0u6s6000aeuiq0x073o29` | Achievement → Conformity Interpersonal (A→C) | Job candidate A embodies Achievement; candidate B embodies Conformity |
+| `cmmz0u6t1000ceuiqu334qxhk` | Conformity Interpersonal → Achievement (C→A) | Job candidate A embodies Conformity; candidate B embodies Achievement |
+
+Each vignette has **25 conditions** (a 5×5 grid of two attribute dimensions: negligible / minimal / moderate / substantial / full).
+
+---
+
+## Trial Counts Per Condition (Default Model Filter, All Signatures)
+
+Default model filter = 8 models: Claude Sonnet 4.5, DeepSeek Chat, DeepSeek Reasoner, Gemini 2.5 Flash, GPT-5.1, Grok 4.1 Fast Reasoning, Mistral Large (Dec 2025), Mistral Small.
+
+Only non-aggregate runs whose `config.models` includes all 8 defaults are counted.
+
+### A→C Vignette — Achievement-first direction
+
+3 qualifying source runs. All 25 conditions, all 8 models: **7 trials each** (uniform).
+
+| Condition | Trials/model |
+|---|---|
+| negligible × negligible | 7 |
+| negligible × minimal | 7 |
+| negligible × moderate | 7 |
+| negligible × substantial | 7 |
+| negligible × full | 7 |
+| minimal × negligible | 7 |
+| minimal × minimal | 7 |
+| minimal × moderate | 7 |
+| minimal × substantial | 7 |
+| minimal × full | 7 |
+| moderate × negligible | 7 |
+| moderate × minimal | 7 |
+| moderate × moderate | 7 |
+| moderate × substantial | 7 |
+| moderate × full | 7 |
+| substantial × negligible | 7 |
+| substantial × minimal | 7 |
+| substantial × moderate | 7 |
+| substantial × substantial | 7 |
+| substantial × full | 7 |
+| full × negligible | 7 |
+| full × minimal | 7 |
+| full × moderate | 7 |
+| full × substantial | 7 |
+| full × full | 7 |
+
+**Conformity-first direction: 0 qualifying runs.**
+
+### C→A Vignette — by direction
+
+3 qualifying source runs, but split across two directions:
+
+| Run | `jobChoiceValueFirst` | Trials/model/condition |
+|---|---|---|
+| `cmmzan1xf03a` | `achievement` | 5 |
+| `cmmz0ur0o004` | `achievement` | 1 |
+| `cmnfng34k00t` | `conformity_interpersonal` | 1 |
+
+**Achievement-first direction** (2 runs): all 25 conditions, all 8 models: **6 trials each** (uniform).
+
+**Conformity-first direction** (1 run): all 25 conditions, all 8 models: **1 trial each** (uniform).
+
+---
+
+## Coverage Matrix Calculation
+
+The coverage cell value = `min(Achievement-first batch equivalents, Conformity-first batch equivalents)`.
+
+Batch equivalents are computed across all definitions in the pair, merging their scenario sets:
+
+| Direction | Source | Conditions | Trials/model | Batch equivalent |
+|---|---|---|---|---|
+| Achievement-first | A→C (25 conditions) | 25 | 7 | — |
+| Achievement-first | C→A (25 conditions) | 25 | 6 | — |
+| Achievement-first | **combined min** | 50 | min = 6 | **6** |
+| Conformity-first | C→A (25 conditions) | 25 | 1 | **1** |
+
+**Cell value = min(6, 1) = 1.**
+
+---
+
+## Root Cause
+
+The 2 oldest qualifying runs on the C→A definition (`cmmzan1xf03a`, `cmmz0ur0o004`) were launched with Achievement presented first (`jobChoiceValueFirst = 'achievement'`, derived from `jobChoicePresentationOrder = 'B_first'`). They were created as paired companions to A→C runs — both directions of the pair running Achievement first for presentation-order control. This adds trials to the Achievement direction but contributes nothing to the Conformity-first direction.
+
+The A→C definition has no Conformity-first runs at all — all 3 qualifying source runs ran Achievement first.
+
+The only Conformity-first qualifying run is `cmnfng34k00t` on the C→A definition (1 trial/model/condition).
+
+---
+
+## What's Needed
+
+To reach **6 Conformity-first batch equivalents** (matching Achievement-first), 5 more Conformity-first batches are needed. Each batch should use the 8 default models.
+
+Options:
+- Launch on C→A definition with Conformity-first direction (`jobChoiceValueFirst = 'conformity_interpersonal'`)
+- Launch on A→C definition with B-first direction (`jobChoiceValueFirst = 'conformity_interpersonal'`)
+
+The "Match Pair Counts" button in the coverage matrix popover for this cell will pre-fill the correct parameters.


### PR DESCRIPTION
## Summary

- `getCoverageDirection` now reads `definitionSnapshot.components.value_first.token` as its primary signal for which value was shown first to the LLM, replacing `jobChoiceValueFirst`
- The old `jobChoiceValueFirst` field was backfilled with incorrect logic for B-first runs: it read `value_second.token` when it should have read `value_first.token` (the slot `assembleTemplate` always renders first, regardless of presentation order)
- This caused C→A vignette runs to be counted as Achievement-first when they were actually Conformity-first, making the Achievement × Conformity coverage cell show 1 instead of 7
- `jobChoiceValueFirst` is retained as a fallback and marked `@deprecated` in both API and web types
- The backfill CLI script is marked `@deprecated` with an explanation of why its derivation was wrong and must not be run

## Root cause

`assembleTemplate` always renders `value_first` first — the order is baked into the template text at definition-creation time. `definitionSnapshot.components.value_first.token` is therefore the canonical ground truth for direction. The old `jobChoicePresentationOrder = 'B_first'` backfill incorrectly derived `jobChoiceValueFirst = value_second.token`, yielding the wrong value for any run on a B-first definition.

## Test plan

- [x] `getCoverageDirection` unit tests updated — added snapshot-path tests and a "snapshot wins over conflicting `jobChoiceValueFirst`" test (86 tests pass)
- [x] `npm run lint` — warnings only, no errors (pre-existing)
- [x] `npm run build` — clean for both API and web

🤖 Generated with [Claude Code](https://claude.com/claude-code)