### PR TITLE
Add shared analysis context bar

### DIFF
--- a/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
+++ b/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
@@ -1,0 +1,89 @@
+import { forwardRef, useEffect, useState, type ReactNode } from 'react';
+import { cn } from '../../lib/utils';
+
+type AnalysisContextBarProps = {
+  title: string;
+  summary: string;
+  children: ReactNode;
+  secondary?: ReactNode;
+  headerActions?: ReactNode;
+  className?: string;
+};
+
+export const AnalysisContextBar = forwardRef<HTMLElement, AnalysisContextBarProps>(function AnalysisContextBar(
+  {
+    title,
+    summary,
+    children,
+    secondary,
+    headerActions,
+    className,
+  },
+  ref,
+) {
+  const isMobile = useIsMobile();
+
+  return (
+    <section ref={ref} className={cn('rounded-xl border border-gray-200 bg-white p-4 md:p-5', className)}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 space-y-1">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">{title}</h2>
+          <p className="text-sm text-gray-600">{summary}</p>
+        </div>
+        {headerActions != null && (
+          <div className="shrink-0">{headerActions}</div>
+        )}
+      </div>
+
+      {isMobile ? (
+        <div className="mt-4">
+          <details className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+              <span className="text-sm font-medium text-gray-800">Adjust controls</span>
+              <span className="text-xs text-gray-500">Show</span>
+            </summary>
+            <div className="mt-3 space-y-4">
+              {children}
+              {secondary != null && secondary}
+            </div>
+          </details>
+        </div>
+      ) : (
+        <>
+          <div className="mt-4">
+            {children}
+          </div>
+          {secondary != null && (
+            <div className="mt-4">
+              {secondary}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+});
+
+function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+    return window.matchMedia('(max-width: 767px)').matches;
+  });
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(max-width: 767px)');
+    const handleChange = () => setIsMobile(mediaQuery.matches);
+
+    handleChange();
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return isMobile;
+}

--- a/cloud/apps/web/src/components/models/PressureSensitivityFilters.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityFilters.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { ChevronDown, ChevronUp, Filter } from 'lucide-react';
+import { AnalysisContextBar } from '../analysis/AnalysisContextBar';
 import { Button } from '../ui/Button';
 import { Select } from '../ui/Select';
 
@@ -71,9 +72,78 @@ export function PressureSensitivityFilters({
     onModelSelectionChange([...defaultSelection]);
   };
 
+  const domainSummary = domainId == null
+    ? 'All domains'
+    : domainOptions.find((option) => option.value === domainId)?.label ?? 'Selected domain';
+  const summary = `${domainSummary} · ${selectedSummary} · ${signature}`;
+
   return (
-    <section className="rounded-xl border border-gray-200 bg-white p-4">
-      <div className="flex flex-wrap gap-4">
+    <AnalysisContextBar
+      title="Analysis Context"
+      summary={summary}
+      secondary={(
+        <>
+          {isModelsOpen && (
+            <div role="group" aria-label="Model filter" className="mt-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <span className="text-xs font-medium uppercase tracking-wide text-gray-600">Select models</span>
+                <div className="flex items-center gap-3">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-auto min-h-0 px-0 py-0 text-xs font-medium text-teal-700 hover:text-teal-800"
+                    onClick={handleSelectAll}
+                  >
+                    Select all
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-auto min-h-0 px-0 py-0 text-xs font-medium text-gray-600 hover:text-gray-800"
+                    onClick={handleClear}
+                  >
+                    Clear
+                  </Button>
+                </div>
+              </div>
+
+              <div className="max-h-60 space-y-2 overflow-y-auto">
+                {modelOptions.map((model) => {
+                  const isSelected = selectedModelIds.includes(model.value);
+                  return (
+                    <label key={model.value} className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => handleToggleModel(model.value)}
+                        className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+                      />
+                      <span className="truncate flex-1" title={model.label}>
+                        {model.label}
+                      </span>
+                      {model.isDefault ? (
+                        <span className="shrink-0 rounded-full bg-teal-50 px-2 py-0.5 text-[11px] font-medium text-teal-700">
+                          default
+                        </span>
+                      ) : null}
+                    </label>
+                  );
+                })}
+              </div>
+
+              {modelOptions.length === 0 ? (
+                <p className="mt-2 text-xs text-gray-500">No active models are available yet.</p>
+              ) : null}
+            </div>
+          )}
+
+          <p className="mt-3 text-xs text-gray-500">
+            Domain and signature stay URL-driven. Model selection uses the standard default-model picker.
+          </p>
+        </>
+      )}
+    >
+      <div className="flex flex-wrap items-end gap-4">
         <div className="min-w-[220px] flex-1">
           <Select
             label="Domain"
@@ -82,18 +152,7 @@ export function PressureSensitivityFilters({
             options={[{ value: 'all', label: 'All domains' }, ...domainOptions]}
           />
         </div>
-        <div className="min-w-[220px] flex-1">
-          <Select
-            label="Signature"
-            value={signature}
-            onChange={(value) => onSignatureChange(value)}
-            options={signatureOptions.length > 0 ? signatureOptions : [{ value: signature, label: signature }]}
-          />
-        </div>
-      </div>
-
-      <div className="mt-4 border-t border-gray-200 pt-4">
-        <div className="flex items-center gap-3 flex-wrap">
+        <div className="flex min-w-[260px] flex-1 items-end gap-3">
           <div className="flex items-center gap-1.5 text-xs font-medium text-gray-500">
             <Filter className="h-3.5 w-3.5" />
             <span>Models:</span>
@@ -139,65 +198,15 @@ export function PressureSensitivityFilters({
             )}
           </Button>
         </div>
-
-        {isModelsOpen && (
-          <div role="group" aria-label="Model filter" className="mt-3 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <span className="text-xs font-medium uppercase tracking-wide text-gray-600">Select models</span>
-              <div className="flex items-center gap-3">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-auto min-h-0 px-0 py-0 text-xs font-medium text-teal-700 hover:text-teal-800"
-                  onClick={handleSelectAll}
-                >
-                  Select all
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-auto min-h-0 px-0 py-0 text-xs font-medium text-gray-600 hover:text-gray-800"
-                  onClick={handleClear}
-                >
-                  Clear
-                </Button>
-              </div>
-            </div>
-
-            <div className="max-h-60 space-y-2 overflow-y-auto">
-              {modelOptions.map((model) => {
-                const isSelected = selectedModelIds.includes(model.value);
-                return (
-                  <label key={model.value} className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
-                    <input
-                      type="checkbox"
-                      checked={isSelected}
-                      onChange={() => handleToggleModel(model.value)}
-                      className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                    />
-                    <span className="truncate flex-1" title={model.label}>
-                      {model.label}
-                    </span>
-                    {model.isDefault ? (
-                      <span className="shrink-0 rounded-full bg-teal-50 px-2 py-0.5 text-[11px] font-medium text-teal-700">
-                        default
-                      </span>
-                    ) : null}
-                  </label>
-                );
-              })}
-            </div>
-
-            {modelOptions.length === 0 ? (
-              <p className="mt-2 text-xs text-gray-500">No active models are available yet.</p>
-            ) : null}
-          </div>
-        )}
+        <div className="ml-auto min-w-[220px] max-w-xs flex-1">
+          <Select
+            label="Signature"
+            value={signature}
+            onChange={(value) => onSignatureChange(value)}
+            options={signatureOptions.length > 0 ? signatureOptions : [{ value: signature, label: signature }]}
+          />
+        </div>
       </div>
-
-      <p className="mt-3 text-xs text-gray-500">
-        Domain and signature stay URL-driven. Model selection uses the standard default-model picker.
-      </p>
-    </section>
+    </AnalysisContextBar>
   );
 }

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -5,6 +5,7 @@ import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { Loading } from '../components/ui/Loading';
 import { Button } from '../components/ui/Button';
 import { Select } from '../components/ui/Select';
+import { AnalysisContextBar } from '../components/analysis/AnalysisContextBar';
 import {
   DOMAIN_AVAILABLE_SIGNATURES_QUERY,
   DOMAIN_ANALYSIS_QUERY,
@@ -271,6 +272,11 @@ export function DomainAnalysis() {
         ? 'All models'
         : `${selectedModelIds.length} of ${models.length} selected`;
 
+  const selectedDomainLabel = isAllDomains
+    ? 'All domains'
+    : domains.find((domain) => domain.id === selectedDomainId)?.name ?? 'Selected domain';
+  const contextSummary = `${selectedDomainLabel} · ${modelSetSummary} · ${selectedSignature === '' ? 'No signature' : selectedSignature}`;
+
   const toggleModelId = (modelId: string) => {
     setSelectedModelIds((current) => (
       current.includes(modelId)
@@ -331,53 +337,60 @@ export function DomainAnalysis() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-lg border border-gray-200 bg-white p-4">
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <div>
-            <h2 className="text-sm font-semibold text-gray-900">Domain Selection</h2>
-            <p className="text-xs text-gray-600">
-              {isAllDomains
-                ? 'Cross-domain analysis is read-only and pools every visible domain that matches the selected signature.'
-                : 'Analysis is shown from the latest saved snapshot for this domain.'}
-            </p>
-          </div>
-          <div className="flex flex-col gap-2 md:flex-row md:items-end">
-            <div className="min-w-[210px]">
-              <Select
-                label="Domain scope"
-                options={[
-                  { value: ALL_DOMAINS_SCOPE, label: 'All domains' },
-                  ...domains.map((domain) => ({ value: domain.id, label: domain.name })),
-                ]}
-                value={isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId}
-                onChange={(value) => {
-                  if (value === ALL_DOMAINS_SCOPE) {
-                    setSelectedScope('ALL_DOMAINS');
-                    return;
-                  }
-                  setSelectedScope('DOMAIN');
-                  setSelectedDomainId(value);
-                }}
-                disabled={domainsLoading || (domains.length === 0 && !isAllDomains)}
-              />
-            </div>
-            <div className="min-w-[210px]">
-              <Select
-                label="Signature"
-                options={
-                  signatureOptions.length === 0
-                    ? [{ value: '', label: 'No signatures with completed runs', disabled: true }]
-                    : signatureOptions.map((opt) => ({
-                      value: opt.signature,
-                      label: formatSignatureOptionLabel(opt),
-                    }))
+      <AnalysisContextBar
+        title="Domain Selection"
+        summary={contextSummary}
+        headerActions={(
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={handleExport}
+            disabled={selectedDomainId === '' || exportLoading || isAllDomains}
+            title={isAllDomains ? 'CSV export is unavailable in All domains mode' : undefined}
+          >
+            {exportLoading ? 'Exporting…' : 'Export CSV'}
+          </Button>
+        )}
+      >
+        <div className="flex flex-wrap items-end gap-4">
+          <div className="min-w-[210px] flex-1">
+            <Select
+              label="Domain scope"
+              options={[
+                { value: ALL_DOMAINS_SCOPE, label: 'All domains' },
+                ...domains.map((domain) => ({ value: domain.id, label: domain.name })),
+              ]}
+              value={isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId}
+              onChange={(value) => {
+                if (value === ALL_DOMAINS_SCOPE) {
+                  setSelectedScope('ALL_DOMAINS');
+                  return;
                 }
-                value={selectedSignature}
-                onChange={(value) => setSelectedSignature(value)}
-                disabled={signaturesLoading || signatureOptions.length === 0}
-              />
-            </div>
-            <details className="min-w-[210px]">
+                setSelectedScope('DOMAIN');
+                setSelectedDomainId(value);
+              }}
+              disabled={domainsLoading || (domains.length === 0 && !isAllDomains)}
+            />
+          </div>
+          <div className="min-w-[210px] flex-1">
+            <Select
+              label="Signature"
+              options={
+                signatureOptions.length === 0
+                  ? [{ value: '', label: 'No signatures with completed runs', disabled: true }]
+                  : signatureOptions.map((opt) => ({
+                    value: opt.signature,
+                    label: formatSignatureOptionLabel(opt),
+                  }))
+              }
+              value={selectedSignature}
+              onChange={(value) => setSelectedSignature(value)}
+              disabled={signaturesLoading || signatureOptions.length === 0}
+            />
+          </div>
+          <div className="ml-auto min-w-[210px] flex-1">
+            <details>
               <summary className="cursor-pointer list-none">
                 <p className="mb-1 text-sm font-medium text-gray-700">Model focus</p>
                 <div className="inline-flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm min-h-[44px] hover:border-gray-400 sm:min-h-0">
@@ -423,44 +436,35 @@ export function DomainAnalysis() {
                 </div>
               </div>
             </details>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={handleExport}
-              disabled={selectedDomainId === '' || exportLoading || isAllDomains}
-              title={isAllDomains ? 'CSV export is unavailable in All domains mode' : undefined}
-            >
-              {exportLoading ? 'Exporting…' : 'Export CSV'}
-            </Button>
           </div>
-          {exportError !== null && <p className="mt-1 text-xs text-amber-700">{exportError}</p>}
         </div>
-        {singleSelectedModelId !== null && (
-          <p className="mt-2 text-xs text-gray-500">
-            Showing only {models.find((model) => model.model === singleSelectedModelId)?.label ?? 'the selected model'} across all tables.
-          </p>
-        )}
-        {data?.domainAnalysis != null && missingDefinitionCount > 0 && !isAllDomains && (
-          <div className="mt-2 space-y-1 text-xs text-gray-500">
-            <>
-              <div className="flex flex-wrap items-center gap-2">
-                <p className="text-amber-700">Analysis filter excluded {missingDefinitionCount} vignette{missingDefinitionCount === 1 ? '' : 's'}.</p>
-                <Button type="button" variant="secondary" size="sm" onClick={handleRunMissingVignettes} disabled={allMissingDefinitionIds.length === 0}>
-                  Run Missing Vignettes
-                </Button>
-              </div>
-              <ul className="list-disc space-y-1 pl-5 text-amber-800">
-                {(data.domainAnalysis.missingDefinitions ?? []).map((m) => (
-                  <li key={m.definitionId}>
-                    {m.definitionName} ({m.definitionId}) - {m.reasonLabel} - AIs: {m.missingAllModels ? 'All AIs' : m.missingModelLabels.join(', ')}
-                  </li>
-                ))}
-              </ul>
-            </>
-          </div>
-        )}
-      </section>
+      </AnalysisContextBar>
+
+      {exportError !== null && <p className="mt-1 text-xs text-amber-700">{exportError}</p>}
+      {singleSelectedModelId !== null && (
+        <p className="mt-2 text-xs text-gray-500">
+          Showing only {models.find((model) => model.model === singleSelectedModelId)?.label ?? 'the selected model'} across all tables.
+        </p>
+      )}
+      {data?.domainAnalysis != null && missingDefinitionCount > 0 && !isAllDomains && (
+        <div className="mt-2 space-y-1 text-xs text-gray-500">
+          <>
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-amber-700">Analysis filter excluded {missingDefinitionCount} vignette{missingDefinitionCount === 1 ? '' : 's'}.</p>
+              <Button type="button" variant="secondary" size="sm" onClick={handleRunMissingVignettes} disabled={allMissingDefinitionIds.length === 0}>
+                Run Missing Vignettes
+              </Button>
+            </div>
+            <ul className="list-disc space-y-1 pl-5 text-amber-800">
+              {(data.domainAnalysis.missingDefinitions ?? []).map((m) => (
+                <li key={m.definitionId}>
+                  {m.definitionName} ({m.definitionId}) - {m.reasonLabel} - AIs: {m.missingAllModels ? 'All AIs' : m.missingModelLabels.join(', ')}
+                </li>
+              ))}
+            </ul>
+          </>
+        </div>
+      )}
 
       <div>
         <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Findings</h1>

--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -8,6 +8,7 @@ import { CopyVisualButton } from '../components/ui/CopyVisualButton';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { Loading } from '../components/ui/Loading';
 import { Select } from '../components/ui/Select';
+import { AnalysisContextBar } from '../components/analysis/AnalysisContextBar';
 import { cn } from '../lib/utils';
 import {
   ALL_MODELS_OPTION_VALUE,
@@ -264,6 +265,8 @@ export function DomainValueShiftHeatmap() {
   const isAllModels = selectedModelId === ALL_MODELS_OPTION_VALUE;
   const loading = fetching && data == null;
   const tableRef = useRef<HTMLDivElement>(null);
+  const selectedModelLabel = isAllModels ? 'Default models' : selectedModel?.label ?? 'Selected model';
+  const summary = `${selectedModelLabel} · ${selectedSignature}`;
 
   return (
     <div className="space-y-6">
@@ -282,8 +285,13 @@ export function DomainValueShiftHeatmap() {
         <ErrorMessage message={`Failed to load signature options: ${signatureError.message}`} />
       )}
 
-      <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
-        <div className="flex flex-wrap items-end gap-5">
+      <AnalysisContextBar
+        title="Analysis Context"
+        summary={summary}
+        headerActions={<CopyVisualButton targetRef={tableRef} label="domain shifts table" />}
+        secondary={<DisplayModeToggle displayMode={displayMode} onChange={setDisplayMode} />}
+      >
+        <div className="flex flex-wrap items-end gap-4">
           <div className="min-w-[260px] max-w-sm flex-1">
             <Select
               label="Model"
@@ -294,7 +302,7 @@ export function DomainValueShiftHeatmap() {
               disabled={loading || models.length === 0}
             />
           </div>
-          <div className="min-w-[240px] max-w-xs flex-1">
+          <div className="ml-auto min-w-[240px] max-w-xs flex-1">
             <Select
               label="Signature"
               options={signatureOptions}
@@ -304,9 +312,8 @@ export function DomainValueShiftHeatmap() {
               disabled={fetchingSignatures && signatureData == null}
             />
           </div>
-          <DisplayModeToggle displayMode={displayMode} onChange={setDisplayMode} />
         </div>
-      </section>
+      </AnalysisContextBar>
 
       {loading && <Loading size="lg" text="Loading domain shifts..." />}
 

--- a/cloud/apps/web/src/pages/ModelsConfidence.tsx
+++ b/cloud/apps/web/src/pages/ModelsConfidence.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { Loading } from '../components/ui/Loading';
 import { Select } from '../components/ui/Select';
+import { AnalysisContextBar } from '../components/analysis/AnalysisContextBar';
 import {
   AVAILABLE_SIGNATURES_QUERY,
   type AvailableSignaturesQueryResult,
@@ -25,7 +26,7 @@ import { useDomains } from '../hooks/useDomains';
 export function ModelsConfidence() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const heatmapRef = useRef<HTMLDivElement>(null);
+  const heatmapRef = useRef<HTMLElement>(null);
   const signatureParam = searchParams.get('signature');
 
   const { domains } = useDomains();
@@ -145,6 +146,16 @@ export function ModelsConfidence() {
     setSelectedModelIds(next);
   };
 
+  const selectedDomainLabel = selectedDomainId == null
+    ? 'All domains'
+    : domainOptions.find((option) => option.value === selectedDomainId)?.label ?? 'Selected domain';
+  const selectedModelLabel = selectedModelIds === null || isDefaultSelection
+    ? 'Default models'
+    : selectedModelIds.length === 0
+      ? 'No models selected'
+      : `${selectedModelIds.length} of ${allModels.length} selected`;
+  const summary = `${selectedDomainLabel} · ${selectedModelLabel} · ${selectedSignature}`;
+
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -156,129 +167,131 @@ export function ModelsConfidence() {
         </p>
       </div>
 
-      <section ref={heatmapRef} className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
-        <div className="mb-3 flex items-start justify-between gap-3">
-          <div className="flex min-w-0 flex-wrap items-center gap-4">
-            {domains.length > 0 && (
-              <div className="flex items-center gap-2">
-                <label className="text-sm text-gray-600">Domain</label>
-                <Select
-                  value={selectedDomainId ?? ''}
-                  onChange={(value) => setSelectedDomainId(value === '' ? null : value)}
-                  options={domainOptions}
-                />
+      <AnalysisContextBar
+        ref={heatmapRef}
+        title="Analysis Context"
+        summary={summary}
+        headerActions={<CopyVisualButton targetRef={heatmapRef} label="confidence heatmap" />}
+        secondary={(
+          <>
+            {/* Model filter panel (expands below the controls row) */}
+            {modelFilterOpen && allModels.length > 0 && (
+              <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+                <div className="mb-3 flex items-center justify-between">
+                  <span className="text-xs font-medium uppercase tracking-wide text-gray-600">
+                    Select models
+                  </span>
+                  <div className="flex items-center gap-3">
+                    {/* eslint-disable-next-line react/forbid-elements */}
+                    <button
+                      type="button"
+                      className="text-xs font-medium text-teal-700 hover:text-teal-800"
+                      onClick={() => setSelectedModelIds(allModels.map((m) => m.modelId))}
+                    >
+                      Select all
+                    </button>
+                    {/* eslint-disable-next-line react/forbid-elements */}
+                    <button
+                      type="button"
+                      className="text-xs font-medium text-gray-600 hover:text-gray-800"
+                      onClick={() => setSelectedModelIds([])}
+                    >
+                      Clear
+                    </button>
+                  </div>
+                </div>
+                <div className="max-h-52 space-y-2 overflow-y-auto">
+                  {allModels.map((m) => (
+                    <label
+                      key={m.modelId}
+                      className="flex cursor-pointer items-center gap-2 text-sm text-gray-700"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={(selectedModelIds ?? []).includes(m.modelId)}
+                        onChange={() => handleToggleModel(m.modelId)}
+                        className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+                      />
+                      <span className="flex-1 truncate" title={m.modelId}>
+                        {m.displayName}
+                      </span>
+                    </label>
+                  ))}
+                </div>
               </div>
             )}
+          </>
+        )}
+      >
+        <div className="flex flex-wrap items-end gap-4">
+          <div className="min-w-[220px] flex-1">
+            <Select
+              label="Domain"
+              value={selectedDomainId ?? ''}
+              onChange={(value) => setSelectedDomainId(value === '' ? null : value)}
+              options={domainOptions}
+            />
+          </div>
 
-            {allModels.length > 0 && (
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-600">Models:</span>
-                {selectedModelIds === null || isDefaultSelection ? (
-                  <span className="text-xs font-medium text-gray-700">Default</span>
-                ) : selectedModelIds.length === 0 ? (
-                  <span className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700">
-                    None selected
-                  </span>
-                ) : (
-                  <span className="text-xs font-medium text-gray-700">
-                    {selectedModelIds.length} of {allModels.length}
-                  </span>
-                )}
-                {selectedModelIds !== null && !isDefaultSelection && defaultModelIds.length > 0 && (
-                  // eslint-disable-next-line react/forbid-elements
-                  <button
-                    type="button"
-                    className="text-xs text-teal-600 underline-offset-2 hover:text-teal-800 hover:underline"
-                    onClick={() => setSelectedModelIds(defaultModelIds)}
-                  >
-                    Reset to default
-                  </button>
-                )}
-                {/* eslint-disable-next-line react/forbid-elements */}
-                <button
-                  type="button"
-                  className="text-xs text-gray-500 underline-offset-2 hover:text-gray-700 hover:underline"
-                  onClick={() => setModelFilterOpen((v) => !v)}
-                >
-                  {modelFilterOpen ? '▴ Close' : '▾ Change'}
-                </button>
-              </div>
-            )}
-
+          <div className="flex min-w-[260px] flex-1 flex-wrap items-end gap-3">
             <div className="flex items-center gap-2">
-              <label className="text-sm text-gray-600">Signature</label>
-              <Select
-                value={selectedSignature}
-                onChange={(value) => {
-                  setSelectedSignature(value);
-                  setSearchParams({ signature: value });
-                }}
-                options={signatureOptions}
-              />
+              <span className="text-sm text-gray-600">Models:</span>
+              {selectedModelIds === null || isDefaultSelection ? (
+                <span className="text-xs font-medium text-gray-700">Default</span>
+              ) : selectedModelIds.length === 0 ? (
+                <span className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700">
+                  None selected
+                </span>
+              ) : (
+                <span className="text-xs font-medium text-gray-700">
+                  {selectedModelIds.length} of {allModels.length}
+                </span>
+              )}
             </div>
+            {selectedModelIds !== null && !isDefaultSelection && defaultModelIds.length > 0 && (
+              // eslint-disable-next-line react/forbid-elements
+              <button
+                type="button"
+                className="text-xs text-teal-600 underline-offset-2 hover:text-teal-800 hover:underline"
+                onClick={() => setSelectedModelIds(defaultModelIds)}
+              >
+                Reset to default
+              </button>
+            )}
+            {/* eslint-disable-next-line react/forbid-elements */}
+            <button
+              type="button"
+              className="text-xs text-gray-500 underline-offset-2 hover:text-gray-700 hover:underline"
+              onClick={() => setModelFilterOpen((v) => !v)}
+            >
+              {modelFilterOpen ? '▴ Close' : '▾ Change'}
+            </button>
           </div>
 
-          <CopyVisualButton targetRef={heatmapRef} label="confidence heatmap" />
+          <div className="ml-auto min-w-[220px] max-w-xs flex-1">
+            <Select
+              label="Signature"
+              value={selectedSignature}
+              onChange={(value) => {
+                setSelectedSignature(value);
+                setSearchParams({ signature: value });
+              }}
+              options={signatureOptions}
+            />
+          </div>
         </div>
+      </AnalysisContextBar>
 
-        {/* Model filter panel (expands below the controls row) */}
-        {modelFilterOpen && allModels.length > 0 && (
-          <div className="mb-4 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-            <div className="mb-3 flex items-center justify-between">
-              <span className="text-xs font-medium uppercase tracking-wide text-gray-600">
-                Select models
-              </span>
-              <div className="flex items-center gap-3">
-                {/* eslint-disable-next-line react/forbid-elements */}
-                <button
-                  type="button"
-                  className="text-xs font-medium text-teal-700 hover:text-teal-800"
-                  onClick={() => setSelectedModelIds(allModels.map((m) => m.modelId))}
-                >
-                  Select all
-                </button>
-                {/* eslint-disable-next-line react/forbid-elements */}
-                <button
-                  type="button"
-                  className="text-xs font-medium text-gray-600 hover:text-gray-800"
-                  onClick={() => setSelectedModelIds([])}
-                >
-                  Clear
-                </button>
-              </div>
-            </div>
-            <div className="max-h-52 space-y-2 overflow-y-auto">
-              {allModels.map((m) => (
-                <label
-                  key={m.modelId}
-                  className="flex cursor-pointer items-center gap-2 text-sm text-gray-700"
-                >
-                  <input
-                    type="checkbox"
-                    checked={(selectedModelIds ?? []).includes(m.modelId)}
-                    onChange={() => handleToggleModel(m.modelId)}
-                    className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                  />
-                  <span className="flex-1 truncate" title={m.modelId}>
-                    {m.displayName}
-                  </span>
-                </label>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {error != null && <ErrorMessage message={error.message} />}
-        {loading ? (
-          <Loading />
-        ) : (
-          <ConfidenceHeatmap
-            models={models}
-            selectedModelIds={filteredModelIds ?? undefined}
-            onCellClick={handleCellClick}
-          />
-        )}
-      </section>
+      {error != null && <ErrorMessage message={error.message} />}
+      {loading ? (
+        <Loading />
+      ) : (
+        <ConfidenceHeatmap
+          models={models}
+          selectedModelIds={filteredModelIds ?? undefined}
+          onCellClick={handleCellClick}
+        />
+      )}
 
       {/* How the % is calculated */}
       <section className="rounded-lg border border-gray-100 bg-gray-50 p-5 text-sm text-gray-700 space-y-3 max-w-3xl">

--- a/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
@@ -365,9 +365,9 @@ describe('PressureSensitivity page', () => {
     }
     const pressureQueryArgs = pressureQueryCall[0] as { variables?: Record<string, unknown> };
     expect(pressureQueryArgs.variables).not.toHaveProperty('domainId');
-    expect(screen.getByText('All domains')).toBeDefined();
+    expect(screen.getByRole('button', { name: /^All domains$/i })).toBeDefined();
     expect(screen.getByText('Models:')).toBeDefined();
-    expect(screen.getByText('Default models')).toBeDefined();
+    expect(screen.getByText(/^Default models$/i)).toBeDefined();
     expect(screen.queryByText('Provider')).toBeNull();
     expect(
       screen.queryByText(


### PR DESCRIPTION
## Summary
- Add a shared analysis context bar component for analysis-family pages
- Move model, domain, and signature controls into the shared bar on Pressure Sensitivity, Confidence Heatmap, Domain Shifts, and Domain Analysis
- Update the pressure sensitivity test to target the actual control instead of the summary copy

## Validation
- [x] npm run lint --workspace @valuerank/web
- [x] npm run build --workspace @valuerank/web
- [x] npm run test --workspace @valuerank/web -- --run src/pages/PressureSensitivity.test.tsx tests/pages/DomainAnalysis.test.tsx tests/pages/DomainValueShiftHeatmap.test.tsx

🤖 Generated with Codex
