### PR TITLE
Tighten analysis context bar layout and add to Model Groups page

### DIFF
--- a/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
+++ b/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { Button } from '../ui/Button';
-import { Select } from '../ui/Select';
+import { Select, selectTriggerVariants } from '../ui/Select';
 
 type Option = {
   value: string;
@@ -44,6 +45,23 @@ function sameSelection(left: readonly string[], right: readonly string[]): boole
   return left.every((value) => right.includes(value));
 }
 
+function ContextField({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex min-w-0 items-center gap-2', className)}>
+      <span className="shrink-0 text-sm font-medium text-gray-700">{label}</span>
+      {children}
+    </div>
+  );
+}
+
 export function AnalysisContextBar({
   domain,
   signature,
@@ -64,6 +82,8 @@ export function AnalysisContextBar({
           : `${currentModelIds.length} of ${availableModelIds.length} selected`;
 
   const [isOpen, setIsOpen] = useState(false);
+  const modelPickerRef = useRef<HTMLDivElement>(null);
+  const modelMenuRef = useRef<HTMLDivElement>(null);
 
   const handleToggleModel = (modelId: string) => {
     const next = currentModelIds.includes(modelId)
@@ -72,80 +92,126 @@ export function AnalysisContextBar({
     models.onChange(next);
   };
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (modelPickerRef.current?.contains(target) || modelMenuRef.current?.contains(target)) {
+        return;
+      }
+      setIsOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
   return (
-    <section className={cn('sticky top-14 z-20 border-b border-gray-200 bg-[#FDFBF7]/95 backdrop-blur', className)}>
-      <div className="mx-auto flex max-w-7xl flex-wrap items-end gap-4 px-4 py-4">
-        <div className="min-w-[210px] flex-1">
+    <section className={cn('sticky top-14 z-40 overflow-visible border-b border-gray-200 bg-[#FDFBF7]/95 backdrop-blur', className)}>
+      <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-x-3 gap-y-2 overflow-visible px-4 py-3">
+        <ContextField label={domain.label ?? 'Domain'} className="flex-1 min-w-[14rem]">
           <Select
-            label={domain.label ?? 'Domain'}
+            ariaLabel={domain.label ?? 'Domain'}
             value={domain.value}
             onChange={domain.onChange}
             options={domain.options}
             disabled={domain.disabled}
+            size="sm"
+            className="w-full min-w-0"
           />
-        </div>
+        </ContextField>
 
-        <div className="min-w-[210px] flex-1">
+        <ContextField label={signature.label ?? 'Signature'} className="flex-1 min-w-[14rem]">
           <Select
-            label={signature.label ?? 'Signature'}
+            ariaLabel={signature.label ?? 'Signature'}
             value={signature.value}
             onChange={signature.onChange}
             options={signature.options}
             disabled={signature.disabled}
+            size="sm"
+            className="w-full min-w-0"
           />
-        </div>
+        </ContextField>
 
-        <div className="ml-auto min-w-[210px] flex-1">
-          <details open={isOpen} onToggle={(event) => setIsOpen(event.currentTarget.open)}>
-            <summary className="cursor-pointer list-none">
-              <p className="mb-1 text-sm font-medium text-gray-700">{models.label ?? 'Models'}</p>
-              <div className="inline-flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm min-h-[44px] hover:border-gray-400 sm:min-h-0">
-                <span className={availableModelIds.length === 0 ? 'text-gray-400' : ''}>{modelSummary}</span>
-                <ChevronDown className={`ml-2 h-4 w-4 text-gray-400 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-              </div>
-            </summary>
-            <div className="mt-1 space-y-2 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-              <div className="flex flex-wrap gap-1.5">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => models.onChange([...models.defaultModelIds])}
-                  className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
-                    isDefaultSelection
-                      ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
-                      : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
-                  }`}
-                >
-                  Default Models
-                </Button>
-                {models.options.map((model) => {
-                  const isSelected = currentModelIds.includes(model.value);
-                  return (
-                    <Button
-                      key={model.value}
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleToggleModel(model.value)}
-                      className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
-                        isSelected
-                          ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
-                          : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
-                      }`}
-                      title={model.label}
-                    >
-                      {model.label}
-                    </Button>
-                  );
-                })}
-              </div>
+        <div className="ml-auto flex min-w-[14rem] flex-1 items-center gap-2">
+          <span className="shrink-0 text-sm font-medium text-gray-700">{models.label ?? 'Models'}</span>
+          <div ref={modelPickerRef} className="relative min-w-0 flex-1">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => setIsOpen((value) => !value)}
+              aria-expanded={isOpen}
+              aria-haspopup="listbox"
+              aria-label={`${models.label ?? 'Models'}: ${modelSummary}`}
+              className={cn(
+                selectTriggerVariants({ size: 'sm' }),
+                'w-full min-w-0 justify-between text-left focus:ring-teal-500 focus:border-teal-500 focus:ring-offset-0',
+                availableModelIds.length === 0 && 'text-gray-400',
+              )}
+            >
+              <span className="min-w-0 flex-1 truncate">{modelSummary}</span>
+              <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 text-gray-400 transition-transform', isOpen && 'rotate-180')} />
+            </Button>
 
-              {models.options.length === 0 ? (
-                <p className="text-xs text-gray-500">No active models are available yet.</p>
-              ) : null}
-            </div>
-          </details>
+            {isOpen && (
+              <div
+                ref={modelMenuRef}
+                className="absolute right-0 top-full z-50 mt-2 w-[min(32rem,calc(100vw-2rem))] rounded-lg border border-gray-200 bg-white p-3 shadow-xl"
+              >
+                <div className="flex flex-wrap gap-1.5">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => models.onChange([...models.defaultModelIds])}
+                    className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
+                      isDefaultSelection
+                        ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
+                        : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
+                    }`}
+                  >
+                    Default Models
+                  </Button>
+                  {models.options.map((model) => {
+                    const isSelected = currentModelIds.includes(model.value);
+                    return (
+                      <Button
+                        key={model.value}
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleToggleModel(model.value)}
+                        className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
+                          isSelected
+                            ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
+                            : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
+                        }`}
+                        title={model.label}
+                      >
+                        {model.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+
+                {models.options.length === 0 ? (
+                  <p className="text-xs text-gray-500">No active models are available yet.</p>
+                ) : null}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </section>

--- a/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
+++ b/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
@@ -30,7 +30,7 @@ type AnalysisContextBarProps = {
     onChange: (value: string) => void;
     disabled?: boolean;
   };
-  models: {
+  models?: {
     label?: string;
     selectedModelIds: string[] | null;
     defaultModelIds: string[];
@@ -68,9 +68,9 @@ export function AnalysisContextBar({
   models,
   className,
 }: AnalysisContextBarProps) {
-  const currentModelIds = models.selectedModelIds ?? models.defaultModelIds;
-  const availableModelIds = useMemo(() => models.options.map((option) => option.value), [models.options]);
-  const isDefaultSelection = models.defaultModelIds.length > 0 && sameSelection(currentModelIds, models.defaultModelIds);
+  const currentModelIds = models != null ? (models.selectedModelIds ?? models.defaultModelIds) : [];
+  const availableModelIds = useMemo(() => models?.options.map((option) => option.value) ?? [], [models?.options]);
+  const isDefaultSelection = models != null && models.defaultModelIds.length > 0 && sameSelection(currentModelIds, models.defaultModelIds);
   const modelSummary = availableModelIds.length === 0
     ? 'No active models'
     : currentModelIds.length === 0
@@ -86,6 +86,7 @@ export function AnalysisContextBar({
   const modelMenuRef = useRef<HTMLDivElement>(null);
 
   const handleToggleModel = (modelId: string) => {
+    if (models == null) return;
     const next = currentModelIds.includes(modelId)
       ? currentModelIds.filter((id) => id !== modelId)
       : [...currentModelIds, modelId];
@@ -93,7 +94,7 @@ export function AnalysisContextBar({
   };
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || models == null) return;
 
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as Node;
@@ -144,75 +145,77 @@ export function AnalysisContextBar({
           />
         </ContextField>
 
-        <div className="ml-auto flex min-w-[14rem] flex-1 items-center gap-2">
-          <span className="shrink-0 text-sm font-medium text-gray-700">{models.label ?? 'Models'}</span>
-          <div ref={modelPickerRef} className="relative min-w-0 flex-1">
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => setIsOpen((value) => !value)}
-              aria-expanded={isOpen}
-              aria-haspopup="listbox"
-              aria-label={`${models.label ?? 'Models'}: ${modelSummary}`}
-              className={cn(
-                selectTriggerVariants({ size: 'sm' }),
-                'w-full min-w-0 justify-between text-left focus:ring-teal-500 focus:border-teal-500 focus:ring-offset-0',
-                availableModelIds.length === 0 && 'text-gray-400',
-              )}
-            >
-              <span className="min-w-0 flex-1 truncate">{modelSummary}</span>
-              <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 text-gray-400 transition-transform', isOpen && 'rotate-180')} />
-            </Button>
-
-            {isOpen && (
-              <div
-                ref={modelMenuRef}
-                className="absolute right-0 top-full z-50 mt-2 w-[min(32rem,calc(100vw-2rem))] rounded-lg border border-gray-200 bg-white p-3 shadow-xl"
+        {models != null && (
+          <div className="ml-auto flex min-w-[14rem] flex-1 items-center gap-2">
+            <span className="shrink-0 text-sm font-medium text-gray-700">{models.label ?? 'Models'}</span>
+            <div ref={modelPickerRef} className="relative min-w-0 flex-1">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => setIsOpen((value) => !value)}
+                aria-expanded={isOpen}
+                aria-haspopup="listbox"
+                aria-label={`${models.label ?? 'Models'}: ${modelSummary}`}
+                className={cn(
+                  selectTriggerVariants({ size: 'sm' }),
+                  'w-full min-w-0 justify-between text-left focus:ring-teal-500 focus:border-teal-500 focus:ring-offset-0',
+                  availableModelIds.length === 0 && 'text-gray-400',
+                )}
               >
-                <div className="flex flex-wrap gap-1.5">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => models.onChange([...models.defaultModelIds])}
-                    className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
-                      isDefaultSelection
-                        ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
-                        : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
-                    }`}
-                  >
-                    Default Models
-                  </Button>
-                  {models.options.map((model) => {
-                    const isSelected = currentModelIds.includes(model.value);
-                    return (
-                      <Button
-                        key={model.value}
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleToggleModel(model.value)}
-                        className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
-                          isSelected
-                            ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
-                            : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
-                        }`}
-                        title={model.label}
-                      >
-                        {model.label}
-                      </Button>
-                    );
-                  })}
-                </div>
+                <span className="min-w-0 flex-1 truncate">{modelSummary}</span>
+                <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 text-gray-400 transition-transform', isOpen && 'rotate-180')} />
+              </Button>
 
-                {models.options.length === 0 ? (
-                  <p className="text-xs text-gray-500">No active models are available yet.</p>
-                ) : null}
-              </div>
-            )}
+              {isOpen && (
+                <div
+                  ref={modelMenuRef}
+                  className="absolute right-0 top-full z-50 mt-2 w-[min(32rem,calc(100vw-2rem))] rounded-lg border border-gray-200 bg-white p-3 shadow-xl"
+                >
+                  <div className="flex flex-wrap gap-1.5">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => models.onChange([...models.defaultModelIds])}
+                      className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
+                        isDefaultSelection
+                          ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
+                          : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
+                      }`}
+                    >
+                      Default Models
+                    </Button>
+                    {models.options.map((model) => {
+                      const isSelected = currentModelIds.includes(model.value);
+                      return (
+                        <Button
+                          key={model.value}
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleToggleModel(model.value)}
+                          className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
+                            isSelected
+                              ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
+                              : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
+                          }`}
+                          title={model.label}
+                        >
+                          {model.label}
+                        </Button>
+                      );
+                    })}
+                  </div>
+
+                  {models.options.length === 0 ? (
+                    <p className="text-xs text-gray-500">No active models are available yet.</p>
+                  ) : null}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </section>
   );

--- a/cloud/apps/web/src/components/ui/Select.tsx
+++ b/cloud/apps/web/src/components/ui/Select.tsx
@@ -40,6 +40,7 @@ export type SelectProps<T = string> = VariantProps<typeof selectTriggerVariants>
   disabled?: boolean;
   className?: string;
   label?: string;
+  ariaLabel?: string;
   error?: string;
   /** Render custom option content */
   renderOption?: (option: SelectOption<T>, isSelected: boolean) => ReactNode;
@@ -55,6 +56,7 @@ export function Select<T extends string = string>({
   size,
   className,
   label,
+  ariaLabel,
   error,
   renderOption,
 }: SelectProps<T>) {
@@ -64,6 +66,7 @@ export function Select<T extends string = string>({
   const listboxRef = useRef<HTMLUListElement>(null);
 
   const selectedOption = options.find((opt) => opt.value === value);
+  const accessibleLabel = ariaLabel ?? label ?? 'Select';
 
   // Close on outside click
   useEffect(() => {
@@ -175,12 +178,16 @@ export function Select<T extends string = string>({
     triggerRef.current?.focus();
   };
 
-  const listboxId = `select-listbox-${label?.replace(/\s+/g, '-').toLowerCase() || 'default'}`;
+  const slug = accessibleLabel
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const listboxId = `select-listbox-${slug || 'default'}`;
 
   return (
     <div className={cn('relative', className)}>
       {label && (
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="mb-1 block text-sm font-medium text-gray-700">
           {label}
         </label>
       )}
@@ -199,10 +206,10 @@ export function Select<T extends string = string>({
         disabled={disabled}
         aria-haspopup="listbox"
         aria-expanded={isOpen}
-        aria-labelledby={label ? `${listboxId}-label` : undefined}
+        aria-label={`${accessibleLabel}: ${selectedOption?.label || placeholder}`}
         aria-controls={isOpen ? listboxId : undefined}
       >
-        <span className={cn(!selectedOption && 'text-gray-400')}>
+        <span className={cn('min-w-0 flex-1 truncate', !selectedOption && 'text-gray-400')}>
           {selectedOption?.label || placeholder}
         </span>
         <ChevronDown
@@ -219,8 +226,8 @@ export function Select<T extends string = string>({
           ref={listboxRef}
           id={listboxId}
           role="listbox"
-          aria-label={label}
-          className="absolute z-50 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto py-1"
+          aria-label={accessibleLabel}
+          className="absolute z-50 mt-1 w-full max-h-60 overflow-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
         >
           {options.map((option, index) => {
             const isSelected = option.value === value;

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'urql';
 import { useSearchParams } from 'react-router-dom';
+import { AnalysisContextBar } from '../components/analysis/AnalysisContextBar';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { Loading } from '../components/ui/Loading';
-import { Select } from '../components/ui/Select';
 import {
   DOMAIN_ANALYSIS_QUERY,
   DOMAIN_ANALYSIS_QUERY_LEGACY,
@@ -183,98 +183,84 @@ export function ModelsGroups() {
     [data?.domainAnalysis.models, modelsAnalysisData?.modelsAnalysis.models],
   );
   const isAllDomains = selectedScope === 'ALL_DOMAINS';
-  const domainSelectionSection = (
-    <section className="rounded-lg border border-gray-200 bg-white p-4">
-      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h2 className="text-sm font-semibold text-gray-900">Domain Selection</h2>
-          <p className="text-xs text-gray-600">
-            {isAllDomains
-              ? 'Cross-domain analysis is read-only and pools every visible domain that matches the selected signature.'
-              : 'Model groups are shown from the latest saved snapshot for this domain.'}
-          </p>
-        </div>
-        <div className="flex flex-col gap-2 md:flex-row md:items-end">
-          <div className="min-w-[210px]">
-            <Select
-              label="Domain scope"
-              options={[
-                { value: ALL_DOMAINS_SCOPE, label: 'All domains' },
-                ...domains.map((domain) => ({ value: domain.id, label: domain.name })),
-              ]}
-              value={isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId}
-              onChange={(value) => {
-                if (value === ALL_DOMAINS_SCOPE) {
-                  setSelectedScope('ALL_DOMAINS');
-                  return;
-                }
-                setSelectedScope('DOMAIN');
-                setSelectedDomainId(value);
-              }}
-              disabled={domainsLoading || (domains.length === 0 && !isAllDomains)}
-            />
-          </div>
-          <div className="min-w-[210px]">
-            <Select
-              label="Signature"
-              options={
-                signatureOptions.length === 0
-                  ? [{ value: '', label: 'No signatures with completed runs', disabled: true }]
-                  : signatureOptions.map((option) => ({
-                    value: option.signature,
-                    label: formatSignatureOptionLabel(option),
-                  }))
-              }
-              value={selectedSignature}
-              onChange={(value) => setSelectedSignature(value)}
-              disabled={signaturesLoading || signatureOptions.length === 0}
-            />
-          </div>
-        </div>
-      </div>
-    </section>
+  const contextBar = (
+    <AnalysisContextBar
+      domain={{
+        label: 'Domain',
+        value: isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId,
+        options: [
+          { value: ALL_DOMAINS_SCOPE, label: 'All domains' },
+          ...domains.map((domain) => ({ value: domain.id, label: domain.name })),
+        ],
+        onChange: (value) => {
+          if (value === ALL_DOMAINS_SCOPE) {
+            setSelectedScope('ALL_DOMAINS');
+            return;
+          }
+          setSelectedScope('DOMAIN');
+          setSelectedDomainId(value);
+        },
+        disabled: domainsLoading || (domains.length === 0 && !isAllDomains),
+      }}
+      signature={{
+        label: 'Signature',
+        value: selectedSignature,
+        options:
+          signatureOptions.length === 0
+            ? [{ value: '', label: 'No signatures with completed runs', disabled: true }]
+            : signatureOptions.map((option) => ({
+              value: option.signature,
+              label: formatSignatureOptionLabel(option),
+            })),
+        onChange: (value) => setSelectedSignature(value),
+        disabled: signaturesLoading || signatureOptions.length === 0,
+      }}
+    />
   );
 
   if (domainsError != null || signaturesError != null || error != null || modelsAnalysisError != null) {
     return (
-      <div className="space-y-6">
-        {domainSelectionSection}
-        <ErrorMessage message={`Failed to load model groups report: ${(domainsError ?? signaturesError ?? error ?? modelsAnalysisError)?.message ?? 'Unknown error'}`} />
-      </div>
+      <>
+        {contextBar}
+        <div className="space-y-6 px-4 py-6">
+          <ErrorMessage message={`Failed to load model groups report: ${(domainsError ?? signaturesError ?? error ?? modelsAnalysisError)?.message ?? 'Unknown error'}`} />
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="space-y-6">
-      {domainSelectionSection}
+    <>
+      {contextBar}
+      <div className="space-y-6 px-4 py-6">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
+          <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Model Groups</h1>
+          <p className="max-w-3xl text-sm text-gray-600">
+            Clustered model families for the selected domain and signature.
+          </p>
+          {cacheStatusCopy != null && (
+            <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+              <span className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${cacheStatusCopy.badgeClassName}`}>
+                {cacheStatusCopy.badgeLabel}
+              </span>
+              <span>{cacheStatusCopy.detail}</span>
+            </div>
+          )}
+        </div>
 
-      <div className="space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
-        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Model Groups</h1>
-        <p className="max-w-3xl text-sm text-gray-600">
-          Clustered model families for the selected domain and signature.
-        </p>
-        {cacheStatusCopy != null && (
-          <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
-            <span className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${cacheStatusCopy.badgeClassName}`}>
-              {cacheStatusCopy.badgeLabel}
-            </span>
-            <span>{cacheStatusCopy.detail}</span>
+        {showPageLoader ? (
+          <Loading size="lg" text="Loading model groups..." />
+        ) : (
+          <div className="space-y-6">
+            <ModelGroupsSection
+              clusterAnalysis={data?.domainAnalysis.clusterAnalysis}
+              models={models}
+            />
+            <ModelSimilarityTableSection models={models} />
           </div>
         )}
       </div>
-
-      {showPageLoader ? (
-        <Loading size="lg" text="Loading model groups..." />
-      ) : (
-        <div className="space-y-6">
-          <ModelGroupsSection
-            clusterAnalysis={data?.domainAnalysis.clusterAnalysis}
-            models={models}
-          />
-          <ModelSimilarityTableSection models={models} />
-        </div>
-      )}
-    </div>
+    </>
   );
 }

--- a/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
@@ -378,7 +378,7 @@ describe('PressureSensitivity page', () => {
     }
     const pressureQueryArgs = pressureQueryCall[0] as { variables?: Record<string, unknown> };
     expect(pressureQueryArgs.variables).not.toHaveProperty('domainId');
-    expect(screen.getByRole('button', { name: /^All domains$/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /^Domain: All domains$/i })).toBeDefined();
     expect(screen.getByText(/^Models$/i)).toBeDefined();
     expect(screen.getByText(/^Default — 2 models$/i)).toBeDefined();
     expect(screen.queryByText('Provider')).toBeNull();

--- a/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
@@ -363,6 +363,7 @@ describe('DomainValueShiftHeatmap page', () => {
   });
 
   it('renders the selected model heatmap with raw detail in accessible text', async () => {
+    const user = userEvent.setup({ delay: null });
     installModels([makeModel()]);
 
     renderPage();
@@ -371,8 +372,9 @@ describe('DomainValueShiftHeatmap page', () => {
       expect(screen.getByRole('heading', { name: 'Model A' })).toBeInTheDocument();
     });
     expect(screen.getByRole('table')).toHaveClass('table-auto');
+    await user.click(screen.getByRole('button', { name: /default — 1 model/i }));
     expect(screen.getByRole('button', { name: /default models/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Latest @ default/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /signature: latest @ default/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sort by Avg Win Rate descending/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sort by Value descending/i })).toHaveTextContent('Value↓');
     expect(screen.getByLabelText(/Achievement in City Planning: raw win rate 80\.0%; shift \+20\.0 pts/i)).toHaveAccessibleName(
@@ -393,7 +395,7 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    await screen.findByRole('button', { name: /default models/i });
+    await screen.findByRole('button', { name: /default — 1 model/i });
     const initialModelsCalls = useQueryMock.mock.calls.filter(([args]: [{ query: unknown }]) => getOperationName(args.query) === 'ModelsAnalysis');
     expect(initialModelsCalls.at(-1)?.[0]).toEqual(expect.objectContaining({
       variables: { signature: 'vnewtd' },
@@ -459,6 +461,7 @@ describe('DomainValueShiftHeatmap page', () => {
     renderPage();
 
     expect(await screen.findByText('Default — 2 models')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /default — 2 models/i }));
     await user.click(screen.getByRole('button', { name: 'Alpha' }));
 
     expect(screen.getByRole('heading', { name: 'Zulu' })).toBeInTheDocument();
@@ -474,6 +477,7 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
+    await user.click(screen.getByRole('button', { name: /default — 2 models/i }));
     const modelButtons = screen
       .getAllByRole('button', { name: /^(Default Models|Alpha|Charlie|Bravo)$/i })
       .map((button) => button.textContent?.trim());

--- a/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
@@ -152,7 +152,7 @@ describe('ModelsGroups', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByRole('heading', { name: 'Domain Selection' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /domain:/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Model Groups' })).toBeInTheDocument();
     expect(screen.getByText(/mock model groups section/i)).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- Make the analysis context bar more compact with inline labels and shorter selects
- Keep the models menu as an overlay so it stays above the page content
- Make the \`models\` prop optional so pages without model-filtering can omit it
- Add \`AnalysisContextBar\` to the Model Groups page, replacing the standalone domain-selection card
- Update the heatmap test to open the models menu the same way a user does

## Test plan
- \`npm run test --workspace @valuerank/web -- --run tests/pages/ModelsGroups.test.tsx tests/pages/DomainValueShiftHeatmap.test.tsx\`
- \`npm run lint --workspace @valuerank/web\`
- \`npm run build --workspace @valuerank/web\`

## Validation
All preflight checks passed:
- lint: 0 errors (125 warnings, all pre-existing)
- tests: 19/19 passed
- build: ✓