### PR TITLE
feat(api): include mirror conditions in pressure sensitivity Overall

### DIFF
--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-compute.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-compute.ts
@@ -255,21 +255,19 @@ function computeModelPushedEffects(
   const allPairKeys = new Set<string>();
 
   for (const d of domainAccum.values()) {
-    const dp = mean(d.push);
-    const db = mean(d.balanced);
-    const dm = mean(d.mirror);
-    if (dp != null && db != null) {
-      pushedForDomains.push(dp - db);
-      for (const pk of d.pairKeys) allPairKeys.add(pk);
-    }
-    if (db != null && dm != null) pushedAgainstDomains.push(db - dm);
+    const [dp, db, dm] = [mean(d.push), mean(d.balanced), mean(d.mirror)];
+    const fxs: number[] = [];
+    if (dp != null && db != null) { fxs.push(dp - db); for (const pk of d.pairKeys) allPairKeys.add(pk); }
+    if (db != null && dm != null) { fxs.push(db - dm); pushedAgainstDomains.push(db - dm); }
+    const fx = mean(fxs); if (fx != null) pushedForDomains.push(fx);
   }
 
   const domainPressureEffects: DomainPressureEffectShape[] = [...domainAccum.entries()]
     .filter(([dk]) => domainNameById.has(dk))
     .map(([dk, d]) => {
-      const [dp, db] = [mean(d.push), mean(d.balanced)];
-      return { domainId: dk, domainName: domainNameById.get(dk)!, pushedForEffect: dp != null && db != null ? dp - db : null };
+      const [dp, db, dm] = [mean(d.push), mean(d.balanced), mean(d.mirror)];
+      const fx = [dp != null && db != null ? dp - db : null, db != null && dm != null ? db - dm : null].filter((v): v is number => v != null);
+      return { domainId: dk, domainName: domainNameById.get(dk)!, pushedForEffect: mean(fx) };
     });
 
   return {

--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-types.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-types.ts
@@ -1,3 +1,3 @@
 export const PRESSURE_SENSITIVITY_SNAPSHOT_TYPE = 'pressure_sensitivity';
-export const PRESSURE_SENSITIVITY_SNAPSHOT_CODE_VERSION = '1.2.0';
+export const PRESSURE_SENSITIVITY_SNAPSHOT_CODE_VERSION = '1.3.0';
 export const PRESSURE_SENSITIVITY_ASSUMPTION_PREFIX = 'pressure-sensitivity';


### PR DESCRIPTION
## Summary
- The Overall column in Pressure Sensitivity by Domain was one-sided: it only measured the lift when the alphabetically-first value in a pair was under pressure (push conditions). Mirror conditions — where the second value is pushed — were never included.
- Each domain now contributes the average of its push effect (first value pushed vs. balanced) and its mirror effect (second value pushed vs. balanced). Per-domain cells in the breakdown table are updated the same way.
- Snapshot version bumped 1.2.0 → 1.3.0 to force recompute of stale snapshots.

## What this means conceptually
The Overall now matches what you'd get if you took every row in the Pressure Response by Value table, computed (high pressure on value − balanced) per row, and averaged across all values — modulo aggregation-order differences between the two reports. Previously it only captured half those rows.

## Test plan
- [ ] Preflight passed (lint + tests + build)
- [ ] Smoke test: load Pressure Sensitivity for a domain with data and confirm Overall values change
- [ ] Per-domain cells in the breakdown table still delta correctly relative to the new Overall

🤖 Generated with [Claude Code](https://claude.com/claude-code)