### PR TITLE
[codex] Model groups landing page

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -92,6 +92,7 @@ Once the above are resolved:
 - [x] Domain Shifts by Value heatmap implemented at `/models/domain-shifts`; focused tests and web preflight pass.
 - [x] Domain Shifts readability controls added locally: cells can toggle between shift and raw win rate, and table columns are sortable.
 - [x] Domain Shifts model picker now groups default models first and separates non-default models with `---` before alphabetical non-default options.
+- [x] Model Groups visualization now lives at `/models` under the Models dropdown first item, with the domain selection bar at the top of the page driving the report.
 - [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, and model rows no longer repeat the model ID line.
 - [x] Domain Shifts by Value now has an `All models` aggregate view, one-decimal formatting throughout, and content-fit Value / Avg Win Rate columns in the local branch.
 - [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, the all-domains value priorities table now includes stability circles, and the comparison table stays below it.

--- a/cloud/apps/web/src/App.tsx
+++ b/cloud/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import { DomainAnalysis } from './pages/DomainAnalysis';
 import { DomainCoverage } from './pages/DomainCoverage';
 import { DomainAnalysisValueDetail } from './pages/DomainAnalysisValueDetail';
 import { DomainValueShiftHeatmap } from './pages/DomainValueShiftHeatmap';
+import { ModelsGroups } from './pages/ModelsGroups';
 import { ModelsConsistency } from './pages/ModelsConsistency';
 import { PressureSensitivity } from './pages/PressureSensitivity';
 import { ModelsCircumplex } from './pages/ModelsCircumplex';
@@ -169,7 +170,14 @@ function App() {
                 </ProtectedLayout>
               }
             />
-            <Route path="/models" element={<Navigate to="/domains/analysis" replace />} />
+            <Route
+              path="/models"
+              element={
+                <ProtectedLayout>
+                  <ModelsGroups />
+                </ProtectedLayout>
+              }
+            />
             <Route
               path="/models/domain-shifts"
               element={

--- a/cloud/apps/web/src/components/layout/Header.tsx
+++ b/cloud/apps/web/src/components/layout/Header.tsx
@@ -54,6 +54,7 @@ const domainMenuItems: MenuItem[] = [
 ];
 
 const modelsMenuItems: MenuItem[] = [
+  { name: 'Model Groups', path: '/models', match: 'exact' },
   { name: 'Domain Analysis', path: '/domains/analysis' },
   { name: 'Domain Shifts', path: '/models/domain-shifts' },
   { name: 'Pressure Sensitivity', path: '/models/pressure-sensitivity' },
@@ -269,7 +270,7 @@ export function Header() {
         </div>
 
         <nav className="hidden min-w-0 flex-1 sm:flex items-stretch gap-1">
-          {renderMenu(modelsMenuRef, 'Models', '/domains/analysis', Cpu, modelsMenuItems, isModelsActive, isModelsMenuOpen, setIsModelsMenuOpen)}
+          {renderMenu(modelsMenuRef, 'Models', '/models', Cpu, modelsMenuItems, isModelsActive, isModelsMenuOpen, setIsModelsMenuOpen)}
           {renderMenu(domainsMenuRef, 'Domains', '/domains', FolderTree, visibleDomainMenuItems, isDomainsActive, isDomainsMenuOpen, setIsDomainsMenuOpen)}
           {renderMenu(vignettesMenuRef, 'Vignettes', '/definitions', Library, vignettesMenuItems, isVignettesActive, isVignettesMenuOpen, setIsVignettesMenuOpen)}
           {isAdmin ? renderMenu(archiveMenuRef, 'Archive', '/archive', Archive, archiveMenuItems, isArchiveActive, isArchiveMenuOpen, setIsArchiveMenuOpen) : null}

--- a/cloud/apps/web/src/components/layout/MobileNav.tsx
+++ b/cloud/apps/web/src/components/layout/MobileNav.tsx
@@ -23,7 +23,8 @@ const navItems: NavItem[] = [
     icon: Cpu,
     activateWithChildren: true,
     children: [
-      { name: 'Matrix', path: '/models', icon: Cpu, match: 'exact' },
+      { name: 'Model Groups', path: '/models', icon: Cpu, match: 'exact' },
+      { name: 'Domain Analysis', path: '/domains/analysis', icon: BarChart2 },
       { name: 'Domain Shifts', path: '/models/domain-shifts', icon: BarChart2 },
       { name: 'Pressure Sensitivity', path: '/models/pressure-sensitivity', icon: BarChart2 },
     ],
@@ -33,7 +34,6 @@ const navItems: NavItem[] = [
     path: '/domains',
     icon: FolderTree,
     children: [
-      { name: 'Domain Analysis', path: '/domains/analysis', icon: BarChart2 },
       { name: 'Manage Domains', path: '/domains/manage', icon: FolderTree },
     ],
   },

--- a/cloud/apps/web/src/components/layout/NavTabs.tsx
+++ b/cloud/apps/web/src/components/layout/NavTabs.tsx
@@ -35,6 +35,7 @@ const domainMenuItems: MenuItem[] = [
 ];
 
 const modelsMenuItems: MenuItem[] = [
+  { name: 'Model Groups', path: '/models', match: 'exact' },
   { name: 'Domain Analysis', path: '/domains/analysis' },
   { name: 'Domain Shifts', path: '/models/domain-shifts' },
   { name: 'Pressure Sensitivity', path: '/models/pressure-sensitivity' },
@@ -242,7 +243,7 @@ export function NavTabs() {
     <nav className="hidden sm:block bg-[#1A1A1A] border-t border-gray-800 sticky top-14 z-10">
       <div className="max-w-7xl mx-auto px-4">
         <div className="flex gap-1">
-          {renderMenu(modelsMenuRef, 'Models', '/domains/analysis', Cpu, modelsMenuItems, isModelsActive, isModelsMenuOpen, setIsModelsMenuOpen)}
+          {renderMenu(modelsMenuRef, 'Models', '/models', Cpu, modelsMenuItems, isModelsActive, isModelsMenuOpen, setIsModelsMenuOpen)}
           {renderMenu(domainMenuRef, 'Domains', '/domains', FolderTree, visibleDomainMenuItems, isDomainsActive, isDomainsMenuOpen, setIsDomainsMenuOpen)}
           {renderMenu(vignettesMenuRef, 'Vignettes', '/definitions', Library, vignettesMenuItems, isVignettesActive, isVignettesMenuOpen, setIsVignettesMenuOpen)}
           {isAdmin ? renderMenu(archiveMenuRef, 'Archive', '/archive', Archive, archiveMenuItems, isArchiveActive, isArchiveMenuOpen, setIsArchiveMenuOpen) : null}

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -24,7 +24,6 @@ import {
   type ModelsAnalysisQueryVariables,
 } from '../api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
-import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
 import { DominanceSection } from '../components/domains/DominanceSection';
 import { SimilaritySection } from '../components/domains/SimilaritySection';
 import { ValuePrioritiesSection } from '../components/domains/ValuePrioritiesSection';
@@ -502,11 +501,6 @@ export function DomainAnalysis() {
         <Loading size="lg" text="Loading domain analysis..." />
       ) : (
         <>
-          <ModelGroupsSection
-            clusterAnalysis={data?.domainAnalysis.clusterAnalysis}
-            models={visibleModels}
-            selectedModelId={singleSelectedModelId}
-          />
           <ValuePrioritiesSection
             models={visibleModels}
             selectedDomainId={selectedDomainId}

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from 'urql';
+import { useSearchParams } from 'react-router-dom';
+import { ErrorMessage } from '../components/ui/ErrorMessage';
+import { Loading } from '../components/ui/Loading';
+import { Select } from '../components/ui/Select';
+import {
+  DOMAIN_ANALYSIS_QUERY,
+  DOMAIN_ANALYSIS_QUERY_LEGACY,
+  DOMAIN_AVAILABLE_SIGNATURES_QUERY,
+  type DomainAnalysisQueryResult,
+  type DomainAnalysisQueryVariables,
+  type DomainAnalysisModel,
+  type DomainAvailableSignature,
+  type DomainAvailableSignaturesQueryResult,
+  type DomainAvailableSignaturesQueryVariables,
+} from '../api/operations/domainAnalysis';
+import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
+import { useDomains } from '../hooks/useDomains';
+import { VALUES, type ModelEntry, type ValueKey } from '../data/domainAnalysisData';
+import { formatSignatureOptionLabel, getCacheStatusCopy, getSignaturePriority } from '../utils/domainAnalysisUtils';
+
+const ALL_DOMAINS_SCOPE = 'all-domains';
+
+function buildModelEntries(models: DomainAnalysisModel[]): ModelEntry[] {
+  return models.map((model) => {
+    const valueMap = new Map(model.values.map((value) => [value.valueKey, value.score] as const));
+    const values = VALUES.reduce<Record<ValueKey, number>>((acc, valueKey) => {
+      acc[valueKey] = valueMap.get(valueKey) ?? 0;
+      return acc;
+    }, {} as Record<ValueKey, number>);
+
+    return {
+      model: model.model,
+      label: model.label,
+      values,
+    };
+  });
+}
+
+export function ModelsGroups() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { domains, queryLoading: domainsLoading, error: domainsError } = useDomains();
+  const initialDomainId = searchParams.get('domainId') ?? '';
+  const [selectedScope, setSelectedScope] = useState<'DOMAIN' | 'ALL_DOMAINS'>(
+    searchParams.get('scope') === ALL_DOMAINS_SCOPE || initialDomainId.trim() === '' ? 'ALL_DOMAINS' : 'DOMAIN',
+  );
+  const [selectedDomainId, setSelectedDomainId] = useState<string>(initialDomainId);
+  const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
+  const [useLegacyQuery, setUseLegacyQuery] = useState(false);
+
+  const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
+    DomainAvailableSignaturesQueryResult,
+    DomainAvailableSignaturesQueryVariables
+  >({
+    query: DOMAIN_AVAILABLE_SIGNATURES_QUERY,
+    variables: {
+      domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
+      scope: selectedScope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined,
+    },
+    pause: selectedDomainId === '',
+    requestPolicy: 'cache-and-network',
+  });
+
+  const signatureOptions = useMemo<DomainAvailableSignature[]>(() => {
+    const options = signatureData?.domainAvailableSignatures ?? [];
+    return options
+      .map((option, index) => ({ option, index }))
+      .sort((a, b) => {
+        const priority = getSignaturePriority(a.option) - getSignaturePriority(b.option);
+        return priority !== 0 ? priority : a.index - b.index;
+      })
+      .map(({ option }) => option);
+  }, [signatureData]);
+
+  useEffect(() => {
+    if (domains.length === 0) return;
+    if (selectedDomainId !== '' && domains.some((domain) => domain.id === selectedDomainId)) return;
+    setSelectedDomainId(domains[0]?.id ?? '');
+  }, [domains, selectedDomainId]);
+
+  useEffect(() => {
+    if (signatureOptions.length === 0) {
+      setSelectedSignature('');
+      return;
+    }
+    if (selectedSignature !== '' && signatureOptions.some((option) => option.signature === selectedSignature)) return;
+    setSelectedSignature(signatureOptions[0]?.signature ?? '');
+  }, [selectedSignature, signatureOptions]);
+
+  useEffect(() => {
+    const currentScope = searchParams.get('scope') === ALL_DOMAINS_SCOPE ? 'ALL_DOMAINS' : 'DOMAIN';
+    const nextDomainId = selectedDomainId !== '' ? selectedDomainId : (domains[0]?.id ?? '');
+    if (nextDomainId === '' && selectedScope === 'DOMAIN') return;
+    if (
+      searchParams.get('domainId') === nextDomainId
+      && (searchParams.get('signature') ?? '') === selectedSignature
+      && currentScope === selectedScope
+    ) return;
+    const next = new URLSearchParams(searchParams);
+    if (nextDomainId !== '') next.set('domainId', nextDomainId);
+    else next.delete('domainId');
+    if (selectedScope === 'ALL_DOMAINS') next.set('scope', ALL_DOMAINS_SCOPE);
+    else next.delete('scope');
+    if (selectedSignature === '') next.delete('signature');
+    else next.set('signature', selectedSignature);
+    setSearchParams(next, { replace: true });
+  }, [domains, searchParams, selectedDomainId, selectedSignature, selectedScope, setSearchParams]);
+
+  const activeUseLegacyQuery = useLegacyQuery && selectedScope !== 'ALL_DOMAINS';
+  const [{ data: scoredData, fetching: scoredFetching, error: scoredError }] = useQuery<DomainAnalysisQueryResult, DomainAnalysisQueryVariables>({
+    query: DOMAIN_ANALYSIS_QUERY,
+    variables: {
+      domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
+      scope: selectedScope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined,
+      signature: selectedSignature === '' ? undefined : selectedSignature,
+    },
+    pause: selectedDomainId === '' || activeUseLegacyQuery,
+    requestPolicy: 'cache-and-network',
+  });
+  const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<DomainAnalysisQueryResult, { domainId: string }>({
+    query: DOMAIN_ANALYSIS_QUERY_LEGACY,
+    variables: { domainId: selectedDomainId },
+    pause: selectedDomainId === '' || !activeUseLegacyQuery,
+    requestPolicy: 'cache-and-network',
+  });
+
+  useEffect(() => {
+    const message = scoredError?.message ?? '';
+    const isFieldError = message.includes('Unknown argument "signature"')
+      || message.includes('Cannot query field')
+      || message.includes('Unknown field');
+    if (isFieldError && !useLegacyQuery && selectedScope !== 'ALL_DOMAINS') setUseLegacyQuery(true);
+  }, [scoredError, selectedScope, useLegacyQuery]);
+
+  const data = activeUseLegacyQuery ? legacyData : scoredData;
+  const fetching = activeUseLegacyQuery ? legacyFetching : scoredFetching;
+  const error = activeUseLegacyQuery ? legacyError : scoredError;
+  const cacheStatusCopy = useMemo(
+    () => getCacheStatusCopy(data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt),
+    [data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt],
+  );
+  const showPageLoader = domainsLoading || (selectedDomainId !== '' && data?.domainAnalysis == null && fetching);
+  const models = useMemo(() => buildModelEntries(data?.domainAnalysis.models ?? []), [data?.domainAnalysis.models]);
+  const isAllDomains = selectedScope === 'ALL_DOMAINS';
+  const domainSelectionSection = (
+    <section className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-900">Domain Selection</h2>
+          <p className="text-xs text-gray-600">
+            {isAllDomains
+              ? 'Cross-domain analysis is read-only and pools every visible domain that matches the selected signature.'
+              : 'Model groups are shown from the latest saved snapshot for this domain.'}
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 md:flex-row md:items-end">
+          <div className="min-w-[210px]">
+            <Select
+              label="Domain scope"
+              options={[
+                { value: ALL_DOMAINS_SCOPE, label: 'All domains' },
+                ...domains.map((domain) => ({ value: domain.id, label: domain.name })),
+              ]}
+              value={isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId}
+              onChange={(value) => {
+                if (value === ALL_DOMAINS_SCOPE) {
+                  setSelectedScope('ALL_DOMAINS');
+                  return;
+                }
+                setSelectedScope('DOMAIN');
+                setSelectedDomainId(value);
+              }}
+              disabled={domainsLoading || (domains.length === 0 && !isAllDomains)}
+            />
+          </div>
+          <div className="min-w-[210px]">
+            <Select
+              label="Signature"
+              options={
+                signatureOptions.length === 0
+                  ? [{ value: '', label: 'No signatures with completed runs', disabled: true }]
+                  : signatureOptions.map((option) => ({
+                    value: option.signature,
+                    label: formatSignatureOptionLabel(option),
+                  }))
+              }
+              value={selectedSignature}
+              onChange={(value) => setSelectedSignature(value)}
+              disabled={signaturesLoading || signatureOptions.length === 0}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+
+  if (domainsError != null || signaturesError != null || error != null) {
+    return (
+      <div className="space-y-6">
+        {domainSelectionSection}
+        <ErrorMessage message={`Failed to load model groups report: ${(domainsError ?? signaturesError ?? error)?.message ?? 'Unknown error'}`} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {domainSelectionSection}
+
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
+        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Model Groups</h1>
+        <p className="max-w-3xl text-sm text-gray-600">
+          Clustered model families for the selected domain and signature.
+        </p>
+        {cacheStatusCopy != null && (
+          <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+            <span className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${cacheStatusCopy.badgeClassName}`}>
+              {cacheStatusCopy.badgeLabel}
+            </span>
+            <span>{cacheStatusCopy.detail}</span>
+          </div>
+        )}
+      </div>
+
+      {showPageLoader ? (
+        <Loading size="lg" text="Loading model groups..." />
+      ) : (
+        <ModelGroupsSection
+          clusterAnalysis={data?.domainAnalysis.clusterAnalysis}
+          models={models}
+        />
+      )}
+    </div>
+  );
+}

--- a/cloud/apps/web/tests/App.test.tsx
+++ b/cloud/apps/web/tests/App.test.tsx
@@ -15,6 +15,10 @@ vi.mock('../src/pages/DomainValueShiftHeatmap', () => ({
   DomainValueShiftHeatmap: () => <div>Domain shifts route smoke</div>,
 }));
 
+vi.mock('../src/pages/ModelsGroups', () => ({
+  ModelsGroups: () => <div>Model groups route smoke</div>,
+}));
+
 // Mock localStorage
 beforeEach(() => {
   localStorage.clear();
@@ -66,6 +70,21 @@ describe('App Routing', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Domain shifts route smoke')).toBeInTheDocument();
+    });
+  });
+
+  it('should render the protected models route when authenticated', async () => {
+    localStorage.setItem('valuerank_token', 'test-token');
+    window.history.pushState({}, '', '/models');
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'user-1', email: 'researcher@example.com', name: 'Researcher' }),
+    } as Response);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Model groups route smoke')).toBeInTheDocument();
     });
   });
 });

--- a/cloud/apps/web/tests/components/layout/MobileNav.test.tsx
+++ b/cloud/apps/web/tests/components/layout/MobileNav.test.tsx
@@ -36,7 +36,7 @@ describe('MobileNav Component', () => {
     expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
     expect(screen.getByRole('link', { name: 'Domains' })).toHaveAttribute('href', '/domains');
     expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/models');
-    expect(screen.getByRole('link', { name: 'Matrix' })).toHaveAttribute('href', '/models');
+    expect(screen.getByRole('link', { name: 'Model Groups' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Domain Shifts' })).toHaveAttribute('href', '/models/domain-shifts');
     expect(screen.getByRole('link', { name: 'Consistency' })).toHaveAttribute('href', '/archive/consistency');
     expect(screen.getByRole('link', { name: 'Circumplex' })).toHaveAttribute('href', '/archive/circumplex');
@@ -48,16 +48,17 @@ describe('MobileNav Component', () => {
     await renderMobileNav('/models/domain-shifts');
 
     expect(screen.getByRole('link', { name: 'Models' }).className).toContain('border-teal-500');
-    expect(screen.getByRole('link', { name: 'Matrix' }).className).not.toContain('border-teal-500');
+    expect(screen.getByRole('link', { name: 'Model Groups' }).className).not.toContain('border-teal-500');
     expect(screen.getByRole('link', { name: 'Domain Shifts' }).className).toContain('border-teal-500');
     expect(screen.getByRole('link', { name: 'Consistency' }).className).not.toContain('border-teal-500');
     expect(screen.getByRole('link', { name: 'Circumplex' }).className).not.toContain('border-teal-500');
   });
 
-  it('keeps the domain compatibility links nested under Domains', async () => {
+  it('keeps the model and domain compatibility links available in the mobile menu', async () => {
     await renderMobileNav('/domains');
 
     expect(screen.getByRole('link', { name: 'Vignettes' })).toHaveAttribute('href', '/definitions');
+    expect(screen.getByRole('link', { name: 'Model Groups' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Domain Analysis' })).toHaveAttribute('href', '/domains/analysis');
     expect(screen.getByRole('link', { name: 'Manage Domains' })).toHaveAttribute('href', '/domains/manage');
     expect(screen.queryByRole('link', { name: 'Coverage' })).not.toBeInTheDocument();

--- a/cloud/apps/web/tests/components/layout/NavTabs.test.tsx
+++ b/cloud/apps/web/tests/components/layout/NavTabs.test.tsx
@@ -35,7 +35,7 @@ describe('NavTabs Component', () => {
     renderNavTabs();
 
     expect(screen.queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/domains/analysis');
+    expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Domains' })).toHaveAttribute('href', '/domains');
     expect(screen.getByRole('link', { name: 'Vignettes' })).toHaveAttribute('href', '/definitions');
     expect(screen.getByRole('link', { name: 'Archive' })).toHaveAttribute('href', '/archive');
@@ -60,7 +60,8 @@ describe('NavTabs Component', () => {
     await waitFor(() => {
       expect(toggle).toHaveAttribute('aria-expanded', 'true');
     });
-    expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/domains/analysis');
+    expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/models');
+    expect(screen.getByRole('link', { name: 'Model Groups' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Domain Analysis' })).toHaveAttribute('href', '/domains/analysis');
     expect(screen.getByRole('link', { name: 'Domain Shifts' })).toHaveAttribute('href', '/models/domain-shifts');
   });
@@ -70,6 +71,7 @@ describe('NavTabs Component', () => {
     await openMenu('Models');
 
     expect(screen.getByRole('link', { name: 'Models' }).parentElement?.className).toContain('border-teal-500');
+    expect(screen.getByRole('link', { name: 'Model Groups' }).className).not.toContain('bg-teal-600/20');
     expect(screen.getByRole('link', { name: 'Domain Analysis' }).className).not.toContain('bg-teal-600/20');
     expect(screen.getByRole('link', { name: 'Domain Shifts' }).className).toContain('bg-teal-600/20');
     expect(screen.getByRole('link', { name: 'Consistency' }).className).not.toContain('bg-teal-600/20');

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -79,7 +79,6 @@ const defaultModelsAnalysis = {
 };
 
 const valuePrioritiesSectionMock = vi.fn(() => <div>Mock value priorities section</div>);
-const modelGroupsSectionMock = vi.fn(() => <div>Mock model groups section</div>);
 
 function installQueryResponses(options?: {
   findingsData?: typeof defaultFindingsEligibility | undefined;
@@ -167,10 +166,6 @@ vi.mock('../../src/components/domains/DominanceSection', () => ({
   DominanceSection: () => <div>Mock dominance section</div>,
 }));
 
-vi.mock('../../src/components/domains/ModelGroupsSection', () => ({
-  ModelGroupsSection: (props: unknown) => modelGroupsSectionMock(props),
-}));
-
 vi.mock('../../src/components/domains/SimilaritySection', () => ({
   SimilaritySection: () => <div>Mock similarity section</div>,
 }));
@@ -185,7 +180,6 @@ describe('DomainAnalysis', () => {
     useMutationMock.mockReset();
     refreshMutationExecuteMock.mockReset();
     valuePrioritiesSectionMock.mockClear();
-    modelGroupsSectionMock.mockClear();
     useMutationMock.mockImplementation((query: unknown) => {
       if (query === REFRESH_DOMAIN_ANALYSIS_MUTATION) {
         return [{ fetching: false }, refreshMutationExecuteMock];
@@ -215,13 +209,11 @@ describe('DomainAnalysis', () => {
 
     const domainSelection = await screen.findByRole('heading', { name: 'Domain Selection' });
     const findingsHeading = screen.getByRole('heading', { name: 'Findings' });
-    const modelGroups = await screen.findByText(/mock model groups section/i);
     const valuePriorities = screen.getByText(/mock value priorities section/i);
     const dominance = screen.getByText(/mock dominance section/i);
     const similarity = screen.getByText(/mock similarity section/i);
 
     expect(domainSelection.compareDocumentPosition(findingsHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(modelGroups.compareDocumentPosition(valuePriorities) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(valuePriorities.compareDocumentPosition(dominance) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(dominance.compareDocumentPosition(similarity) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
@@ -366,72 +358,6 @@ describe('DomainAnalysis', () => {
         }),
       }),
     ]);
-  });
-
-  it('passes only picker-selected models into model groups', async () => {
-    installQueryResponses({
-      analysisData: {
-        domainAnalysis: {
-          ...defaultDomainAnalysis.domainAnalysis,
-          models: [
-            {
-              model: 'model-a',
-              label: 'Model A',
-              values: [
-                {
-                  valueKey: 'Achievement',
-                  score: 0,
-                  prioritized: 9,
-                  deprioritized: 1,
-                  neutral: 0,
-                  totalComparisons: 10,
-                },
-              ],
-            },
-            {
-              model: 'model-b',
-              label: 'Model B',
-              values: [
-                {
-                  valueKey: 'Achievement',
-                  score: 0,
-                  prioritized: 4,
-                  deprioritized: 6,
-                  neutral: 0,
-                  totalComparisons: 10,
-                },
-              ],
-            },
-          ],
-        },
-      },
-      llmModelsData: {
-        llmModels: [
-          { modelId: 'model-a', isDefault: true },
-          { modelId: 'model-b', isDefault: false },
-        ],
-      },
-    });
-
-    render(
-      <MemoryRouter>
-        <DomainAnalysis />
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(modelGroupsSectionMock).toHaveBeenCalled();
-    });
-
-    const lastCall = modelGroupsSectionMock.mock.calls.at(-1)?.[0] as {
-      models: Array<{ model: string }>;
-      selectedModelId: string | null;
-    };
-
-    expect(lastCall.models).toEqual([
-      expect.objectContaining({ model: 'model-a' }),
-    ]);
-    expect(lastCall.selectedModelId).toBe('model-a');
   });
 
   it('does not fall back to pooled counts when canonical models-analysis data is missing', async () => {

--- a/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ModelsGroups } from '../../src/pages/ModelsGroups';
+import {
+  DOMAIN_ANALYSIS_QUERY,
+  DOMAIN_ANALYSIS_QUERY_LEGACY,
+  DOMAIN_AVAILABLE_SIGNATURES_QUERY,
+} from '../../src/api/operations/domainAnalysis';
+
+const useQueryMock = vi.fn();
+const modelGroupsSectionMock = vi.fn(() => <div>Mock model groups section</div>);
+
+const defaultSignatureData = {
+  domainAvailableSignatures: [
+    { signature: 'vnewtd', label: 'Latest @ default', isVirtual: true, temperature: null },
+    { signature: 'v1td', label: 'v1 default', isVirtual: false, temperature: null },
+  ],
+};
+
+const defaultAnalysis = {
+  domainAnalysis: {
+    domainId: 'domain-a',
+    domainName: 'Domain A',
+    contributionSummary: [],
+    excludedDataSummary: [],
+    totalDefinitions: 2,
+    targetedDefinitions: 2,
+    coveredDefinitions: 2,
+    missingDefinitionIds: [],
+    missingDefinitions: [],
+    definitionsWithAnalysis: 2,
+    cacheStatus: 'FRESH',
+    generatedAt: '2026-03-15T12:00:00.000Z',
+    models: [
+      {
+        model: 'model-a',
+        label: 'Model A',
+        values: [
+          { valueKey: 'Achievement', score: 1 },
+          { valueKey: 'Hedonism', score: -1 },
+        ],
+      },
+    ],
+    unavailableModels: [],
+    clusterAnalysis: {
+      skipped: false,
+      skipReason: null,
+      defaultPair: null,
+      clusters: [
+        {
+          id: 'cluster-a',
+          name: 'Cluster A',
+          definingValues: ['Achievement'],
+          centroid: { Achievement: 1 },
+          members: [
+            {
+              model: 'model-a',
+              label: 'Model A',
+              silhouetteScore: 0.5,
+              isOutlier: false,
+              nearestClusterIds: null,
+              distancesToNearestClusters: null,
+            },
+          ],
+        },
+      ],
+      faultLinesByPair: {},
+    },
+  },
+};
+
+function installQueryResponses() {
+  useQueryMock.mockImplementation((args: { query: unknown }) => {
+    if (args.query === DOMAIN_AVAILABLE_SIGNATURES_QUERY) {
+      return [{
+        data: defaultSignatureData,
+        fetching: false,
+        error: undefined,
+      }];
+    }
+    if (args.query === DOMAIN_ANALYSIS_QUERY || args.query === DOMAIN_ANALYSIS_QUERY_LEGACY) {
+      return [{
+        data: defaultAnalysis,
+        fetching: false,
+        error: undefined,
+      }];
+    }
+    return [{ data: undefined, fetching: false, error: undefined }];
+  });
+}
+
+vi.mock('urql', async () => {
+  const actual = await vi.importActual<typeof import('urql')>('urql');
+  return {
+    ...actual,
+    useQuery: (args: unknown) => useQueryMock(args),
+  };
+});
+
+vi.mock('../../src/hooks/useDomains', () => ({
+  useDomains: () => ({
+    domains: [{ id: 'domain-a', name: 'Domain A', definitionCount: 2 }],
+    queryLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/components/domains/ModelGroupsSection', () => ({
+  ModelGroupsSection: (props: unknown) => modelGroupsSectionMock(props),
+}));
+
+describe('ModelsGroups', () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    modelGroupsSectionMock.mockClear();
+    installQueryResponses();
+  });
+
+  it('renders the domain selection bar and model groups visualization', async () => {
+    render(
+      <MemoryRouter initialEntries={['/models?domainId=domain-a&signature=vnewtd']}>
+        <ModelsGroups />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Domain Selection' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Model Groups' })).toBeInTheDocument();
+    expect(screen.getByText(/mock model groups section/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(modelGroupsSectionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clusterAnalysis: defaultAnalysis.domainAnalysis.clusterAnalysis,
+          models: [
+            {
+              model: 'model-a',
+              label: 'Model A',
+              values: {
+                Self_Direction_Action: 0,
+                Universalism_Nature: 0,
+                Benevolence_Dependability: 0,
+                Security_Personal: 0,
+                Power_Dominance: 0,
+                Achievement: 1,
+                Tradition: 0,
+                Stimulation: 0,
+                Hedonism: -1,
+                Conformity_Interpersonal: 0,
+              },
+            },
+          ],
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Summary

Adds a dedicated `/models` landing page for Model Groups, moves the visualization there, and keeps the domain selection bar at the top so the page drives the report data.

# What changed

- Added a new Models Groups page and routed `/models` to it.
- Removed the embedded Model Groups section from Domain Analysis.
- Updated the Models menu so Model Groups is the first item.
- Added and updated tests for the new route and nav labels.

# Why

The Models dropdown needed a clear landing page for grouping work, instead of hiding the visualization inside Domain Analysis.

# Validation

- `npm test -- tests/pages/ModelsGroups.test.tsx tests/pages/DomainAnalysis.test.tsx tests/components/layout/NavTabs.test.tsx tests/components/layout/MobileNav.test.tsx tests/App.test.tsx`
- `npm run typecheck`
- `npm run build`
