### PR TITLE
feat(pressure-sensitivity): domain breakdown table

### DIFF
--- a/cloud/apps/api/src/graphql/types/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/types/pressure-sensitivity.ts
@@ -68,6 +68,12 @@ export type PressureSensitivityValueRateShape = {
   pairsMeasured: number;
 };
 
+export type DomainPressureEffectShape = {
+  domainId: string;
+  domainName: string;
+  pushedForEffect: number | null;
+};
+
 export type PressureSensitivityModelShape = {
   modelId: string;
   label: string;
@@ -79,6 +85,7 @@ export type PressureSensitivityModelShape = {
   pushedForEffect: number | null;
   pushedAgainstEffect: number | null;
   pushedEffectPairsUsed: number;
+  domainPressureEffects: DomainPressureEffectShape[];
 };
 
 export type InsufficientPressureSensitivityModelShape = {
@@ -139,6 +146,7 @@ const PressureSensitivityValuePairRef = builder.objectRef<PressureSensitivityVal
 const PressureSensitivityValueRateRef = builder.objectRef<PressureSensitivityValueRateShape>(
   'PressureSensitivityValueRate',
 );
+const DomainPressureEffectRef = builder.objectRef<DomainPressureEffectShape>('DomainPressureEffect');
 const PressureSensitivityModelRef = builder.objectRef<PressureSensitivityModelShape>(
   'PressureSensitivityModel',
 );
@@ -238,6 +246,14 @@ builder.objectType(PressureSensitivityValueRateRef, {
   }),
 });
 
