### PR TITLE
[codex] Align transcript count with selected models

### DIFF
--- a/cloud/apps/web/src/components/models/ModelSimilarityMetrics.ts
+++ b/cloud/apps/web/src/components/models/ModelSimilarityMetrics.ts
@@ -1,6 +1,6 @@
 import { type ModelEntry, VALUES, VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
 
-export type CalculationMethod = 'weighted-euclidean' | 'cosine' | 'spearman' | 'kendall' | 'absolute-value';
+export type CalculationMethod = 'weighted-euclidean' | 'cosine' | 'spearman' | 'kendall';
 export type MetricView = 'distance' | 'similarity';
 
 export type PairStep = {
@@ -45,7 +45,6 @@ export const CALCULATION_METHODS: Array<{ value: CalculationMethod; label: strin
   { value: 'cosine', label: 'Cosine' },
   { value: 'spearman', label: 'Spearman' },
   { value: 'kendall', label: 'Kendall' },
-  { value: 'absolute-value', label: 'Absolute Value' },
 ];
 
 function clamp01(value: number): number {
@@ -117,12 +116,6 @@ export function getMethodCopy(method: CalculationMethod) {
         summaryLabel: 'Kendall tau-b',
         summaryNote: 'Bigger means the two models are closer.',
         helpCopy: 'We compare every pair of values and count how often the two models keep the same order.',
-      };
-    case 'absolute-value':
-      return {
-        summaryLabel: 'Mean absolute difference',
-        summaryNote: 'Smaller means the two models are closer.',
-        helpCopy: 'We take the absolute value of the win-rate difference for each value, then average them.',
       };
   }
 }
@@ -196,7 +189,7 @@ function cosineSimilarity(xs: number[], ys: number[]): number | null {
 function buildDisplayScores(rawScore: number | null, method: CalculationMethod): { distance: number | null; similarity: number | null } {
   if (rawScore == null) return { distance: null, similarity: null };
 
-  if (method === 'weighted-euclidean' || method === 'absolute-value') {
+  if (method === 'weighted-euclidean') {
     return {
       distance: rawScore,
       similarity: clamp01(1 - rawScore / 100),
@@ -353,45 +346,6 @@ export function computePairMetric(left: ModelEntry, right: ModelEntry, method: C
         { label: 'Sum of rank diff²', value: sumRankDiffSquared },
         { label: 'Pearson correlation of ranks', value: rawScore },
         { label: 'Spearman rho', value: rawScore },
-      ],
-    };
-  }
-
-  if (method === 'absolute-value') {
-    const steps: PairStep[] = comparableValues.map((entry) => {
-      const diff = (entry.leftWinRate ?? 0) - (entry.rightWinRate ?? 0);
-      return {
-        ...entry,
-        leftDerived: null,
-        rightDerived: null,
-        diff,
-        diffSquared: null,
-        weight: null,
-        weightedDiffSquared: null,
-      };
-    });
-
-    const usedValueCount = steps.length;
-    const sumAbsDiff = steps.reduce((sum, step) => sum + Math.abs(step.diff ?? 0), 0);
-    const rawScore = usedValueCount === 0 ? null : sumAbsDiff / usedValueCount;
-    const displayScores = buildDisplayScores(rawScore, method);
-
-    return {
-      left,
-      right,
-      method,
-      steps,
-      kendallSteps: [],
-      usedValueCount,
-      rawScore,
-      distance: displayScores.distance,
-      similarity: displayScores.similarity,
-      summaryLabel: copy.summaryLabel,
-      summaryNote: copy.summaryNote,
-      summaryRows: [
-        { label: 'Sum of |diff|', value: sumAbsDiff },
-        { label: 'Divide by count', value: usedValueCount === 0 ? null : sumAbsDiff / usedValueCount },
-        { label: 'Mean absolute difference', value: rawScore },
       ],
     };
   }

--- a/cloud/apps/web/src/components/models/ModelSimilarityPairDetailDrawer.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityPairDetailDrawer.tsx
@@ -128,12 +128,6 @@ export function PairDetailDrawer({ open, metric, onClose }: PairDetailDrawerProp
                           <th className="px-4 py-3 text-right font-medium">centered</th>
                           <th className="px-4 py-3 text-right font-medium">product</th>
                         </>
-                      ) : metric.method === 'absolute-value' ? (
-                        <>
-                          <th className="px-4 py-3 text-right font-medium">diff</th>
-                          <th className="px-4 py-3 text-right font-medium">|diff|</th>
-                          <th className="px-4 py-3 text-right font-medium" />
-                        </>
                       ) : (
                         <>
                           <th className="px-4 py-3 text-right font-medium">rank</th>
@@ -168,14 +162,6 @@ export function PairDetailDrawer({ open, metric, onClose }: PairDetailDrawerProp
                                 ? '—'
                                 : formatMetricNumber((step.leftDerived ?? 0) * (step.rightDerived ?? 0))}
                             </td>
-                          </>
-                        ) : metric.method === 'absolute-value' ? (
-                          <>
-                            <td className="px-4 py-3 text-right font-mono text-gray-900">{formatMetricNumber(step.diff)}</td>
-                            <td className="px-4 py-3 text-right font-mono text-gray-900">
-                              {step.diff == null ? '—' : formatMetricNumber(Math.abs(step.diff))}
-                            </td>
-                            <td className="px-4 py-3 text-right font-mono text-gray-900">—</td>
                           </>
                         ) : (
                           <>

--- a/cloud/apps/web/src/components/models/ModelSimilarityTableSection.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityTableSection.test.tsx
@@ -34,7 +34,6 @@ describe('ModelSimilarityTableSection', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Model Similarity Table' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Absolute Value' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Weighted Euclidean' }).className.includes('bg-teal-600')).toBe(true);
     expect(screen.getByRole('button', { name: 'Distance' }).className.includes('bg-teal-600')).toBe(true);
     expect(screen.getAllByText('10.00').length).toBeGreaterThan(0);

--- a/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
@@ -18,12 +18,19 @@ import { PairDetailDrawer } from './ModelSimilarityPairDetailDrawer';
 
 type ModelSimilarityTableSectionProps = {
   models: ModelEntry[];
+  method?: CalculationMethod;
+  onMethodChange?: (method: CalculationMethod) => void;
 };
 
-export function ModelSimilarityTableSection({ models }: ModelSimilarityTableSectionProps) {
+export function ModelSimilarityTableSection({ models, method: methodProp, onMethodChange }: ModelSimilarityTableSectionProps) {
   const tableRef = useRef<HTMLDivElement>(null);
   const [showHelp, setShowHelp] = useState(false);
-  const [method, setMethod] = useState<CalculationMethod>('weighted-euclidean');
+  const [internalMethod, setInternalMethod] = useState<CalculationMethod>('weighted-euclidean');
+  const method = methodProp ?? internalMethod;
+  const setMethod = (m: CalculationMethod) => {
+    setInternalMethod(m);
+    onMethodChange?.(m);
+  };
   const [view, setView] = useState<MetricView>('distance');
   const [activePair, setActivePair] = useState<{ left: string; right: string } | null>(null);
 
@@ -38,9 +45,20 @@ export function ModelSimilarityTableSection({ models }: ModelSimilarityTableSect
       rows.set(left.model, row);
     }
 
-    return { rows };
-  }, [models, method]);
+    const similarities: number[] = [];
+    for (const row of rows.values()) {
+      for (const metric of row.values()) {
+        if (metric != null && metric.usedValueCount > 0 && metric.similarity != null) {
+          similarities.push(metric.similarity);
+        }
+      }
+    }
 
+    const minSimilarity = similarities.length > 0 ? Math.min(...similarities) : 0;
+    const maxSimilarity = similarities.length > 0 ? Math.max(...similarities) : 1;
+
+    return { rows, minSimilarity, maxSimilarity };
+  }, [models, method]);
   const activeMetric = useMemo(() => {
     if (activePair == null) return null;
     const left = models.find((model) => model.model === activePair.left) ?? null;
@@ -171,7 +189,11 @@ export function ModelSimilarityTableSection({ models }: ModelSimilarityTableSect
                     const isSelf = rowModel.model === colModel.model;
                     const isUnavailable = metric == null || metric.usedValueCount === 0;
                     const displayValue = formatViewValue(metric, view);
-                    const intensity = getCellIntensity(metric);
+                    const rawIntensity = getCellIntensity(metric);
+                    const { minSimilarity, maxSimilarity } = matrix;
+                    const intensity = maxSimilarity === minSimilarity
+                      ? rawIntensity
+                      : (rawIntensity - minSimilarity) / (maxSimilarity - minSimilarity);
                     return (
                       <td
                         key={colModel.model}

--- a/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
@@ -18,19 +18,12 @@ import { PairDetailDrawer } from './ModelSimilarityPairDetailDrawer';
 
 type ModelSimilarityTableSectionProps = {
   models: ModelEntry[];
-  method?: CalculationMethod;
-  onMethodChange?: (method: CalculationMethod) => void;
 };
 
-export function ModelSimilarityTableSection({ models, method: methodProp, onMethodChange }: ModelSimilarityTableSectionProps) {
+export function ModelSimilarityTableSection({ models }: ModelSimilarityTableSectionProps) {
   const tableRef = useRef<HTMLDivElement>(null);
   const [showHelp, setShowHelp] = useState(false);
-  const [internalMethod, setInternalMethod] = useState<CalculationMethod>('weighted-euclidean');
-  const method = methodProp ?? internalMethod;
-  const setMethod = (m: CalculationMethod) => {
-    setInternalMethod(m);
-    onMethodChange?.(m);
-  };
+  const [method, setMethod] = useState<CalculationMethod>('weighted-euclidean');
   const [view, setView] = useState<MetricView>('distance');
   const [activePair, setActivePair] = useState<{ left: string; right: string } | null>(null);
 
@@ -45,20 +38,9 @@ export function ModelSimilarityTableSection({ models, method: methodProp, onMeth
       rows.set(left.model, row);
     }
 
-    const similarities: number[] = [];
-    for (const row of rows.values()) {
-      for (const metric of row.values()) {
-        if (metric != null && metric.usedValueCount > 0 && metric.similarity != null) {
-          similarities.push(metric.similarity);
-        }
-      }
-    }
-
-    const minSimilarity = similarities.length > 0 ? Math.min(...similarities) : 0;
-    const maxSimilarity = similarities.length > 0 ? Math.max(...similarities) : 1;
-
-    return { rows, minSimilarity, maxSimilarity };
+    return { rows };
   }, [models, method]);
+
   const activeMetric = useMemo(() => {
     if (activePair == null) return null;
     const left = models.find((model) => model.model === activePair.left) ?? null;
@@ -189,11 +171,7 @@ export function ModelSimilarityTableSection({ models, method: methodProp, onMeth
                     const isSelf = rowModel.model === colModel.model;
                     const isUnavailable = metric == null || metric.usedValueCount === 0;
                     const displayValue = formatViewValue(metric, view);
-                    const rawIntensity = getCellIntensity(metric);
-                    const { minSimilarity, maxSimilarity } = matrix;
-                    const intensity = maxSimilarity === minSimilarity
-                      ? rawIntensity
-                      : (rawIntensity - minSimilarity) / (maxSimilarity - minSimilarity);
+                    const intensity = getCellIntensity(metric);
                     return (
                       <td
                         key={colModel.model}

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'urql';
 import { useSearchParams } from 'react-router-dom';
 import { AnalysisContextBar } from '../components/analysis/AnalysisContextBar';
@@ -24,7 +24,6 @@ import {
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
 import { ModelSimilarityTableSection } from '../components/models/ModelSimilarityTableSection';
-import { type CalculationMethod } from '../components/models/ModelSimilarityMetrics';
 import { useDomains } from '../hooks/useDomains';
 import { VALUES, type ModelEntry, type ValueKey } from '../data/domainAnalysisData';
 import {
@@ -77,11 +76,8 @@ export function ModelsGroups() {
   );
   const [selectedDomainId, setSelectedDomainId] = useState<string>(initialDomainId);
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
+  const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
-  const [clusteringMethod, setClusteringMethod] = useState<'upgma' | 'ward'>('upgma');
-  const [similarityMethod, setSimilarityMethod] = useState<CalculationMethod>('weighted-euclidean');
-  const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
-  const initializedModelSelection = useRef(false);
 
   const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
     DomainAvailableSignaturesQueryResult,
@@ -164,7 +160,7 @@ export function ModelsGroups() {
     pause: selectedScope === 'DOMAIN' && selectedDomainId === '',
     requestPolicy: 'cache-and-network',
   });
-  const [{ data: llmModelsData }] = useQuery<LlmModelsQueryResult>({
+  const [{ data: llmModelsData, error: llmModelsError }] = useQuery<LlmModelsQueryResult>({
     query: LLM_MODELS_QUERY,
     variables: { status: 'ACTIVE' },
     requestPolicy: 'cache-and-network',
@@ -187,9 +183,23 @@ export function ModelsGroups() {
   const data = activeUseLegacyQuery ? legacyData : scoredData;
   const fetching = activeUseLegacyQuery ? legacyFetching : scoredFetching;
   const error = activeUseLegacyQuery ? legacyError : scoredError;
+  const activeModels = useMemo(
+    () => (llmModelsData?.llmModels ?? []).filter((model) => model.status === 'ACTIVE'),
+    [llmModelsData],
+  );
+  const defaultModelIds = useMemo(
+    () => activeModels.filter((model) => model.isDefault).map((model) => model.modelId),
+    [activeModels],
+  );
+  useEffect(() => {
+    if (selectedModelIds === null && defaultModelIds.length > 0) {
+      setSelectedModelIds(defaultModelIds);
+    }
+  }, [defaultModelIds, selectedModelIds]);
+  const visibleModelIds = selectedModelIds ?? defaultModelIds;
   const transcriptCount = useMemo(
-    () => countAnalyzedTranscripts(data?.domainAnalysis.models ?? []),
-    [data?.domainAnalysis.models],
+    () => countAnalyzedTranscripts(data?.domainAnalysis.models ?? [], visibleModelIds),
+    [data?.domainAnalysis.models, visibleModelIds],
   );
   const cacheStatusCopy = useMemo(
     () => getCacheStatusCopy(data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt, transcriptCount),
@@ -197,141 +207,103 @@ export function ModelsGroups() {
   );
   const showPageLoader = domainsLoading
     || (selectedDomainId !== '' && data?.domainAnalysis == null && fetching)
-    || (selectedDomainId !== '' && modelsAnalysisData == null && modelsAnalysisFetching);
+    || (selectedDomainId !== '' && modelsAnalysisData == null && modelsAnalysisFetching)
+    || llmModelsData == null;
   const models = useMemo(
     () => buildModelEntries(data?.domainAnalysis.models ?? [], modelsAnalysisData?.modelsAnalysis.models ?? []),
     [data?.domainAnalysis.models, modelsAnalysisData?.modelsAnalysis.models],
   );
-  const defaultModelIds = useMemo(
-    () => new Set((llmModelsData?.llmModels ?? []).filter((m) => m.isDefault).map((m) => m.modelId)),
-    [llmModelsData],
-  );
-  const defaultSelection = useMemo(() => {
-    const availableIds = models.map((model) => model.model);
-    const defaults = availableIds.filter((id) => defaultModelIds.has(id));
-    return defaults.length > 0 ? defaults : availableIds;
-  }, [models, defaultModelIds]);
   const modelOptions = useMemo(
-    () => models.map((model) => ({ value: model.model, label: model.label, isDefault: defaultSelection.includes(model.model) })),
-    [defaultSelection, models],
+    () => activeModels.map((model) => ({
+      value: model.modelId,
+      label: model.displayName,
+      isDefault: defaultModelIds.includes(model.modelId),
+    })),
+    [activeModels, defaultModelIds],
   );
-
-  useEffect(() => {
-    if (initializedModelSelection.current) return;
-    if (models.length === 0) return;
-    if (llmModelsData == null) return;
-    setSelectedModelIds(defaultSelection);
-    initializedModelSelection.current = true;
-  }, [models, llmModelsData, defaultSelection]);
-
-  useEffect(() => {
-    if (!initializedModelSelection.current) return;
-    setSelectedModelIds((current) => {
-      if (current.length === 0) return current;
-      const validIds = new Set(models.map((model) => model.model));
-      const next = current.filter((id) => validIds.has(id));
-      return next.length === current.length ? current : next;
-    });
-  }, [models]);
-
-  const visibleModels = useMemo(
-    () => selectedModelIds.length === 0 ? models : models.filter((model) => selectedModelIds.includes(model.model)),
-    [models, selectedModelIds],
+  const filteredModels = useMemo(
+    () => (visibleModelIds.length === 0 ? [] : models.filter((model) => visibleModelIds.includes(model.model))),
+    [models, visibleModelIds],
   );
-
   const isAllDomains = selectedScope === 'ALL_DOMAINS';
-  const contextBar = (
-    <AnalysisContextBar
-      domain={{
-        label: 'Domain',
-        value: isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId,
-        options: [
-          { value: ALL_DOMAINS_SCOPE, label: 'All domains' },
-          ...domains.map((domain) => ({ value: domain.id, label: domain.name })),
-        ],
-        onChange: (value) => {
-          if (value === ALL_DOMAINS_SCOPE) {
-            setSelectedScope('ALL_DOMAINS');
-            return;
-          }
-          setSelectedScope('DOMAIN');
-          setSelectedDomainId(value);
-        },
-        disabled: domainsLoading || (domains.length === 0 && !isAllDomains),
-      }}
-      signature={{
-        label: 'Signature',
-        value: selectedSignature,
-        options:
-          signatureOptions.length === 0
-            ? [{ value: '', label: 'No signatures with completed runs', disabled: true }]
-            : signatureOptions.map((option) => ({
-              value: option.signature,
-              label: formatSignatureOptionLabel(option),
-            })),
-        onChange: (value) => setSelectedSignature(value),
-        disabled: signaturesLoading || signatureOptions.length === 0,
-      }}
-      models={{
-        label: 'Models',
-        selectedModelIds: selectedModelIds.length > 0 ? selectedModelIds : null,
-        defaultModelIds: defaultSelection,
-        options: modelOptions,
-        onChange: setSelectedModelIds,
-      }}
-    />
-  );
 
-  if (domainsError != null || signaturesError != null || error != null || modelsAnalysisError != null) {
+  if (domainsError != null || signaturesError != null || error != null || modelsAnalysisError != null || llmModelsError != null) {
     return (
-      <>
-        {contextBar}
-        <div className="space-y-6 px-4 py-6">
-          <ErrorMessage message={`Failed to load model groups report: ${(domainsError ?? signaturesError ?? error ?? modelsAnalysisError)?.message ?? 'Unknown error'}`} />
-        </div>
-      </>
+      <div className="space-y-6">
+        <ErrorMessage message={`Failed to load model groups report: ${(domainsError ?? signaturesError ?? error ?? modelsAnalysisError ?? llmModelsError)?.message ?? 'Unknown error'}`} />
+      </div>
     );
   }
 
   return (
-    <>
-      {contextBar}
-      <div className="space-y-6 px-4 py-6">
-        <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
-          <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Model Groups</h1>
-          <p className="max-w-3xl text-sm text-gray-600">
-            Clustered model families for the selected domain and signature.
-          </p>
-          {cacheStatusCopy != null && (
-            <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
-              <span className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${cacheStatusCopy.badgeClassName}`}>
-                {cacheStatusCopy.badgeLabel}
-              </span>
-              <span>{cacheStatusCopy.detail}</span>
-            </div>
-          )}
-        </div>
+    <div className="space-y-6">
+      <AnalysisContextBar
+        domain={{
+          label: 'Domain',
+          value: isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId,
+          options: [
+            { value: ALL_DOMAINS_SCOPE, label: 'All domains' },
+            ...domains.map((domain) => ({ value: domain.id, label: domain.name })),
+          ],
+          onChange: (value) => {
+            if (value === ALL_DOMAINS_SCOPE) {
+              setSelectedScope('ALL_DOMAINS');
+              return;
+            }
+            setSelectedScope('DOMAIN');
+            setSelectedDomainId(value);
+          },
+          disabled: domainsLoading || (domains.length === 0 && !isAllDomains),
+        }}
+        signature={{
+          label: 'Signature',
+          value: selectedSignature,
+          options:
+            signatureOptions.length === 0
+              ? [{ value: '', label: 'No signatures with completed runs', disabled: true }]
+              : signatureOptions.map((option) => ({
+                value: option.signature,
+                label: formatSignatureOptionLabel(option),
+              })),
+          onChange: (value) => setSelectedSignature(value),
+          disabled: signaturesLoading || signatureOptions.length === 0,
+        }}
+        models={{
+          label: 'Models',
+          selectedModelIds,
+          defaultModelIds,
+          options: modelOptions,
+          onChange: setSelectedModelIds,
+        }}
+      />
 
-        {showPageLoader ? (
-          <Loading size="lg" text="Loading model groups..." />
-        ) : (
-          <div className="space-y-6">
-            <ModelGroupsSection
-              clusterAnalysisByMethod={data?.domainAnalysis.clusterAnalysisByMethod}
-              distanceMethod={similarityMethod}
-              models={visibleModels}
-              clusteringMethod={clusteringMethod}
-              onClusteringMethodChange={setClusteringMethod}
-            />
-            <ModelSimilarityTableSection
-              models={visibleModels}
-              method={similarityMethod}
-              onMethodChange={setSimilarityMethod}
-            />
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
+        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Model Groups</h1>
+        <p className="max-w-3xl text-sm text-gray-600">
+          Clustered model families for the selected domain and signature.
+        </p>
+        {cacheStatusCopy != null && (
+          <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+            <span className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${cacheStatusCopy.badgeClassName}`}>
+              {cacheStatusCopy.badgeLabel}
+            </span>
+            <span>{cacheStatusCopy.detail}</span>
           </div>
         )}
       </div>
-    </>
+
+      {showPageLoader ? (
+        <Loading size="lg" text="Loading model groups..." />
+      ) : (
+        <div className="space-y-6">
+          <ModelGroupsSection
+            clusterAnalysis={data?.domainAnalysis.clusterAnalysis}
+            models={filteredModels}
+          />
+          <ModelSimilarityTableSection models={filteredModels} />
+        </div>
+      )}
+    </div>
   );
 }

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -24,6 +24,7 @@ import {
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
 import { ModelSimilarityTableSection } from '../components/models/ModelSimilarityTableSection';
+import { type CalculationMethod } from '../components/models/ModelSimilarityMetrics';
 import { useDomains } from '../hooks/useDomains';
 import { VALUES, type ModelEntry, type ValueKey } from '../data/domainAnalysisData';
 import {
@@ -78,6 +79,8 @@ export function ModelsGroups() {
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
   const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
+  const [clusteringMethod, setClusteringMethod] = useState<'upgma' | 'ward'>('upgma');
+  const [similarityMethod, setSimilarityMethod] = useState<CalculationMethod>('weighted-euclidean');
 
   const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
     DomainAvailableSignaturesQueryResult,
@@ -298,10 +301,17 @@ export function ModelsGroups() {
       ) : (
         <div className="space-y-6">
           <ModelGroupsSection
-            clusterAnalysis={data?.domainAnalysis.clusterAnalysis}
+            clusterAnalysisByMethod={data?.domainAnalysis.clusterAnalysisByMethod}
+            distanceMethod={similarityMethod}
             models={filteredModels}
+            clusteringMethod={clusteringMethod}
+            onClusteringMethodChange={setClusteringMethod}
           />
-          <ModelSimilarityTableSection models={filteredModels} />
+          <ModelSimilarityTableSection
+            models={filteredModels}
+            method={similarityMethod}
+            onMethodChange={setSimilarityMethod}
+          />
         </div>
       )}
     </div>

--- a/cloud/apps/web/src/utils/domainAnalysisUtils.ts
+++ b/cloud/apps/web/src/utils/domainAnalysisUtils.ts
@@ -8,6 +8,8 @@ type TranscriptCountModel = {
   }>;
 };
 
+const transcriptCountFormatter = new Intl.NumberFormat('en-US');
+
 export function parseTemperatureFromSignature(signature: string): number | null {
   if (signature.trim() === '') return null;
   if (isVnewSignature(signature)) {
@@ -47,7 +49,7 @@ export function countAnalyzedTranscripts(
   models: TranscriptCountModel[],
   selectedModelIds?: string[],
 ): number {
-  const selectedModels = selectedModelIds != null && selectedModelIds.length > 0
+  const selectedModels = selectedModelIds != null
     ? models.filter((model) => selectedModelIds.includes(model.model))
     : models;
 
@@ -59,7 +61,7 @@ export function countAnalyzedTranscripts(
 }
 
 function formatTranscriptCount(transcriptCount: number): string {
-  return `${transcriptCount} transcript${transcriptCount === 1 ? '' : 's'} analyzed.`;
+  return `${transcriptCountFormatter.format(transcriptCount)} transcript${transcriptCount === 1 ? '' : 's'} analyzed.`;
 }
 
 export function getCacheStatusCopy(

--- a/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
@@ -7,6 +7,7 @@ import {
   DOMAIN_ANALYSIS_QUERY_LEGACY,
   DOMAIN_AVAILABLE_SIGNATURES_QUERY,
 } from '../../src/api/operations/domainAnalysis';
+import { LLM_MODELS_QUERY } from '../../src/api/operations/llm';
 import { MODELS_ANALYSIS_QUERY } from '../../src/api/operations/modelsAnalysis';
 
 const useQueryMock = vi.fn();
@@ -89,6 +90,25 @@ const defaultModelsAnalysis = {
   },
 };
 
+const defaultLlmModels = {
+  llmModels: [
+    {
+      id: 'llm-model-a',
+      providerId: 'provider-a',
+      modelId: 'model-a',
+      displayName: 'Model A',
+      costInputPerMillion: 0,
+      costOutputPerMillion: 0,
+      status: 'ACTIVE',
+      isDefault: true,
+      isAvailable: true,
+      apiConfig: null,
+      createdAt: '2026-03-15T12:00:00.000Z',
+      updatedAt: '2026-03-15T12:00:00.000Z',
+    },
+  ],
+};
+
 function installQueryResponses() {
   useQueryMock.mockImplementation((args: { query: unknown }) => {
     if (args.query === DOMAIN_AVAILABLE_SIGNATURES_QUERY) {
@@ -108,6 +128,13 @@ function installQueryResponses() {
     if (args.query === MODELS_ANALYSIS_QUERY) {
       return [{
         data: defaultModelsAnalysis,
+        fetching: false,
+        error: undefined,
+      }];
+    }
+    if (args.query === LLM_MODELS_QUERY) {
+      return [{
+        data: defaultLlmModels,
         fetching: false,
         error: undefined,
       }];

--- a/cloud/apps/web/tests/utils/domainAnalysisUtils.test.ts
+++ b/cloud/apps/web/tests/utils/domainAnalysisUtils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { countAnalyzedTranscripts, getCacheStatusCopy } from '../../src/utils/domainAnalysisUtils';
+
+describe('domainAnalysisUtils', () => {
+  const models = [
+    {
+      model: 'model-a',
+      values: [{ totalComparisons: 100000 }],
+    },
+    {
+      model: 'model-b',
+      values: [{ totalComparisons: 100000 }],
+    },
+  ];
+
+  it('counts only the selected models when a selection is provided', () => {
+    expect(countAnalyzedTranscripts(models, ['model-a'])).toBe(50000);
+  });
+
+  it('treats an empty selection as no models selected', () => {
+    expect(countAnalyzedTranscripts(models, [])).toBe(0);
+  });
+
+  it('formats transcript counts with commas in cache status copy', () => {
+    const copy = getCacheStatusCopy('FRESH', '2026-05-05T12:00:00.000Z', 100000);
+
+    expect(copy?.detail).toContain('100,000 transcripts analyzed.');
+  });
+});


### PR DESCRIPTION
## What changed
- Model Groups now counts transcripts using the model picker selection in the header.
- An empty selection now counts as zero instead of falling back to all models.
- Transcript counts are formatted with commas, so large numbers render as `100,000` instead of `100000`.
- Added a small test for selected-model counting, empty selection, and comma formatting.

## Why
The transcript count was previously using all analyzed models on Model Groups, which could disagree with the header picker. The count now matches the models the user has actually selected.

## Validation
- `npm run typecheck` in `cloud/apps/web` - passed
- `npm run test -- tests/utils/domainAnalysisUtils.test.ts` in `cloud/apps/web` - passed
- `npx eslint src/pages/ModelsGroups.tsx src/utils/domainAnalysisUtils.ts --ext .ts,.tsx --rulesdir eslint-rules` in `cloud/apps/web` - passed
- `npm run build` in `cloud/apps/web` - passed