### PR TITLE
fix(api): recompute snapshot when pushed effects are missing from cache

### DIFF
--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-cache.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-cache.ts
@@ -24,12 +24,13 @@ const log = createLogger('pressure-sensitivity:cache');
 export function parseSnapshotOutput(raw: unknown): PressureSensitivityResultShape | null {
   if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return null;
   const result = raw as PressureSensitivityResultShape;
-  // Backfill fields added after the snapshot was written (pushedEffectPairsUsed is Int! so null crashes).
-  for (const model of result.models) {
-    if ((model as { pushedEffectPairsUsed?: unknown }).pushedEffectPairsUsed == null) {
-      model.pushedEffectPairsUsed = 0;
-    }
-  }
+  // Snapshots written before v1.1.0 don't have pushedForEffect / pushedAgainstEffect.
+  // Return null so the caller falls through to synchronous recompute rather than
+  // serving stale data that makes the "Does pressure work both ways?" table invisible.
+  const missingNewFields = result.models.some(
+    (m) => (m as { pushedEffectPairsUsed?: unknown }).pushedEffectPairsUsed == null,
+  );
+  if (missingNewFields) return null;
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Fixes the "Does pressure work both ways?" table being invisible after #900 deployed.
- Old snapshots in the DB have `pushedEffectPairsUsed` backfilled to `0` (from #901) but still lack `pushedForEffect` and `pushedAgainstEffect`. The component skips every model where both are null, so the table renders empty.
- Instead of returning the incomplete cached snapshot, `parseSnapshotOutput` now returns `null` when any model is missing the new fields. This makes `getPressureSensitivityResult` fall through to its synchronous recompute path — one recompute per signature, then the fresh snapshot is stored and all subsequent requests are fast.

## Supersedes
The backfill approach in #901 (`pushedEffectPairsUsed = 0`) prevented the GraphQL crash but didn't restore the table. This PR replaces that logic.

## Validation
- `npm run build --workspace @valuerank/api` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)