### PR TITLE
Pre-compute all clustering combinations (5 methods × 2 data sources × 2 linkages)

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-clustering.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-clustering.ts
@@ -3,15 +3,12 @@ import { cosineSimilarity } from '@valuerank/shared';
 /**
  * domain-clustering.ts
  *
- * Pure computation helpers for cluster analysis (#025).
+ * Pure computation helpers for cluster analysis.
  * No database access. No external dependencies.
  *
- * Algorithm: Average-Linkage Hierarchical Clustering (UPGMA)
- * Valid for arbitrary symmetric distance matrices (cosine distance).
- * O(N³) — acceptable for N ≤ 20.
- *
- * Calibration constants — validate against real domain data before launch.
- * All threshold names match spec documentation for traceability.
+ * Algorithms: UPGMA and Ward's minimum-variance hierarchical clustering.
+ * Supports 5 distance methods × 2 data sources × 2 linkages = 20 combinations.
+ * O(N³) per combination — acceptable for N ≤ 20.
  */
 
 export type ClusterMember = {
@@ -36,7 +33,7 @@ export type ValueFaultLine = {
 export type ClusterPairFaultLines = {
   clusterAId: string;
   clusterBId: string;
-  distance: number;                // mean inter-cluster cosine distance
+  distance: number;                // mean inter-cluster distance
   faultLines: ValueFaultLine[];   // top 3, sorted by absDelta descending
 };
 
@@ -59,8 +56,13 @@ export type ClusterAnalysis = {
 export type ClusterModelInput = {
   model: string;
   label: string;
-  scores: Record<string, number>;
+  scores: Record<string, number>;        // log-odds scores
+  winRates?: Record<string, number | null>; // domain-local win rates (0–1)
 };
+
+export type ClusteringMethod = 'upgma' | 'ward';
+export type ClusterDistanceMethod = 'cosine' | 'euclidean' | 'absolute-value' | 'spearman' | 'kendall';
+export type ClusterDataSource = 'log-odds' | 'win-rate';
 
 // --- Calibration constants ---
 const OUTLIER_SILHOUETTE_THRESHOLD = 0.2;
@@ -68,16 +70,16 @@ const MIN_CLUSTER_GAP = 0.015;
 const MAX_CLUSTERS = 4;
 const MIN_MODELS_FOR_CLUSTERING = 3;
 
-/**
- * Compute cosine similarity between two numeric vectors.
- */
+const CLUSTER_DISTANCE_METHODS: ClusterDistanceMethod[] = ['cosine', 'euclidean', 'absolute-value', 'spearman', 'kendall'];
+const CLUSTER_DATA_SOURCES: ClusterDataSource[] = ['log-odds', 'win-rate'];
+const CLUSTER_LINKAGE_METHODS: ClusteringMethod[] = ['upgma', 'ward'];
+
 export { cosineSimilarity };
 
-/**
- * Build N×N cosine distance matrix.
- * Distance = (1 - similarity) / 2, range [0, 1].
- * Diagonal is 0. Matrix is symmetric.
- */
+// ---------------------------------------------------------------------------
+// Distance matrix builders
+// ---------------------------------------------------------------------------
+
 export function cosineDistanceMatrix(vectors: number[][]): number[][] {
   const n = vectors.length;
   const matrix: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0));
@@ -91,14 +93,143 @@ export function cosineDistanceMatrix(vectors: number[][]): number[][] {
   return matrix;
 }
 
-/**
- * Average linkage distance between two clusters (by model indices).
- */
-function avgLinkageDist(
-  clusterA: number[],
-  clusterB: number[],
-  distMatrix: number[][],
-): number {
+function euclideanDistanceMatrix(vectors: number[][]): number[][] {
+  const n = vectors.length;
+  const matrix: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0));
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const v1 = vectors[i]!, v2 = vectors[j]!;
+      let sum = 0;
+      for (let k = 0; k < v1.length; k++) { const d = v1[k]! - v2[k]!; sum += d * d; }
+      const dist = v1.length > 0 ? Math.sqrt(sum / v1.length) : 0;
+      matrix[i]![j] = dist;
+      matrix[j]![i] = dist;
+    }
+  }
+  return matrix;
+}
+
+function absoluteValueDistanceMatrix(vectors: number[][]): number[][] {
+  const n = vectors.length;
+  const matrix: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0));
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const v1 = vectors[i]!, v2 = vectors[j]!;
+      let sum = 0;
+      for (let k = 0; k < v1.length; k++) sum += Math.abs(v1[k]! - v2[k]!);
+      const dist = v1.length > 0 ? sum / v1.length : 0;
+      matrix[i]![j] = dist;
+      matrix[j]![i] = dist;
+    }
+  }
+  return matrix;
+}
+
+function rankVector(values: number[]): number[] {
+  const indexed = values.map((v, i) => ({ v, i }));
+  indexed.sort((a, b) => b.v - a.v);
+  const ranks = new Array<number>(values.length).fill(0);
+  let i = 0;
+  while (i < indexed.length) {
+    let end = i + 1;
+    while (end < indexed.length && Math.abs(indexed[end]!.v - indexed[i]!.v) < 1e-9) end++;
+    const avgRank = ((i + 1) + end) / 2;
+    for (let j = i; j < end; j++) ranks[indexed[j]!.i] = avgRank;
+    i = end;
+  }
+  return ranks;
+}
+
+function pearsonCorrelation(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  if (n === 0) return 0;
+  const meanX = xs.reduce((s, v) => s + v, 0) / n;
+  const meanY = ys.reduce((s, v) => s + v, 0) / n;
+  let num = 0, denomX = 0, denomY = 0;
+  for (let k = 0; k < n; k++) {
+    const dx = xs[k]! - meanX, dy = ys[k]! - meanY;
+    num += dx * dy; denomX += dx * dx; denomY += dy * dy;
+  }
+  const denom = Math.sqrt(denomX * denomY);
+  return denom === 0 ? 0 : num / denom;
+}
+
+function kendallTau(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  let concordant = 0, discordant = 0, tieX = 0, tieY = 0;
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const dx = xs[i]! - xs[j]!, dy = ys[i]! - ys[j]!;
+      const tiedX = Math.abs(dx) < 1e-9, tiedY = Math.abs(dy) < 1e-9;
+      if (tiedX) tieX++;
+      if (tiedY) tieY++;
+      if (!tiedX && !tiedY) {
+        if (Math.sign(dx) === Math.sign(dy)) concordant++;
+        else discordant++;
+      }
+    }
+  }
+  const n0 = n * (n - 1) / 2;
+  const denom = Math.sqrt((n0 - tieX) * (n0 - tieY));
+  return denom === 0 ? 0 : (concordant - discordant) / denom;
+}
+
+function spearmanDistanceMatrix(vectors: number[][]): number[][] {
+  const n = vectors.length;
+  const ranked = vectors.map(rankVector);
+  const matrix: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0));
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const dist = (1 - pearsonCorrelation(ranked[i]!, ranked[j]!)) / 2;
+      matrix[i]![j] = dist;
+      matrix[j]![i] = dist;
+    }
+  }
+  return matrix;
+}
+
+function kendallDistanceMatrix(vectors: number[][]): number[][] {
+  const n = vectors.length;
+  const matrix: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0));
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const dist = (1 - kendallTau(vectors[i]!, vectors[j]!)) / 2;
+      matrix[i]![j] = dist;
+      matrix[j]![i] = dist;
+    }
+  }
+  return matrix;
+}
+
+function buildDistanceMatrixForMethod(
+  models: ClusterModelInput[],
+  distanceMethod: ClusterDistanceMethod,
+  dataSource: ClusterDataSource,
+): number[][] {
+  const valueKeys = Object.keys(models[0]!.scores);
+  const rawVectors = models.map((m) => {
+    if (dataSource === 'win-rate') {
+      return valueKeys.map((vk) => { const wr = m.winRates?.[vk]; return wr != null ? wr : 0; });
+    }
+    return valueKeys.map((vk) => m.scores[vk] ?? 0);
+  });
+
+  if (distanceMethod === 'cosine') {
+    // Mean-center before cosine to measure shape of profile rather than level
+    const vectors = rawVectors.map((v) => { const mean = v.reduce((s, x) => s + x, 0) / v.length; return v.map((x) => x - mean); });
+    return cosineDistanceMatrix(vectors);
+  }
+  if (distanceMethod === 'euclidean') return euclideanDistanceMatrix(rawVectors);
+  if (distanceMethod === 'absolute-value') return absoluteValueDistanceMatrix(rawVectors);
+  if (distanceMethod === 'spearman') return spearmanDistanceMatrix(rawVectors);
+  return kendallDistanceMatrix(rawVectors);
+}
+
+// ---------------------------------------------------------------------------
+// UPGMA
+// ---------------------------------------------------------------------------
+
+function avgLinkageDist(clusterA: number[], clusterB: number[], distMatrix: number[][]): number {
   let total = 0;
   for (const i of clusterA) {
     for (const j of clusterB) {
@@ -108,23 +239,15 @@ function avgLinkageDist(
   return total / (clusterA.length * clusterB.length);
 }
 
-export type ClusteringMethod = 'upgma' | 'ward';
-
 export type MergeStep = {
   height: number;
 };
 
 export type UpgmaResult = {
   mergeHeights: number[];
-  // snapshots[k] = cluster assignments after k merges (N-k clusters)
   snapshots: number[][][];
 };
 
-/**
- * Run UPGMA on an N×N distance matrix.
- * snapshots[0] = initial N singleton clusters.
- * snapshots[k] = state after k merges (N-k clusters).
- */
 export function upgma(distMatrix: number[][], n: number): UpgmaResult {
   if (n === 0) return { mergeHeights: [], snapshots: [] };
 
@@ -140,15 +263,10 @@ export function upgma(distMatrix: number[][], n: number): UpgmaResult {
     for (let i = 0; i < clusters.length; i++) {
       for (let j = i + 1; j < clusters.length; j++) {
         const d = avgLinkageDist(clusters[i]!, clusters[j]!, distMatrix);
-        if (d < minDist) {
-          minDist = d;
-          minI = i;
-          minJ = j;
-        }
+        if (d < minDist) { minDist = d; minI = i; minJ = j; }
       }
     }
 
-    // Merge clusters[minI] and clusters[minJ] (remove higher index first)
     const newCluster = [...clusters[minI]!, ...clusters[minJ]!];
     clusters.splice(minJ, 1);
     clusters.splice(minI, 1);
@@ -161,21 +279,17 @@ export function upgma(distMatrix: number[][], n: number): UpgmaResult {
   return { mergeHeights, snapshots };
 }
 
-/**
- * Run Ward's minimum-variance clustering on an N×N distance matrix.
- * Uses the Lance-Williams update formula to maintain inter-cluster distances.
- * Returns the same UpgmaResult shape so it can share cutAtLargestGap.
- */
+// ---------------------------------------------------------------------------
+// Ward (Lance-Williams update formula)
+// ---------------------------------------------------------------------------
+
 export function ward(distMatrix: number[][], n: number): UpgmaResult {
   if (n === 0) return { mergeHeights: [], snapshots: [] };
 
   const sizes: number[] = Array(n).fill(1) as number[];
   const members: number[][] = Array.from({ length: n }, (_, i) => [i]);
   const active: boolean[] = Array(n).fill(true) as boolean[];
-
-  // Working copy of the distance matrix — updated in place
   const d: number[][] = distMatrix.map((row) => [...row]);
-
   const mergeHeights: number[] = [];
   const snapshots: number[][][] = [members.map((c) => [...c])];
 
@@ -188,11 +302,7 @@ export function ward(distMatrix: number[][], n: number): UpgmaResult {
       if (!active[i]) continue;
       for (let j = i + 1; j < n; j++) {
         if (!active[j]) continue;
-        if ((d[i]![j] ?? 0) < minDist) {
-          minDist = d[i]![j] ?? 0;
-          minI = i;
-          minJ = j;
-        }
+        if ((d[i]![j] ?? 0) < minDist) { minDist = d[i]![j] ?? 0; minI = i; minJ = j; }
       }
     }
 
@@ -202,7 +312,6 @@ export function ward(distMatrix: number[][], n: number): UpgmaResult {
     const nB = sizes[minJ]!;
     const dAB = d[minI]![minJ] ?? 0;
 
-    // Update distances using Lance-Williams formula for Ward's method
     for (let k = 0; k < n; k++) {
       if (!active[k] || k === minI || k === minJ) continue;
       const nC = sizes[k]!;
@@ -219,36 +328,21 @@ export function ward(distMatrix: number[][], n: number): UpgmaResult {
     active[minJ] = false;
 
     mergeHeights.push(minDist);
-    const activeClusters = members.filter((_, i) => active[i]);
-    snapshots.push(activeClusters.map((c) => [...c]));
+    snapshots.push(members.filter((_, i) => active[i]).map((c) => [...c]));
   }
 
   return { mergeHeights, snapshots };
 }
 
-/**
- * Cut dendrogram to find the most clusters supported by the data.
- *
- * Strategy: find the EARLIEST significant gap in the valid range rather than
- * the largest. The largest gap is usually the outlier merge (e.g. one very
- * different model joining last), which produces only 2 clusters and hides
- * meaningful sub-structure in the rest. By taking the earliest significant gap
- * we surface as many real groups as possible, capped at MAX_CLUSTERS.
- *
- * Valid range: snapshot indices that produce between 2 and MAX_CLUSTERS clusters.
- * Returns single cluster when no meaningful structure exists.
- */
-export function cutAtLargestGap(
-  mergeHeights: number[],
-  snapshots: number[][][],
-  n: number,
-): number[][] {
+// ---------------------------------------------------------------------------
+// Dendrogram cutting
+// ---------------------------------------------------------------------------
+
+export function cutAtLargestGap(mergeHeights: number[], snapshots: number[][][], n: number): number[][] {
   const fallback = snapshots[snapshots.length - 1] ?? [Array.from({ length: n }, (_, i) => i)];
 
   if (mergeHeights.length < 2) return fallback;
 
-  // snapshots[k] has N-k clusters.
-  // Valid range: 2 ≤ (N-k) ≤ MAX_CLUSTERS  →  N-MAX_CLUSTERS ≤ k ≤ N-2
   const minCutIdx = Math.max(1, n - MAX_CLUSTERS);
   const maxCutIdx = n - 2;
 
@@ -262,26 +356,20 @@ export function cutAtLargestGap(
     if (gap > MIN_CLUSTER_GAP) {
       hasAnySignificantGap = true;
       const cutIdx = j + 1;
-      if (cutIdx >= minCutIdx && cutIdx <= maxCutIdx) {
-        validCuts.push(cutIdx);
-      }
+      if (cutIdx >= minCutIdx && cutIdx <= maxCutIdx) validCuts.push(cutIdx);
     }
   }
 
-  if (!hasAnySignificantGap) {
-    // No meaningful structure — all models are similar
-    return fallback;
-  }
+  if (!hasAnySignificantGap) return fallback;
+  if (validCuts.length === 0) return snapshots[minCutIdx] ?? fallback;
 
-  if (validCuts.length === 0) {
-    // Gaps exist but all produce too many clusters — cap at MAX_CLUSTERS
-    return snapshots[minCutIdx] ?? fallback;
-  }
-
-  // Earliest valid cut = most clusters within the cap
   validCuts.sort((a, b) => a - b);
   return snapshots[validCuts[0]!] ?? fallback;
 }
+
+// ---------------------------------------------------------------------------
+// Silhouettes
+// ---------------------------------------------------------------------------
 
 type SilhouetteEntry = {
   score: number;
@@ -289,21 +377,13 @@ type SilhouetteEntry = {
   nearestOtherDistances: [number, number] | null;
 };
 
-/**
- * Compute silhouette score for each model.
- * Keys are original model indices (0..N-1).
- */
-export function computeSilhouettes(
-  rawClusters: number[][],
-  distMatrix: number[][],
-): Map<number, SilhouetteEntry> {
+export function computeSilhouettes(rawClusters: number[][], distMatrix: number[][]): Map<number, SilhouetteEntry> {
   const result = new Map<number, SilhouetteEntry>();
 
   for (let ci = 0; ci < rawClusters.length; ci++) {
     const cluster = rawClusters[ci]!;
 
     for (const m of cluster) {
-      // a(m) = mean distance to other members of same cluster
       let a = 0;
       if (cluster.length > 1) {
         let sum = 0;
@@ -313,15 +393,12 @@ export function computeSilhouettes(
         a = sum / (cluster.length - 1);
       }
 
-      // Mean distance from m to each other cluster
       const otherMeans: Array<{ clusterIdx: number; mean: number }> = [];
       for (let cj = 0; cj < rawClusters.length; cj++) {
         if (cj === ci) continue;
         const other = rawClusters[cj]!;
         let sum = 0;
-        for (const o of other) {
-          sum += distMatrix[m]![o] ?? 0;
-        }
+        for (const o of other) sum += distMatrix[m]![o] ?? 0;
         otherMeans.push({ clusterIdx: cj, mean: sum / other.length });
       }
       otherMeans.sort((x, y) => x.mean - y.mean);
@@ -343,13 +420,11 @@ export function computeSilhouettes(
   return result;
 }
 
-/**
- * Name cluster from the top 3 centroid values.
- */
-export function nameCluster(
-  centroid: Record<string, number>,
-  valueKeys: string[],
-): { name: string; definingValues: string[] } {
+// ---------------------------------------------------------------------------
+// Cluster naming
+// ---------------------------------------------------------------------------
+
+export function nameCluster(centroid: Record<string, number>, valueKeys: string[]): { name: string; definingValues: string[] } {
   const top3 = [...valueKeys]
     .sort((a, b) => (centroid[b] ?? 0) - (centroid[a] ?? 0))
     .slice(0, 3)
@@ -358,86 +433,56 @@ export function nameCluster(
   return { name: top3.join(' / '), definingValues: top3 };
 }
 
-/**
- * Main entry point. Compute full cluster analysis from model score vectors.
- */
-export function computeClusterAnalysis(models: ClusterModelInput[], method: ClusteringMethod = 'upgma'): ClusterAnalysis {
+// ---------------------------------------------------------------------------
+// Core clustering from a pre-built distance matrix
+// ---------------------------------------------------------------------------
+
+function runClusteringFromDistMatrix(
+  models: ClusterModelInput[],
+  distMatrix: number[][],
+  valueKeys: string[],
+  linkage: ClusteringMethod,
+): ClusterAnalysis {
   const n = models.length;
 
   if (n < MIN_MODELS_FOR_CLUSTERING) {
-    return {
-      clusters: [],
-      faultLinesByPair: {},
-      defaultPair: null,
-      skipped: true,
-      skipReason: `Clustering requires at least ${MIN_MODELS_FOR_CLUSTERING} models; ${n} available.`,
-    };
+    return { clusters: [], faultLinesByPair: {}, defaultPair: null, skipped: true,
+      skipReason: `Clustering requires at least ${MIN_MODELS_FOR_CLUSTERING} models; ${n} available.` };
   }
 
-  // Build value key list and score vectors, mean-centered so cosine distance
-  // measures shape of priorities (like Pearson r) rather than raw magnitude.
-  const valueKeys = Object.keys(models[0]!.scores);
-  const rawVectors = models.map((m) => valueKeys.map((vk) => m.scores[vk] ?? 0));
-  const vectors = rawVectors.map((v) => {
-    const mean = v.reduce((s, x) => s + x, 0) / v.length;
-    return v.map((x) => x - mean);
-  });
-
-  const distMatrix = cosineDistanceMatrix(vectors);
-  const { mergeHeights, snapshots } = method === 'ward' ? ward(distMatrix, n) : upgma(distMatrix, n);
+  const { mergeHeights, snapshots } = linkage === 'ward' ? ward(distMatrix, n) : upgma(distMatrix, n);
   const rawClusters = cutAtLargestGap(mergeHeights, snapshots, n);
 
   if (rawClusters.length === 1) {
-    return {
-      clusters: [],
-      faultLinesByPair: {},
-      defaultPair: null,
-      skipped: true,
-      skipReason: 'All models in this domain have similar value profiles.',
-    };
+    return { clusters: [], faultLinesByPair: {}, defaultPair: null, skipped: true,
+      skipReason: 'All models in this domain have similar value profiles.' };
   }
 
   const silhouettes = computeSilhouettes(rawClusters, distMatrix);
 
-  // Build DomainCluster objects
   const clusters: DomainCluster[] = rawClusters.map((memberIndices, ci) => {
     const id = `cluster-${ci + 1}`;
-
     const centroid: Record<string, number> = {};
     for (const vk of valueKeys) {
       centroid[vk] = memberIndices.reduce((acc, mi) => acc + (models[mi]!.scores[vk] ?? 0), 0) / memberIndices.length;
     }
-
     const { name, definingValues } = nameCluster(centroid, valueKeys);
-
     const members: ClusterMember[] = memberIndices.map((mi) => {
       const entry = silhouettes.get(mi);
       const silhouetteScore = entry?.score ?? 0;
       const isOutlier = silhouetteScore < OUTLIER_SILHOUETTE_THRESHOLD;
-
       let nearestClusterIds: [string, string] | null = null;
       let distancesToNearestClusters: [number, number] | null = null;
-
       if (isOutlier && entry?.nearestOtherClusterIndices != null) {
         const [nc1, nc2] = entry.nearestOtherClusterIndices;
         nearestClusterIds = [`cluster-${nc1 + 1}`, `cluster-${nc2 + 1}`];
         distancesToNearestClusters = entry.nearestOtherDistances ?? null;
       }
-
-      return {
-        model: models[mi]!.model,
-        label: models[mi]!.label,
-        silhouetteScore,
-        isOutlier,
-        nearestClusterIds,
-        distancesToNearestClusters,
-      };
+      return { model: models[mi]!.model, label: models[mi]!.label, silhouetteScore, isOutlier, nearestClusterIds, distancesToNearestClusters };
     });
-
     return { id, name, members, centroid, definingValues };
   });
 
-  // Compute fault lines for all cluster pairs + find default pair
   const faultLinesByPair: Record<string, ClusterPairFaultLines> = {};
   let defaultPair: [string, string] | null = null;
   let maxInterClusterDist = -Infinity;
@@ -449,7 +494,6 @@ export function computeClusterAnalysis(models: ClusterModelInput[], method: Clus
       const aMemberIndices = rawClusters[i]!;
       const bMemberIndices = rawClusters[j]!;
 
-      // Mean inter-cluster cosine distance
       let distSum = 0;
       for (const ai of aMemberIndices) {
         for (const bi of bMemberIndices) {
@@ -458,10 +502,7 @@ export function computeClusterAnalysis(models: ClusterModelInput[], method: Clus
       }
       const distance = distSum / (aMemberIndices.length * bMemberIndices.length);
 
-      if (distance > maxInterClusterDist) {
-        maxInterClusterDist = distance;
-        defaultPair = [a.id, b.id];
-      }
+      if (distance > maxInterClusterDist) { maxInterClusterDist = distance; defaultPair = [a.id, b.id]; }
 
       const faultLines: ValueFaultLine[] = valueKeys.map((vk) => {
         const clusterAScore = a.centroid[vk] ?? 0;
@@ -470,15 +511,53 @@ export function computeClusterAnalysis(models: ClusterModelInput[], method: Clus
         return { valueKey: vk, clusterAId: a.id, clusterBId: b.id, clusterAScore, clusterBScore, delta, absDelta: Math.abs(delta) };
       });
       faultLines.sort((x, y) => y.absDelta - x.absDelta);
-
-      faultLinesByPair[`${a.id}:${b.id}`] = {
-        clusterAId: a.id,
-        clusterBId: b.id,
-        distance,
-        faultLines: faultLines.slice(0, 3),
-      };
+      faultLinesByPair[`${a.id}:${b.id}`] = { clusterAId: a.id, clusterBId: b.id, distance, faultLines: faultLines.slice(0, 3) };
     }
   }
 
   return { clusters, faultLinesByPair, defaultPair, skipped: false, skipReason: null };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry points
+// ---------------------------------------------------------------------------
+
+/**
+ * Pre-compute all 20 clustering combinations: 5 distance methods × 2 data sources × 2 linkages.
+ * Keys are formatted as "${dataSource}-${distanceMethod}-${linkage}" (e.g., "log-odds-cosine-upgma").
+ */
+export function computeAllClusterAnalyses(models: ClusterModelInput[]): Record<string, ClusterAnalysis> {
+  const result: Record<string, ClusterAnalysis> = {};
+  if (models.length === 0) return result;
+  const valueKeys = Object.keys(models[0]!.scores);
+
+  for (const dataSource of CLUSTER_DATA_SOURCES) {
+    for (const distanceMethod of CLUSTER_DISTANCE_METHODS) {
+      const distMatrix = buildDistanceMatrixForMethod(models, distanceMethod, dataSource);
+      for (const linkage of CLUSTER_LINKAGE_METHODS) {
+        const key = `${dataSource}-${distanceMethod}-${linkage}`;
+        result[key] = runClusteringFromDistMatrix(models, distMatrix, valueKeys, linkage);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Compute cluster analysis using log-odds scores with cosine distance.
+ * Kept for backward compatibility; prefer computeAllClusterAnalyses for new code.
+ */
+export function computeClusterAnalysis(models: ClusterModelInput[], method: ClusteringMethod = 'upgma'): ClusterAnalysis {
+  if (models.length === 0) {
+    return { clusters: [], faultLinesByPair: {}, defaultPair: null, skipped: true,
+      skipReason: 'No models provided.' };
+  }
+  const valueKeys = Object.keys(models[0]!.scores);
+  const rawVectors = models.map((m) => valueKeys.map((vk) => m.scores[vk] ?? 0));
+  const vectors = rawVectors.map((v) => {
+    const mean = v.reduce((s, x) => s + x, 0) / v.length;
+    return v.map((x) => x - mean);
+  });
+  return runClusteringFromDistMatrix(models, cosineDistanceMatrix(vectors), valueKeys, method);
 }

--- a/cloud/apps/api/src/graphql/queries/domain/analysis/domain-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/analysis/domain-analysis.ts
@@ -4,7 +4,6 @@ import {
   DomainAnalysisResultRef,
 } from '../types.js';
 import { parseDomainAnalysisScope } from '../../../../services/analysis/domain-analysis-scope.js';
-import type { ClusteringMethod } from '../../domain-clustering.js';
 
 builder.queryField('domainAnalysis', (t) =>
   t.field({
@@ -13,7 +12,6 @@ builder.queryField('domainAnalysis', (t) =>
       domainId: t.arg.id({ required: true }),
       scope: t.arg.string({ required: false }),
       signature: t.arg.string({ required: false }),
-      clusteringMethod: t.arg.string({ required: false }),
     },
     resolve: async (_root, args, ctx) => {
       const domainId = String(args.domainId);
@@ -21,8 +19,6 @@ builder.queryField('domainAnalysis', (t) =>
       const requestedSignature = typeof args.signature === 'string' && args.signature.trim() !== ''
         ? args.signature.trim()
         : null;
-      const clusteringMethod: ClusteringMethod =
-        args.clusteringMethod === 'ward' ? 'ward' : 'upgma';
       if (requestedSignature === null) {
         ctx.log.warn({ domainId }, 'domainAnalysis called without signature; defaulting to first vnew signature');
       }
@@ -30,7 +26,6 @@ builder.queryField('domainAnalysis', (t) =>
         scope,
         domainId,
         requestedSignature,
-        clusteringMethod,
       });
     },
   }),

--- a/cloud/apps/api/src/graphql/queries/domain/types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/types.ts
@@ -63,6 +63,7 @@ export type DomainAnalysisResult = {
   cacheStatus: DomainAnalysisCacheStatus;
   rankingShapeBenchmarks: RankingShapeBenchmarks;
   clusterAnalysis: ClusterAnalysis;
+  clusterAnalysisByMethod: Record<string, ClusterAnalysis>;
 };
 
 export const RankingShapeRef = builder.objectRef<RankingShape>('RankingShape');
@@ -279,6 +280,7 @@ builder.objectType(DomainAnalysisResultRef, {
       type: ClusterAnalysisRef,
       resolve: (parent) => parent.clusterAnalysis,
     }),
+    clusterAnalysisByMethod: t.expose('clusterAnalysisByMethod', { type: 'JSON' }),
   }),
 });
 

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -53,7 +53,7 @@ async function getCurrentSnapshot(
   });
 }
 
-function extractWinRates(snapshotModel: DomainAnalysisSnapshotModel, valueKeys: string[]): Record<string, number | null> {
+function extractWinRates(snapshotModel: DomainAnalysisSnapshotModel, valueKeys: readonly string[]): Record<string, number | null> {
   const result: Record<string, number | null> = {};
   for (const vk of valueKeys) {
     if (snapshotModel.valueWinRates != null && snapshotModel.valueWinRates[vk] != null) {

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -9,7 +9,7 @@ import {
   computeSmoothedLogOddsScore,
 } from '../../graphql/queries/domain/shared.js';
 import { computeRankingShapes } from '../../graphql/queries/domain-shape.js';
-import { computeClusterAnalysis, type ClusteringMethod } from '../../graphql/queries/domain-clustering.js';
+import { computeClusterAnalysis, computeAllClusterAnalyses } from '../../graphql/queries/domain-clustering.js';
 import type {
   DomainAnalysisModel,
   DomainAnalysisResult,
@@ -19,6 +19,7 @@ import {
   DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
   type DomainAnalysisCacheStatus,
   type DomainAnalysisSnapshotOutput,
+  type DomainAnalysisSnapshotModel,
   type SnapshotClient,
 } from './domain-analysis-cache-types.js';
 import {
@@ -52,12 +53,27 @@ async function getCurrentSnapshot(
   });
 }
 
+function extractWinRates(snapshotModel: DomainAnalysisSnapshotModel, valueKeys: string[]): Record<string, number | null> {
+  const result: Record<string, number | null> = {};
+  for (const vk of valueKeys) {
+    if (snapshotModel.valueWinRates != null && snapshotModel.valueWinRates[vk] != null) {
+      // valueWinRates is stored on a 0–100 scale; normalize to [0, 1]
+      result[vk] = (snapshotModel.valueWinRates[vk] ?? 0) / 100;
+    } else {
+      const counts = snapshotModel.counts[vk];
+      if (counts == null) { result[vk] = null; continue; }
+      const total = counts.prioritized + counts.deprioritized + counts.neutral;
+      result[vk] = total > 0 ? counts.prioritized / total : null;
+    }
+  }
+  return result;
+}
+
 function buildDomainAnalysisResultFromSnapshot(params: {
   snapshot: DomainAnalysisSnapshotOutput;
   activeModels: Array<{ modelId: string; displayName: string; isDefault: boolean }>;
   generatedAt: Date;
   cacheStatus: DomainAnalysisCacheStatus;
-  clusteringMethod?: ClusteringMethod;
 }): DomainAnalysisResult {
   const activeModelLabelById = new Map(params.activeModels.map((model) => [model.modelId, model.displayName]));
 
@@ -88,14 +104,23 @@ function buildDomainAnalysisResultFromSnapshot(params: {
 
   const { shapes, benchmarks } = computeRankingShapes(modelsSortedScores);
   const defaultModelIds = new Set(params.activeModels.filter((m) => m.isDefault).map((m) => m.modelId));
+
+  // Build cluster model inputs with both log-odds scores and domain-local win rates
+  const snapshotModelByModelId = new Map(params.snapshot.models.map((m) => [m.model, m]));
   const clusterModels = modelsBase
     .filter((model) => defaultModelIds.has(model.model))
-    .map((model) => ({
-      model: model.model,
-      label: model.label,
-      scores: Object.fromEntries(model.values.map((value) => [value.valueKey, value.score])),
-    }));
-  const clusterAnalysis = computeClusterAnalysis(clusterModels, params.clusteringMethod);
+    .map((model) => {
+      const snapshotModel = snapshotModelByModelId.get(model.model);
+      return {
+        model: model.model,
+        label: model.label,
+        scores: Object.fromEntries(model.values.map((value) => [value.valueKey, value.score])),
+        winRates: snapshotModel != null ? extractWinRates(snapshotModel, DOMAIN_ANALYSIS_VALUE_KEYS) : undefined,
+      };
+    });
+
+  const clusterAnalysis = computeClusterAnalysis(clusterModels);
+  const clusterAnalysisByMethod = computeAllClusterAnalyses(clusterModels);
 
   const models: DomainAnalysisModel[] = modelsBase.map((model) => ({
     ...model,
@@ -138,6 +163,7 @@ function buildDomainAnalysisResultFromSnapshot(params: {
     generatedAt: params.generatedAt,
     rankingShapeBenchmarks: benchmarks,
     clusterAnalysis,
+    clusterAnalysisByMethod,
     cacheStatus: params.cacheStatus,
     contributionSummary: params.snapshot.contributionSummary ?? [],
     excludedDataSummary: params.snapshot.excludedDataSummary ?? [],
@@ -203,7 +229,6 @@ export async function getDomainAnalysisResult(params: {
   scope: DomainAnalysisScope;
   domainId: string;
   requestedSignature: string | null;
-  clusteringMethod?: ClusteringMethod;
 }): Promise<DomainAnalysisResult> {
   const state = await prepareDomainAnalysisState({
     scope: params.scope,
@@ -234,6 +259,7 @@ export async function getDomainAnalysisResult(params: {
       generatedAt: new Date(),
       rankingShapeBenchmarks: { domainMeanTopGap: 0, domainStdTopGap: null, medianSpread: 0 },
       clusterAnalysis: { clusters: [], faultLinesByPair: {}, defaultPair: null, skipped: true, skipReason: 'No vignettes found in this scope.' },
+      clusterAnalysisByMethod: {},
       cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.FRESH,
       contributionSummary: [],
       excludedDataSummary: [],
@@ -249,7 +275,6 @@ export async function getDomainAnalysisResult(params: {
       activeModels,
       generatedAt: currentSnapshot.createdAt,
       cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.FRESH,
-      clusteringMethod: params.clusteringMethod,
     });
   }
 
@@ -265,7 +290,6 @@ export async function getDomainAnalysisResult(params: {
       activeModels,
       generatedAt: currentSnapshot.createdAt,
       cacheStatus: queued ? DOMAIN_ANALYSIS_CACHE_STATUS.UPDATING : DOMAIN_ANALYSIS_CACHE_STATUS.OUT_OF_DATE,
-      clusteringMethod: params.clusteringMethod,
     });
   }
 
@@ -283,6 +307,5 @@ export async function getDomainAnalysisResult(params: {
     activeModels,
     generatedAt: refreshed.snapshot.createdAt,
     cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.FRESH,
-    clusteringMethod: params.clusteringMethod,
   });
 }

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -858,6 +858,7 @@ type DomainAnalysisRefreshResult {
 type DomainAnalysisResult {
   cacheStatus: String!
   clusterAnalysis: ClusterAnalysis!
+  clusterAnalysisByMethod: JSON!
   contributionSummary: [DomainAnalysisContributionSummary!]!
   coveredDefinitions: Int!
   definitionsWithAnalysis: Int!
@@ -2494,7 +2495,7 @@ type Query {
     withoutDomain: Boolean
   ): [Definition!]!
   domain(id: ID!): Domain
-  domainAnalysis(clusteringMethod: String, domainId: ID!, scope: String, signature: String): DomainAnalysisResult!
+  domainAnalysis(domainId: ID!, scope: String, signature: String): DomainAnalysisResult!
   domainAnalysisConditionTranscripts(definitionId: ID!, domainId: ID!, limit: Int, modelId: String!, scenarioId: ID, signature: String, valueKey: String!): [DomainAnalysisConditionTranscript!]!
   domainAnalysisValueDetail(domainId: ID!, modelId: String!, signature: String, valueKey: String!): DomainAnalysisValueDetailResult!
   domainAvailableSignatures(domainId: ID!, scope: String): [DomainAvailableSignature!]!

--- a/cloud/apps/web/src/api/operations/domainAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.graphql
@@ -1,5 +1,5 @@
-query DomainAnalysis($domainId: ID!, $scope: String, $signature: String, $clusteringMethod: String) {
-  domainAnalysis(domainId: $domainId, scope: $scope, signature: $signature, clusteringMethod: $clusteringMethod) {
+query DomainAnalysis($domainId: ID!, $scope: String, $signature: String) {
+  domainAnalysis(domainId: $domainId, scope: $scope, signature: $signature) {
     domainId
     domainName
     contributionSummary {
@@ -81,6 +81,7 @@ query DomainAnalysis($domainId: ID!, $scope: String, $signature: String, $cluste
       }
       faultLinesByPair
     }
+    clusterAnalysisByMethod
   }
 }
 

--- a/cloud/apps/web/src/api/operations/domainAnalysis.ts
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.ts
@@ -143,6 +143,7 @@ export type DomainAnalysisResult = {
   unavailableModels: DomainAnalysisUnavailableModel[];
   rankingShapeBenchmarks?: RankingShapeBenchmarks;
   clusterAnalysis?: ClusterAnalysis;
+  clusterAnalysisByMethod?: Record<string, ClusterAnalysis>;
 };
 
 export type DomainAnalysisQueryResult = {

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -4,6 +4,7 @@ import { Button } from '../ui/Button';
 import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { type ClusterAnalysis, type DomainCluster } from '../../api/operations/domainAnalysis';
 import { type ModelEntry } from '../../data/domainAnalysisData';
+import { type CalculationMethod } from '../models/ModelSimilarityMetrics';
 import { ClusterBarPlot } from './ClusterBarPlot';
 import { ClusterDotPlot } from './ClusterDotPlot';
 import { ClusterRadarChart } from './ClusterRadarChart';
@@ -24,19 +25,26 @@ const LEGEND_COLORS = [
   { border: 'border-yellow-500', text: 'text-yellow-700', light: 'bg-yellow-50', color: '#ca8a04' },
 ] as const;
 
-type ClusteringMethod = 'upgma' | 'ward';
+type ClusteringLinkage = 'upgma' | 'ward';
+type ClusterDataSource = 'log-odds' | 'win-rate';
 
-const CLUSTERING_METHOD_OPTIONS: Array<{ value: ClusteringMethod; label: string }> = [
+const LINKAGE_OPTIONS: Array<{ value: ClusteringLinkage; label: string }> = [
   { value: 'upgma', label: 'UPGMA' },
   { value: 'ward', label: 'Ward' },
 ];
 
+const DATA_SOURCE_OPTIONS: Array<{ value: ClusterDataSource; label: string }> = [
+  { value: 'log-odds', label: 'Log Odds' },
+  { value: 'win-rate', label: 'Win Rate' },
+];
+
 type ModelGroupsSectionProps = {
-  clusterAnalysis?: ClusterAnalysis;
+  clusterAnalysisByMethod?: Record<string, ClusterAnalysis>;
+  distanceMethod?: CalculationMethod;
   models: ModelEntry[];
   selectedModelId?: string | null;
-  clusteringMethod?: ClusteringMethod;
-  onClusteringMethodChange?: (method: ClusteringMethod) => void;
+  clusteringMethod?: ClusteringLinkage;
+  onClusteringMethodChange?: (method: ClusteringLinkage) => void;
 };
 
 type ClusterViewMode = 'dot' | 'bar' | 'radar';
@@ -53,6 +61,12 @@ const GROUP_DISPLAY_OPTIONS: Array<{ value: GroupDisplayMode; label: string }> =
   { value: 'individual', label: 'Individual' },
 ];
 
+// The similarity table uses 'weighted-euclidean'; backend distance key uses 'euclidean'
+function toBackendDistanceMethod(method: CalculationMethod | undefined): string {
+  if (method == null || method === 'weighted-euclidean') return 'euclidean';
+  return method;
+}
+
 function getLegendColor(index: number) {
   return LEGEND_COLORS[index % LEGEND_COLORS.length]!;
 }
@@ -62,7 +76,8 @@ function getGroupLabel(cluster: DomainCluster): string {
 }
 
 export function ModelGroupsSection({
-  clusterAnalysis,
+  clusterAnalysisByMethod,
+  distanceMethod,
   models,
   selectedModelId = null,
   clusteringMethod = 'upgma',
@@ -73,9 +88,13 @@ export function ModelGroupsSection({
   const [viewMode, setViewMode] = useState<ClusterViewMode>('dot');
   const [groupDisplayMode, setGroupDisplayMode] = useState<GroupDisplayMode>('groups');
   const [activeGroupIds, setActiveGroupIds] = useState<string[]>([]);
+  const [dataSource, setDataSource] = useState<ClusterDataSource>('log-odds');
 
-  const hasGroupedClusters = clusterAnalysis != null && !clusterAnalysis.skipped;
-  const groupedClusters = useMemo(() => clusterAnalysis?.clusters ?? [], [clusterAnalysis]);
+  const backendKey = `${dataSource}-${toBackendDistanceMethod(distanceMethod)}-${clusteringMethod}`;
+  const activeClusterAnalysis = clusterAnalysisByMethod?.[backendKey] ?? null;
+
+  const hasGroupedClusters = activeClusterAnalysis != null && !activeClusterAnalysis.skipped;
+  const groupedClusters = useMemo(() => activeClusterAnalysis?.clusters ?? [], [activeClusterAnalysis]);
   const individualClusters = useMemo(() => buildIndividualClusters(models), [models]);
 
   const sourceClusters = useMemo(
@@ -154,26 +173,56 @@ export function ModelGroupsSection({
             })}
           </div>
 
-          {groupDisplayMode === 'groups' && onClusteringMethodChange != null && (
-            <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
-              {CLUSTERING_METHOD_OPTIONS.map((option) => {
-                const active = clusteringMethod === option.value;
-                return (
-                  <Button
-                    key={option.value}
-                    type="button"
-                    variant={active ? 'primary' : 'ghost'}
-                    size="sm"
-                    onClick={() => onClusteringMethodChange(option.value)}
-                    className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
-                      active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-white hover:text-gray-900'
-                    }`}
-                  >
-                    {option.label}
-                  </Button>
-                );
-              })}
-            </div>
+          {groupDisplayMode === 'groups' && (
+            <>
+              {onClusteringMethodChange != null && (
+                <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
+                  <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Linkage</span>
+                  <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
+                    {LINKAGE_OPTIONS.map((option) => {
+                      const active = clusteringMethod === option.value;
+                      return (
+                        <Button
+                          key={option.value}
+                          type="button"
+                          variant={active ? 'primary' : 'ghost'}
+                          size="sm"
+                          onClick={() => onClusteringMethodChange(option.value)}
+                          className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
+                            active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-white hover:text-gray-900'
+                          }`}
+                        >
+                          {option.label}
+                        </Button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
+                <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Data</span>
+                <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
+                  {DATA_SOURCE_OPTIONS.map((option) => {
+                    const active = dataSource === option.value;
+                    return (
+                      <Button
+                        key={option.value}
+                        type="button"
+                        variant={active ? 'primary' : 'ghost'}
+                        size="sm"
+                        onClick={() => setDataSource(option.value)}
+                        className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
+                          active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-white hover:text-gray-900'
+                        }`}
+                      >
+                        {option.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+            </>
           )}
 
           <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
@@ -241,22 +290,15 @@ export function ModelGroupsSection({
           <div>
             <p className="mb-1 font-semibold text-gray-800">How are the groups formed?</p>
             <p>
-              We use a method called UPGMA (Unweighted Pair Group Method with Arithmetic Mean). It builds
-              groups like a reverse tournament: start with every model alone, find the two most similar
-              models and merge them, repeat until you have 4 groups.
+              We use hierarchical clustering. Start with every model alone, find the two most similar
+              models and merge them, repeat until we have up to 4 groups.
             </p>
             <p className="mt-1">
-              Similarity is measured using cosine distance on the mean-centered scores. Think of each
-              model&apos;s 10 scores as an arrow pointing in a direction. Two models that rank values in a
-              similar order point in nearly the same direction - small distance. Models that disagree on
-              priorities point in different directions - large distance.
-            </p>
-            <p className="mt-1">
-              Use the group toggle above to compare clustered groups against individual models. The dot map
-              and bar chart show each value on a fixed scale from -2.5 to +2.5, with 0 in the middle.
-              Values are sorted from the ones the groups favor most on average to the ones they favor least.
-              The bar view shows the same scores as bars instead of dots, with shorter bars rendered on top
-              so they stay visible.
+              <strong>Linkage</strong> controls how cluster distance is measured: UPGMA averages distances
+              across all member pairs; Ward minimizes within-cluster variance.
+              <strong> Data</strong> controls what scores drive the distance: Log Odds uses the smoothed
+              log-odds ranking scores; Win Rate uses domain-local win rates.
+              The distance method comes from the Similarity Table selector below.
             </p>
           </div>
         </div>
@@ -266,7 +308,7 @@ export function ModelGroupsSection({
         {groupDisplayMode === 'groups' && !hasGroupedClusters ? (
           <div className="space-y-1 text-xs text-gray-500 italic">
             <p>Cluster analysis not available.</p>
-            {clusterAnalysis?.skipReason && <p>{clusterAnalysis.skipReason}</p>}
+            {activeClusterAnalysis?.skipReason != null && <p>{activeClusterAnalysis.skipReason}</p>}
           </div>
         ) : groupDisplayMode === 'individual' && models.length === 0 ? (
           <div className="space-y-1 text-xs text-gray-500 italic">

--- a/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
@@ -18,12 +18,19 @@ import { PairDetailDrawer } from './ModelSimilarityPairDetailDrawer';
 
 type ModelSimilarityTableSectionProps = {
   models: ModelEntry[];
+  method?: CalculationMethod;
+  onMethodChange?: (method: CalculationMethod) => void;
 };
 
-export function ModelSimilarityTableSection({ models }: ModelSimilarityTableSectionProps) {
+export function ModelSimilarityTableSection({ models, method: methodProp, onMethodChange }: ModelSimilarityTableSectionProps) {
   const tableRef = useRef<HTMLDivElement>(null);
   const [showHelp, setShowHelp] = useState(false);
-  const [method, setMethod] = useState<CalculationMethod>('weighted-euclidean');
+  const [internalMethod, setInternalMethod] = useState<CalculationMethod>('weighted-euclidean');
+  const method = methodProp ?? internalMethod;
+  const setMethod = (m: CalculationMethod) => {
+    setInternalMethod(m);
+    onMethodChange?.(m);
+  };
   const [view, setView] = useState<MetricView>('distance');
   const [activePair, setActivePair] = useState<{ left: string; right: string } | null>(null);
 

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -24,6 +24,7 @@ import {
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
 import { ModelSimilarityTableSection } from '../components/models/ModelSimilarityTableSection';
+import { type CalculationMethod } from '../components/models/ModelSimilarityMetrics';
 import { useDomains } from '../hooks/useDomains';
 import { VALUES, type ModelEntry, type ValueKey } from '../data/domainAnalysisData';
 import { formatSignatureOptionLabel, getCacheStatusCopy, getSignaturePriority } from '../utils/domainAnalysisUtils';
@@ -73,6 +74,7 @@ export function ModelsGroups() {
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
   const [clusteringMethod, setClusteringMethod] = useState<'upgma' | 'ward'>('upgma');
+  const [similarityMethod, setSimilarityMethod] = useState<CalculationMethod>('weighted-euclidean');
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
   const initializedModelSelection = useRef(false);
 
@@ -141,7 +143,6 @@ export function ModelsGroups() {
       domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
       scope: selectedScope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined,
       signature: selectedSignature === '' ? undefined : selectedSignature,
-      clusteringMethod,
     },
     pause: selectedDomainId === '' || activeUseLegacyQuery,
     requestPolicy: 'cache-and-network',
@@ -308,12 +309,17 @@ export function ModelsGroups() {
         ) : (
           <div className="space-y-6">
             <ModelGroupsSection
-              clusterAnalysis={data?.domainAnalysis.clusterAnalysis}
+              clusterAnalysisByMethod={data?.domainAnalysis.clusterAnalysisByMethod}
+              distanceMethod={similarityMethod}
               models={visibleModels}
               clusteringMethod={clusteringMethod}
               onClusteringMethodChange={setClusteringMethod}
             />
-            <ModelSimilarityTableSection models={visibleModels} />
+            <ModelSimilarityTableSection
+              models={visibleModels}
+              method={similarityMethod}
+              onMethodChange={setSimilarityMethod}
+            />
           </div>
         )}
       </div>

--- a/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
+++ b/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
@@ -69,7 +69,7 @@ describe('ModelGroupsSection', () => {
   });
 
   it('renders the plain model groups heading without numbering', () => {
-    render(<ModelGroupsSection clusterAnalysis={skippedClusterAnalysis} models={populatedModels} />);
+    render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': skippedClusterAnalysis }} models={populatedModels} />);
 
     expect(screen.getByRole('heading', { name: 'Model Groups' })).toBeInTheDocument();
     expect(screen.getByText(/cluster analysis not available/i)).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe('ModelGroupsSection', () => {
   });
 
   it('offers group and individual views without heatmap', () => {
-    render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} models={populatedModels} />);
+    render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': populatedClusterAnalysis }} models={populatedModels} />);
 
     expect(screen.getByRole('button', { name: 'Groups' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Individual' })).toBeInTheDocument();
@@ -91,7 +91,7 @@ describe('ModelGroupsSection', () => {
   });
 
   it('lights up the selected legend item and fades the others', () => {
-    const { container } = render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} models={populatedModels} />);
+    const { container } = render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': populatedClusterAnalysis }} models={populatedModels} />);
 
     const legendButton = screen.getByRole('button', { name: 'Model A' });
     fireEvent.click(legendButton);
@@ -105,7 +105,7 @@ describe('ModelGroupsSection', () => {
   });
 
   it('allows multi-select in individual mode', () => {
-    const { container } = render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} models={populatedModels} />);
+    const { container } = render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': populatedClusterAnalysis }} models={populatedModels} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Individual' }));
 
@@ -134,7 +134,7 @@ describe('ModelGroupsSection', () => {
   it('shows a value tooltip with color rows and logit values on bar hover', () => {
     vi.useFakeTimers();
 
-    const { container } = render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} models={populatedModels} />);
+    const { container } = render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': populatedClusterAnalysis }} models={populatedModels} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Bar' }));
 
@@ -157,7 +157,7 @@ describe('ModelGroupsSection', () => {
   });
 
   it('shows the Schwartz category ring in radar view', () => {
-    render(<ModelGroupsSection clusterAnalysis={populatedClusterAnalysis} models={populatedModels} />);
+    render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': populatedClusterAnalysis }} models={populatedModels} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Radar' }));
 

--- a/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
@@ -20,6 +20,31 @@ const defaultSignatureData = {
   ],
 };
 
+const defaultClusterAnalysis = {
+  skipped: false,
+  skipReason: null,
+  defaultPair: null,
+  clusters: [
+    {
+      id: 'cluster-a',
+      name: 'Cluster A',
+      definingValues: ['Achievement'],
+      centroid: { Achievement: 1 },
+      members: [
+        {
+          model: 'model-a',
+          label: 'Model A',
+          silhouetteScore: 0.5,
+          isOutlier: false,
+          nearestClusterIds: null,
+          distancesToNearestClusters: null,
+        },
+      ],
+    },
+  ],
+  faultLinesByPair: {},
+};
+
 const defaultAnalysis = {
   domainAnalysis: {
     domainId: 'domain-a',
@@ -45,30 +70,8 @@ const defaultAnalysis = {
       },
     ],
     unavailableModels: [],
-    clusterAnalysis: {
-      skipped: false,
-      skipReason: null,
-      defaultPair: null,
-      clusters: [
-        {
-          id: 'cluster-a',
-          name: 'Cluster A',
-          definingValues: ['Achievement'],
-          centroid: { Achievement: 1 },
-          members: [
-            {
-              model: 'model-a',
-              label: 'Model A',
-              silhouetteScore: 0.5,
-              isOutlier: false,
-              nearestClusterIds: null,
-              distancesToNearestClusters: null,
-            },
-          ],
-        },
-      ],
-      faultLinesByPair: {},
-    },
+    clusterAnalysis: defaultClusterAnalysis,
+    clusterAnalysisByMethod: { 'log-odds-euclidean-upgma': defaultClusterAnalysis },
   },
 };
 
@@ -159,7 +162,7 @@ describe('ModelsGroups', () => {
     await waitFor(() => {
       expect(modelGroupsSectionMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          clusterAnalysis: defaultAnalysis.domainAnalysis.clusterAnalysis,
+          clusterAnalysisByMethod: defaultAnalysis.domainAnalysis.clusterAnalysisByMethod,
           models: expect.arrayContaining([
             expect.objectContaining({
               model: 'model-a',


### PR DESCRIPTION
## Summary
- Backend pre-computes 20 cluster analysis results at load time: 5 distance methods (cosine, euclidean, absolute-value, spearman, kendall) × 2 data sources (log-odds scores, domain-local win rates) × 2 linkage algorithms (UPGMA, Ward). All stored in `clusterAnalysisByMethod` on `DomainAnalysisResult`.
- The similarity table method selector now controls clustering distance too — changing "Cosine" / "Euclidean" etc. in the table instantly switches the model groups to that same distance method with zero additional latency.
- New **Data** toggle in Model Groups: **Log Odds** (smoothed log-odds ranking scores) vs **Win Rate** (domain-local per-vignette win rates, normalized to 0–1).
- Removed the now-redundant `clusteringMethod` GraphQL argument from `domainAnalysis`; linkage is selected entirely client-side from the pre-computed map.

## Validation
- `npm run lint --workspace @valuerank/api` — 0 errors
- `npm run build --workspace @valuerank/api` — clean
- `npm run lint --workspace @valuerank/web` — 0 errors
- `npm run build --workspace @valuerank/web` — clean

## Test plan
- [ ] Model Groups page loads; default clustering (log-odds, euclidean, UPGMA) renders groups
- [ ] Changing the Similarity Table method (e.g., Cosine → Spearman) updates the Model Groups clusters immediately
- [ ] Switching linkage (UPGMA ↔ Ward) updates clusters without a network request
- [ ] Switching data source (Log Odds ↔ Win Rate) produces different groupings when data differs
- [ ] "Individual" display mode still works independently of method selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)