### PR TITLE
feat(web): reorder Conservation columns, clean up Value Priorities UI

### DIFF
--- a/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesSection.tsx
@@ -44,8 +44,8 @@ export function ValuePrioritiesSection({
           {showSectionHelp && <ValuePrioritiesHelpPanel />}
         </div>
         <div className="flex flex-col items-start gap-2 md:items-end">
-          <fieldset className="space-y-2">
-            <legend className="block text-xs font-medium text-gray-500">Cell metric</legend>
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-gray-500">Cell metric</span>
             <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
               {DISPLAY_METRICS.map((metric) => (
                 <Button
@@ -65,10 +65,7 @@ export function ValuePrioritiesSection({
                 </Button>
               ))}
             </div>
-          </fieldset>
-          <p className="text-xs text-gray-500">
-            Click a column heading to sort by the selected metric.
-          </p>
+          </div>
         </div>
       </div>
 

--- a/cloud/apps/web/src/components/domains/ValuePrioritiesTable.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesTable.tsx
@@ -22,8 +22,8 @@ type SortState = {
 const COLUMN_VALUES: ValueKey[] = [
   'Universalism_Nature',
   'Benevolence_Dependability',
-  'Conformity_Interpersonal',
   'Tradition',
+  'Conformity_Interpersonal',
   'Security_Personal',
   'Power_Dominance',
   'Achievement',
@@ -34,7 +34,7 @@ const COLUMN_VALUES: ValueKey[] = [
 
 const TOP_COLUMN_GROUPS: Array<{ label: string; values: ValueKey[] }> = [
   { label: 'Self-Transcendence', values: ['Universalism_Nature', 'Benevolence_Dependability'] },
-  { label: 'Conservation', values: ['Conformity_Interpersonal', 'Tradition', 'Security_Personal'] },
+  { label: 'Conservation', values: ['Tradition', 'Conformity_Interpersonal', 'Security_Personal'] },
   { label: 'Self-Enhancement', values: ['Power_Dominance', 'Achievement'] },
   { label: 'Openness to Change', values: ['Hedonism', 'Stimulation', 'Self_Direction_Action'] },
 ];
@@ -53,7 +53,7 @@ type ValuePrioritiesTableProps = {
 function hasGroupStartBorder(value: ValueKey): boolean {
   return (
     value === 'Universalism_Nature' ||
-    value === 'Conformity_Interpersonal' ||
+    value === 'Tradition' ||
     value === 'Power_Dominance'
   );
 }

--- a/cloud/apps/web/src/components/domains/useDominanceGraph.ts
+++ b/cloud/apps/web/src/components/domains/useDominanceGraph.ts
@@ -106,7 +106,7 @@ export function buildValueAngles(): Map<ValueKey, number> {
   });
 
   const conservation = QUADRANT_ARCS[1];
-  ['Conformity_Interpersonal', 'Tradition', 'Security_Personal'].forEach((value, index) => {
+  ['Tradition', 'Conformity_Interpersonal', 'Security_Personal'].forEach((value, index) => {
     const t = (index + 0.5) / 3;
     result.set(
       value as ValueKey,

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -25,7 +25,6 @@ import {
 } from '../api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { DominanceSection } from '../components/domains/DominanceSection';
-import { SimilaritySection } from '../components/domains/SimilaritySection';
 import { ValuePrioritiesSection } from '../components/domains/ValuePrioritiesSection';
 import {
   VALUES,
@@ -445,7 +444,6 @@ export function DomainAnalysis() {
             models={models}
             defaultModelIds={defaultModelIds}
           />
-          <SimilaritySection models={visibleModels} />
         </>
       )}
 

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -166,10 +166,6 @@ vi.mock('../../src/components/domains/DominanceSection', () => ({
   DominanceSection: () => <div>Mock dominance section</div>,
 }));
 
-vi.mock('../../src/components/domains/SimilaritySection', () => ({
-  SimilaritySection: () => <div>Mock similarity section</div>,
-}));
-
 vi.mock('../../src/components/domains/ValuePrioritiesSection', () => ({
   ValuePrioritiesSection: (props: unknown) => valuePrioritiesSectionMock(props),
 }));
@@ -212,11 +208,9 @@ describe('DomainAnalysis', () => {
     const findingsHeading = screen.getByRole('heading', { name: 'Findings' });
     const valuePriorities = screen.getByText(/mock value priorities section/i);
     const dominance = screen.getByText(/mock dominance section/i);
-    const similarity = screen.getByText(/mock similarity section/i);
 
     expect(domainSelection.compareDocumentPosition(findingsHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(valuePriorities.compareDocumentPosition(dominance) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(dominance.compareDocumentPosition(similarity) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('defaults the scope dropdown to all domains when no domain is selected', async () => {


### PR DESCRIPTION
## Summary

- Reorder Conservation group to **Tradition → Conformity → Security** in the Value Priorities table and the Ranking & Cycles chart (clockwise)
- Move **Cell metric** label inline beside the Win rate / Logit toggle (was stacked above)
- Remove "Click a column heading to sort by the selected metric" hint text
- Remove **Similarities and Differences** table from the bottom of the domain analysis page

## Validation

- `npm run build --workspace @valuerank/web` — ✅ pass (tsc + vite, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)