### PR TITLE
fix: count transcripts across all runs for batch equivalent coverage

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-coverage.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-coverage.ts
@@ -281,15 +281,6 @@ builder.queryField('domainValueCoverage', (t) =>
             continue;
           }
 
-          const models = Array.isArray(config.models)
-            ? config.models.filter((model): model is string => typeof model === 'string' && model.length > 0)
-            : null;
-          const matchesEffectiveModelSet = activeModelFilter.length === 0
-            || (models !== null && activeModelFilter.every((id) => models.includes(id)));
-          if (!matchesEffectiveModelSet) {
-            continue;
-          }
-
           const direction = getCoverageDirection(run.config);
           if (direction === null) {
             continue;


### PR DESCRIPTION
## Summary

- **Old behavior:** Before counting a run's transcripts toward `batchEquivalent`, there was a run-level filter that required the run's `config.models` array to include _every_ active default model ID. A run with only 7 of 8 models would be silently skipped entirely.
- **New behavior:** All non-aggregate completed runs are counted. Transcript-level filtering (already present) ensures only transcripts from the selected model set are tallied. `computeBatchEquivalent` then takes the minimum trial count across all (scenario × model) combinations, which naturally handles partial-model runs correctly.
- **Impact:** A Mar 23 run with 7/8 models combined with an Apr 4 run contributing the missing 1 model now correctly combine to count as 1 batch equivalent, rather than both runs being excluded because neither individually covered all 8 models.

## Validation

Build and preflight checks were run and passed before this change was authored. The only modification is a 9-line deletion removing the `matchesEffectiveModelSet` guard block in `domain-coverage.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)