+builder.objectType(DomainPressureEffectRef, {
+  fields: (t) => ({
+    domainId: t.exposeString('domainId'),
+    domainName: t.exposeString('domainName'),
+    pushedForEffect: t.exposeFloat('pushedForEffect', { nullable: true }),
+  }),
+});
+
 builder.objectType(PressureSensitivityModelRef, {
   fields: (t) => ({
     modelId: t.exposeString('modelId'),
@@ -252,6 +268,7 @@ builder.objectType(PressureSensitivityModelRef, {
     pushedForEffect: t.exposeFloat('pushedForEffect', { nullable: true }),
     pushedAgainstEffect: t.exposeFloat('pushedAgainstEffect', { nullable: true }),
     pushedEffectPairsUsed: t.exposeInt('pushedEffectPairsUsed'),
+    domainPressureEffects: t.expose('domainPressureEffects', { type: [DomainPressureEffectRef] }),
   }),
 });
 

--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-cache.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-cache.ts
@@ -24,12 +24,13 @@ const log = createLogger('pressure-sensitivity:cache');
 export function parseSnapshotOutput(raw: unknown): PressureSensitivityResultShape | null {
   if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return null;
   const result = raw as PressureSensitivityResultShape;
-  // Snapshots written before v1.1.0 don't have pushedForEffect / pushedAgainstEffect.
+  // Snapshots written before v1.2.0 lack pushedEffectPairsUsed or domainPressureEffects.
   // Return null so the caller falls through to synchronous recompute rather than
-  // serving stale data that makes the "Does pressure work both ways?" table invisible.
-  const missingNewFields = result.models.some(
-    (m) => (m as { pushedEffectPairsUsed?: unknown }).pushedEffectPairsUsed == null,
-  );
+  // serving stale data that renders the table incomplete.
+  const missingNewFields = result.models.some((m) => {
+    const model = m as { pushedEffectPairsUsed?: unknown; domainPressureEffects?: unknown };
+    return model.pushedEffectPairsUsed == null || model.domainPressureEffects == null;
+  });
   if (missingNewFields) return null;
   return result;
 }

--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-compute.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-compute.ts
@@ -265,14 +265,12 @@ function computeModelPushedEffects(
     if (db != null && dm != null) pushedAgainstDomains.push(db - dm);
   }
 
-  const domainPressureEffects: DomainPressureEffectShape[] = [];
-  for (const [dk, d] of domainAccum.entries()) {
-    const name = domainNameById.get(dk);
-    if (name == null) continue;
-    const dp = mean(d.push);
-    const db = mean(d.balanced);
-    domainPressureEffects.push({ domainId: dk, domainName: name, pushedForEffect: dp != null && db != null ? dp - db : null });
-  }
+  const domainPressureEffects: DomainPressureEffectShape[] = [...domainAccum.entries()]
+    .filter(([dk]) => domainNameById.has(dk))
+    .map(([dk, d]) => {
+      const [dp, db] = [mean(d.push), mean(d.balanced)];
+      return { domainId: dk, domainName: domainNameById.get(dk)!, pushedForEffect: dp != null && db != null ? dp - db : null };
+    });
 
   return {
     pushedForEffect: mean(pushedForDomains),
@@ -415,11 +413,10 @@ export async function buildPressureSensitivitySnapshotOutput(
     if (meta.domainId != null) domainByDef.set(defId, meta.domainId);
   }
   const distinctDomainIds = [...new Set(domainByDef.values())];
-  const domainNameRows = distinctDomainIds.length === 0 ? [] : await db.domain.findMany({
-    where: { id: { in: distinctDomainIds } },
-    select: { id: true, name: true },
-  });
-  const domainNameById = new Map<string, string>(domainNameRows.map((d) => [d.id, d.name]));
+  const domainNameById = new Map<string, string>(
+    (distinctDomainIds.length === 0 ? [] : await db.domain.findMany({ where: { id: { in: distinctDomainIds } }, select: { id: true, name: true } }))
+      .map((d) => [d.id, d.name]),
+  );
 
   const sourceRunToDefId = new Map<string, string>();
   for (const run of state.eligibleRuns) {

--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-compute.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-compute.ts
@@ -4,6 +4,7 @@ import { resolveTranscriptDecisionModel } from '../../graphql/queries/domain/sha
 import type {
   DirectionalSanityCheckEntryShape,
   DirectionalSanityCheckShape,
+  DomainPressureEffectShape,
   ExcludedDefinitionShape,
   InsufficientPressureSensitivityModelShape,
   PressureSensitivityModelShape,
@@ -165,7 +166,8 @@ function computeModelPushedEffects(
   pairs: ReadonlyMap<string, PairAccumulator>,
   authoredFirstTokenByDef: ReadonlyMap<string, string>,
   domainByDef: ReadonlyMap<string, string>,
-): { pushedForEffect: number | null; pushedAgainstEffect: number | null; pairsUsed: number } {
+  domainNameById: ReadonlyMap<string, string>,
+): { pushedForEffect: number | null; pushedAgainstEffect: number | null; pairsUsed: number; domainPressureEffects: DomainPressureEffectShape[] } {
   type DirBuckets = { first: number[]; second: number[] };
 
   const pushBuckets = new Map<string, DirBuckets>();
@@ -263,10 +265,20 @@ function computeModelPushedEffects(
     if (db != null && dm != null) pushedAgainstDomains.push(db - dm);
   }
 
+  const domainPressureEffects: DomainPressureEffectShape[] = [];
+  for (const [dk, d] of domainAccum.entries()) {
+    const name = domainNameById.get(dk);
+    if (name == null) continue;
+    const dp = mean(d.push);
+    const db = mean(d.balanced);
+    domainPressureEffects.push({ domainId: dk, domainName: name, pushedForEffect: dp != null && db != null ? dp - db : null });
+  }
+
   return {
     pushedForEffect: mean(pushedForDomains),
     pushedAgainstEffect: mean(pushedAgainstDomains),
     pairsUsed: allPairKeys.size,
+    domainPressureEffects,
   };
 }
 
@@ -402,6 +414,12 @@ export async function buildPressureSensitivitySnapshotOutput(
   for (const [defId, meta] of definitionMeta.entries()) {
     if (meta.domainId != null) domainByDef.set(defId, meta.domainId);
   }
+  const distinctDomainIds = [...new Set(domainByDef.values())];
+  const domainNameRows = distinctDomainIds.length === 0 ? [] : await db.domain.findMany({
+    where: { id: { in: distinctDomainIds } },
+    select: { id: true, name: true },
+  });
+  const domainNameById = new Map<string, string>(domainNameRows.map((d) => [d.id, d.name]));
 
   const sourceRunToDefId = new Map<string, string>();
   for (const run of state.eligibleRuns) {
@@ -638,8 +656,8 @@ export async function buildPressureSensitivitySnapshotOutput(
       insufficient.push({ modelId: model.modelId, label: model.displayName, providerName: model.provider.displayName ?? model.provider.name, reason: 'no-coverage' });
       continue;
     }
-    const { pushedForEffect, pushedAgainstEffect, pairsUsed: pushedEffectPairsUsed } =
-      computeModelPushedEffects(pairs, authoredFirstTokenByDef, domainByDef);
+    const { pushedForEffect, pushedAgainstEffect, pairsUsed: pushedEffectPairsUsed, domainPressureEffects } =
+      computeModelPushedEffects(pairs, authoredFirstTokenByDef, domainByDef, domainNameById);
     outputModels.push({
       modelId: model.modelId,
       label: model.displayName,
@@ -651,6 +669,7 @@ export async function buildPressureSensitivitySnapshotOutput(
       pushedForEffect,
       pushedAgainstEffect,
       pushedEffectPairsUsed,
+      domainPressureEffects,
     });
   }
 

--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-types.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-types.ts
@@ -1,3 +1,3 @@
 export const PRESSURE_SENSITIVITY_SNAPSHOT_TYPE = 'pressure_sensitivity';
-export const PRESSURE_SENSITIVITY_SNAPSHOT_CODE_VERSION = '1.1.0';
+export const PRESSURE_SENSITIVITY_SNAPSHOT_CODE_VERSION = '1.2.0';
 export const PRESSURE_SENSITIVITY_ASSUMPTION_PREFIX = 'pressure-sensitivity';

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -2110,7 +2110,14 @@ type PressureResponseSummary {
   rangeMin: Float
 }
 
+type DomainPressureEffect {
+  domainId: String!
+  domainName: String!
+  pushedForEffect: Float
+}
+
 type PressureSensitivityModel {
+  domainPressureEffects: [DomainPressureEffect!]!
   label: String!
   modelId: String!
   pressureResponseSummary: PressureResponseSummary!

--- a/cloud/apps/web/src/api/operations/pressureSensitivity.graphql
+++ b/cloud/apps/web/src/api/operations/pressureSensitivity.graphql
@@ -16,6 +16,11 @@ query PressureSensitivity(
       pushedForEffect
       pushedAgainstEffect
       pushedEffectPairsUsed
+      domainPressureEffects {
+        domainId
+        domainName
+        pushedForEffect
+      }
       pressureResponseSummary {
         mean
         rangeMin

--- a/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.test.tsx
@@ -4,12 +4,13 @@ import { PressureDirectionalBreakdown } from './PressureDirectionalBreakdown';
 import { formatSignedPoints } from './pressureSensitivityFormatting';
 import type { PressureSensitivityModel } from '../../api/operations/pressureSensitivity';
 
+type DomainEffect = { domainId: string; domainName: string; pushedForEffect: number | null };
+
 function createModel(
   modelId: string,
   label: string,
   pushedForEffect: number | null,
-  pushedAgainstEffect: number | null,
-  pushedEffectPairsUsed = 1,
+  domainEffects: DomainEffect[] = [],
 ): PressureSensitivityModel {
   return {
     modelId,
@@ -17,13 +18,19 @@ function createModel(
     providerName: 'Provider',
     unscoredCount: 0,
     pushedForEffect,
-    pushedAgainstEffect,
-    pushedEffectPairsUsed,
+    pushedAgainstEffect: null,
+    pushedEffectPairsUsed: domainEffects.length,
+    domainPressureEffects: domainEffects,
     pressureResponseSummary: { mean: 0.1, rangeMin: 0.05, rangeMax: 0.15, pairsMeasured: 1 },
     valueRates: [],
     valuePairs: [],
   } as unknown as PressureSensitivityModel;
 }
+
+const DOMAINS: DomainEffect[] = [
+  { domainId: 'dom-1', domainName: 'Ethics', pushedForEffect: 0.3 },
+  { domainId: 'dom-2', domainName: 'Politics', pushedForEffect: 0.1 },
+];
 
 function renderBreakdown(models: PressureSensitivityModel[]) {
   render(<PressureDirectionalBreakdown models={models} />);
@@ -41,36 +48,40 @@ function getCells(row: HTMLTableRowElement) {
 
 describe('PressureDirectionalBreakdown', () => {
   it('renders heading and column headers', () => {
-    renderBreakdown([createModel('alpha', 'Alpha', 0.2, 0.1)]);
+    renderBreakdown([createModel('alpha', 'Alpha', 0.2, DOMAINS)]);
 
-    expect(screen.getByText('Does pressure work both ways?')).toBeDefined();
-    expect(screen.getByText('Pushed for')).toBeDefined();
-    expect(screen.getByText('Pushed against')).toBeDefined();
-    expect(screen.getByText('Gap')).toBeDefined();
+    expect(screen.getByText('Pressure sensitivity by domain')).toBeDefined();
+    expect(screen.getByText('Overall')).toBeDefined();
+    expect(screen.getByText('Ethics')).toBeDefined();
+    expect(screen.getByText('Politics')).toBeDefined();
   });
 
-  it('displays backend-provided pushed-for, pushed-against, and gap values', () => {
-    renderBreakdown([createModel('alpha', 'Alpha', 0.2, 0.1)]);
+  it('displays overall effect and domain effects', () => {
+    renderBreakdown([createModel('alpha', 'Alpha', 0.2, DOMAINS)]);
 
     const row = getRowByLabel('Alpha');
     const cells = getCells(row);
     expect(cells[1]?.textContent ?? '').toBe(formatSignedPoints(0.2));
-    expect(cells[2]?.textContent ?? '').toBe(formatSignedPoints(0.1));
+    expect(cells[2]?.textContent ?? '').toBe(formatSignedPoints(0.3));
     expect(cells[3]?.textContent ?? '').toBe(formatSignedPoints(0.1));
   });
 
-  it('displays pairs count from backend', () => {
-    renderBreakdown([createModel('alpha', 'Alpha', 0.2, 0.1, 5)]);
+  it('shows em dash for null domain effect', () => {
+    renderBreakdown([
+      createModel('alpha', 'Alpha', 0.2, [
+        { domainId: 'dom-1', domainName: 'Ethics', pushedForEffect: null },
+      ]),
+    ]);
 
     const row = getRowByLabel('Alpha');
     const cells = getCells(row);
-    expect(cells[4]?.textContent ?? '').toBe('5');
+    expect(cells[2]?.textContent ?? '').toBe('—');
   });
 
-  it('sorts by absolute gap descending', () => {
+  it('sorts by overall effect descending', () => {
     renderBreakdown([
-      createModel('model-b', 'ModelB', 0.55, 0.5),  // gap = 0.05
-      createModel('model-a', 'ModelA', 0.7, 0.5),   // gap = 0.20
+      createModel('model-b', 'ModelB', 0.1, DOMAINS),
+      createModel('model-a', 'ModelA', 0.3, DOMAINS),
     ]);
 
     const rows = screen.getAllByRole('row');
@@ -80,8 +91,8 @@ describe('PressureDirectionalBreakdown', () => {
 
   it('breaks ties alphabetically', () => {
     renderBreakdown([
-      createModel('bravo', 'Bravo', 0.7, 0.5),  // gap = 0.2
-      createModel('alpha', 'Alpha', 0.3, 0.5),  // gap = -0.2, same |gap|
+      createModel('bravo', 'Bravo', 0.2, DOMAINS),
+      createModel('alpha', 'Alpha', 0.2, DOMAINS),
     ]);
 
     const rows = screen.getAllByRole('row');
@@ -89,41 +100,41 @@ describe('PressureDirectionalBreakdown', () => {
     expect(rows[2]?.textContent ?? '').toContain('Bravo');
   });
 
-  it('excludes models where pushed effects are null', () => {
+  it('excludes models where overall pushed effect is null', () => {
     renderBreakdown([
-      createModel('invalid', 'Invalid', null, null),
-      createModel('valid', 'Valid', 0.7, 0.4),
+      createModel('invalid', 'Invalid', null, DOMAINS),
+      createModel('valid', 'Valid', 0.2, DOMAINS),
     ]);
 
     expect(screen.queryByText('Invalid')).toBeNull();
     expect(screen.getByText('Valid')).toBeDefined();
   });
 
-  it('returns null when all models have null effects', () => {
+  it('returns null when all models have null overall effect', () => {
     renderBreakdown([
-      createModel('invalid-a', 'Invalid A', null, null),
-      createModel('invalid-b', 'Invalid B', null, null),
+      createModel('a', 'A', null),
+      createModel('b', 'B', null),
     ]);
 
-    expect(screen.queryByText('Does pressure work both ways?')).toBeNull();
+    expect(screen.queryByText('Pressure sensitivity by domain')).toBeNull();
   });
 
   it('returns null for an empty models array', () => {
     renderBreakdown([]);
 
-    expect(screen.queryByText('Does pressure work both ways?')).toBeNull();
+    expect(screen.queryByText('Pressure sensitivity by domain')).toBeNull();
   });
 
-  it('uses red text for a negative pushed-for effect', () => {
-    renderBreakdown([createModel('alpha', 'Alpha', -0.1, 0.1)]);
+  it('uses red text for a negative overall effect', () => {
+    renderBreakdown([createModel('alpha', 'Alpha', -0.1, DOMAINS)]);
 
     const row = getRowByLabel('Alpha');
-    const cell = within(row).getByText(formatSignedPoints(-0.1)).closest('td');
+    const cell = getCells(row)[1];
     expect(cell?.className ?? '').toContain('text-red-700');
   });
 
-  it('uses gray text for a positive pushed-for effect', () => {
-    renderBreakdown([createModel('alpha', 'Alpha', 0.1, 0.05)]);
+  it('uses default text for a positive overall effect', () => {
+    renderBreakdown([createModel('alpha', 'Alpha', 0.1, DOMAINS)]);
 
     const row = getRowByLabel('Alpha');
     const cell = getCells(row)[1];
@@ -131,45 +142,44 @@ describe('PressureDirectionalBreakdown', () => {
     expect(cell?.className ?? '').not.toContain('text-red-700');
   });
 
-  it('uses red text for a negative gap', () => {
-    renderBreakdown([createModel('alpha', 'Alpha', 0.3, 0.5)]);  // gap = -0.2
+  it('uses red text for a negative domain effect', () => {
+    renderBreakdown([
+      createModel('alpha', 'Alpha', 0.1, [
+        { domainId: 'dom-1', domainName: 'Ethics', pushedForEffect: -0.2 },
+      ]),
+    ]);
 
     const row = getRowByLabel('Alpha');
-    const cell = getCells(row)[3];
+    const cell = getCells(row)[2];
     expect(cell?.className ?? '').toContain('text-red-700');
   });
 
-  it('sorts by absolute gap — negative gap same magnitude as positive', () => {
+  it('sorts domain columns alphabetically by name', () => {
     renderBreakdown([
-      createModel('model-b', 'ModelB', 0.6, 0.5),  // gap = 0.1
-      createModel('model-a', 'ModelA', 0.3, 0.5),  // gap = -0.2
+      createModel('alpha', 'Alpha', 0.2, [
+        { domainId: 'dom-z', domainName: 'Zoology', pushedForEffect: 0.1 },
+        { domainId: 'dom-a', domainName: 'Art', pushedForEffect: 0.2 },
+      ]),
     ]);
 
-    const rows = screen.getAllByRole('row');
-    expect(rows[1]?.textContent ?? '').toContain('ModelA');
-    expect(rows[2]?.textContent ?? '').toContain('ModelB');
+    const headers = screen.getAllByRole('columnheader');
+    const headerText = headers.map((h) => h.textContent ?? '');
+    const artIdx = headerText.findIndex((t) => t.includes('Art'));
+    const zooIdx = headerText.findIndex((t) => t.includes('Zoology'));
+    expect(artIdx).toBeLessThan(zooIdx);
   });
 
-  it('shows all four tooltip texts', () => {
-    renderBreakdown([createModel('alpha', 'Alpha', 0.2, 0.1)]);
+  it('shows overall and domain tooltips', () => {
+    renderBreakdown([createModel('alpha', 'Alpha', 0.2, DOMAINS)]);
 
-    const pushedForTrigger = screen.getByRole('button', { name: /show pushed for help/i });
-    fireEvent.focus(pushedForTrigger);
+    const overallTrigger = screen.getByRole('button', { name: /show overall help/i });
+    fireEvent.focus(overallTrigger);
     expect(screen.getByRole('tooltip').textContent ?? '').toContain('Win-rate lift above balanced baseline');
-    fireEvent.blur(pushedForTrigger);
+    fireEvent.blur(overallTrigger);
 
-    const pushedAgainstTrigger = screen.getByRole('button', { name: /show pushed against help/i });
-    fireEvent.focus(pushedAgainstTrigger);
-    expect(screen.getByRole('tooltip').textContent ?? '').toContain('moves away from a value');
-    fireEvent.blur(pushedAgainstTrigger);
-
-    const gapTrigger = screen.getByRole('button', { name: /show gap help/i });
-    fireEvent.focus(gapTrigger);
-    expect(screen.getByRole('tooltip').textContent ?? '').toContain('Pushed-for effect minus pushed-against effect');
-    fireEvent.blur(gapTrigger);
-
-    const pairsTrigger = screen.getByRole('button', { name: /show pairs help/i });
-    fireEvent.focus(pairsTrigger);
-    expect(screen.getByRole('tooltip').textContent ?? '').toContain('sufficient data to compute the pushed-for effect');
+    const ethicsTrigger = screen.getByRole('button', { name: /show ethics help/i });
+    fireEvent.focus(ethicsTrigger);
+    expect(screen.getByRole('tooltip').textContent ?? '').toContain('Pressure sensitivity within Ethics');
+    fireEvent.blur(ethicsTrigger);
   });
 });

--- a/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.tsx
+++ b/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.tsx
@@ -11,66 +11,65 @@ type Props = {
 type ModelRow = {
   modelId: string;
   label: string;
-  pushedForEffect: number;
-  pushedAgainstEffect: number;
-  gap: number;
-  pairsUsed: number;
+  overallEffect: number;
+  domainEffects: Map<string, number | null>;
 };
 
-const PUSHED_FOR_TOOLTIP =
-  "Win-rate lift above balanced baseline when a value's pressure is high and the other's is calm. Direction-balanced and domain-averaged across all measured pairs for this model. Positive means the model moves toward the value being pressed.";
-const PUSHED_AGAINST_TOOLTIP =
-  "How much the model moves away from a value when the competing value is championed. Direction-balanced and domain-averaged across all measured pairs for this model. A large positive value means the model follows opposing pressure — it yields. Near zero means it holds its position.";
-const GAP_TOOLTIP =
-  'Pushed-for effect minus pushed-against effect. Near zero means pressure works equally in both directions. A large positive gap means the model responds more when a value is directly championed than when it is opposed.';
-const PAIRS_TOOLTIP =
-  'Number of value pairs that had sufficient data to compute the pushed-for effect for this model.';
+type Domain = { id: string; name: string };
+
+const OVERALL_TOOLTIP =
+  "Win-rate lift above balanced baseline when a value's pressure is high and the other's is calm. Direction-balanced and averaged across all domains and measured pairs.";
+
+function domainTooltip(domainName: string): string {
+  return `Pressure sensitivity within ${domainName}. Win-rate lift above balanced baseline, averaged across pairs in this domain.`;
+}
 
 export function PressureDirectionalBreakdown({ models }: Props) {
+  const domains = useMemo<Domain[]>(() => {
+    const domainMap = new Map<string, string>();
+    for (const model of models) {
+      for (const de of model.domainPressureEffects) {
+        domainMap.set(de.domainId, de.domainName);
+      }
+    }
+    return [...domainMap.entries()]
+      .map(([id, name]) => ({ id, name }))
+      .sort((a, b) => a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }));
+  }, [models]);
+
   const rows = useMemo<ModelRow[]>(() => {
     const nextRows: ModelRow[] = [];
-
     for (const model of models) {
-      const pushedForEffect = model.pushedForEffect;
-      const pushedAgainstEffect = model.pushedAgainstEffect;
-      if (pushedForEffect == null || pushedAgainstEffect == null) continue;
-
+      if (model.pushedForEffect == null) continue;
+      const domainEffects = new Map<string, number | null>();
+      for (const de of model.domainPressureEffects) {
+        domainEffects.set(de.domainId, de.pushedForEffect ?? null);
+      }
       nextRows.push({
         modelId: model.modelId,
         label: model.label,
-        pushedForEffect,
-        pushedAgainstEffect,
-        gap: pushedForEffect - pushedAgainstEffect,
-        pairsUsed: model.pushedEffectPairsUsed,
+        overallEffect: model.pushedForEffect,
+        domainEffects,
       });
     }
-
-    return nextRows;
-  }, [models]);
-
-  const sortedRows = useMemo(
-    () => [...rows].sort((a, b) => {
-      const gapDelta = Math.abs(b.gap) - Math.abs(a.gap);
-      if (gapDelta !== 0) return gapDelta;
+    return nextRows.sort((a, b) => {
+      const delta = b.overallEffect - a.overallEffect;
+      if (delta !== 0) return delta;
       const labelDelta = a.label.localeCompare(b.label, 'en', { sensitivity: 'base' });
       if (labelDelta !== 0) return labelDelta;
       return a.modelId.localeCompare(b.modelId);
-    }),
-    [rows],
-  );
+    });
+  }, [models]);
 
-  if (sortedRows.length === 0) {
-    return null;
-  }
+  if (rows.length === 0) return null;
 
   return (
     <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
       <div className="mb-3">
-        <h2 className="text-lg font-semibold text-gray-900">Does pressure work both ways?</h2>
+        <h2 className="text-lg font-semibold text-gray-900">Pressure sensitivity by domain</h2>
         <p className="text-sm text-gray-600">
-          For each model, this table compares how much the model moves when a value is actively
-          pressed versus when it is opposed. Equal effects mean pressure works symmetrically. A
-          large gap means the model responds more to one direction than the other.
+          How much each model shifts toward a value when that value is explicitly pressed, versus a
+          neutral baseline. Broken down by domain to show where pressure sensitivity is strongest.
         </p>
       </div>
       <Table variant="bordered">
@@ -78,33 +77,33 @@ export function PressureDirectionalBreakdown({ models }: Props) {
           <TableRow>
             <TableHead className="text-xs uppercase tracking-wide text-gray-500">Model</TableHead>
             <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Pushed for" content={PUSHED_FOR_TOOLTIP} />
+              <HeaderTooltip label="Overall" content={OVERALL_TOOLTIP} />
             </TableHead>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Pushed against" content={PUSHED_AGAINST_TOOLTIP} />
-            </TableHead>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Gap" content={GAP_TOOLTIP} />
-            </TableHead>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="Pairs" content={PAIRS_TOOLTIP} />
-            </TableHead>
+            {domains.map((domain) => (
+              <TableHead key={domain.id} className="text-xs uppercase tracking-wide text-gray-500">
+                <HeaderTooltip label={domain.name} content={domainTooltip(domain.name)} />
+              </TableHead>
+            ))}
           </TableRow>
         </TableHeader>
         <TableBody>
-          {sortedRows.map((row) => (
+          {rows.map((row) => (
             <TableRow key={row.modelId}>
               <TableCell className="font-medium text-gray-900">{row.label}</TableCell>
-              <TableCell className={`font-mono ${row.pushedForEffect < 0 ? 'text-red-700' : 'text-gray-900'}`}>
-                {formatSignedPoints(row.pushedForEffect)}
+              <TableCell className={`font-mono ${row.overallEffect < 0 ? 'text-red-700' : 'text-gray-900'}`}>
+                {formatSignedPoints(row.overallEffect)}
               </TableCell>
-              <TableCell className={`font-mono ${row.pushedAgainstEffect < 0 ? 'text-red-700' : 'text-gray-900'}`}>
-                {formatSignedPoints(row.pushedAgainstEffect)}
-              </TableCell>
-              <TableCell className={`font-mono ${row.gap < 0 ? 'text-red-700' : 'text-gray-900'}`}>
-                {formatSignedPoints(row.gap)}
-              </TableCell>
-              <TableCell className="font-mono text-gray-700">{row.pairsUsed}</TableCell>
+              {domains.map((domain) => {
+                const effect = row.domainEffects.get(domain.id) ?? null;
+                return (
+                  <TableCell
+                    key={domain.id}
+                    className={`font-mono ${effect != null && effect < 0 ? 'text-red-700' : 'text-gray-500'}`}
+                  >
+                    {effect != null ? formatSignedPoints(effect) : '—'}
+                  </TableCell>
+                );
+              })}
             </TableRow>
           ))}
         </TableBody>

--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
@@ -45,6 +45,7 @@ function createModel(
     providerName: 'Provider',
     unscoredCount: 0,
     pushedEffectPairsUsed: 0,
+    domainPressureEffects: [],
     pressureResponseSummary: {
       mean: 0.1,
       rangeMin: 0.05,

--- a/cloud/apps/web/src/components/models/PressureSensitivityCrossValueMap.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityCrossValueMap.test.tsx
@@ -10,6 +10,7 @@ function createModel(value: number | null = 0.4): PressureSensitivityModel {
     providerName: 'Provider',
     unscoredCount: 0,
     pushedEffectPairsUsed: 0,
+    domainPressureEffects: [],
     pressureResponseSummary: { mean: 0.1, rangeMin: 0.05, rangeMax: 0.15, pairsMeasured: 1 },
     valueRates: [],
     valuePairs: [

--- a/cloud/apps/web/src/components/models/PressureSensitivityDetail.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityDetail.test.tsx
@@ -46,6 +46,7 @@ function createModel(valuePairs: PressureSensitivityValuePair[]): PressureSensit
     providerName: 'Provider',
     unscoredCount: 0,
     pushedEffectPairsUsed: 0,
+    domainPressureEffects: [],
     pressureResponseSummary: { mean: 0.1, rangeMin: 0.05, rangeMax: 0.15, pairsMeasured: 2 },
     valueRates: [],
     valuePairs,

--- a/cloud/apps/web/src/components/models/PressureSensitivitySummary.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivitySummary.test.tsx
@@ -17,6 +17,7 @@ function createModel(
     providerName: 'Provider',
     unscoredCount: 0,
     pushedEffectPairsUsed: 0,
+    domainPressureEffects: [],
     valueRates: [],
     valuePairs: [],
     pressureResponseSummary: { mean, rangeMin, rangeMax, pairsMeasured },

--- a/cloud/apps/web/src/components/models/pressureResponseAggregation.test.ts
+++ b/cloud/apps/web/src/components/models/pressureResponseAggregation.test.ts
@@ -28,6 +28,7 @@ function createModel(modelId: string, valueRates: PressureSensitivityValueRate[]
     providerName: 'Provider',
     unscoredCount: 0,
     pushedEffectPairsUsed: 0,
+    domainPressureEffects: [],
     pressureResponseSummary: {
       mean: 0.1,
       rangeMin: 0.05,

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1058,6 +1058,13 @@ export type DomainMutationResult = {
   success: Scalars['Boolean']['output'];
 };
 
+export type DomainPressureEffect = {
+  __typename?: 'DomainPressureEffect';
+  domainId: Scalars['String']['output'];
+  domainName: Scalars['String']['output'];
+  pushedForEffect?: Maybe<Scalars['Float']['output']>;
+};
+
 export type DomainRunSummary = {
   __typename?: 'DomainRunSummary';
   cancelledEvaluations: Scalars['Int']['output'];
@@ -2395,6 +2402,7 @@ export type PressureResponseSummary = {
 
 export type PressureSensitivityModel = {
   __typename?: 'PressureSensitivityModel';
+  domainPressureEffects: Array<DomainPressureEffect>;
   label: Scalars['String']['output'];
   modelId: Scalars['String']['output'];
   pressureResponseSummary: PressureResponseSummary;
@@ -4693,7 +4701,7 @@ export type PressureSensitivityQueryVariables = Exact<{
 }>;
 
 
-export type PressureSensitivityQuery = { __typename?: 'Query', pressureSensitivity: { __typename?: 'PressureSensitivityResult', pressureConditionExcludedCount: number, transcriptCapHit: boolean, models: Array<{ __typename?: 'PressureSensitivityModel', modelId: string, label: string, providerName: string, unscoredCount: number, pushedForEffect?: number | null, pushedAgainstEffect?: number | null, pushedEffectPairsUsed: number, pressureResponseSummary: { __typename?: 'PressureResponseSummary', mean?: number | null, rangeMin?: number | null, rangeMax?: number | null, pairsMeasured: number }, valueRates: Array<{ __typename?: 'PressureSensitivityValueRate', valueToken: string, valueLabel: string, averageWinRate?: number | null, balancedWinRate?: number | null, highPressureOnThisValueWinRate?: number | null, highPressureOnOpposingValueWinRate?: number | null, pairsMeasured: number }>, valuePairs: Array<{ __typename?: 'PressureSensitivityValuePair', pairKey: string, firstValueToken: string, firstValueLabel: string, secondValueToken: string, secondValueLabel: string, n: number, unscoredCount: number, definitionsMeasured: number, directionBalancedWinRate?: number | null, directionBalancedOpponentWinRate?: number | null, directionBalancedBalancedWinRate?: number | null, directionBalancedBalancedOpponentWinRate?: number | null, directionBalancedHighPressureOwnWinRate?: number | null, directionBalancedHighPressureOwnOpponentWinRate?: number | null, directionBalancedHighPressureOpponentWinRate?: number | null, directionBalancedHighPressureOpponentOpponentWinRate?: number | null, pressureResponse: { __typename?: 'PressureResponse', value?: number | null, baselineRate?: number | null, pushTowardFirstRate?: number | null, pushTowardSecondRate?: number | null, qualifyingTrials: number, ciLow?: number | null, ciHigh?: number | null, reason?: string | null }, grid: Array<{ __typename?: 'SensitivityCell', ownLevel: number, opponentLevel: number, n: number, unscoredCount: number, winRate?: number | null, opponentWinRate?: number | null, conviction?: number | null, netScore?: number | null, lowData: boolean }> }> }>, insufficient: Array<{ __typename?: 'InsufficientPressureSensitivityModel', modelId: string, label: string, providerName: string, reason: string }>, excludedDefinitions: Array<{ __typename?: 'ExcludedDefinition', definitionId: string, name: string, reason: string }>, pressureConditionExclusionBreakdown: { __typename?: 'PressureConditionExclusionBreakdown', sourceRunMapping: number, definitionMetadata: number, missingScenario: number, invalidMetadata: number, levelAssignment: number }, directionalSanityCheck: { __typename?: 'DirectionalSanityCheck', positivePct: number, flatPct: number, negativePct: number, measuredCount: number, unmeasurableCount: number, breakdown: Array<{ __typename?: 'DirectionalSanityCheckEntry', modelId: string, pairKey: string, pressureResponse: number, classification: string }> } } };
+export type PressureSensitivityQuery = { __typename?: 'Query', pressureSensitivity: { __typename?: 'PressureSensitivityResult', pressureConditionExcludedCount: number, transcriptCapHit: boolean, models: Array<{ __typename?: 'PressureSensitivityModel', modelId: string, label: string, providerName: string, unscoredCount: number, pushedForEffect?: number | null, pushedAgainstEffect?: number | null, pushedEffectPairsUsed: number, domainPressureEffects: Array<{ __typename?: 'DomainPressureEffect', domainId: string, domainName: string, pushedForEffect?: number | null }>, pressureResponseSummary: { __typename?: 'PressureResponseSummary', mean?: number | null, rangeMin?: number | null, rangeMax?: number | null, pairsMeasured: number }, valueRates: Array<{ __typename?: 'PressureSensitivityValueRate', valueToken: string, valueLabel: string, averageWinRate?: number | null, balancedWinRate?: number | null, highPressureOnThisValueWinRate?: number | null, highPressureOnOpposingValueWinRate?: number | null, pairsMeasured: number }>, valuePairs: Array<{ __typename?: 'PressureSensitivityValuePair', pairKey: string, firstValueToken: string, firstValueLabel: string, secondValueToken: string, secondValueLabel: string, n: number, unscoredCount: number, definitionsMeasured: number, directionBalancedWinRate?: number | null, directionBalancedOpponentWinRate?: number | null, directionBalancedBalancedWinRate?: number | null, directionBalancedBalancedOpponentWinRate?: number | null, directionBalancedHighPressureOwnWinRate?: number | null, directionBalancedHighPressureOwnOpponentWinRate?: number | null, directionBalancedHighPressureOpponentWinRate?: number | null, directionBalancedHighPressureOpponentOpponentWinRate?: number | null, pressureResponse: { __typename?: 'PressureResponse', value?: number | null, baselineRate?: number | null, pushTowardFirstRate?: number | null, pushTowardSecondRate?: number | null, qualifyingTrials: number, ciLow?: number | null, ciHigh?: number | null, reason?: string | null }, grid: Array<{ __typename?: 'SensitivityCell', ownLevel: number, opponentLevel: number, n: number, unscoredCount: number, winRate?: number | null, opponentWinRate?: number | null, conviction?: number | null, netScore?: number | null, lowData: boolean }> }> }>, insufficient: Array<{ __typename?: 'InsufficientPressureSensitivityModel', modelId: string, label: string, providerName: string, reason: string }>, excludedDefinitions: Array<{ __typename?: 'ExcludedDefinition', definitionId: string, name: string, reason: string }>, pressureConditionExclusionBreakdown: { __typename?: 'PressureConditionExclusionBreakdown', sourceRunMapping: number, definitionMetadata: number, missingScenario: number, invalidMetadata: number, levelAssignment: number }, directionalSanityCheck: { __typename?: 'DirectionalSanityCheck', positivePct: number, flatPct: number, negativePct: number, measuredCount: number, unmeasurableCount: number, breakdown: Array<{ __typename?: 'DirectionalSanityCheckEntry', modelId: string, pairKey: string, pressureResponse: number, classification: string }> } } };
 
 export type OpenRunAnomaliesQueryVariables = Exact<{
   domainId?: InputMaybe<Scalars['ID']['input']>;
@@ -7241,6 +7249,11 @@ export const PressureSensitivityDocument = gql`
       pushedForEffect
       pushedAgainstEffect
       pushedEffectPairsUsed
+      domainPressureEffects {
+        domainId
+        domainName
+        pushedForEffect
+      }
       pressureResponseSummary {
         mean
         rangeMin

--- a/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
@@ -36,6 +36,7 @@ function createPressureData(
           providerName: 'Provider',
           unscoredCount: 0,
           pushedEffectPairsUsed: 0,
+          domainPressureEffects: [],
           pressureResponseSummary: {
             mean: 0.1,
             rangeMin: 0.05,
@@ -83,6 +84,7 @@ function createPressureData(
           providerName: 'Provider',
           unscoredCount: 0,
           pushedEffectPairsUsed: 0,
+          domainPressureEffects: [],
           pressureResponseSummary: {
             mean: 0.2,
             rangeMin: 0.1,


### PR DESCRIPTION
## Summary
- Replaces the pushed-for / pushed-against / gap / pairs columns in the "Does pressure work both ways?" table with **Overall + one column per domain**
- Renames the table heading to "Pressure sensitivity by domain"
- Backend computes per-domain pushed-for effects inside the existing snapshot pass and exposes them via a new `DomainPressureEffect` GraphQL type on each model
- Snapshot version bumped from 1.1.0 → 1.2.0; `parseSnapshotOutput` returns null when models lack `domainPressureEffects`, forcing synchronous recompute on first load
- Columns sorted alphabetically by domain name; rows sorted by overall effect descending

## Test plan
- [ ] Preflight passed: lint + tests (148 files) + build
- [ ] Snapshot version bump confirmed (1.2.0)
- [ ] `parseSnapshotOutput` rejects v1.1.0 snapshots missing `domainPressureEffects`
- [ ] `PressureDirectionalBreakdown` test suite fully rewritten for new design (13 tests)
- [ ] All 6 fixture files updated with `domainPressureEffects: []`

## Validation
- `npm run lint --workspace @valuerank/shared` ✅
- `npm run lint --workspace @valuerank/db` ✅
- `npm run lint --workspace @valuerank/api` ✅
- `npm run build --workspace @valuerank/api` ✅
- `npm run lint --workspace @valuerank/web` ✅
- `npm run test --workspace @valuerank/web` ✅ 148 passed
- `npm run build --workspace @valuerank/web` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)