### PR TITLE
dedup: consolidate wilsonInterval; null on invalid inputs (DEDUP-9)

### DIFF
--- a/cloud/apps/api/src/services/consistency/modelsConsistencyData.ts
+++ b/cloud/apps/api/src/services/consistency/modelsConsistencyData.ts
@@ -175,16 +175,17 @@ export function computeRepeatability(perScenario: ConsistencyParsedScenario[]) {
     betweenScenarioSd: pooled.betweenSd,
     scenariosMeasured: ordered.length,
     perDomain: [] as Array<{ domainId: string; domainName: string; value: number; ciLow: number; ciHigh: number; scenariosMeasured: number }>,
-    perScenario: ordered.map((scenario) => {
+    perScenario: ordered.flatMap((scenario) => {
       const interval = wilsonInterval(scenario.matches, scenario.trials);
-      return {
+      if (interval == null) return [];
+      return [{
         scenarioId: scenario.scenarioId,
         matches: scenario.matches,
         trials: scenario.trials,
         p: interval.p,
         ciLow: interval.low,
         ciHigh: interval.high,
-      };
+      }];
     }),
   };
 }

--- a/cloud/apps/api/src/services/consistency/statistics.ts
+++ b/cloud/apps/api/src/services/consistency/statistics.ts
@@ -1,5 +1,7 @@
 import { spearmanRankCorrelation } from '../statistics/spearman.js';
 export { spearmanRankCorrelation } from '../statistics/spearman.js';
+import { wilsonInterval } from '../statistics/wilson-interval.js';
+export { wilsonInterval } from '../statistics/wilson-interval.js';
 
 export type CanonicalAppealLevel =
   | 'strongly'
@@ -7,12 +9,6 @@ export type CanonicalAppealLevel =
   | 'neutral'
   | 'opponentSomewhat'
   | 'opponentStrongly';
-
-export type WilsonIntervalResult = {
-  low: number;
-  high: number;
-  p: number;
-};
 
 export type DlsScenarioStat = {
   p: number;
@@ -53,39 +49,8 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
-function validateProportion(matches: number, trials: number): void {
-  if (!Number.isInteger(matches) || !Number.isInteger(trials)) {
-    throw new RangeError('matches and trials must be integers');
-  }
-  if (matches < 0 || trials < 0 || matches > trials) {
-    throw new RangeError('matches must be between 0 and trials');
-  }
-}
-
 function scenarioMatchesFromProportion(p: number, n: number): number {
   return Math.max(0, Math.min(n, Math.round(p * n)));
-}
-
-export function wilsonInterval(matches: number, trials: number, z = Z_95): WilsonIntervalResult {
-  validateProportion(matches, trials);
-  if (trials === 0) {
-    return { low: 0, high: 0, p: 0 };
-  }
-
-  const p = matches / trials;
-  const zSquared = z * z;
-  const denominator = 1 + zSquared / trials;
-  const center = (p + zSquared / (2 * trials)) / denominator;
-  const margin = (
-    z
-    * Math.sqrt((p * (1 - p) + zSquared / (4 * trials)) / trials)
-  ) / denominator;
-
-  return {
-    p,
-    low: clamp01(center - margin),
-    high: clamp01(center + margin),
-  };
 }
 
 export function dersimonianLairdPool(scenarioStats: DlsScenarioStat[]): DlsPoolResult {
@@ -105,6 +70,9 @@ export function dersimonianLairdPool(scenarioStats: DlsScenarioStat[]): DlsPoolR
     const scenario = usable[0]!;
     const matches = scenarioMatchesFromProportion(scenario.p, scenario.n);
     const wilson = wilsonInterval(matches, scenario.n);
+    if (wilson == null) {
+      return { estimate: 0, ciLow: 0, ciHigh: 0, withinSd: 0, betweenSd: 0, tauSquared: 0 };
+    }
     const variance = Math.pow((wilson.high - wilson.low) / (2 * Z_95), 2);
     return {
       estimate: wilson.p,
@@ -116,15 +84,16 @@ export function dersimonianLairdPool(scenarioStats: DlsScenarioStat[]): DlsPoolR
     };
   }
 
-  const studies = usable.map((scenario) => {
+  const studies = usable.flatMap((scenario) => {
     const matches = scenarioMatchesFromProportion(scenario.p, scenario.n);
     const wilson = wilsonInterval(matches, scenario.n);
+    if (wilson == null) return [];
     const variance = Math.max(EPSILON, Math.pow((wilson.high - wilson.low) / (2 * Z_95), 2));
-    return {
+    return [{
       p: wilson.p,
       variance,
       weight: 1 / variance,
-    };
+    }];
   });
 
   const fixedWeightTotal = studies.reduce((sum, study) => sum + study.weight, 0);

--- a/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts
@@ -375,30 +375,7 @@ function wilsonIntervalFromProportion(
   };
 }
 
-export function wilsonInterval(
-  matches: number,
-  trials: number,
-  z = Z_95,
-): { p: number; low: number; high: number } | null {
-  if (
-    !Number.isFinite(matches)
-    || !Number.isFinite(trials)
-    || !Number.isFinite(z)
-    || !Number.isInteger(matches)
-    || !Number.isInteger(trials)
-    || matches < 0
-    || trials <= 0
-    || matches > trials
-  ) {
-    return null;
-  }
-
-  const result = wilsonIntervalFromProportion(matches / trials, trials, z);
-  if (result === null) return null;
-  if (matches === 0) result.low = 0;
-  if (matches === trials) result.high = 1;
-  return result;
-}
+export { wilsonInterval } from '../statistics/wilson-interval.js';
 
 /**
  * Compute Newcombe Method-10 confidence interval on the difference of two proportions.

--- a/cloud/apps/api/src/services/statistics/wilson-interval.ts
+++ b/cloud/apps/api/src/services/statistics/wilson-interval.ts
@@ -1,0 +1,59 @@
+/**
+ * Canonical Wilson score confidence interval.
+ *
+ * Single source of truth — replaces the duplicate implementations in
+ * pressure-sensitivity/aggregation.ts and consistency/statistics.ts (DEDUP-9).
+ */
+
+// Default z for a two-tailed 95% CI
+const Z_95 = 1.96;
+
+function clamp01(value: number): number {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/**
+ * Compute the Wilson score confidence interval.
+ *
+ * Returns `null` for any invalid input (trials <= 0, non-integer counts,
+ * negative counts, NaN, infinity). This is the "fail-loud" contract: callers
+ * must handle null rather than silently receiving zeros.
+ *
+ * @param matches - Number of successes (non-negative integer, <= trials)
+ * @param trials  - Total number of trials (positive integer)
+ * @param z       - Normal quantile; defaults to 1.96 (95% CI)
+ */
+export function wilsonInterval(
+  matches: number,
+  trials: number,
+  z = Z_95,
+): { low: number; high: number; p: number } | null {
+  if (
+    !Number.isFinite(matches)
+    || !Number.isFinite(trials)
+    || !Number.isFinite(z)
+    || !Number.isInteger(matches)
+    || !Number.isInteger(trials)
+    || matches < 0
+    || trials <= 0
+    || matches > trials
+  ) {
+    return null;
+  }
+
+  const p = matches / trials;
+  const zSquared = z * z;
+  const denominator = 1 + zSquared / trials;
+  const center = (p + zSquared / (2 * trials)) / denominator;
+  const margin = (
+    z
+    * Math.sqrt((p * (1 - p) + zSquared / (4 * trials)) / trials)
+  ) / denominator;
+
+  const low = matches === 0 ? 0 : clamp01(center - margin);
+  const high = matches === trials ? 1 : clamp01(center + margin);
+
+  return { p, low, high };
+}

--- a/cloud/apps/api/tests/services/consistency/statistics.test.ts
+++ b/cloud/apps/api/tests/services/consistency/statistics.test.ts
@@ -15,8 +15,8 @@ describe('wilsonInterval', () => {
     expect(result.high).toBeCloseTo(0.9114, 3);
   });
 
-  it('returns zeros when there are no trials', () => {
-    expect(wilsonInterval(0, 0)).toEqual({ low: 0, high: 0, p: 0 });
+  it('returns null when there are no trials', () => {
+    expect(wilsonInterval(0, 0)).toBeNull();
   });
 });
 
@@ -24,11 +24,12 @@ describe('dersimonianLairdPool', () => {
   it('falls back to Wilson for a single scenario', () => {
     const single = dersimonianLairdPool([{ p: 0.8, n: 25 }]);
     const wilson = wilsonInterval(20, 25);
+    expect(wilson).not.toBeNull();
     expect(single.betweenSd).toBe(0);
     expect(single.tauSquared).toBe(0);
-    expect(single.estimate).toBeCloseTo(wilson.p, 6);
-    expect(single.ciLow).toBeCloseTo(wilson.low, 6);
-    expect(single.ciHigh).toBeCloseTo(wilson.high, 6);
+    expect(single.estimate).toBeCloseTo(wilson!.p, 6);
+    expect(single.ciLow).toBeCloseTo(wilson!.low, 6);
+    expect(single.ciHigh).toBeCloseTo(wilson!.high, 6);
   });
 
   it('pools heterogeneous studies with random effects', () => {

--- a/docs/tech-debt/dedup-inventory.md
+++ b/docs/tech-debt/dedup-inventory.md
@@ -46,7 +46,7 @@ DEDUP-8 (`isRecord`) is independent of report output — pure type guard.
 | DEDUP-6 | Snapshot builder twin (domain-analysis vs pressure-sensitivity) | API | Medium | Large | Decision needed |
 | DEDUP-7 | `cloud/packages/db/src/queries/*` mostly orphaned | API/db | High | Medium | Decision needed |
 | ~~DEDUP-8~~ | ~~`isRecord` defined 9 times~~ | ~~API~~ | ~~Medium~~ | ~~Trivial~~ | **Resolved — PR #928** |
-| ~~DEDUP-9~~ | ~~`wilsonInterval` defined twice~~ | ~~API~~ | ~~Medium~~ | ~~Small~~ | **Resolved — PR #TBD** |
+| ~~DEDUP-9~~ | ~~`wilsonInterval` defined twice~~ | ~~API~~ | ~~Medium~~ | ~~Small~~ | **Resolved — PR #943** |
 | DEDUP-10 | Decision-summary utility sprawl | Web | Medium-High | Large | Decision needed |
 | DEDUP-11 | Shared `*-value-statements.ts` (4× boilerplate) | Shared | Medium | Small | Open |
 | DEDUP-12 | Run lifecycle / recovery sprawl | API | Medium-Low | Large | Decision needed |
@@ -152,7 +152,7 @@ Added `hasAnalysis?: boolean` and `analysisStatus?` params to `useRuns` and `use
 
 ### DEDUP-9 — `wilsonInterval` defined twice
 
-**Status: Resolved in PR #TBD (2026-05-05).**
+**Status: Resolved in PR #943 (2026-05-05).**
 
 Canonical implementation: `cloud/apps/api/src/services/statistics/wilson-interval.ts`.
 Signature: `wilsonInterval(matches, trials, z?) → { low, high, p } | null`.
@@ -270,7 +270,7 @@ Tracking infrastructure that protects against dedup-induced (or any) drift in us
 | DEDUP-3 | `useRuns` / `useRunsWithAnalysis` hook collapse | #934 | 2026-05-05 | Added `hasAnalysis` + `analysisStatus` params to `useRuns` and `useInfiniteRuns`. Deleted `useRunsWithAnalysis.ts` and `useInfiniteRunsWithAnalysis.ts`. `comparison.graphql:RunsWithAnalysis` left in place (different resolver). |
 | DEDUP-15 | `runsWithAnalysis(ids:)` resolver and web query deleted | #936 | 2026-05-05 | Zero consumers. Architecture decision at `cloud/specs/016-analysis-tab/plan.md` chose `runs(hasAnalysis:)` instead. ~250 LOC removed across API resolver, tests, web query, re-export, manual types. Schema snapshot and codegen regenerated. |
 | DEDUP-2 | `signaturePreference` fork web↔shared (partial) | #937 | 2026-05-06 | Deleted `cloud/apps/web/src/utils/signaturePreference.ts` (57 LOC). Updated 2 importers to use `@valuerank/shared`. `schwartz.ts` NOT deleted — not a true duplicate (exports different function). |
-| DEDUP-9 | `wilsonInterval` consolidation | #TBD | 2026-05-05 | Canonical: `cloud/apps/api/src/services/statistics/wilson-interval.ts`. Invalid inputs now return `null` (fail-loud contract). `WilsonIntervalResult` type deleted. Both prior sites re-export from canonical. `wilsonIntervalFromProportion` stays local in `aggregation.ts` (used by `diffProportionCI`). |
+| DEDUP-9 | `wilsonInterval` consolidation | #943 | 2026-05-05 | Canonical: `cloud/apps/api/src/services/statistics/wilson-interval.ts`. Invalid inputs now return `null` (fail-loud contract). `WilsonIntervalResult` type deleted. Both prior sites re-export from canonical. `wilsonIntervalFromProportion` stays local in `aggregation.ts` (used by `diffProportionCI`). |
 
 ### Dead-code deletions
 

--- a/docs/tech-debt/dedup-inventory.md
+++ b/docs/tech-debt/dedup-inventory.md
@@ -46,7 +46,7 @@ DEDUP-8 (`isRecord`) is independent of report output — pure type guard.
 | DEDUP-6 | Snapshot builder twin (domain-analysis vs pressure-sensitivity) | API | Medium | Large | Decision needed |
 | DEDUP-7 | `cloud/packages/db/src/queries/*` mostly orphaned | API/db | High | Medium | Decision needed |
 | ~~DEDUP-8~~ | ~~`isRecord` defined 9 times~~ | ~~API~~ | ~~Medium~~ | ~~Trivial~~ | **Resolved — PR #928** |
-| DEDUP-9 | `wilsonInterval` defined twice | API | Medium | Small | Open |
+| ~~DEDUP-9~~ | ~~`wilsonInterval` defined twice~~ | ~~API~~ | ~~Medium~~ | ~~Small~~ | **Resolved — PR #TBD** |
 | DEDUP-10 | Decision-summary utility sprawl | Web | Medium-High | Large | Decision needed |
 | DEDUP-11 | Shared `*-value-statements.ts` (4× boilerplate) | Shared | Medium | Small | Open |
 | DEDUP-12 | Run lifecycle / recovery sprawl | API | Medium-Low | Large | Decision needed |
@@ -151,6 +151,16 @@ Added `hasAnalysis?: boolean` and `analysisStatus?` params to `useRuns` and `use
 - Body: `value !== null && typeof value === 'object' && !Array.isArray(value)`. `modelsConsistencyData.ts` narrowed to `RawRecord`.
 
 ### DEDUP-9 — `wilsonInterval` defined twice
+
+**Status: Resolved in PR #TBD (2026-05-05).**
+
+Canonical implementation: `cloud/apps/api/src/services/statistics/wilson-interval.ts`.
+Signature: `wilsonInterval(matches, trials, z?) → { low, high, p } | null`.
+Default z = 1.96 (matching both prior implementations).
+
+**Boundary-contract decision:** Invalid inputs (trials ≤ 0, NaN, non-integer, etc.) now return `null` instead of throwing (was throwing in consistency) or returning zeros (was returning `{ low:0, high:0, p:0 }` for `trials=0` in consistency). This is the user-approved fail-loud contract. The `WilsonIntervalResult` type was deleted from `consistency/statistics.ts`.
+
+Both `aggregation.ts` and `consistency/statistics.ts` now re-export `wilsonInterval` from the canonical module — external consumers see no import-path change. The `wilsonIntervalFromProportion` private helper stays in `aggregation.ts` because `diffProportionCI` calls it directly with a proportion input. All callers updated to handle `null`. Consistency test updated to expect `null` for `wilsonInterval(0, 0)`.
 
 **Files:** `cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts:378`, `cloud/apps/api/src/services/consistency/statistics.ts:69`.
 **Shared:** Wilson confidence interval for a binomial proportion. Same math.
@@ -260,6 +270,7 @@ Tracking infrastructure that protects against dedup-induced (or any) drift in us
 | DEDUP-3 | `useRuns` / `useRunsWithAnalysis` hook collapse | #934 | 2026-05-05 | Added `hasAnalysis` + `analysisStatus` params to `useRuns` and `useInfiniteRuns`. Deleted `useRunsWithAnalysis.ts` and `useInfiniteRunsWithAnalysis.ts`. `comparison.graphql:RunsWithAnalysis` left in place (different resolver). |
 | DEDUP-15 | `runsWithAnalysis(ids:)` resolver and web query deleted | #936 | 2026-05-05 | Zero consumers. Architecture decision at `cloud/specs/016-analysis-tab/plan.md` chose `runs(hasAnalysis:)` instead. ~250 LOC removed across API resolver, tests, web query, re-export, manual types. Schema snapshot and codegen regenerated. |
 | DEDUP-2 | `signaturePreference` fork web↔shared (partial) | #937 | 2026-05-06 | Deleted `cloud/apps/web/src/utils/signaturePreference.ts` (57 LOC). Updated 2 importers to use `@valuerank/shared`. `schwartz.ts` NOT deleted — not a true duplicate (exports different function). |
+| DEDUP-9 | `wilsonInterval` consolidation | #TBD | 2026-05-05 | Canonical: `cloud/apps/api/src/services/statistics/wilson-interval.ts`. Invalid inputs now return `null` (fail-loud contract). `WilsonIntervalResult` type deleted. Both prior sites re-export from canonical. `wilsonIntervalFromProportion` stays local in `aggregation.ts` (used by `diffProportionCI`). |
 
 ### Dead-code deletions
 
@@ -270,10 +281,11 @@ Tracking infrastructure that protects against dedup-induced (or any) drift in us
 
 ## Phase 2 — recommended starting order
 
-DEDUP-8, DEDUP-3, and DEDUP-2 (partial) are done. Suggested next picks:
+DEDUP-8, DEDUP-3, DEDUP-2 (partial), and DEDUP-9 are done. Suggested next picks:
 
-1. **DEDUP-9** (`wilsonInterval`) — small statistics-helper consolidation; 2 callsites, contract change is contained.
-2. **DEDUP-1** (`pauseQueue`) — start with a design note, not code. The only active-bug cluster.
+1. **DEDUP-11** (`*-value-statements.ts` boilerplate) — 4× identical shape; pure mechanical consolidation.
+2. **DEDUP-13** (`validate_input` in 5 workers) — small, self-contained, no contract changes.
+3. **DEDUP-1** (`pauseQueue`) — start with a design note, not code. The only active-bug cluster.
 
 Note: `cloud/apps/web/src/utils/schwartz.ts` was audited during DEDUP-2 and found NOT to be a duplicate. It exports `formatFullSchwartzValueName` which has no equivalent in shared. Remove the schwartz half of DEDUP-2 from any future planning.
 


### PR DESCRIPTION
## Summary

- Creates `cloud/apps/api/src/services/statistics/wilson-interval.ts` as the single canonical implementation of `wilsonInterval`
- Removes the duplicate implementations from `pressure-sensitivity/aggregation.ts` and `consistency/statistics.ts`; both now re-export from the canonical module so callers see no import-path change
- **Boundary-contract decision (user-approved):** invalid inputs now return `null` instead of throwing a `RangeError` (was consistency's behavior) or returning `{ low:0, high:0, p:0 }` (was consistency's `trials=0` case). Fail-loud: callers must handle null.

## Contract details

- Signature: `wilsonInterval(matches, trials, z?) → { low, high, p } | null`
- Default z = 1.96 (identical to both prior implementations)
- Field names: `low`, `high`, `p` (matching consistency's existing exported shape; no lo/hi accessor existed publicly in aggregation)
- Math formula: byte-equivalent to both prior implementations for valid inputs — only the boundary behavior changed
- `WilsonIntervalResult` type deleted from `consistency/statistics.ts` (was only used internally)
- `wilsonIntervalFromProportion` stays as a local private helper in `aggregation.ts` — `diffProportionCI` calls it directly with proportion inputs, so it cannot be replaced by the count-based canonical

## Callers updated

- `consistency/statistics.ts` — `dersimonianLairdPool` now guards both `wilsonInterval` call sites with `if (wilson == null)` before accessing `.p`, `.high`, `.low`
- `consistency/modelsConsistencyData.ts` — `computeRepeatability` perScenario map changed to `flatMap` that silently skips scenarios where wilson returns null (only possible if `trials <= 0`, which shouldn't occur in production data)
- `consistency/statistics.test.ts` — test updated to assert `null` for `wilsonInterval(0, 0)` (was `{ low:0, high:0, p:0 }`)
- `dersimonianLairdPool` test updated to use non-null assertion after `expect(wilson).not.toBeNull()`

## Files modified

| File | Change |
|---|---|
| `cloud/apps/api/src/services/statistics/wilson-interval.ts` | **New** — canonical implementation (62 LOC) |
| `cloud/apps/api/src/services/pressure-sensitivity/aggregation.ts` | Remove local impl; add re-export |
| `cloud/apps/api/src/services/consistency/statistics.ts` | Remove local impl + WilsonIntervalResult; add import + re-export; add null guards in dersimonianLairdPool |
| `cloud/apps/api/src/services/consistency/modelsConsistencyData.ts` | Add null guard in perScenario map |
| `cloud/apps/api/tests/services/consistency/statistics.test.ts` | Update wilsonInterval(0,0) and DL pool tests |
| `docs/tech-debt/dedup-inventory.md` | Mark DEDUP-9 resolved; update Phase 2 order |

Net: +79 / -72 lines across implementation files.

## Validation

- Lint: 0 errors (11105 pre-existing warnings unchanged)
- Build: passes after building workspace dependencies
- Tests: 204 test files, 2329 passed, 4 skipped — all green
- Snapshot check: `pressure-sensitivity` passes; `models-confidence` has pre-existing data drift unrelated to this change (new prod transcripts)

**Note:** This is the first dedup PR to touch a Models-report calculation path (`consistency/statistics.ts`). The snapshot CI check on this PR is the real canary for math correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)