### PR TITLE
Condition-detail picks aggregate-kind-matching companion + clarify Pooled label

### DIFF
--- a/cloud/apps/web/src/pages/AnalysisConditionDetail.tsx
+++ b/cloud/apps/web/src/pages/AnalysisConditionDetail.tsx
@@ -115,7 +115,8 @@ export function AnalysisConditionDetail() {
   // (Definition.pairedSibling) over the legacy run-proximity heuristic. Order:
   //   1. ?companionRunId= URL hint (caller already picked a run)
   //   2. run.companionRunId (run config has a direct link)
-  //   3. The most-recent COMPLETED non-aggregate run of run.definition.pairedSibling
+  //   3. The most-recent COMPLETED run of run.definition.pairedSibling,
+  //      preferring the same aggregate kind when possible
   const directCompanionRunId = run?.companionRunId ?? null;
   const pairedSiblingDefinitionId = run?.definition?.pairedSibling?.id ?? null;
   const hasExplicitCompanionId = companionRunIdHint != null || directCompanionRunId != null;
@@ -130,18 +131,31 @@ export function AnalysisConditionDetail() {
 
   const siblingFallbackRunId = useMemo(() => {
     if (siblingRuns == null || siblingRuns.length === 0) return null;
-    const completedNonAggregate = siblingRuns.filter(
-      (candidate) => candidate.status === 'COMPLETED'
-        && candidate.id !== run?.id
-        && !candidate.tags?.some((tag) => tag.name === 'Aggregate'),
+    const currentIsAggregate = run?.isAggregate === true
+      || run?.tags?.some((tag) => tag.name === 'Aggregate') === true;
+    const isAggregateKind = (candidate: Run) => (
+      candidate.isAggregate === true
+      || candidate.tags?.some((tag) => tag.name === 'Aggregate') === true
     );
-    const pool = completedNonAggregate.length > 0 ? completedNonAggregate : siblingRuns;
-    const sorted = [...pool].sort((left, right) => (
-      new Date(right.completedAt ?? right.createdAt).getTime()
-      - new Date(left.completedAt ?? left.createdAt).getTime()
-    ));
+    const completedSiblingRuns = siblingRuns.filter(
+      (candidate) => candidate.status === 'COMPLETED' && candidate.id !== run?.id,
+    );
+    const sameKindRuns = completedSiblingRuns.filter(
+      (candidate) => isAggregateKind(candidate) === currentIsAggregate,
+    );
+    const pool = sameKindRuns.length > 0
+      ? sameKindRuns
+      : completedSiblingRuns;
+    const sorted = [...pool].sort((left, right) => {
+      const leftMatchesCurrentKind = isAggregateKind(left) === currentIsAggregate;
+      const rightMatchesCurrentKind = isAggregateKind(right) === currentIsAggregate;
+
+      return Number(rightMatchesCurrentKind) - Number(leftMatchesCurrentKind)
+        || new Date(right.completedAt ?? right.createdAt).getTime()
+        - new Date(left.completedAt ?? left.createdAt).getTime();
+    });
     return sorted[0]?.id ?? null;
-  }, [run?.id, siblingRuns]);
+  }, [run?.id, run?.isAggregate, run?.tags, siblingRuns]);
 
   const resolvedCompanionRunId = companionRunIdHint ?? directCompanionRunId ?? siblingFallbackRunId ?? null;
 
@@ -233,7 +247,7 @@ export function AnalysisConditionDetail() {
 
       rows.push(buildDetailRow(
         'pooled',
-        'Pooled',
+        'Both directions combined',
         pooledTranscripts,
         makeBaseSearch({
           companionRunId,

--- a/cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx
+++ b/cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx
@@ -157,6 +157,8 @@ function createRun(
     id,
     name,
     createdAt: id === 'run-1' ? '2026-03-10T10:00:00Z' : '2026-03-10T10:05:00Z',
+    status: 'COMPLETED',
+    isAggregate: false,
     analysisStatus: 'completed',
     config: {
       jobChoiceLaunchMode: 'PAIRED_BATCH',
@@ -293,7 +295,7 @@ describe('AnalysisConditionDetail', () => {
     expect(screen.getByText('Condition Detail')).toBeInTheDocument();
     expect(screen.getByText('Freedom = High, Harmony = Low')).toBeInTheDocument();
     expect(screen.getByText('model1')).toBeInTheDocument();
-    expect(screen.getByText('Pooled')).toBeInTheDocument();
+    expect(screen.getByText('Both directions combined')).toBeInTheDocument();
     expect(screen.getByText('Freedom -> Harmony')).toBeInTheDocument();
     expect(screen.getByText('Harmony -> Freedom')).toBeInTheDocument();
     expect(screen.getByText('Strongly favors Freedom')).toBeInTheDocument();
@@ -304,7 +306,7 @@ describe('AnalysisConditionDetail', () => {
     expect(screen.getByText('Unknown Count')).toBeInTheDocument();
     expect(screen.queryByText('Mean')).not.toBeInTheDocument();
     expect(screen.getByText('Canonical transcript counts by decision label. Click any non-zero count to open the matching transcripts.')).toBeInTheDocument();
-    const row = screen.getByText('Pooled').closest('tr');
+    const row = screen.getByText('Both directions combined').closest('tr');
     expect(row).not.toBeNull();
     expect(within(row as HTMLElement).getAllByRole('button').length).toBeGreaterThan(0);
   });
@@ -475,9 +477,9 @@ describe('AnalysisConditionDetail', () => {
     ]);
   });
 
-  it('routes a pooled row count click to the matching transcript slice', () => {
+  it('routes a combined row count click to the matching transcript slice', () => {
     renderPage('/analysis/run-1/conditions/High%7C%7CLow?rowDim=Freedom&colDim=Harmony&modelId=model1&mode=paired');
-    const row = screen.getByText('Pooled').closest('tr');
+    const row = screen.getByText('Both directions combined').closest('tr');
     expect(row).not.toBeNull();
 
     const buttons = within(row as HTMLElement).getAllByRole('button');
@@ -695,7 +697,7 @@ describe('AnalysisConditionDetail', () => {
       renderPage('/analysis/run-1/conditions/High%7C%7CLow?rowDim=Freedom&colDim=Harmony&modelId=model1&mode=paired');
 
       // Paired rows must appear (companion was resolved via direct link)
-      expect(screen.getByText('Pooled')).toBeInTheDocument();
+      expect(screen.getByText('Both directions combined')).toBeInTheDocument();
       expect(screen.getByText('Freedom -> Harmony')).toBeInTheDocument();
       expect(screen.getByText('Harmony -> Freedom')).toBeInTheDocument();
 
@@ -745,7 +747,7 @@ describe('AnalysisConditionDetail', () => {
       renderPage('/analysis/run-1/conditions/High%7C%7CLow?rowDim=Freedom&colDim=Harmony&modelId=model1&mode=paired');
 
       // Paired rows must appear (companion resolved via pairedSibling -> sibling runs)
-      expect(screen.getByText('Pooled')).toBeInTheDocument();
+      expect(screen.getByText('Both directions combined')).toBeInTheDocument();
       expect(screen.getByText('Freedom -> Harmony')).toBeInTheDocument();
       expect(screen.getByText('Harmony -> Freedom')).toBeInTheDocument();
 
@@ -756,6 +758,72 @@ describe('AnalysisConditionDetail', () => {
           ([args]) => args?.pause === false && args?.definitionId === 'def-run-2',
         ),
       ).toBe(true);
+    });
+
+    it('matches the aggregate-kind of the current run when picking from sibling runs', () => {
+      const baseCurrent = createRun('run-1', 'A_first', [
+        createTranscript('tx-1', 's1', 'A_first', '5'),
+      ]);
+      const currentRun = {
+        ...baseCurrent,
+        isAggregate: true,
+        definition: {
+          ...baseCurrent.definition,
+          pairedSibling: { id: 'def-run-2', name: 'Harmony -> Freedom', content: {} },
+        },
+      };
+      const aggregateSibling = {
+        ...createRun('run-agg', 'B_first', [
+          createTranscript('tx-agg', 's2', 'B_first', '1'),
+        ]),
+        isAggregate: true,
+        completedAt: '2026-04-30T10:00:00Z',
+      };
+      const nonAggregateSibling = {
+        ...createRun('run-solo', 'B_first', [
+          createTranscript('tx-solo', 's3', 'B_first', '1'),
+        ]),
+        completedAt: '2026-04-03T10:00:00Z',
+      };
+
+      mockUseRun.mockImplementation((args?: { id?: string }) => {
+        if (args?.id === 'run-agg') {
+          return { run: aggregateSibling, loading: false, error: null, refetch: vi.fn() };
+        }
+        if (args?.id === 'run-solo') {
+          return { run: nonAggregateSibling, loading: false, error: null, refetch: vi.fn() };
+        }
+        return { run: currentRun, loading: false, error: null, refetch: vi.fn() };
+      });
+
+      mockUseRuns.mockImplementation((args?: { definitionId?: string; pause?: boolean }) => {
+        if (args?.pause === false && args?.definitionId === 'def-run-2') {
+          return {
+            runs: [nonAggregateSibling, aggregateSibling],
+            loading: false,
+            error: null,
+            refetch: vi.fn(),
+          };
+        }
+        return { runs: [], loading: false, error: null, refetch: vi.fn() };
+      });
+
+      mockUseAnalysis.mockImplementation((args?: { runId?: string; pause?: boolean }) => {
+        if (args?.pause) return { analysis: null, loading: false, error: null, refetch: vi.fn(), recompute: vi.fn(), recomputing: false };
+        if (args?.runId === 'run-agg') return { analysis: createAnalysis('run-agg', 's2'), loading: false, error: null, refetch: vi.fn(), recompute: vi.fn(), recomputing: false };
+        if (args?.runId === 'run-solo') return { analysis: createAnalysis('run-solo', 's3'), loading: false, error: null, refetch: vi.fn(), recompute: vi.fn(), recomputing: false };
+        return { analysis: createAnalysis('run-1', 's1'), loading: false, error: null, refetch: vi.fn(), recompute: vi.fn(), recomputing: false };
+      });
+
+      renderPage('/analysis/run-1/conditions/High%7C%7CLow?rowDim=Freedom&colDim=Harmony&modelId=model1&mode=paired');
+
+      expect(screen.getByText('Both directions combined')).toBeInTheDocument();
+      expect(
+        (mockUseRun.mock.calls as Array<[{ id?: string }]>).some(([args]) => args?.id === 'run-agg'),
+      ).toBe(true);
+      expect(
+        (mockUseRun.mock.calls as Array<[{ id?: string }]>).some(([args]) => args?.id === 'run-solo'),
+      ).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Two fixes following PR #933:

1. **Aggregate-kind matching for companion selection.** When the current run on `/analysis/<runId>/conditions/...?mode=paired` is an aggregate, the companion picker was excluding aggregate sibling runs and silently grabbing a small non-aggregate sibling whose transcripts did not cover the cell. Now the picker matches the current run's `isAggregate` kind: aggregate → aggregate, non-aggregate → non-aggregate. Falls back to the opposite kind only when no same-kind sibling exists.

2. **Renames the "Pooled" row label to "Both directions combined"** so the row's meaning is self-explanatory. Row contents are unchanged (transcripts from both vignettes for the same cell, merged).

## Reported regression

URL: `/analysis/cmndi250101168yvcmp305k5k/conditions/negligible%7C%7Cminimal?...&mode=paired`

The current run is a 1275-transcript aggregate. PR #933 picked a 25-transcript non-aggregate sibling because aggregates were filtered out unconditionally. Result: companion row showed 0 trials. The matching 1525-transcript aggregate sibling existed and should have been picked.

## Test plan

- [x] `npm run lint --workspace @valuerank/web` — 0 errors
- [x] `npm run test --workspace @valuerank/web` — 1400 passed, 8 skipped (one new test added)
- [x] `npm run build --workspace @valuerank/web` — clean
- [ ] Manual smoke (post-deploy): reload the URL above and confirm both directions populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)