### PR TITLE
Add Absolute Value method and relative heat map to model similarity table

### DIFF
--- a/cloud/apps/web/src/components/models/ModelSimilarityMetrics.ts
+++ b/cloud/apps/web/src/components/models/ModelSimilarityMetrics.ts
@@ -1,6 +1,6 @@
 import { type ModelEntry, VALUES, VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
 
-export type CalculationMethod = 'weighted-euclidean' | 'cosine' | 'spearman' | 'kendall';
+export type CalculationMethod = 'weighted-euclidean' | 'cosine' | 'spearman' | 'kendall' | 'absolute-value';
 export type MetricView = 'distance' | 'similarity';
 
 export type PairStep = {
@@ -45,6 +45,7 @@ export const CALCULATION_METHODS: Array<{ value: CalculationMethod; label: strin
   { value: 'cosine', label: 'Cosine' },
   { value: 'spearman', label: 'Spearman' },
   { value: 'kendall', label: 'Kendall' },
+  { value: 'absolute-value', label: 'Absolute Value' },
 ];
 
 function clamp01(value: number): number {
@@ -116,6 +117,12 @@ export function getMethodCopy(method: CalculationMethod) {
         summaryLabel: 'Kendall tau-b',
         summaryNote: 'Bigger means the two models are closer.',
         helpCopy: 'We compare every pair of values and count how often the two models keep the same order.',
+      };
+    case 'absolute-value':
+      return {
+        summaryLabel: 'Mean absolute difference',
+        summaryNote: 'Smaller means the two models are closer.',
+        helpCopy: 'We take the absolute value of the win-rate difference for each value, then average them.',
       };
   }
 }
@@ -189,7 +196,7 @@ function cosineSimilarity(xs: number[], ys: number[]): number | null {
 function buildDisplayScores(rawScore: number | null, method: CalculationMethod): { distance: number | null; similarity: number | null } {
   if (rawScore == null) return { distance: null, similarity: null };
 
-  if (method === 'weighted-euclidean') {
+  if (method === 'weighted-euclidean' || method === 'absolute-value') {
     return {
       distance: rawScore,
       similarity: clamp01(1 - rawScore / 100),
@@ -346,6 +353,45 @@ export function computePairMetric(left: ModelEntry, right: ModelEntry, method: C
         { label: 'Sum of rank diff²', value: sumRankDiffSquared },
         { label: 'Pearson correlation of ranks', value: rawScore },
         { label: 'Spearman rho', value: rawScore },
+      ],
+    };
+  }
+
+  if (method === 'absolute-value') {
+    const steps: PairStep[] = comparableValues.map((entry) => {
+      const diff = (entry.leftWinRate ?? 0) - (entry.rightWinRate ?? 0);
+      return {
+        ...entry,
+        leftDerived: null,
+        rightDerived: null,
+        diff,
+        diffSquared: null,
+        weight: null,
+        weightedDiffSquared: null,
+      };
+    });
+
+    const usedValueCount = steps.length;
+    const sumAbsDiff = steps.reduce((sum, step) => sum + Math.abs(step.diff ?? 0), 0);
+    const rawScore = usedValueCount === 0 ? null : sumAbsDiff / usedValueCount;
+    const displayScores = buildDisplayScores(rawScore, method);
+
+    return {
+      left,
+      right,
+      method,
+      steps,
+      kendallSteps: [],
+      usedValueCount,
+      rawScore,
+      distance: displayScores.distance,
+      similarity: displayScores.similarity,
+      summaryLabel: copy.summaryLabel,
+      summaryNote: copy.summaryNote,
+      summaryRows: [
+        { label: 'Sum of |diff|', value: sumAbsDiff },
+        { label: 'Divide by count', value: usedValueCount === 0 ? null : sumAbsDiff / usedValueCount },
+        { label: 'Mean absolute difference', value: rawScore },
       ],
     };
   }

--- a/cloud/apps/web/src/components/models/ModelSimilarityPairDetailDrawer.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityPairDetailDrawer.tsx
@@ -128,6 +128,12 @@ export function PairDetailDrawer({ open, metric, onClose }: PairDetailDrawerProp
                           <th className="px-4 py-3 text-right font-medium">centered</th>
                           <th className="px-4 py-3 text-right font-medium">product</th>
                         </>
+                      ) : metric.method === 'absolute-value' ? (
+                        <>
+                          <th className="px-4 py-3 text-right font-medium">diff</th>
+                          <th className="px-4 py-3 text-right font-medium">|diff|</th>
+                          <th className="px-4 py-3 text-right font-medium" />
+                        </>
                       ) : (
                         <>
                           <th className="px-4 py-3 text-right font-medium">rank</th>
@@ -162,6 +168,14 @@ export function PairDetailDrawer({ open, metric, onClose }: PairDetailDrawerProp
                                 ? '—'
                                 : formatMetricNumber((step.leftDerived ?? 0) * (step.rightDerived ?? 0))}
                             </td>
+                          </>
+                        ) : metric.method === 'absolute-value' ? (
+                          <>
+                            <td className="px-4 py-3 text-right font-mono text-gray-900">{formatMetricNumber(step.diff)}</td>
+                            <td className="px-4 py-3 text-right font-mono text-gray-900">
+                              {step.diff == null ? '—' : formatMetricNumber(Math.abs(step.diff))}
+                            </td>
+                            <td className="px-4 py-3 text-right font-mono text-gray-900">—</td>
                           </>
                         ) : (
                           <>

--- a/cloud/apps/web/src/components/models/ModelSimilarityTableSection.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityTableSection.test.tsx
@@ -34,6 +34,7 @@ describe('ModelSimilarityTableSection', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Model Similarity Table' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Absolute Value' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Weighted Euclidean' }).className.includes('bg-teal-600')).toBe(true);
     expect(screen.getByRole('button', { name: 'Distance' }).className.includes('bg-teal-600')).toBe(true);
     expect(screen.getAllByText('10.00').length).toBeGreaterThan(0);

--- a/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
@@ -38,7 +38,19 @@ export function ModelSimilarityTableSection({ models }: ModelSimilarityTableSect
       rows.set(left.model, row);
     }
 
-    return { rows };
+    const similarities: number[] = [];
+    for (const row of rows.values()) {
+      for (const metric of row.values()) {
+        if (metric != null && metric.usedValueCount > 0 && metric.similarity != null) {
+          similarities.push(metric.similarity);
+        }
+      }
+    }
+
+    const minSimilarity = similarities.length > 0 ? Math.min(...similarities) : 0;
+    const maxSimilarity = similarities.length > 0 ? Math.max(...similarities) : 1;
+
+    return { rows, minSimilarity, maxSimilarity };
   }, [models, method]);
 
   const activeMetric = useMemo(() => {
@@ -171,7 +183,11 @@ export function ModelSimilarityTableSection({ models }: ModelSimilarityTableSect
                     const isSelf = rowModel.model === colModel.model;
                     const isUnavailable = metric == null || metric.usedValueCount === 0;
                     const displayValue = formatViewValue(metric, view);
-                    const intensity = getCellIntensity(metric);
+                    const rawIntensity = getCellIntensity(metric);
+                    const { minSimilarity, maxSimilarity } = matrix;
+                    const intensity = maxSimilarity === minSimilarity
+                      ? rawIntensity
+                      : (rawIntensity - minSimilarity) / (maxSimilarity - minSimilarity);
                     return (
                       <td
                         key={colModel.model}


### PR DESCRIPTION
## Summary
- Adds a new **Absolute Value** calculation method — mean absolute difference of win rates across all shared value dimensions
- Pair detail drawer shows `diff` and `|diff|` columns when this method is selected
- Cell heat map is now normalized relative to the min/max similarity in the current matrix, so the closest model pair always renders green (was previously absolute, making all cells look similar when models cluster closely)

## Test plan
- [x] Preflight passed (lint + build clean, 150 test files pass)
- [ ] Manual smoke test: verify Absolute Value button appears and produces values, verify green cell is always the closest pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)