### PR TITLE
Rename pressure-sensitivity baseline copy to balanced

### DIFF
--- a/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.test.tsx
@@ -178,7 +178,7 @@ describe('PressureDirectionalBreakdown', () => {
 
     const overallTrigger = screen.getByRole('button', { name: /show overall help/i });
     fireEvent.focus(overallTrigger);
-    expect(screen.getByRole('tooltip').textContent ?? '').toContain('Win-rate lift above balanced baseline');
+    expect(screen.getByRole('tooltip').textContent ?? '').toContain('Win-rate lift above balanced');
     fireEvent.blur(overallTrigger);
 
     const ethicsTrigger = screen.getByRole('button', { name: /show ethics help/i });

--- a/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.tsx
+++ b/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.tsx
@@ -21,7 +21,7 @@ type Domain = { id: string; name: string };
 const MAX_DELTA = 0.25;
 
 const OVERALL_TOOLTIP =
-  "Win-rate lift above balanced baseline when a value's pressure is high and the other's is calm. Direction-balanced and averaged across all domains and measured pairs.";
+  "Win-rate lift above balanced when a value's pressure is high and the other's is calm. Direction-balanced and averaged across all domains and measured pairs.";
 
 function domainTooltip(domainName: string): string {
   return `How this model's pressure sensitivity in ${domainName} compares to its overall average. Green means more pressure-sensitive here; red means less.`;
@@ -92,7 +92,7 @@ export function PressureDirectionalBreakdown({ models }: Props) {
           <h2 className="text-lg font-semibold text-gray-900">Pressure sensitivity by domain</h2>
           <p className="text-sm text-gray-600">
             How much each model shifts toward a value when that value is explicitly pressed, versus a
-            neutral baseline. Domain cells show the delta from each model&apos;s overall average.
+            neutral balanced reference. Domain cells show the delta from each model&apos;s overall average.
           </p>
         </div>
         <ScreenshotButton targetRef={tableRef} label="pressure sensitivity by domain" />

--- a/cloud/apps/web/src/components/models/PressureSensitivityDetail.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityDetail.test.tsx
@@ -78,7 +78,7 @@ describe('PressureSensitivityDetail', () => {
 
     expect(screen.getByText('Pressure Response by Value Pair')).toBeDefined();
     expect(screen.getByText('Value Pair')).toBeDefined();
-    expect(screen.getByText('Baseline')).toBeDefined();
+    expect(screen.getByText('Balanced')).toBeDefined();
     expect(screen.getByText('Push toward first')).toBeDefined();
     expect(screen.getByText('Push toward other')).toBeDefined();
     expect(screen.getByText('Pressure response')).toBeDefined();
@@ -94,7 +94,7 @@ describe('PressureSensitivityDetail', () => {
 
   it('shows the thin-pool reason on the dash pressure-response cell', () => {
     vi.useFakeTimers();
-    // directional-thin: pushTowardFirstRate null, pushTowardSecondRate/baselineRate available
+    // directional-thin: pushTowardFirstRate null, pushTowardSecondRate/balancedRate available
     renderDetail(
       createModel([
         createPair('alpha::delta', 'Alpha', 'Delta', null, 0.5, null, 0.6, null, null, 'directional-thin', 17),
@@ -102,7 +102,7 @@ describe('PressureSensitivityDetail', () => {
     );
 
     const row = getRow('Alpha ↔ Delta');
-    // Pressure response is column index 4 (Value Pair=0, Baseline=1, Push1=2, Push2=3, Response=4, Trials=5)
+    // Pressure response is column index 4 (Value Pair=0, Balanced=1, Push1=2, Push2=3, Response=4, Trials=5)
     const cells = within(row).getAllByRole('cell');
     const responseCell = cells[4];
     if (!responseCell) throw new Error('Expected pressure response cell at index 4');

--- a/cloud/apps/web/src/components/models/PressureSensitivityDetail.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityDetail.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from '../ui/Tooltip';
 import { PressureGrid } from './PressureGrid';
 import type { PressureSensitivityModel, PressureSensitivityValuePair } from '../../api/operations/pressureSensitivity';
 import {
-  BASELINE_TOOLTIP,
+  BALANCED_TOOLTIP,
   PUSH_TOWARD_FIRST_TOOLTIP,
   PUSH_TOWARD_OTHER_TOOLTIP,
   PAIR_PRESSURE_RESPONSE_TOOLTIP,
@@ -120,7 +120,7 @@ export function PressureSensitivityDetail({ model }: Props) {
         <div className="space-y-1">
           <h2 className="text-lg font-semibold text-gray-900">Pressure Response by Value Pair</h2>
           <p className="text-sm text-gray-600">
-            This table shows the baseline win rate and push rates for each value pair. The Pressure response column is
+            This table shows the balanced win rate and push rates for each value pair. The Pressure response column is
             the signed difference between push directions, and the Trials column counts the scored observations used
             to pool those rates.
           </p>
@@ -137,7 +137,7 @@ export function PressureSensitivityDetail({ model }: Props) {
                 <HeaderTooltip label="Value Pair" content={VALUE_PAIR_TOOLTIP} />
               </TableHead>
               <TableHead className="text-xs uppercase tracking-wide text-gray-700">
-                <HeaderTooltip label="Baseline" content={BASELINE_TOOLTIP} />
+                <HeaderTooltip label="Balanced" content={BALANCED_TOOLTIP} />
               </TableHead>
               <TableHead className="text-xs uppercase tracking-wide text-gray-700">
                 <HeaderTooltip label="Push toward first" content={PUSH_TOWARD_FIRST_TOOLTIP} />

--- a/cloud/apps/web/src/components/models/pressureSensitivityFormatting.ts
+++ b/cloud/apps/web/src/components/models/pressureSensitivityFormatting.ts
@@ -9,7 +9,7 @@ export const SUMMARY_PRESSURE_RESPONSE_TOOLTIP =
 export const PAIR_PRESSURE_RESPONSE_TOOLTIP =
   'Signed push-rate difference: Push toward first minus Push toward other, in percentage points. The CI is the Newcombe 95% confidence interval for the difference of two proportions.';
 
-export const BASELINE_TOOLTIP =
+export const BALANCED_TOOLTIP =
   'Win rate when own and opponent pressure are both at moderate levels. Used as the reference for the push columns.';
 
 export const PUSH_TOWARD_FIRST_TOOLTIP =
@@ -19,7 +19,7 @@ export const PUSH_TOWARD_OTHER_TOOLTIP =
   "Win rate when the other value's pressure is high (levels 4–5) and the first value's pressure is moderate. A higher rate means the model picks the other value more under pressure.";
 
 export const TRIALS_TOOLTIP =
-  'Qualifying scored observations that contributed to the Baseline, Push toward first, and Push toward other rates. These observations feed the pooled rates used to compute the Pressure response and its confidence interval.';
+  'Qualifying scored observations that contributed to the Balanced, Push toward first, and Push toward other rates. These observations feed the pooled rates used to compute the Pressure response and its confidence interval.';
 
 export function formatPercent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
@@ -67,7 +67,7 @@ export function reasonHoverText(reason: string | null | undefined): string {
     return 'Neither direction pool has enough vignette observations. This pair needs more coverage to compute a pressure response.';
   }
   if (reason === 'baseline-thin') {
-    return 'Pressure response is defined but the baseline pool does not yet have enough vignette observations.';
+    return 'Pressure response is defined but the balanced pool does not yet have enough vignette observations.';
   }
   return '';
 }


### PR DESCRIPTION
## Summary
- Rename the pressure-sensitivity UI copy from "Baseline" to "Balanced" to reduce confusion.
- Keep the backend field name `baselineRate` unchanged so the GraphQL contract stays stable.

## Validation
- `npm run test -- --run src/components/models/PressureSensitivityDetail.test.tsx src/components/models/PressureDirectionalBreakdown.test.tsx` (pass)
- `npx turbo lint --filter=@valuerank/web` (pass, existing repo warnings only)
- `npx turbo test --filter=@valuerank/web` (pass, existing repo warnings only)
- `npx turbo build --filter=@valuerank/web` (pass, existing build warning only)