### PR TITLE
[codex] surface pending launches in status page

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -37,6 +37,7 @@
 
 | Feature | Branch | Status | Notes |
 |---------|--------|--------|-------|
+| **status-page-pending-launches** | `—` | 🟢 Done locally | Status page active-evaluation query now includes PENDING, RUNNING, PAUSED, and SUMMARIZING launches so stuck-but-working runs show up again. Added API regression coverage and updated the section copy to match. |
 | **pressure-response-by-value-direct-rates** | `codex/value-priorities-logit-toggle` | 🟢 Done locally | Pressure Response by Value now uses direct win rates for both sides of each pair, instead of flipping the first value's rate for the second value. The table also keeps the vignette-level weighting rule so repeated measurements do not overcount a vignette. |
 | **model-groups-visualization-toggle** | `codex/pressure-response-tooltip-grid` | 🟢 Done locally | Domain Analysis model groups now support radar, dot map, and heatmap views with a view toggle, shared cluster ordering, and a fixed symmetric dot-map axis. |
 | **pressure-sensitivity-coverage-fix** | `codex/pressure-sensitivity-coverage-fix` | 🟢 Done locally | Follow-up to PR #770. The pressure-sensitivity resolver now keeps a lightweight resolved Definition snapshot (`template`, `dimensions`, `components`) when resolving transcript decisions, instead of token-only stubs that made every transcript resolve as unknown/unscored and pushed all models below coverage. Focused API regression test added. |

--- a/cloud/apps/api/src/graphql/queries/active-evaluations.ts
+++ b/cloud/apps/api/src/graphql/queries/active-evaluations.ts
@@ -1,13 +1,15 @@
 import { db, type Prisma } from '@valuerank/db';
 import { AuthenticationError } from '@valuerank/shared';
 import { builder } from '../builder.js';
-import { DomainEvaluationRef } from './domain/evaluation/types.js';
+import { ACTIVE_RUN_STATUSES, DomainEvaluationRef } from './domain/evaluation/types.js';
 import { evaluationInclude, toShape } from './domain/evaluation/helpers.js';
