### PR TITLE
[codex] Rename Domain Analysis to Win Rate and embed Domain Shifts

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -90,7 +90,7 @@ Once the above are resolved:
 
 ### Analysis Reports
 - [x] Model Groups page now includes a win-rate similarity table with method toggles for weighted Euclidean, cosine, Spearman, and Kendall, plus a distance/similarity view toggle and per-pair detail drawer.
-- [x] Domain Shifts by Value heatmap implemented at `/models/domain-shifts`; focused tests and web preflight pass.
+- [x] Win Rate page now includes the Domain Shifts report at the bottom of `/models/win-rate`; focused tests and web preflight pass.
 - [x] Domain Shifts readability controls added locally: cells can toggle between shift and raw win rate, and table columns are sortable.
 - [x] Domain Shifts model picker now groups default models first and separates non-default models with `---` before alphabetical non-default options.
 - [x] Model Groups visualization now lives at `/models` under the Models dropdown first item, with the domain selection bar at the top of the page driving the report.
@@ -98,7 +98,7 @@ Once the above are resolved:
 - [x] Domain Shifts by Value now has an `All models` aggregate view, one-decimal formatting throughout, and content-fit Value / Avg Win Rate columns in the local branch.
 - [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, the all-domains value priorities table now includes stability circles, and the comparison table stays below it.
 - [x] `/models` reporting now uses the canonical equal-vignette methodology in both tables, with one-decimal display, vignette-weighted cross-domain pooling, and no silent fallback to pooled raw counts when vignette-aware data is missing.
-- [x] Domain Analysis findings controls now live at the top of the page, and the model focus selector applies across the model groups, value priorities, dominance, and similarity sections.
+- [x] Win Rate findings controls now live at the top of the page, and the model focus selector applies across the model groups, value priorities, dominance, similarity, and embedded Domain Shifts sections.
 - [x] Value Priorities now uses win rate only, with the retired Full BT toggle removed and the cell dots rendered under the numbers.
 - [x] Pressure Sensitivity page now includes a **Pressure Directional Breakdown** cross-model table showing pushed-for effect, pushed-against effect, gap, and pairs per model. Answers: "Does pressure work equally in both directions?" PR #834.
 - [x] Pressure Sensitivity now uses the standard default-model multi-select, keeps the tooltip anchored while scrolling, and moves the cross-model response table to the bottom of the report.

--- a/cloud/apps/web/src/App.tsx
+++ b/cloud/apps/web/src/App.tsx
@@ -16,7 +16,6 @@ import { DomainStatus } from './pages/DomainStatus';
 import { DomainAnalysis } from './pages/DomainAnalysis';
 import { DomainCoverage } from './pages/DomainCoverage';
 import { DomainAnalysisValueDetail } from './pages/DomainAnalysisValueDetail';
-import { DomainValueShiftHeatmap } from './pages/DomainValueShiftHeatmap';
 import { ModelsGroups } from './pages/ModelsGroups';
 import { ModelsConsistency } from './pages/ModelsConsistency';
 import { PressureSensitivity } from './pages/PressureSensitivity';
@@ -81,7 +80,7 @@ function App() {
             <Route path="/login" element={<Login />} />
 
             {/* Protected routes with layout */}
-            <Route path="/" element={<Navigate to="/domains/analysis" replace />} />
+            <Route path="/" element={<Navigate to="/models/win-rate" replace />} />
             <Route
               path="/status"
               element={
@@ -155,7 +154,7 @@ function App() {
               }
             />
             <Route
-              path="/domains/analysis"
+              path="/models/win-rate"
               element={
                 <ProtectedLayout>
                   <DomainAnalysis />
@@ -175,14 +174,6 @@ function App() {
               element={
                 <ProtectedLayout>
                   <ModelsGroups />
-                </ProtectedLayout>
-              }
-            />
-            <Route
-              path="/models/domain-shifts"
-              element={
-                <ProtectedLayout>
-                  <DomainValueShiftHeatmap />
                 </ProtectedLayout>
               }
             />
@@ -229,7 +220,7 @@ function App() {
               }
             />
             <Route
-              path="/domains/analysis/value-detail"
+              path="/models/win-rate/value-detail"
               element={
                 <ProtectedLayout fullWidth>
                   <DomainAnalysisValueDetail />

--- a/cloud/apps/web/src/components/domains/ValuePrioritiesTable.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesTable.tsx
@@ -162,7 +162,7 @@ export function ValuePrioritiesTable({
       valueKey,
     });
     if (selectedSignature !== null) params.set('signature', selectedSignature);
-    navigate(`/domains/analysis/value-detail?${params.toString()}`);
+    navigate(`/models/win-rate/value-detail?${params.toString()}`);
   };
 
   return (

--- a/cloud/apps/web/src/components/layout/Header.tsx
+++ b/cloud/apps/web/src/components/layout/Header.tsx
@@ -55,8 +55,7 @@ const domainMenuItems: MenuItem[] = [
 
 const modelsMenuItems: MenuItem[] = [
   { name: 'Model Groups', path: '/models', match: 'exact' },
-  { name: 'Domain Analysis', path: '/domains/analysis' },
-  { name: 'Domain Shifts', path: '/models/domain-shifts' },
+  { name: 'Win Rate', path: '/models/win-rate' },
   { name: 'Pressure Sensitivity', path: '/models/pressure-sensitivity' },
   { name: 'Confidence', path: '/models/confidence' },
 ];

--- a/cloud/apps/web/src/components/layout/MobileNav.tsx
+++ b/cloud/apps/web/src/components/layout/MobileNav.tsx
@@ -24,8 +24,7 @@ const navItems: NavItem[] = [
     activateWithChildren: true,
     children: [
       { name: 'Model Groups', path: '/models', icon: Cpu, match: 'exact' },
-      { name: 'Domain Analysis', path: '/domains/analysis', icon: BarChart2 },
-      { name: 'Domain Shifts', path: '/models/domain-shifts', icon: BarChart2 },
+      { name: 'Win Rate', path: '/models/win-rate', icon: BarChart2 },
       { name: 'Pressure Sensitivity', path: '/models/pressure-sensitivity', icon: BarChart2 },
     ],
   },

--- a/cloud/apps/web/src/components/layout/NavTabs.tsx
+++ b/cloud/apps/web/src/components/layout/NavTabs.tsx
@@ -36,8 +36,7 @@ const domainMenuItems: MenuItem[] = [
 
 const modelsMenuItems: MenuItem[] = [
   { name: 'Model Groups', path: '/models', match: 'exact' },
-  { name: 'Domain Analysis', path: '/domains/analysis' },
-  { name: 'Domain Shifts', path: '/models/domain-shifts' },
+  { name: 'Win Rate', path: '/models/win-rate' },
   { name: 'Pressure Sensitivity', path: '/models/pressure-sensitivity' },
   { name: 'Confidence', path: '/models/confidence' },
 ];

--- a/cloud/apps/web/src/components/models/ConsistencyDrill.tsx
+++ b/cloud/apps/web/src/components/models/ConsistencyDrill.tsx
@@ -26,7 +26,7 @@ function conditionMatrixUrl(args: { domainId: string; modelId: string; valueKey:
     valueKey: args.valueKey,
     signature: args.signature,
   });
-  return `/domains/analysis/value-detail?${params.toString()}`;
+  return `/models/win-rate/value-detail?${params.toString()}`;
 }
 
 type PerPair = ModelsConsistencyModel['coherence']['perPair'][number];

--- a/cloud/apps/web/src/components/models/DomainShiftsReportSection.tsx
+++ b/cloud/apps/web/src/components/models/DomainShiftsReportSection.tsx
@@ -1,0 +1,378 @@
+import { useMemo, useRef, useState } from 'react';
+import type { ModelsAnalysisModelResult } from '../../api/operations/modelsAnalysis';
+import { cn } from '../../lib/utils';
+import { Button } from '../ui/Button';
+import { CopyVisualButton } from '../ui/CopyVisualButton';
+import { ErrorMessage } from '../ui/ErrorMessage';
+import { Loading } from '../ui/Loading';
+import {
+  buildDomainShiftHeatmap,
+  DEFAULT_DOMAIN_SHIFT_SORT,
+  formatEvidenceWeight,
+  formatPercent,
+  formatPointShift,
+  getNextDomainShiftSort,
+  type DomainShiftCell,
+  type DomainShiftDisplayMode,
+  type DomainShiftSort,
+  type DomainShiftSortKey,
+  sortHeatmapRows,
+} from '../../pages/domainValueShiftHeatmapUtils';
+
+type DomainShiftsReportSectionProps = {
+  models: ModelsAnalysisModelResult[];
+  selectedModelIds: string[];
+  defaultModelIds: string[];
+  fetching?: boolean;
+  errorMessage?: string | null;
+};
+
+function getCellToneClass(shift: number): string {
+  const clamped = Math.max(-25, Math.min(25, shift));
+  const intensity = Math.abs(clamped) / 25;
+  if (Math.abs(shift) < 0.5) {
+    return 'border-gray-200 bg-gray-50 text-gray-700';
+  }
+  if (shift > 0) {
+    return intensity > 0.66
+      ? 'border-emerald-300 bg-emerald-100 text-emerald-900'
+      : intensity > 0.33
+        ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+        : 'border-emerald-100 bg-emerald-50/60 text-emerald-700';
+  }
+  return intensity > 0.66
+    ? 'border-rose-300 bg-rose-100 text-rose-900'
+    : intensity > 0.33
+      ? 'border-rose-200 bg-rose-50 text-rose-800'
+      : 'border-rose-100 bg-rose-50/60 text-rose-700';
+}
+
+function getWinRateToneClass(winRate: number): string {
+  if (winRate >= 75) return 'border-sky-300 bg-sky-100 text-sky-950';
+  if (winRate >= 50) return 'border-sky-200 bg-sky-50 text-sky-900';
+  if (winRate >= 25) return 'border-gray-200 bg-gray-50 text-gray-800';
+  return 'border-slate-200 bg-slate-50 text-slate-700';
+}
+
+function getSortDirectionLabel(direction: DomainShiftSort['direction']): 'ascending' | 'descending' {
+  return direction === 'asc' ? 'ascending' : 'descending';
+}
+
+function getNextSortDirectionLabel(sort: DomainShiftSort, key: DomainShiftSortKey): 'ascending' | 'descending' {
+  if (sort.key !== key) return key === 'value' ? 'ascending' : 'descending';
+  return sort.direction === 'asc' ? 'descending' : 'ascending';
+}
+
+function SortableHeader({
+  label,
+  sortKey,
+  sort,
+  onSort,
+  align = 'center',
+  className,
+}: {
+  label: string;
+  sortKey: DomainShiftSortKey;
+  sort: DomainShiftSort;
+  onSort: (sort: DomainShiftSort) => void;
+  align?: 'left' | 'center' | 'right';
+  className?: string;
+}) {
+  const isActive = sort.key === sortKey;
+  const nextDirection = getNextSortDirectionLabel(sort, sortKey);
+
+  return (
+    <th
+      scope="col"
+      aria-sort={isActive ? getSortDirectionLabel(sort.direction) : 'none'}
+      className={cn(
+        'border-b border-gray-200 bg-white px-2 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-gray-500',
+        className,
+      )}
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => onSort(getNextDomainShiftSort(sort, sortKey))}
+        className={cn(
+          'w-full gap-1 rounded-none bg-transparent px-0 py-0 min-h-0 text-[11px] font-semibold uppercase tracking-wide text-gray-500 shadow-none transition-colors hover:bg-transparent hover:text-gray-900 focus:ring-0 focus:ring-offset-0',
+          align === 'left' && 'justify-start text-left',
+          align === 'center' && 'justify-center text-center',
+          align === 'right' && 'justify-end text-right',
+          isActive && 'text-teal-700',
+        )}
+        aria-label={`Sort by ${label} ${nextDirection}`}
+      >
+        <span className="whitespace-nowrap">{label}</span>
+        {isActive && (
+          <span aria-hidden="true" className="text-[11px] leading-none text-gray-400">
+            {sort.direction === 'desc' ? '↑' : '↓'}
+          </span>
+        )}
+      </Button>
+    </th>
+  );
+}
+
+function DisplayModeToggle({
+  displayMode,
+  onChange,
+}: {
+  displayMode: DomainShiftDisplayMode;
+  onChange: (displayMode: DomainShiftDisplayMode) => void;
+}) {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="block text-sm font-medium text-gray-700">Cell metric</legend>
+      <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+        {([
+          ['shift', 'Shift vs avg'],
+          ['winRate', 'Raw win rate'],
+        ] as const).map(([mode, label]) => (
+          <Button
+            key={mode}
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-pressed={displayMode === mode}
+            onClick={() => onChange(mode)}
+            className={cn(
+              'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+              displayMode === mode
+                ? 'bg-white text-teal-800 shadow-sm ring-1 ring-teal-200'
+                : 'text-gray-600 hover:text-gray-900',
+            )}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+function Cell({
+  cell,
+  valueLabel,
+  displayMode,
+  evidenceLabel,
+}: {
+  cell: DomainShiftCell | null;
+  valueLabel: string;
+  displayMode: DomainShiftDisplayMode;
+  evidenceLabel: string;
+}) {
+  if (cell == null) {
+    return <span className="inline-flex w-full justify-center text-xs font-semibold text-gray-400">n/a</span>;
+  }
+
+  const detail = `${valueLabel} in ${cell.domainName}: raw win rate ${formatPercent(cell.winRate)}; shift ${formatPointShift(cell.shift)} versus this value's equal-domain average; average ${formatPercent(cell.averageWinRate)}; ${evidenceLabel} ${formatEvidenceWeight(cell.evidenceWeight)}.`;
+  const visibleValue = displayMode === 'shift' ? formatPointShift(cell.shift) : formatPercent(cell.winRate);
+
+  return (
+    <span className="inline-flex w-full justify-center text-xs font-semibold" title={detail} aria-label={detail}>
+      {visibleValue}
+    </span>
+  );
+}
+
+export function DomainShiftsReportSection({
+  models,
+  selectedModelIds,
+  defaultModelIds,
+  fetching = false,
+  errorMessage = null,
+}: DomainShiftsReportSectionProps) {
+  const [displayMode, setDisplayMode] = useState<DomainShiftDisplayMode>('shift');
+  const [sort, setSort] = useState<DomainShiftSort>(DEFAULT_DOMAIN_SHIFT_SORT);
+  const tableRef = useRef<HTMLDivElement>(null);
+
+  const selectedModelIdSet = useMemo(() => new Set(selectedModelIds), [selectedModelIds]);
+  const defaultModelIdSet = useMemo(() => new Set(defaultModelIds), [defaultModelIds]);
+  const selectedModels = useMemo(
+    () => (selectedModelIds.length === 0 ? [] : models.filter((model) => selectedModelIdSet.has(model.modelId))),
+    [models, selectedModelIds.length, selectedModelIdSet],
+  );
+  const isDefaultSelection = useMemo(() => (
+    selectedModels.length > 0
+    && selectedModels.length === defaultModelIds.length
+    && selectedModels.every((model) => defaultModelIdSet.has(model.modelId))
+  ), [defaultModelIdSet, defaultModelIds.length, selectedModels]);
+
+  const heatmap = useMemo(
+    () => buildDomainShiftHeatmap(selectedModels),
+    [selectedModels],
+  );
+  const sortedRows = useMemo(
+    () => sortHeatmapRows(heatmap.rows, sort, displayMode),
+    [displayMode, heatmap.rows, sort],
+  );
+  const selectedModelsLabel = useMemo(() => {
+    if (selectedModels.length === 0) return 'No models selected';
+    if (selectedModels.length === 1) return selectedModels[0]?.label ?? 'Selected model';
+    return isDefaultSelection ? 'Default models' : `${selectedModels.length} selected models`;
+  }, [isDefaultSelection, selectedModels]);
+
+  if (errorMessage != null) {
+    return <ErrorMessage message={`Failed to load domain shifts: ${errorMessage}`} />;
+  }
+
+  if (fetching && models.length === 0) {
+    return <Loading size="lg" text="Loading domain shifts..." />;
+  }
+
+  if (models.length === 0) {
+    return (
+      <section className="rounded-xl border border-amber-200 bg-amber-50 p-6">
+        <h2 className="text-base font-semibold text-amber-950">No active models are available yet</h2>
+        <p className="mt-2 text-sm text-amber-900">
+          Create or activate models first, then reopen this report.
+        </p>
+      </section>
+    );
+  }
+
+  if (selectedModels.length === 0) {
+    return (
+      <section className="rounded-xl border border-amber-200 bg-amber-50 p-6">
+        <h2 className="text-base font-semibold text-amber-950">Pick at least one model</h2>
+        <p className="mt-2 text-sm text-amber-900">
+          Use the Models picker above to choose the default set or your own subset.
+        </p>
+      </section>
+    );
+  }
+
+  if (heatmap.eligibleDomainCount < 2) {
+    return (
+      <section className="rounded-xl border border-amber-200 bg-amber-50 p-6">
+        <h2 className="text-base font-semibold text-amber-950">More domain coverage needed</h2>
+        <p className="mt-2 text-sm text-amber-900">
+          Domain-shift analysis needs at least one value with eligible win-rate data in two or more domains for the
+          selected model set. With only one domain for a value, the shift would be 0.0 pts by definition and would not
+          be meaningful.
+        </p>
+      </section>
+    );
+  }
+
+  const domainColumnWidth = heatmap.columns.length > 0 ? `${100 / heatmap.columns.length}%` : '100%';
+
+  return (
+    <section className="space-y-6 rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
+        <h2 className="text-2xl font-serif font-medium text-[#1A1A1A]">Domain Shifts</h2>
+        <p className="max-w-3xl text-sm text-gray-600">
+          Exploratory heatmap for domain-associated value shifts, using the current Win Rate filters above.
+        </p>
+      </div>
+
+      <div ref={tableRef} className="space-y-4">
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">{selectedModelsLabel}</h3>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <DisplayModeToggle displayMode={displayMode} onChange={setDisplayMode} />
+            <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+              <span className="font-semibold text-gray-800">Metric:</span>{' '}
+              {displayMode === 'shift' ? 'percentage-point shift, not percent change' : 'raw domain win rate'}
+            </div>
+            <CopyVisualButton targetRef={tableRef} label="domain shifts table" />
+          </div>
+        </div>
+
+        <div className="overflow-x-auto rounded border border-gray-100 bg-white p-2">
+          <table className="w-full table-auto border-collapse text-xs">
+            <colgroup>
+              <col className="w-max" />
+              <col className="w-max" />
+              {heatmap.columns.map((domain) => (
+                <col key={domain.domainId} style={{ width: domainColumnWidth }} />
+              ))}
+            </colgroup>
+            <thead>
+              <tr className="border-b border-gray-200 text-gray-600">
+                <SortableHeader
+                  label="Value"
+                  sortKey="value"
+                  sort={sort}
+                  onSort={setSort}
+                  align="left"
+                  className="border-r-2 border-gray-300"
+                />
+                <SortableHeader
+                  label="Avg Win Rate"
+                  sortKey="average"
+                  sort={sort}
+                  onSort={setSort}
+                  align="right"
+                  className="border-r-2 border-gray-300"
+                />
+                {heatmap.columns.map((domain) => {
+                  const domainSortKey: DomainShiftSortKey = `domain:${domain.domainId}`;
+                  return (
+                    <SortableHeader
+                      key={domain.domainId}
+                      label={domain.domainName}
+                      sortKey={domainSortKey}
+                      sort={sort}
+                      onSort={setSort}
+                    />
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {sortedRows.map((row) => (
+                <tr key={row.valueKey} className="border-b border-gray-100">
+                  <th
+                    scope="row"
+                    className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 whitespace-nowrap text-left font-medium text-gray-900"
+                  >
+                    {row.valueLabel}
+                  </th>
+                  <td className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 whitespace-nowrap text-right font-mono text-gray-700">
+                    {formatPercent(row.averageWinRate)}
+                    {row.averageMatchesPooled === false && (
+                      <span
+                        className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-xs font-sans text-amber-800"
+                        title="Computed average differs from the API pooled win rate by more than the allowed tolerance."
+                      >
+                        check
+                      </span>
+                    )}
+                  </td>
+                  {heatmap.columns.map((domain) => {
+                    const cell = row.cells.get(domain.domainId) ?? null;
+                    const tdClassName = cn(
+                      'border-b border-gray-100 px-2 py-2 text-center align-middle transition-colors',
+                      cell == null
+                        ? 'border-gray-100 bg-gray-50 text-gray-400'
+                        : displayMode === 'shift'
+                          ? getCellToneClass(cell.shift)
+                          : getWinRateToneClass(cell.winRate),
+                    );
+
+                    return (
+                      <td key={domain.domainId} className={tdClassName}>
+                        <Cell
+                          cell={cell}
+                          valueLabel={row.valueLabel}
+                          displayMode={displayMode}
+                          evidenceLabel={isDefaultSelection ? 'average evidence vignettes' : 'evidence vignettes'}
+                        />
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
+++ b/cloud/apps/web/src/components/models/ModelValueDetailDrawer.tsx
@@ -200,8 +200,8 @@ export function ModelValueDetailDrawer({
                     {domains.map((domain) => (
                       <tr key={domain.domainId} className="hover:bg-gray-50">
                         <td className="border-b border-gray-100 px-4 py-3">
-                          <Link
-                            to={`/domains/analysis/value-detail?domainId=${encodeURIComponent(domain.domainId)}&modelId=${encodeURIComponent(model.modelId)}&valueKey=${encodeURIComponent(value.valueKey)}`}
+                        <Link
+                            to={`/models/win-rate/value-detail?domainId=${encodeURIComponent(domain.domainId)}&modelId=${encodeURIComponent(model.modelId)}&valueKey=${encodeURIComponent(value.valueKey)}`}
                             className="font-medium text-teal-700 hover:text-teal-900 hover:underline"
                           >
                             {domain.domainName}

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -25,7 +25,9 @@ import {
 } from '../api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { DominanceSection } from '../components/domains/DominanceSection';
+import { SimilaritySection } from '../components/domains/SimilaritySection';
 import { ValuePrioritiesSection } from '../components/domains/ValuePrioritiesSection';
+import { DomainShiftsReportSection } from '../components/models/DomainShiftsReportSection';
 import {
   VALUES,
   type ModelEntry,
@@ -142,7 +144,10 @@ export function DomainAnalysis() {
     pause: selectedDomainId === '' || !activeUseLegacyQuery,
     requestPolicy: 'cache-and-network',
   });
-  const [{ data: modelsAnalysisData }] = useQuery<ModelsAnalysisQueryResult, ModelsAnalysisQueryVariables>({
+  const [{ data: modelsAnalysisData, fetching: modelsAnalysisFetching, error: modelsAnalysisError }] = useQuery<
+    ModelsAnalysisQueryResult,
+    ModelsAnalysisQueryVariables
+  >({
     query: MODELS_ANALYSIS_QUERY,
     variables: {
       ...(selectedScope === 'DOMAIN' && selectedDomainId !== '' ? { domainId: selectedDomainId } : {}),
@@ -362,9 +367,9 @@ export function DomainAnalysis() {
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="space-y-2">
-          <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Findings</h1>
+          <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Win Rate</h1>
           <p className="text-sm text-gray-600">
-            Structured domain interpretation across priorities, ranking behavior, and similarity for the selected domain.
+            Structured win-rate interpretation across priorities, ranking behavior, and similarity for the selected domain.
           </p>
         </div>
         <Button
@@ -426,11 +431,11 @@ export function DomainAnalysis() {
       )}
 
       {(domainsError != null || signaturesError != null || error != null) && (
-        <ErrorMessage message={`Failed to load domain analysis: ${(domainsError ?? signaturesError ?? error)?.message ?? 'Unknown error'}`} />
+        <ErrorMessage message={`Failed to load win rate page: ${(domainsError ?? signaturesError ?? error)?.message ?? 'Unknown error'}`} />
       )}
 
       {showPageLoader ? (
-        <Loading size="lg" text="Loading domain analysis..." />
+        <Loading size="lg" text="Loading win rate page..." />
       ) : (
         <>
           <ValuePrioritiesSection
@@ -443,6 +448,14 @@ export function DomainAnalysis() {
           <DominanceSection
             models={models}
             defaultModelIds={defaultModelIds}
+          />
+          <SimilaritySection models={visibleModels} />
+          <DomainShiftsReportSection
+            models={modelsAnalysisData?.modelsAnalysis.models ?? []}
+            selectedModelIds={selectedModelIds}
+            defaultModelIds={defaultSelection}
+            fetching={modelsAnalysisFetching}
+            errorMessage={modelsAnalysisError?.message ?? null}
           />
         </>
       )}

--- a/cloud/apps/web/src/pages/DomainAnalysisValueDetail.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysisValueDetail.tsx
@@ -36,7 +36,7 @@ export function DomainAnalysisValueDetail() {
   const backParams = new URLSearchParams();
   if (domainId !== '') backParams.set('domainId', domainId);
   if (signature !== null && signature !== '') backParams.set('signature', signature);
-  const backLink = `/domains/analysis?${backParams.toString()}`;
+  const backLink = `/models/win-rate?${backParams.toString()}`;
   const [{ data: scoredData, fetching: scoredFetching, error: scoredError }] = useQuery<
     DomainAnalysisValueDetailQueryResult,
     DomainAnalysisValueDetailQueryVariables
@@ -123,9 +123,9 @@ export function DomainAnalysisValueDetail() {
   if (domainId === '' || modelId === '' || valueKey === '') {
     return (
       <div className="space-y-4">
-        <ErrorMessage message="Missing parameters. Open this page from a value cell in Domain Analysis." />
-        <Link to="/domains/analysis" className="inline-flex text-sm text-sky-700 hover:text-sky-900 hover:underline">
-          Back to Domain Analysis
+        <ErrorMessage message="Missing parameters. Open this page from a value cell in Win Rate." />
+        <Link to="/models/win-rate" className="inline-flex text-sm text-sky-700 hover:text-sky-900 hover:underline">
+          Back to Win Rate
         </Link>
       </div>
     );
@@ -137,7 +137,7 @@ export function DomainAnalysisValueDetail() {
       <div className="space-y-4">
         <ErrorMessage message={`Failed to load value detail: ${scoredError?.message ?? 'Unknown error'}`} />
         <Link to={backLink} className="inline-flex text-sm text-sky-700 hover:text-sky-900 hover:underline">
-          Back to Domain Analysis
+          Back to Win Rate
         </Link>
       </div>
     );
@@ -164,7 +164,7 @@ export function DomainAnalysisValueDetail() {
     <div className="space-y-6">
       <div className="space-y-2">
         <Link to={backLink} className="inline-flex text-sm text-sky-700 hover:text-sky-900 hover:underline">
-          ← Back to Domain Analysis
+          ← Back to Win Rate
         </Link>
         <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Value Score Detail</h1>
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">

--- a/cloud/apps/web/tests/App.test.tsx
+++ b/cloud/apps/web/tests/App.test.tsx
@@ -11,8 +11,8 @@ vi.mock('../src/api/client', () => ({
   },
 }));
 
-vi.mock('../src/pages/DomainValueShiftHeatmap', () => ({
-  DomainValueShiftHeatmap: () => <div>Domain shifts route smoke</div>,
+vi.mock('../src/pages/DomainAnalysis', () => ({
+  DomainAnalysis: () => <div>Win rate route smoke</div>,
 }));
 
 vi.mock('../src/pages/ModelsGroups', () => ({
@@ -58,7 +58,37 @@ describe('App Routing', () => {
     });
   });
 
-  it('should render the protected domain shifts route when authenticated', async () => {
+  it('should render the protected win rate route when authenticated', async () => {
+    localStorage.setItem('valuerank_token', 'test-token');
+    window.history.pushState({}, '', '/models/win-rate');
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'user-1', email: 'researcher@example.com', name: 'Researcher' }),
+    } as Response);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Win rate route smoke')).toBeInTheDocument();
+    });
+  });
+
+  it('should 404 the old domain analysis route when authenticated', async () => {
+    localStorage.setItem('valuerank_token', 'test-token');
+    window.history.pushState({}, '', '/domains/analysis');
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'user-1', email: 'researcher@example.com', name: 'Researcher' }),
+    } as Response);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /page not found/i })).toBeInTheDocument();
+    });
+  });
+
+  it('should 404 the old domain shifts route when authenticated', async () => {
     localStorage.setItem('valuerank_token', 'test-token');
     window.history.pushState({}, '', '/models/domain-shifts');
     vi.mocked(fetch).mockResolvedValue({
@@ -69,7 +99,7 @@ describe('App Routing', () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByText('Domain shifts route smoke')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /page not found/i })).toBeInTheDocument();
     });
   });
 

--- a/cloud/apps/web/tests/components/layout/MobileNav.test.tsx
+++ b/cloud/apps/web/tests/components/layout/MobileNav.test.tsx
@@ -37,19 +37,19 @@ describe('MobileNav Component', () => {
     expect(screen.getByRole('link', { name: 'Domains' })).toHaveAttribute('href', '/domains');
     expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Model Groups' })).toHaveAttribute('href', '/models');
-    expect(screen.getByRole('link', { name: 'Domain Shifts' })).toHaveAttribute('href', '/models/domain-shifts');
+    expect(screen.getByRole('link', { name: 'Win Rate' })).toHaveAttribute('href', '/models/win-rate');
     expect(screen.getByRole('link', { name: 'Consistency' })).toHaveAttribute('href', '/archive/consistency');
     expect(screen.getByRole('link', { name: 'Circumplex' })).toHaveAttribute('href', '/archive/circumplex');
     expect(screen.getByRole('link', { name: 'Archive' })).toHaveAttribute('href', '/archive');
     expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings/account');
   });
 
-  it('highlights Models and Domain Shifts on the domain shifts route', async () => {
-    await renderMobileNav('/models/domain-shifts');
+  it('highlights Models and Win Rate on the win rate route', async () => {
+    await renderMobileNav('/models/win-rate');
 
     expect(screen.getByRole('link', { name: 'Models' }).className).toContain('border-teal-500');
     expect(screen.getByRole('link', { name: 'Model Groups' }).className).not.toContain('border-teal-500');
-    expect(screen.getByRole('link', { name: 'Domain Shifts' }).className).toContain('border-teal-500');
+    expect(screen.getByRole('link', { name: 'Win Rate' }).className).toContain('border-teal-500');
     expect(screen.getByRole('link', { name: 'Consistency' }).className).not.toContain('border-teal-500');
     expect(screen.getByRole('link', { name: 'Circumplex' }).className).not.toContain('border-teal-500');
   });
@@ -59,7 +59,7 @@ describe('MobileNav Component', () => {
 
     expect(screen.getByRole('link', { name: 'Vignettes' })).toHaveAttribute('href', '/definitions');
     expect(screen.getByRole('link', { name: 'Model Groups' })).toHaveAttribute('href', '/models');
-    expect(screen.getByRole('link', { name: 'Domain Analysis' })).toHaveAttribute('href', '/domains/analysis');
+    expect(screen.getByRole('link', { name: 'Win Rate' })).toHaveAttribute('href', '/models/win-rate');
     expect(screen.getByRole('link', { name: 'Manage Domains' })).toHaveAttribute('href', '/domains/manage');
     expect(screen.queryByRole('link', { name: 'Coverage' })).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Runs' })).toHaveAttribute('href', '/runs');
@@ -90,9 +90,9 @@ describe('MobileNav Component', () => {
   });
 
   it('keeps the mobile menu escape behavior after Models gains children', async () => {
-    await renderMobileNav('/models/domain-shifts');
+    await renderMobileNav('/models/win-rate');
 
-    expect(screen.getByRole('link', { name: 'Domain Shifts' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Win Rate' })).toBeInTheDocument();
     await user.keyboard('{Escape}');
     expect(screen.getByRole('button', { name: /open navigation menu/i })).toHaveAttribute('aria-expanded', 'false');
   });

--- a/cloud/apps/web/tests/components/layout/NavTabs.test.tsx
+++ b/cloud/apps/web/tests/components/layout/NavTabs.test.tsx
@@ -48,7 +48,7 @@ describe('NavTabs Component', () => {
   });
 
   it('keeps the model report links available from the models menu', async () => {
-    renderNavTabs('/models/domain-shifts');
+    renderNavTabs('/models/win-rate');
     const toggle = screen.getByRole('button', { name: 'Toggle Models menu' });
     const menuRoot = toggle.closest('.relative');
     if (menuRoot === null) {
@@ -62,18 +62,16 @@ describe('NavTabs Component', () => {
     });
     expect(screen.getByRole('link', { name: 'Models' })).toHaveAttribute('href', '/models');
     expect(screen.getByRole('link', { name: 'Model Groups' })).toHaveAttribute('href', '/models');
-    expect(screen.getByRole('link', { name: 'Domain Analysis' })).toHaveAttribute('href', '/domains/analysis');
-    expect(screen.getByRole('link', { name: 'Domain Shifts' })).toHaveAttribute('href', '/models/domain-shifts');
+    expect(screen.getByRole('link', { name: 'Win Rate' })).toHaveAttribute('href', '/models/win-rate');
   });
 
-  it('highlights only Domain Shifts inside the models menu on the domain shifts route', async () => {
-    renderNavTabs('/models/domain-shifts');
+  it('highlights only Win Rate inside the models menu on the win rate route', async () => {
+    renderNavTabs('/models/win-rate');
     await openMenu('Models');
 
     expect(screen.getByRole('link', { name: 'Models' }).parentElement?.className).toContain('border-teal-500');
     expect(screen.getByRole('link', { name: 'Model Groups' }).className).not.toContain('bg-teal-600/20');
-    expect(screen.getByRole('link', { name: 'Domain Analysis' }).className).not.toContain('bg-teal-600/20');
-    expect(screen.getByRole('link', { name: 'Domain Shifts' }).className).toContain('bg-teal-600/20');
+    expect(screen.getByRole('link', { name: 'Win Rate' }).className).toContain('bg-teal-600/20');
     expect(screen.getByRole('link', { name: 'Consistency' }).className).not.toContain('bg-teal-600/20');
     expect(screen.getByRole('link', { name: 'Circumplex' }).className).not.toContain('bg-teal-600/20');
   });

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -205,12 +205,15 @@ describe('DomainAnalysis', () => {
     );
 
     const domainSelection = await screen.findByRole('button', { name: /all domains/i });
-    const findingsHeading = screen.getByRole('heading', { name: 'Findings' });
     const valuePriorities = screen.getByText(/mock value priorities section/i);
     const dominance = screen.getByText(/mock dominance section/i);
+    const similarity = screen.getByRole('heading', { name: 'Similarities and Differences' });
+    const domainShifts = screen.getByRole('heading', { name: 'No active models are available yet' });
 
-    expect(domainSelection.compareDocumentPosition(findingsHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(domainSelection.compareDocumentPosition(valuePriorities) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(valuePriorities.compareDocumentPosition(dominance) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(dominance.compareDocumentPosition(similarity) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(similarity.compareDocumentPosition(domainShifts) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('defaults the scope dropdown to all domains when no domain is selected', async () => {

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -262,7 +262,7 @@ describe('DomainAnalysis', () => {
 
   it('preserves the all-domains scope and disables domain-only actions', async () => {
     render(
-      <MemoryRouter initialEntries={['/domains/analysis?scope=all-domains&signature=vnewtd']}>
+      <MemoryRouter initialEntries={['/models/win-rate?scope=all-domains&signature=vnewtd']}>
         <DomainAnalysis />
       </MemoryRouter>,
     );

--- a/cloud/apps/web/tests/pages/DomainAnalysisValueDetail.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysisValueDetail.test.tsx
@@ -233,7 +233,7 @@ function mockQueries(options: {
 
 function renderPage() {
   return render(
-    <MemoryRouter initialEntries={['/domains/analysis/value-detail?domainId=domain-a&modelId=gpt-4&valueKey=Achievement']}>
+    <MemoryRouter initialEntries={['/models/win-rate/value-detail?domainId=domain-a&modelId=gpt-4&valueKey=Achievement']}>
       <DomainAnalysisValueDetail />
     </MemoryRouter>,
   );


### PR DESCRIPTION
## What changed
- Renamed the Domain Analysis page to Win Rate and moved it under `/models/win-rate`.
- Replaced the Domain Analysis nav label with Win Rate.
- Updated existing links to point at the new Win Rate route.
- Embedded the Domain Shifts report at the bottom of the Win Rate page.
- Removed the standalone Domain Shifts URL.

## Why
- The page is now centered on win rate analysis, so the URL and navigation should match the product naming.
- Old URLs should fail loudly instead of redirecting.

## Validation
- `npx turbo lint --filter=@valuerank/web`
- `npx turbo test --filter=@valuerank/web`
- `npx turbo build --filter=@valuerank/web`
- `npx vitest run tests/App.test.tsx`
