### PR TITLE
Add UPGMA/Ward clustering method toggle to Model Groups

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-clustering.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-clustering.ts
@@ -108,6 +108,8 @@ function avgLinkageDist(
   return total / (clusterA.length * clusterB.length);
 }
 
+export type ClusteringMethod = 'upgma' | 'ward';
+
 export type MergeStep = {
   height: number;
 };
@@ -154,6 +156,71 @@ export function upgma(distMatrix: number[][], n: number): UpgmaResult {
 
     mergeHeights.push(minDist);
     snapshots.push(clusters.map((c) => [...c]));
+  }
+
+  return { mergeHeights, snapshots };
+}
+
+/**
+ * Run Ward's minimum-variance clustering on an N×N distance matrix.
+ * Uses the Lance-Williams update formula to maintain inter-cluster distances.
+ * Returns the same UpgmaResult shape so it can share cutAtLargestGap.
+ */
+export function ward(distMatrix: number[][], n: number): UpgmaResult {
+  if (n === 0) return { mergeHeights: [], snapshots: [] };
+
+  const sizes: number[] = Array(n).fill(1) as number[];
+  const members: number[][] = Array.from({ length: n }, (_, i) => [i]);
+  const active: boolean[] = Array(n).fill(true) as boolean[];
+
+  // Working copy of the distance matrix — updated in place
+  const d: number[][] = distMatrix.map((row) => [...row]);
+
+  const mergeHeights: number[] = [];
+  const snapshots: number[][][] = [members.map((c) => [...c])];
+
+  for (let step = 0; step < n - 1; step++) {
+    let minDist = Infinity;
+    let minI = -1;
+    let minJ = -1;
+
+    for (let i = 0; i < n; i++) {
+      if (!active[i]) continue;
+      for (let j = i + 1; j < n; j++) {
+        if (!active[j]) continue;
+        if ((d[i]![j] ?? 0) < minDist) {
+          minDist = d[i]![j] ?? 0;
+          minI = i;
+          minJ = j;
+        }
+      }
+    }
+
+    if (minI < 0) break;
+
+    const nA = sizes[minI]!;
+    const nB = sizes[minJ]!;
+    const dAB = d[minI]![minJ] ?? 0;
+
+    // Update distances using Lance-Williams formula for Ward's method
+    for (let k = 0; k < n; k++) {
+      if (!active[k] || k === minI || k === minJ) continue;
+      const nC = sizes[k]!;
+      const dAC = d[minI]![k] ?? 0;
+      const dBC = d[minJ]![k] ?? 0;
+      const total = nA + nB + nC;
+      const newD = ((nA + nC) * dAC + (nB + nC) * dBC - nC * dAB) / total;
+      d[minI]![k] = Math.max(0, newD);
+      d[k]![minI] = Math.max(0, newD);
+    }
+
+    members[minI] = [...members[minI]!, ...members[minJ]!];
+    sizes[minI] = nA + nB;
+    active[minJ] = false;
+
+    mergeHeights.push(minDist);
+    const activeClusters = members.filter((_, i) => active[i]);
+    snapshots.push(activeClusters.map((c) => [...c]));
   }
 
   return { mergeHeights, snapshots };
@@ -294,7 +361,7 @@ export function nameCluster(
 /**
  * Main entry point. Compute full cluster analysis from model score vectors.
  */
-export function computeClusterAnalysis(models: ClusterModelInput[]): ClusterAnalysis {
+export function computeClusterAnalysis(models: ClusterModelInput[], method: ClusteringMethod = 'upgma'): ClusterAnalysis {
   const n = models.length;
 
   if (n < MIN_MODELS_FOR_CLUSTERING) {
@@ -317,7 +384,7 @@ export function computeClusterAnalysis(models: ClusterModelInput[]): ClusterAnal
   });
 
   const distMatrix = cosineDistanceMatrix(vectors);
-  const { mergeHeights, snapshots } = upgma(distMatrix, n);
+  const { mergeHeights, snapshots } = method === 'ward' ? ward(distMatrix, n) : upgma(distMatrix, n);
   const rawClusters = cutAtLargestGap(mergeHeights, snapshots, n);
 
   if (rawClusters.length === 1) {

--- a/cloud/apps/api/src/graphql/queries/domain/analysis/domain-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/analysis/domain-analysis.ts
@@ -4,6 +4,7 @@ import {
   DomainAnalysisResultRef,
 } from '../types.js';
 import { parseDomainAnalysisScope } from '../../../../services/analysis/domain-analysis-scope.js';
+import type { ClusteringMethod } from '../../domain-clustering.js';
 
 builder.queryField('domainAnalysis', (t) =>
   t.field({
@@ -12,6 +13,7 @@ builder.queryField('domainAnalysis', (t) =>
       domainId: t.arg.id({ required: true }),
       scope: t.arg.string({ required: false }),
       signature: t.arg.string({ required: false }),
+      clusteringMethod: t.arg.string({ required: false }),
     },
     resolve: async (_root, args, ctx) => {
       const domainId = String(args.domainId);
@@ -19,6 +21,8 @@ builder.queryField('domainAnalysis', (t) =>
       const requestedSignature = typeof args.signature === 'string' && args.signature.trim() !== ''
         ? args.signature.trim()
         : null;
+      const clusteringMethod: ClusteringMethod =
+        args.clusteringMethod === 'ward' ? 'ward' : 'upgma';
       if (requestedSignature === null) {
         ctx.log.warn({ domainId }, 'domainAnalysis called without signature; defaulting to first vnew signature');
       }
@@ -26,6 +30,7 @@ builder.queryField('domainAnalysis', (t) =>
         scope,
         domainId,
         requestedSignature,
+        clusteringMethod,
       });
     },
   }),

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -9,7 +9,7 @@ import {
   computeSmoothedLogOddsScore,
 } from '../../graphql/queries/domain/shared.js';
 import { computeRankingShapes } from '../../graphql/queries/domain-shape.js';
-import { computeClusterAnalysis } from '../../graphql/queries/domain-clustering.js';
+import { computeClusterAnalysis, type ClusteringMethod } from '../../graphql/queries/domain-clustering.js';
 import type {
   DomainAnalysisModel,
   DomainAnalysisResult,
@@ -57,6 +57,7 @@ function buildDomainAnalysisResultFromSnapshot(params: {
   activeModels: Array<{ modelId: string; displayName: string; isDefault: boolean }>;
   generatedAt: Date;
   cacheStatus: DomainAnalysisCacheStatus;
+  clusteringMethod?: ClusteringMethod;
 }): DomainAnalysisResult {
   const activeModelLabelById = new Map(params.activeModels.map((model) => [model.modelId, model.displayName]));
 
@@ -94,7 +95,7 @@ function buildDomainAnalysisResultFromSnapshot(params: {
       label: model.label,
       scores: Object.fromEntries(model.values.map((value) => [value.valueKey, value.score])),
     }));
-  const clusterAnalysis = computeClusterAnalysis(clusterModels);
+  const clusterAnalysis = computeClusterAnalysis(clusterModels, params.clusteringMethod);
 
   const models: DomainAnalysisModel[] = modelsBase.map((model) => ({
     ...model,
@@ -202,6 +203,7 @@ export async function getDomainAnalysisResult(params: {
   scope: DomainAnalysisScope;
   domainId: string;
   requestedSignature: string | null;
+  clusteringMethod?: ClusteringMethod;
 }): Promise<DomainAnalysisResult> {
   const state = await prepareDomainAnalysisState({
     scope: params.scope,
@@ -247,6 +249,7 @@ export async function getDomainAnalysisResult(params: {
       activeModels,
       generatedAt: currentSnapshot.createdAt,
       cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.FRESH,
+      clusteringMethod: params.clusteringMethod,
     });
   }
 
@@ -262,6 +265,7 @@ export async function getDomainAnalysisResult(params: {
       activeModels,
       generatedAt: currentSnapshot.createdAt,
       cacheStatus: queued ? DOMAIN_ANALYSIS_CACHE_STATUS.UPDATING : DOMAIN_ANALYSIS_CACHE_STATUS.OUT_OF_DATE,
+      clusteringMethod: params.clusteringMethod,
     });
   }
 
@@ -279,5 +283,6 @@ export async function getDomainAnalysisResult(params: {
     activeModels,
     generatedAt: refreshed.snapshot.createdAt,
     cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.FRESH,
+    clusteringMethod: params.clusteringMethod,
   });
 }

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -2494,7 +2494,7 @@ type Query {
     withoutDomain: Boolean
   ): [Definition!]!
   domain(id: ID!): Domain
-  domainAnalysis(domainId: ID!, scope: String, signature: String): DomainAnalysisResult!
+  domainAnalysis(clusteringMethod: String, domainId: ID!, scope: String, signature: String): DomainAnalysisResult!
   domainAnalysisConditionTranscripts(definitionId: ID!, domainId: ID!, limit: Int, modelId: String!, scenarioId: ID, signature: String, valueKey: String!): [DomainAnalysisConditionTranscript!]!
   domainAnalysisValueDetail(domainId: ID!, modelId: String!, signature: String, valueKey: String!): DomainAnalysisValueDetailResult!
   domainAvailableSignatures(domainId: ID!, scope: String): [DomainAvailableSignature!]!

--- a/cloud/apps/web/src/api/operations/domainAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.graphql
@@ -1,5 +1,5 @@
-query DomainAnalysis($domainId: ID!, $scope: String, $signature: String) {
-  domainAnalysis(domainId: $domainId, scope: $scope, signature: $signature) {
+query DomainAnalysis($domainId: ID!, $scope: String, $signature: String, $clusteringMethod: String) {
+  domainAnalysis(domainId: $domainId, scope: $scope, signature: $signature, clusteringMethod: $clusteringMethod) {
     domainId
     domainName
     contributionSummary {

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -24,10 +24,19 @@ const LEGEND_COLORS = [
   { border: 'border-yellow-500', text: 'text-yellow-700', light: 'bg-yellow-50', color: '#ca8a04' },
 ] as const;
 
+type ClusteringMethod = 'upgma' | 'ward';
+
+const CLUSTERING_METHOD_OPTIONS: Array<{ value: ClusteringMethod; label: string }> = [
+  { value: 'upgma', label: 'UPGMA' },
+  { value: 'ward', label: 'Ward' },
+];
+
 type ModelGroupsSectionProps = {
   clusterAnalysis?: ClusterAnalysis;
   models: ModelEntry[];
   selectedModelId?: string | null;
+  clusteringMethod?: ClusteringMethod;
+  onClusteringMethodChange?: (method: ClusteringMethod) => void;
 };
 
 type ClusterViewMode = 'dot' | 'bar' | 'radar';
@@ -56,6 +65,8 @@ export function ModelGroupsSection({
   clusterAnalysis,
   models,
   selectedModelId = null,
+  clusteringMethod = 'upgma',
+  onClusteringMethodChange,
 }: ModelGroupsSectionProps) {
   const summaryTableRef = useRef<HTMLDivElement>(null);
   const [showModelGroupsHelp, setShowModelGroupsHelp] = useState(false);
@@ -142,6 +153,28 @@ export function ModelGroupsSection({
               );
             })}
           </div>
+
+          {groupDisplayMode === 'groups' && onClusteringMethodChange != null && (
+            <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+              {CLUSTERING_METHOD_OPTIONS.map((option) => {
+                const active = clusteringMethod === option.value;
+                return (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    variant={active ? 'primary' : 'ghost'}
+                    size="sm"
+                    onClick={() => onClusteringMethodChange(option.value)}
+                    className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
+                      active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-white hover:text-gray-900'
+                    }`}
+                  >
+                    {option.label}
+                  </Button>
+                );
+              })}
+            </div>
+          )}
 
           <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
             {CLUSTER_VIEW_OPTIONS.map((option) => {

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -2926,6 +2926,7 @@ export type QueryDomainArgs = {
 
 
 export type QueryDomainAnalysisArgs = {
+  clusteringMethod?: InputMaybe<Scalars['String']['input']>;
   domainId: Scalars['ID']['input'];
   scope?: InputMaybe<Scalars['String']['input']>;
   signature?: InputMaybe<Scalars['String']['input']>;
@@ -4264,6 +4265,7 @@ export type DomainAnalysisQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
   scope?: InputMaybe<Scalars['String']['input']>;
   signature?: InputMaybe<Scalars['String']['input']>;
+  clusteringMethod?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -5951,8 +5953,13 @@ export function useDeleteDomainContextMutation() {
   return Urql.useMutation<DeleteDomainContextMutation, DeleteDomainContextMutationVariables>(DeleteDomainContextDocument);
 };
 export const DomainAnalysisDocument = gql`
-    query DomainAnalysis($domainId: ID!, $scope: String, $signature: String) {
-  domainAnalysis(domainId: $domainId, scope: $scope, signature: $signature) {
+    query DomainAnalysis($domainId: ID!, $scope: String, $signature: String, $clusteringMethod: String) {
+  domainAnalysis(
+    domainId: $domainId
+    scope: $scope
+    signature: $signature
+    clusteringMethod: $clusteringMethod
+  ) {
     domainId
     domainName
     contributionSummary {

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -72,6 +72,7 @@ export function ModelsGroups() {
   const [selectedDomainId, setSelectedDomainId] = useState<string>(initialDomainId);
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
+  const [clusteringMethod, setClusteringMethod] = useState<'upgma' | 'ward'>('upgma');
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
   const initializedModelSelection = useRef(false);
 
@@ -140,6 +141,7 @@ export function ModelsGroups() {
       domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
       scope: selectedScope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined,
       signature: selectedSignature === '' ? undefined : selectedSignature,
+      clusteringMethod,
     },
     pause: selectedDomainId === '' || activeUseLegacyQuery,
     requestPolicy: 'cache-and-network',
@@ -308,6 +310,8 @@ export function ModelsGroups() {
             <ModelGroupsSection
               clusterAnalysis={data?.domainAnalysis.clusterAnalysis}
               models={visibleModels}
+              clusteringMethod={clusteringMethod}
+              onClusteringMethodChange={setClusteringMethod}
             />
             <ModelSimilarityTableSection models={visibleModels} />
           </div>


### PR DESCRIPTION
## Summary
- Implement Ward's minimum-variance clustering in the backend (`domain-clustering.ts`) using the Lance-Williams update formula — same O(N³) as UPGMA, runs fresh from cached model scores so no cache changes needed
- Add optional `clusteringMethod: String` arg to the `domainAnalysis` GraphQL resolver; defaults to UPGMA
- Add UPGMA/Ward toggle to the Model Groups section header (visible in Groups display mode only)
- Regenerate GraphQL types

## Test plan
- [ ] Toggle appears in the Model Groups section when "Groups" is selected
- [ ] Switching to Ward produces different cluster groupings than UPGMA on production data
- [ ] Switching back to UPGMA restores the original groupings
- [ ] Toggle is hidden in Individual display mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)