+
+const ACTIVE_EVALUATION_RUN_STATUSES = [...ACTIVE_RUN_STATUSES];
 
 builder.queryField('activeEvaluations', (t) =>
   t.field({
     type: [DomainEvaluationRef],
-    description: 'List DomainEvaluations that have at least one member run currently in RUNNING or SUMMARIZING status. Optional domainId filter scopes to one domain. Used by the cross-domain /status page.',
+    description: 'List DomainEvaluations that have at least one member run currently in PENDING, RUNNING, PAUSED, or SUMMARIZING status. Optional domainId filter scopes to one domain. Used by the cross-domain /status page.',
     args: {
       domainId: t.arg.id({ required: false }),
     },
@@ -21,7 +23,7 @@ builder.queryField('activeEvaluations', (t) =>
         members: {
           some: {
             run: {
-              status: { in: ['RUNNING', 'SUMMARIZING'] },
+              status: { in: ACTIVE_EVALUATION_RUN_STATUSES },
               deletedAt: null,
             },
           },

--- a/cloud/apps/api/tests/graphql/queries/domain.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/domain.test.ts
@@ -759,6 +759,112 @@ describe('GraphQL Domain Query Registration', () => {
     );
   });
 
+  it('includes pending launches in the active evaluations query', async () => {
+    const domain = await db.domain.create({
+      data: {
+        name: 'Pending Evaluation Query Test',
+        normalizedName: `pending-evaluation-query-${Date.now()}`,
+      },
+    });
+    createdDomainIds.push(domain.id);
+
+    const definition = await db.definition.create({
+      data: {
+        name: 'Pending Evaluation Vignette',
+        domainId: domain.id,
+        version: 1,
+        content: { schema_version: 1, preamble: 'pending' },
+        createdByUserId: TEST_USER.id,
+      },
+    });
+    createdDefinitionIds.push(definition.id);
+
+    const pendingRun = await db.run.create({
+      data: {
+        definitionId: definition.id,
+        status: 'PENDING',
+        runCategory: 'PRODUCTION',
+        config: { models: ['test-domain-model'], temperature: null },
+        progress: { total: 1, completed: 0, failed: 0 },
+        createdByUserId: TEST_USER.id,
+      },
+    });
+    createdRunIds.push(pendingRun.id);
+
+    const evaluation = await db.domainEvaluation.create({
+      data: {
+        domainId: domain.id,
+        domainNameAtLaunch: domain.name,
+        scopeCategory: 'PRODUCTION',
+        status: 'PENDING',
+        configSnapshot: {
+          models: ['test-domain-model'],
+          projectedCostUsd: 0.5,
+          startedRuns: 1,
+          skippedForBudget: 0,
+        },
+        createdByUserId: TEST_USER.id,
+      },
+    });
+
+    await db.domainEvaluationRun.create({
+      data: {
+        domainEvaluationId: evaluation.id,
+        runId: pendingRun.id,
+        definitionIdAtLaunch: definition.id,
+        definitionNameAtLaunch: definition.name,
+        domainIdAtLaunch: domain.id,
+      },
+    });
+
+    const query = `
+      query ActiveEvaluations($domainId: ID) {
+        activeEvaluations(domainId: $domainId) {
+          id
+          domainId
+          status
+          memberCount
+          members {
+            runId
+            runStatus
+            runCategory
+          }
+        }
+      }
+    `;
+
+    const response = await request(app)
+      .post('/graphql')
+      .set('Authorization', getAuthHeader())
+      .send({
+        query,
+        variables: {
+          domainId: domain.id,
+        },
+      })
+      .expect(200);
+
+    expect(response.body.errors).toBeUndefined();
+
+    const activeEvaluations = response.body.data.activeEvaluations as Array<Record<string, unknown>>;
+    expect(activeEvaluations).toHaveLength(1);
+    expect(activeEvaluations[0]).toEqual(
+      expect.objectContaining({
+        id: evaluation.id,
+        domainId: domain.id,
+        status: 'RUNNING',
+        memberCount: 1,
+      }),
+    );
+    expect(activeEvaluations[0]?.members).toEqual([
+      expect.objectContaining({
+        runId: pendingRun.id,
+        runStatus: 'PENDING',
+        runCategory: 'PRODUCTION',
+      }),
+    ]);
+  });
+
   it('returns a domain evaluation cost estimate with fallback metadata and confidence', async () => {
     const provider = await db.llmProvider.create({
       data: {

--- a/cloud/apps/web/src/components/status/ActiveEvaluationsSection.tsx
+++ b/cloud/apps/web/src/components/status/ActiveEvaluationsSection.tsx
@@ -222,7 +222,7 @@ export function ActiveEvaluationsSection({
                 </Badge>
               </div>
               <p className="text-sm text-gray-500">
-                Live evaluation launches currently running or summarizing.
+                Live evaluation launches currently pending, running, paused, or summarizing.
               </p>
             </div>
             <div className="flex items-center gap-2">
@@ -262,7 +262,7 @@ export function ActiveEvaluationsSection({
             <div className="rounded-lg border border-gray-200 bg-white px-6 py-10 text-center">
               <p className="text-sm font-medium text-gray-900">No active evaluations.</p>
               <p className="mt-1 text-sm text-gray-500">
-                Nothing is currently running or summarizing.
+                Nothing is currently pending, running, paused, or summarizing.
               </p>
             </div>
           ) : (


### PR DESCRIPTION
## What changed
- Expand the cross-domain active-evaluations query to include `PENDING`, `RUNNING`, `PAUSED`, and `SUMMARIZING` launches.
- Update the status page copy so it matches the broader active-launch behavior.
- Add an API regression test that proves a pending launch now shows up in `activeEvaluations`.
- Record the completed work in `STATUS.md`.

## Why
A run can be doing real work while still stuck in `PENDING`, which hid it from the status page. That made active launches harder to find and diagnose.

## Validation
- `cd cloud && npm run db:test:setup` (failed in this environment because the script resolves Prisma 7 against the older schema format)
- `cd cloud && npx turbo lint --filter=@valuerank/api` ✅
- `cd cloud && npx turbo build --filter=@valuerank/api` ✅
- `cd cloud && npx turbo lint --filter=@valuerank/web` ✅
- `cd cloud && npx turbo build --filter=@valuerank/web` ✅
- `cd cloud && npx turbo test --filter=@valuerank/api` ✅
- `cd cloud && npx turbo test --filter=@valuerank/web` ✅

## Root cause
The status page only queried runs in `RUNNING` or `SUMMARIZING`, but the run lifecycle can leave a live launch in `PENDING` even while work is progressing.