### PR TITLE
Win-rate clustering: use win-rate centroids and update axes

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-clustering.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-clustering.ts
@@ -442,6 +442,7 @@ function runClusteringFromDistMatrix(
   distMatrix: number[][],
   valueKeys: string[],
   linkage: ClusteringMethod,
+  dataSource: ClusterDataSource = 'log-odds',
 ): ClusterAnalysis {
   const n = models.length;
 
@@ -464,7 +465,13 @@ function runClusteringFromDistMatrix(
     const id = `cluster-${ci + 1}`;
     const centroid: Record<string, number> = {};
     for (const vk of valueKeys) {
-      centroid[vk] = memberIndices.reduce((acc, mi) => acc + (models[mi]!.scores[vk] ?? 0), 0) / memberIndices.length;
+      centroid[vk] = memberIndices.reduce((acc, mi) => {
+        if (dataSource === 'win-rate') {
+          const wr = models[mi]!.winRates?.[vk];
+          return acc + (wr != null ? wr : 0);
+        }
+        return acc + (models[mi]!.scores[vk] ?? 0);
+      }, 0) / memberIndices.length;
     }
     const { name, definingValues } = nameCluster(centroid, valueKeys);
     const members: ClusterMember[] = memberIndices.map((mi) => {
@@ -536,7 +543,7 @@ export function computeAllClusterAnalyses(models: ClusterModelInput[]): Record<s
       const distMatrix = buildDistanceMatrixForMethod(models, distanceMethod, dataSource);
       for (const linkage of CLUSTER_LINKAGE_METHODS) {
         const key = `${dataSource}-${distanceMethod}-${linkage}`;
-        result[key] = runClusteringFromDistMatrix(models, distMatrix, valueKeys, linkage);
+        result[key] = runClusteringFromDistMatrix(models, distMatrix, valueKeys, linkage, dataSource);
       }
     }
   }

--- a/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterBarPlot.tsx
@@ -5,33 +5,44 @@ import { Tooltip } from '../ui/Tooltip';
 import {
   DOT_BAR_CLUSTER_SCORE_MAX,
   DOT_BAR_CLUSTER_SCORE_MIN,
+  DOT_BAR_WIN_RATE_MAX,
+  DOT_BAR_WIN_RATE_MIN,
+  WIN_RATE_MIDPOINT,
   formatClusterScoreLabel,
+  formatWinRateLabel,
   getClusterScorePosition,
   getClusterValueOrder,
   getClusterVisualColor,
   isClusterScoreClipped,
 } from './clusterVisualizationUtils';
 
+type ClusterDataSource = 'log-odds' | 'win-rate';
+
 type ClusterBarPlotProps = {
   clusters: DomainCluster[];
   activeGroupIds?: string[];
+  dataSource?: ClusterDataSource;
 };
 
 function ClusterValueTooltip({
   clusters,
   valueKey,
   rankedClusters,
+  dataSource = 'log-odds',
 }: {
   clusters: DomainCluster[];
   valueKey: ValueKey;
   rankedClusters: DomainCluster[];
+  dataSource?: ClusterDataSource;
 }) {
+  const formatScore = dataSource === 'win-rate' ? formatWinRateLabel : formatClusterScoreLabel;
+  const columnLabel = dataSource === 'win-rate' ? 'Win Rate' : 'Logit';
   return (
     <div className="min-w-[220px] max-w-[280px] whitespace-normal">
       <div className="mb-2 text-xs font-semibold text-gray-900">{VALUE_LABELS[valueKey]}</div>
       <div className="mb-1 grid grid-cols-[auto_1fr] gap-x-3 text-[10px] font-medium uppercase tracking-wide text-gray-500">
         <span>Color</span>
-        <span>Logit</span>
+        <span>{columnLabel}</span>
       </div>
       <div className="space-y-1.5">
         {rankedClusters.map((cluster) => {
@@ -47,7 +58,7 @@ function ClusterValueTooltip({
                 className="h-2.5 w-2.5 shrink-0 rounded-full"
                 style={{ backgroundColor: color }}
               />
-              <span className="font-mono text-xs text-gray-900">{formatClusterScoreLabel(score)}</span>
+              <span className="font-mono text-xs text-gray-900">{formatScore(score)}</span>
             </div>
           );
         })}
@@ -66,10 +77,16 @@ function getClusterBarOrder(clusters: DomainCluster[], valueKey: ValueKey): Doma
   });
 }
 
-export function ClusterBarPlot({ clusters, activeGroupIds = [] }: ClusterBarPlotProps) {
+export function ClusterBarPlot({ clusters, activeGroupIds = [], dataSource = 'log-odds' }: ClusterBarPlotProps) {
   const sortedValues = useMemo(() => getClusterValueOrder(clusters), [clusters]);
   const activeGroupSet = useMemo(() => new Set(activeGroupIds), [activeGroupIds]);
   const hasActiveSelection = activeGroupIds.length > 0;
+
+  const isWinRate = dataSource === 'win-rate';
+  const axisMin = isWinRate ? DOT_BAR_WIN_RATE_MIN : DOT_BAR_CLUSTER_SCORE_MIN;
+  const axisMax = isWinRate ? DOT_BAR_WIN_RATE_MAX : DOT_BAR_CLUSTER_SCORE_MAX;
+  const axisMidpoint = isWinRate ? WIN_RATE_MIDPOINT : 0;
+  const formatScore = isWinRate ? formatWinRateLabel : formatClusterScoreLabel;
 
   if (clusters.length === 0) {
     return null;
@@ -81,7 +98,7 @@ export function ClusterBarPlot({ clusters, activeGroupIds = [] }: ClusterBarPlot
         <div className="mb-2 flex items-center justify-between gap-2 text-[11px] text-gray-500">
           <span>Values ordered by average favorability across the shown clusters.</span>
           <span>
-            Fixed axis: {formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MIN)} to {formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MAX)} with 0 at the midpoint.
+            Fixed axis: {formatScore(axisMin)} to {formatScore(axisMax)} with {formatScore(axisMidpoint)} at the midpoint.
           </span>
         </div>
 
@@ -93,19 +110,16 @@ export function ClusterBarPlot({ clusters, activeGroupIds = [] }: ClusterBarPlot
               <div className="absolute right-0 top-0 text-xs text-gray-400">favored →</div>
               <div
                 className="absolute top-0 text-xs font-semibold text-gray-500"
-                style={{
-                  left: '50%',
-                  transform: 'translateX(-50%)',
-                }}
+                style={{ left: '50%', transform: 'translateX(-50%)' }}
               >
-                50/50
+                {isWinRate ? '50%' : '50/50'}
               </div>
             </div>
           </div>
 
           {sortedValues.map((valueKey) => {
             const label = VALUE_LABELS[valueKey];
-            const midpoint = getClusterScorePosition(0, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
+            const midpoint = getClusterScorePosition(axisMidpoint, axisMin, axisMax);
             const rankedClusters = getClusterBarOrder(clusters, valueKey);
 
             return (
@@ -118,20 +132,20 @@ export function ClusterBarPlot({ clusters, activeGroupIds = [] }: ClusterBarPlot
 
                   {rankedClusters.map((cluster, index) => {
                     const score = cluster.centroid[valueKey] ?? 0;
-                    const endPosition = getClusterScorePosition(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
+                    const endPosition = getClusterScorePosition(score, axisMin, axisMax);
                     const left = Math.min(midpoint, endPosition);
                     const width = Math.max(Math.abs(endPosition - midpoint), 1);
                     const clusterIndex = clusters.findIndex((candidate) => candidate.id === cluster.id);
                     const safeClusterIndex = clusterIndex >= 0 ? clusterIndex : 0;
                     const color = getClusterVisualColor(safeClusterIndex);
-                    const clipped = isClusterScoreClipped(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
+                    const clipped = isClusterScoreClipped(score, axisMin, axisMax);
                     const isActive = !hasActiveSelection || activeGroupSet.has(cluster.id);
                     const faded = hasActiveSelection && !isActive;
 
                     return (
                       <Tooltip
                         key={cluster.id}
-                        content={<ClusterValueTooltip clusters={clusters} valueKey={valueKey} rankedClusters={rankedClusters} />}
+                        content={<ClusterValueTooltip clusters={clusters} valueKey={valueKey} rankedClusters={rankedClusters} dataSource={dataSource} />}
                         position="top"
                         variant="light"
                         className="max-w-[300px] whitespace-normal"
@@ -167,21 +181,18 @@ export function ClusterBarPlot({ clusters, activeGroupIds = [] }: ClusterBarPlot
           <div className="flex items-center gap-2">
             <div className="w-32 shrink-0" />
             <div className="relative h-5 flex-1">
-              <div className="absolute left-0 top-0 text-xs text-gray-400">{formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MIN)}</div>
+              <div className="absolute left-0 top-0 text-xs text-gray-400">{formatScore(axisMin)}</div>
               <div
                 className="absolute top-0 text-xs font-semibold text-gray-500"
-                style={{
-                  left: '50%',
-                  transform: 'translateX(-50%)',
-                }}
+                style={{ left: '50%', transform: 'translateX(-50%)' }}
               >
-                0
+                {formatScore(axisMidpoint)}
               </div>
-              <div className="absolute right-0 top-0 text-xs text-gray-400">{formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MAX)}</div>
+              <div className="absolute right-0 top-0 text-xs text-gray-400">{formatScore(axisMax)}</div>
             </div>
           </div>
 
-          {clusters.some((cluster) => sortedValues.some((valueKey) => isClusterScoreClipped(cluster.centroid[valueKey] ?? 0, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX))) && (
+          {clusters.some((cluster) => sortedValues.some((valueKey) => isClusterScoreClipped(cluster.centroid[valueKey] ?? 0, axisMin, axisMax))) && (
             <p className="px-2 pb-1 text-[11px] text-amber-700">
               Scores outside the fixed range are pinned to the edge.
             </p>

--- a/cloud/apps/web/src/components/domains/ClusterDotPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterDotPlot.tsx
@@ -4,22 +4,35 @@ import { VALUE_LABELS } from '../../data/domainAnalysisData';
 import {
   DOT_BAR_CLUSTER_SCORE_MAX,
   DOT_BAR_CLUSTER_SCORE_MIN,
+  DOT_BAR_WIN_RATE_MAX,
+  DOT_BAR_WIN_RATE_MIN,
+  WIN_RATE_MIDPOINT,
   formatClusterScoreLabel,
+  formatWinRateLabel,
   getClusterScorePosition,
   getClusterValueOrder,
   getClusterVisualColor,
   isClusterScoreClipped,
 } from './clusterVisualizationUtils';
 
+type ClusterDataSource = 'log-odds' | 'win-rate';
+
 type ClusterDotPlotProps = {
   clusters: DomainCluster[];
   activeGroupIds?: string[];
+  dataSource?: ClusterDataSource;
 };
 
-export function ClusterDotPlot({ clusters, activeGroupIds = [] }: ClusterDotPlotProps) {
+export function ClusterDotPlot({ clusters, activeGroupIds = [], dataSource = 'log-odds' }: ClusterDotPlotProps) {
   const sortedValues = useMemo(() => getClusterValueOrder(clusters), [clusters]);
   const activeGroupSet = useMemo(() => new Set(activeGroupIds), [activeGroupIds]);
   const hasActiveSelection = activeGroupIds.length > 0;
+
+  const isWinRate = dataSource === 'win-rate';
+  const axisMin = isWinRate ? DOT_BAR_WIN_RATE_MIN : DOT_BAR_CLUSTER_SCORE_MIN;
+  const axisMax = isWinRate ? DOT_BAR_WIN_RATE_MAX : DOT_BAR_CLUSTER_SCORE_MAX;
+  const axisMidpoint = isWinRate ? WIN_RATE_MIDPOINT : 0;
+  const formatScore = isWinRate ? formatWinRateLabel : formatClusterScoreLabel;
 
   if (clusters.length === 0) {
     return null;
@@ -31,7 +44,7 @@ export function ClusterDotPlot({ clusters, activeGroupIds = [] }: ClusterDotPlot
         <div className="mb-2 flex items-center justify-between gap-2 text-[11px] text-gray-500">
           <span>Values ordered by average favorability across the shown clusters.</span>
           <span>
-            Fixed axis: {formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MIN)} to {formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MAX)} with 0 at the midpoint.
+            Fixed axis: {formatScore(axisMin)} to {formatScore(axisMax)} with {formatScore(axisMidpoint)} at the midpoint.
           </span>
         </div>
 
@@ -43,12 +56,9 @@ export function ClusterDotPlot({ clusters, activeGroupIds = [] }: ClusterDotPlot
               <div className="absolute right-0 top-0 text-xs text-gray-400">favored →</div>
               <div
                 className="absolute top-0 text-xs font-semibold text-gray-500"
-                style={{
-                  left: '50%',
-                  transform: 'translateX(-50%)',
-                }}
+                style={{ left: '50%', transform: 'translateX(-50%)' }}
               >
-                50/50
+                {isWinRate ? '50%' : '50/50'}
               </div>
             </div>
           </div>
@@ -65,17 +75,17 @@ export function ClusterDotPlot({ clusters, activeGroupIds = [] }: ClusterDotPlot
                   <div className="absolute bottom-1 top-1 w-px border-l border-dashed border-gray-200" style={{ left: '75%' }} />
                   {clusters.map((cluster, index) => {
                     const score = cluster.centroid[valueKey] ?? 0;
-                    const xPct = getClusterScorePosition(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
+                    const xPct = getClusterScorePosition(score, axisMin, axisMax);
                     const color = getClusterVisualColor(index);
                     const memberLabels = cluster.members.map((member) => member.label).join(', ');
-                    const clipped = isClusterScoreClipped(score, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX);
+                    const clipped = isClusterScoreClipped(score, axisMin, axisMax);
                     const isActive = !hasActiveSelection || activeGroupSet.has(cluster.id);
                     const faded = hasActiveSelection && !isActive;
 
                     return (
                       <div
                         key={cluster.id}
-                        title={`${memberLabels}: ${score.toFixed(2)}`}
+                        title={`${memberLabels}: ${formatScore(score)}`}
                         data-cluster-id={cluster.id}
                         data-value-key={valueKey}
                         className="absolute"
@@ -104,21 +114,18 @@ export function ClusterDotPlot({ clusters, activeGroupIds = [] }: ClusterDotPlot
           <div className="flex items-center gap-2">
             <div className="w-32 shrink-0" />
             <div className="relative h-5 flex-1">
-              <div className="absolute left-0 top-0 text-xs text-gray-400">{formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MIN)}</div>
+              <div className="absolute left-0 top-0 text-xs text-gray-400">{formatScore(axisMin)}</div>
               <div
                 className="absolute top-0 text-xs font-semibold text-gray-500"
-                style={{
-                  left: '50%',
-                  transform: 'translateX(-50%)',
-                }}
+                style={{ left: '50%', transform: 'translateX(-50%)' }}
               >
-                0
+                {formatScore(axisMidpoint)}
               </div>
-              <div className="absolute right-0 top-0 text-xs text-gray-400">{formatClusterScoreLabel(DOT_BAR_CLUSTER_SCORE_MAX)}</div>
+              <div className="absolute right-0 top-0 text-xs text-gray-400">{formatScore(axisMax)}</div>
             </div>
           </div>
 
-          {clusters.some((cluster) => sortedValues.some((valueKey) => isClusterScoreClipped(cluster.centroid[valueKey] ?? 0, DOT_BAR_CLUSTER_SCORE_MIN, DOT_BAR_CLUSTER_SCORE_MAX))) && (
+          {clusters.some((cluster) => sortedValues.some((valueKey) => isClusterScoreClipped(cluster.centroid[valueKey] ?? 0, axisMin, axisMax))) && (
             <p className="px-2 pb-1 text-[11px] text-amber-700">
               Scores outside the fixed range are pinned to the edge.
             </p>

--- a/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterRadarChart.tsx
@@ -8,9 +8,12 @@ import {
 } from './useDominanceGraph';
 import { getClusterVisualColor } from './clusterVisualizationUtils';
 
+type ClusterDataSource = 'log-odds' | 'win-rate';
+
 type ClusterRadarChartProps = {
   clusters: DomainCluster[];
   activeGroupIds?: string[];
+  dataSource?: ClusterDataSource;
 };
 
 const CHART_SIZE = 640;
@@ -23,6 +26,9 @@ const CATEGORY_LABEL_RADIUS = OUTER_RADIUS + 82;
 const RADAR_SCORE_MIN = -2.5;
 const RADAR_SCORE_MAX = 2.5;
 const RADAR_SCORE_RANGE = RADAR_SCORE_MAX - RADAR_SCORE_MIN;
+const RADAR_WIN_RATE_MIN = 0;
+const RADAR_WIN_RATE_MAX = 1;
+const RADAR_WIN_RATE_RANGE = RADAR_WIN_RATE_MAX - RADAR_WIN_RATE_MIN;
 
 function withAlpha(hexColor: string, alpha: number): string {
   const hex = hexColor.replace('#', '');
@@ -43,12 +49,16 @@ function getPoint(angle: number, radius: number) {
   };
 }
 
-function scoreToRadius(score: number): number {
+function scoreToRadius(score: number, dataSource: ClusterDataSource = 'log-odds'): number {
+  if (dataSource === 'win-rate') {
+    const clamped = Math.max(RADAR_WIN_RATE_MIN, Math.min(RADAR_WIN_RATE_MAX, score));
+    return ((clamped - RADAR_WIN_RATE_MIN) / RADAR_WIN_RATE_RANGE) * OUTER_RADIUS;
+  }
   const clamped = Math.max(RADAR_SCORE_MIN, Math.min(RADAR_SCORE_MAX, score));
   return ((clamped - RADAR_SCORE_MIN) / RADAR_SCORE_RANGE) * OUTER_RADIUS;
 }
 
-export function ClusterRadarChart({ clusters, activeGroupIds = [] }: ClusterRadarChartProps) {
+export function ClusterRadarChart({ clusters, activeGroupIds = [], dataSource = 'log-odds' }: ClusterRadarChartProps) {
   const valueAngles = useMemo(() => buildValueAngles(), []);
   const activeGroupSet = useMemo(() => new Set(activeGroupIds), [activeGroupIds]);
   const hasActiveSelection = activeGroupIds.length > 0;
@@ -64,12 +74,16 @@ export function ClusterRadarChart({ clusters, activeGroupIds = [] }: ClusterRada
     }),
     [activeGroupSet, clusters, hasActiveSelection],
   );
+  const radarMin = dataSource === 'win-rate' ? RADAR_WIN_RATE_MIN : RADAR_SCORE_MIN;
+  const radarMax = dataSource === 'win-rate' ? RADAR_WIN_RATE_MAX : RADAR_SCORE_MAX;
+  const radarRange = radarMax - radarMin;
+
   const hasClippedScores = useMemo(
     () => clusters.some((cluster) => DISPLAY_VALUES.some((valueKey) => {
       const score = cluster.centroid[valueKey] ?? 0;
-      return score < RADAR_SCORE_MIN || score > RADAR_SCORE_MAX;
+      return score < radarMin || score > radarMax;
     })),
-    [clusters],
+    [clusters, radarMin, radarMax],
   );
 
   if (clusters.length === 0) {
@@ -91,7 +105,10 @@ export function ClusterRadarChart({ clusters, activeGroupIds = [] }: ClusterRada
 
           {[0, 0.25, 0.5, 0.75, 1].map((fraction) => {
             const radius = OUTER_RADIUS * fraction;
-            const value = RADAR_SCORE_MIN + RADAR_SCORE_RANGE * fraction;
+            const value = radarMin + radarRange * fraction;
+            const label = dataSource === 'win-rate'
+              ? `${Math.round(value * 100)}%`
+              : value.toFixed(1);
             return (
               <g key={fraction}>
                 <circle cx={CENTER_X} cy={CENTER_Y} r={radius} fill="none" stroke="#e5e7eb" strokeWidth="1" />
@@ -109,7 +126,7 @@ export function ClusterRadarChart({ clusters, activeGroupIds = [] }: ClusterRada
                   y={CENTER_Y + 4}
                   className="fill-gray-400 text-[10px]"
                 >
-                  {value.toFixed(1)}
+                  {label}
                 </text>
               </g>
             );
@@ -189,7 +206,7 @@ export function ClusterRadarChart({ clusters, activeGroupIds = [] }: ClusterRada
             const points = orderedValues.map((valueKey) => {
               const angle = valueAngles.get(valueKey) ?? -Math.PI / 2;
               const score = cluster.centroid[valueKey] ?? 0;
-              return getPoint(angle, scoreToRadius(score));
+              return getPoint(angle, scoreToRadius(score, dataSource));
             });
 
             const path = points

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -316,9 +316,9 @@ export function ModelGroupsSection({
           </div>
         ) : (
           <>
-            {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} activeGroupIds={activeGroupIds} />}
-            {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} activeGroupIds={activeGroupIds} />}
-            {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} activeGroupIds={activeGroupIds} />}
+            {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} activeGroupIds={activeGroupIds} dataSource={groupDisplayMode === 'groups' ? dataSource : 'log-odds'} />}
+            {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} activeGroupIds={activeGroupIds} dataSource={groupDisplayMode === 'groups' ? dataSource : 'log-odds'} />}
+            {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} activeGroupIds={activeGroupIds} dataSource={groupDisplayMode === 'groups' ? dataSource : 'log-odds'} />}
 
             <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
               {clusters.map((cluster, index) => {

--- a/cloud/apps/web/src/components/domains/clusterVisualizationUtils.ts
+++ b/cloud/apps/web/src/components/domains/clusterVisualizationUtils.ts
@@ -9,6 +9,10 @@ export const DOT_BAR_CLUSTER_SCORE_MIN = -2.5;
 export const DOT_BAR_CLUSTER_SCORE_MAX = 2.5;
 export const DOT_BAR_CLUSTER_SCORE_RANGE = DOT_BAR_CLUSTER_SCORE_MAX - DOT_BAR_CLUSTER_SCORE_MIN;
 
+export const DOT_BAR_WIN_RATE_MIN = 0;
+export const DOT_BAR_WIN_RATE_MAX = 1;
+export const WIN_RATE_MIDPOINT = 0.5;
+
 export const CLUSTER_VISUAL_COLORS = [
   '#2563eb',
   '#d97706',
@@ -81,6 +85,10 @@ export function getClusterVisualColor(index: number): string {
 
 export function formatClusterScoreLabel(score: number): string {
   return score > 0 ? `+${score.toFixed(2)}` : score.toFixed(2);
+}
+
+export function formatWinRateLabel(rate: number): string {
+  return `${Math.round(rate * 100)}%`;
 }
 
 export function clampClusterScore(score: number, min = CLUSTER_SCORE_MIN, max = CLUSTER_SCORE_MAX): number {


### PR DESCRIPTION
## Summary
- **Backend**: `runClusteringFromDistMatrix` now takes a `dataSource` param; when `'win-rate'`, cluster centroids are computed from the model's win-rate vectors (0–1 scale) instead of log-odds scores. This means the cluster groups are now truly based on win-rate distances.
- **Frontend**: `ClusterBarPlot`, `ClusterDotPlot`, and `ClusterRadarChart` accept a `dataSource` prop. When `'win-rate'` is active, axes switch to 0%–100% with 50% at the midpoint, score labels render as percentages, and radar ring labels show `0%`/`25%`/`50%`/`75%`/`100%`. In individual mode the data-source toggle is hidden, so those charts always use log-odds axes.

## Test plan
- [ ] CI passes
- [ ] On `/models?scope=all-domains`, switch Data to "Win Rate" — clusters visually change and axes show 0%–100%
- [ ] Bar tooltip column reads "Win Rate" instead of "Logit"
- [ ] Radar ring labels show percentages
- [ ] Switching back to Log Odds restores the original `±2.50` axes

🤖 Generated with [Claude Code](https://claude.com/claude-code)