### PR TITLE
Fix z-index stacking and add model picker to Model Groups page

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterDotPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterDotPlot.tsx
@@ -91,7 +91,7 @@ export function ClusterDotPlot({ clusters, activeGroupIds = [] }: ClusterDotPlot
                           border: clipped ? '2px solid rgba(15, 23, 42, 0.45)' : '2px solid white',
                           boxShadow: clipped ? '0 0 0 1px rgba(15, 23, 42, 0.12)' : undefined,
                           filter: isActive && hasActiveSelection ? `drop-shadow(0 0 8px rgba(255,255,255,0.35)) drop-shadow(0 0 12px ${color}aa)` : undefined,
-                          zIndex: isActive ? index + 20 : index + 1,
+                          zIndex: index + 1,
                         }}
                       />
                     );

--- a/cloud/apps/web/src/components/layout/Header.tsx
+++ b/cloud/apps/web/src/components/layout/Header.tsx
@@ -260,7 +260,7 @@ export function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-20 border-b border-gray-800 bg-[#1A1A1A]">
+    <header className="sticky top-0 z-50 border-b border-gray-800 bg-[#1A1A1A]">
       <div className="mx-auto flex h-14 max-w-7xl items-center gap-3 px-4">
         <div className="flex items-center gap-2 shrink-0">
           <MobileNav className="sm:hidden" />

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'urql';
 import { useSearchParams } from 'react-router-dom';
 import { AnalysisContextBar } from '../components/analysis/AnalysisContextBar';
@@ -21,6 +21,7 @@ import {
   type ModelsAnalysisQueryResult,
   type ModelsAnalysisQueryVariables,
 } from '../api/operations/modelsAnalysis';
+import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
 import { ModelSimilarityTableSection } from '../components/models/ModelSimilarityTableSection';
 import { useDomains } from '../hooks/useDomains';
@@ -71,6 +72,8 @@ export function ModelsGroups() {
   const [selectedDomainId, setSelectedDomainId] = useState<string>(initialDomainId);
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
+  const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
+  const initializedModelSelection = useRef(false);
 
   const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
     DomainAvailableSignaturesQueryResult,
@@ -153,6 +156,11 @@ export function ModelsGroups() {
     pause: selectedScope === 'DOMAIN' && selectedDomainId === '',
     requestPolicy: 'cache-and-network',
   });
+  const [{ data: llmModelsData }] = useQuery<LlmModelsQueryResult>({
+    query: LLM_MODELS_QUERY,
+    variables: { status: 'ACTIVE' },
+    requestPolicy: 'cache-and-network',
+  });
   const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<DomainAnalysisQueryResult, { domainId: string }>({
     query: DOMAIN_ANALYSIS_QUERY_LEGACY,
     variables: { domainId: selectedDomainId },
@@ -182,6 +190,43 @@ export function ModelsGroups() {
     () => buildModelEntries(data?.domainAnalysis.models ?? [], modelsAnalysisData?.modelsAnalysis.models ?? []),
     [data?.domainAnalysis.models, modelsAnalysisData?.modelsAnalysis.models],
   );
+  const defaultModelIds = useMemo(
+    () => new Set((llmModelsData?.llmModels ?? []).filter((m) => m.isDefault).map((m) => m.modelId)),
+    [llmModelsData],
+  );
+  const defaultSelection = useMemo(() => {
+    const availableIds = models.map((model) => model.model);
+    const defaults = availableIds.filter((id) => defaultModelIds.has(id));
+    return defaults.length > 0 ? defaults : availableIds;
+  }, [models, defaultModelIds]);
+  const modelOptions = useMemo(
+    () => models.map((model) => ({ value: model.model, label: model.label, isDefault: defaultSelection.includes(model.model) })),
+    [defaultSelection, models],
+  );
+
+  useEffect(() => {
+    if (initializedModelSelection.current) return;
+    if (models.length === 0) return;
+    if (llmModelsData == null) return;
+    setSelectedModelIds(defaultSelection);
+    initializedModelSelection.current = true;
+  }, [models, llmModelsData, defaultSelection]);
+
+  useEffect(() => {
+    if (!initializedModelSelection.current) return;
+    setSelectedModelIds((current) => {
+      if (current.length === 0) return current;
+      const validIds = new Set(models.map((model) => model.model));
+      const next = current.filter((id) => validIds.has(id));
+      return next.length === current.length ? current : next;
+    });
+  }, [models]);
+
+  const visibleModels = useMemo(
+    () => selectedModelIds.length === 0 ? models : models.filter((model) => selectedModelIds.includes(model.model)),
+    [models, selectedModelIds],
+  );
+
   const isAllDomains = selectedScope === 'ALL_DOMAINS';
   const contextBar = (
     <AnalysisContextBar
@@ -214,6 +259,13 @@ export function ModelsGroups() {
             })),
         onChange: (value) => setSelectedSignature(value),
         disabled: signaturesLoading || signatureOptions.length === 0,
+      }}
+      models={{
+        label: 'Models',
+        selectedModelIds: selectedModelIds.length > 0 ? selectedModelIds : null,
+        defaultModelIds: defaultSelection,
+        options: modelOptions,
+        onChange: setSelectedModelIds,
       }}
     />
   );
@@ -255,9 +307,9 @@ export function ModelsGroups() {
           <div className="space-y-6">
             <ModelGroupsSection
               clusterAnalysis={data?.domainAnalysis.clusterAnalysis}
-              models={models}
+              models={visibleModels}
             />
-            <ModelSimilarityTableSection models={models} />
+            <ModelSimilarityTableSection models={visibleModels} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Raise Header from z-20 to z-50 so nav dropdowns clear the sticky AnalysisContextBar (z-40) and are fully clickable
- Remove active-dot z-index boost in ClusterDotPlot so dots stay below sticky headers instead of painting on top
- Add LLM model picker to Model Groups page via AnalysisContextBar, filtering both visualizations by selected models

## Validation
- `npm run lint --workspace @valuerank/web` — pass
- `npm run build --workspace @valuerank/web` — pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)