### PR TITLE
[codex] make domain overview match model page

### DIFF
--- a/cloud/apps/web/src/components/domains/CoverageMatrix.tsx
+++ b/cloud/apps/web/src/components/domains/CoverageMatrix.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
+import { forwardRef, useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'urql';
 import { ErrorMessage } from '../ui/ErrorMessage';
 import { Loading } from '../ui/Loading';
@@ -8,19 +8,11 @@ import {
   type DomainValueCoverageQueryResult,
   type DomainValueCoverageQueryVariables,
 } from '../../api/operations/domainCoverage';
-import {
-  DOMAIN_AVAILABLE_SIGNATURES_QUERY,
-  type DomainAvailableSignature,
-  type DomainAvailableSignaturesQueryResult,
-} from '../../api/operations/domainAnalysis';
 import { VALUE_LABELS } from './domainAnalysisData';
 import { formatDisplayLabel } from '../../utils/displayLabels';
 import { cn } from '../../lib/utils';
 import { getCanonicalDimension } from '@valuerank/shared';
 import { CoverageCell } from './CoverageCell';
-import { selectPreferredSignature } from './coverageMatrixHelpers';
-import { Button } from '../ui/Button';
-import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../../api/operations/llm';
 
 type CategoryGroup = {
   name: string;
@@ -28,413 +20,251 @@ type CategoryGroup = {
   values: string[];
 };
 
+type CoverageMatrixProps = {
+  domainId: string;
+  signature: string;
+  modelIds: string[];
+};
+
 /**
  * CoverageMatrix — embeddable coverage matrix component.
  *
- * Accepts a domainId prop; manages its own signature and model state internally.
- * No URL sync — the parent page owns URL state for domainId.
+ * Accepts the selected domain, signature, and model IDs from the parent page.
+ * The parent owns URL sync and picker state so the matrix only renders data.
  */
-export const CoverageMatrix = forwardRef<HTMLDivElement, { domainId: string }>(
-  function CoverageMatrix({ domainId }, ref) {
-  const [selectedSignature, setSelectedSignature] = useState<string>('');
-  const [allowAllSignatures, setAllowAllSignatures] = useState(false);
-  const [useLegacyQuery, setUseLegacyQuery] = useState(false);
-  const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
-  const initializedModelSelection = useRef(false);
+export const CoverageMatrix = forwardRef<HTMLDivElement, CoverageMatrixProps>(
+  function CoverageMatrix({ domainId, signature, modelIds }, ref) {
+    const [useLegacyQuery, setUseLegacyQuery] = useState(false);
 
-  const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
-    DomainAvailableSignaturesQueryResult,
-    { domainId: string }
-  >({
-    query: DOMAIN_AVAILABLE_SIGNATURES_QUERY,
-    variables: { domainId },
-    pause: domainId === '',
-    requestPolicy: 'network-only',
-  });
+    useEffect(() => {
+      setUseLegacyQuery(false);
+    }, [domainId]);
 
-  const signatureOptions = useMemo<DomainAvailableSignature[]>(
-    () => signatureData?.domainAvailableSignatures ?? [],
-    [signatureData],
-  );
-  const preferredSignature = useMemo(
-    () => selectPreferredSignature(signatureOptions),
-    [signatureOptions],
-  );
-  const hasValidSelectedSignature = useMemo(
-    () => selectedSignature === '' || signatureOptions.some((option) => option.signature === selectedSignature),
-    [selectedSignature, signatureOptions],
-  );
-  const signatureSelectionReady = domainId !== ''
-    && !signaturesLoading
-    && hasValidSelectedSignature
-    && (selectedSignature !== '' || allowAllSignatures || signatureOptions.length === 0);
-
-  const [{ data: llmModelsData }] = useQuery<LlmModelsQueryResult>({
-    query: LLM_MODELS_QUERY,
-    variables: { status: 'ACTIVE' },
-    requestPolicy: 'cache-and-network',
-  });
-
-  // Reset state when domainId changes
-  useEffect(() => {
-    setSelectedSignature('');
-    setAllowAllSignatures(false);
-    setUseLegacyQuery(false);
-    setSelectedModelIds([]);
-    initializedModelSelection.current = false;
-  }, [domainId]);
-
-  useEffect(() => {
-    if (signaturesLoading) return;
-    if (signatureOptions.length === 0) {
-      if (selectedSignature !== '') setSelectedSignature('');
-      return;
-    }
-    if (selectedSignature !== '' && signatureOptions.some((option) => option.signature === selectedSignature)) return;
-    if (selectedSignature === '' && allowAllSignatures) return;
-    setSelectedSignature(preferredSignature);
-  }, [allowAllSignatures, preferredSignature, selectedSignature, signatureOptions, signaturesLoading]);
-
-  const [{ data: scoredData, fetching: scoredFetching, error: scoredError }] = useQuery<
-    DomainValueCoverageQueryResult,
-    DomainValueCoverageQueryVariables
-  >({
-    query: DOMAIN_VALUE_COVERAGE_QUERY,
-    variables: {
-      domainId,
-      signature: selectedSignature === '' ? undefined : selectedSignature,
-      modelIds: selectedModelIds.length === 0 ? undefined : selectedModelIds,
-    },
-    pause: domainId === '' || !signatureSelectionReady || useLegacyQuery,
-    requestPolicy: 'network-only',
-  });
-
-  const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<
-    DomainValueCoverageQueryResult,
-    Omit<DomainValueCoverageQueryVariables, 'signature'>
-  >({
-    query: DOMAIN_VALUE_COVERAGE_QUERY_LEGACY,
-    variables: {
-      domainId,
-    },
-    pause: domainId === '' || !signatureSelectionReady || !useLegacyQuery,
-    requestPolicy: 'network-only',
-  });
-
-  useEffect(() => {
-    const message = scoredError?.message ?? '';
-    const isUnknownArgumentError = message.includes('Unknown argument "signature"');
-    const isUnknownFieldError = message.includes('Cannot query field') || message.includes('Unknown field');
-    if ((isUnknownArgumentError || isUnknownFieldError) && !useLegacyQuery) {
-      setUseLegacyQuery(true);
-    }
-  }, [scoredError, useLegacyQuery]);
-
-  const data = useLegacyQuery ? legacyData : scoredData;
-  const fetching = useLegacyQuery ? legacyFetching : scoredFetching;
-  const error = useLegacyQuery ? legacyError : scoredError;
-
-  const canonicalValues = data?.domainValueCoverage?.values ?? [];
-  const availableModels = data?.domainValueCoverage?.availableModels ?? [];
-
-  const defaultModelIds = useMemo(
-    () => new Set((llmModelsData?.llmModels ?? []).filter((m) => m.isDefault).map((m) => m.modelId)),
-    [llmModelsData],
-  );
-
-  const defaultSelection = useMemo(() => {
-    const availableIds = availableModels.map((m) => m.modelId);
-    const defaults = availableIds.filter((id) => defaultModelIds.has(id));
-    return defaults.length > 0 ? defaults : availableIds;
-  }, [availableModels, defaultModelIds]);
-
-  useEffect(() => {
-    if (initializedModelSelection.current) return;
-    if (availableModels.length === 0) return;
-    if (llmModelsData == null) return;
-    setSelectedModelIds(defaultSelection);
-    initializedModelSelection.current = true;
-  }, [availableModels, llmModelsData, defaultSelection]);
-
-  const isDefaultSelection = useMemo(() => {
-    if (selectedModelIds.length !== defaultSelection.length) return false;
-    const defaultSet = new Set(defaultSelection);
-    return selectedModelIds.every((id) => defaultSet.has(id));
-  }, [selectedModelIds, defaultSelection]);
-
-  const modelSetSummary = availableModels.length === 0
-    ? 'Loading...'
-    : isDefaultSelection
-      ? `Default — ${selectedModelIds.length} model${selectedModelIds.length === 1 ? '' : 's'}`
-      : selectedModelIds.length === availableModels.length
-        ? 'All models'
-        : `${selectedModelIds.length} of ${availableModels.length} selected`;
-
-  const toggleModelId = (modelId: string) => {
-    setSelectedModelIds((current) => (
-      current.includes(modelId)
-        ? current.filter((id) => id !== modelId)
-        : [...current, modelId]
-    ));
-  };
-
-  const cellLookup = useMemo(() => {
-    const defaultCells = data?.domainValueCoverage?.cells ?? [];
-    const map = new Map<string, (typeof defaultCells)[0]>();
-    for (const cell of defaultCells) {
-      map.set([cell.valueA, cell.valueB].sort().join('::'), cell);
-    }
-    return map;
-  }, [data?.domainValueCoverage?.cells]);
-
-  const valueGroups = useMemo(() => {
-    const defaultCanonicalValues = data?.domainValueCoverage?.values ?? [];
-    if (defaultCanonicalValues.length === 0) return [];
-
-    const categories: Record<string, CategoryGroup> = {
-      Openness_to_Change: {
-        name: 'Openness',
-        color: 'bg-orange-100 border-orange-200 text-orange-800',
-        values: [],
+    const [{ data: scoredData, fetching: scoredFetching, error: scoredError }] = useQuery<
+      DomainValueCoverageQueryResult,
+      DomainValueCoverageQueryVariables
+    >({
+      query: DOMAIN_VALUE_COVERAGE_QUERY,
+      variables: {
+        domainId,
+        signature: signature === '' ? undefined : signature,
+        modelIds,
       },
-      Self_Enhancement: {
-        name: 'Enhancement',
-        color: 'bg-purple-100 border-purple-200 text-purple-800',
-        values: [],
-      },
-      Conservation: {
-        name: 'Conservation',
-        color: 'bg-blue-100 border-blue-200 text-blue-800',
-        values: [],
-      },
-      Self_Transcendence: {
-        name: 'Transcendence',
-        color: 'bg-emerald-100 border-emerald-200 text-emerald-800',
-        values: [],
-      },
-    };
-
-    defaultCanonicalValues.forEach((val) => {
-      const canonical = getCanonicalDimension(val);
-      if (canonical) {
-        categories[canonical.higherOrder]?.values.push(val);
-      }
+      pause: domainId === '' || useLegacyQuery,
+      requestPolicy: 'network-only',
     });
 
-    return Object.values(categories).filter((c) => c.values.length > 0);
-  }, [data?.domainValueCoverage?.values]);
+    const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<
+      DomainValueCoverageQueryResult,
+      Omit<DomainValueCoverageQueryVariables, 'signature'>
+    >({
+      query: DOMAIN_VALUE_COVERAGE_QUERY_LEGACY,
+      variables: {
+        domainId,
+        modelIds,
+      },
+      pause: domainId === '' || !useLegacyQuery,
+      requestPolicy: 'network-only',
+    });
 
-  const displayValues = useMemo(
-    () => valueGroups.flatMap((group) => group.values),
-    [valueGroups],
-  );
+    useEffect(() => {
+      const message = scoredError?.message ?? '';
+      const isUnknownArgumentError = message.includes('Unknown argument "signature"');
+      const isUnknownFieldError = message.includes('Cannot query field') || message.includes('Unknown field');
+      if ((isUnknownArgumentError || isUnknownFieldError) && !useLegacyQuery) {
+        setUseLegacyQuery(true);
+      }
+    }, [scoredError, useLegacyQuery]);
 
-  return (
-    <div className="space-y-4">
-      {(signaturesError || error) && (
-        <ErrorMessage
-          message={`Failed to load coverage data: ${(signaturesError ?? error)?.message ?? 'Unknown error'}`}
-        />
-      )}
-      {useLegacyQuery && selectedSignature !== '' && (
-        <ErrorMessage message="Coverage API does not yet support signature filtering in this environment. Showing all signatures." />
-      )}
+    const data = useLegacyQuery ? legacyData : scoredData;
+    const fetching = useLegacyQuery ? legacyFetching : scoredFetching;
+    const error = useLegacyQuery ? legacyError : scoredError;
 
-      {/* Controls */}
-      <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
-        <div className="flex items-center justify-between w-full md:w-auto">
-          <h2 className="text-sm font-semibold text-gray-900 min-w-[140px]">Batch Signature</h2>
-        </div>
-        <div className="flex items-center gap-3 flex-1">
-          <select
-            aria-label="Batch Signature"
-            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 flex-1 max-w-sm"
-            value={selectedSignature}
-            onChange={(event) => {
-              const nextSignature = event.target.value;
-              setAllowAllSignatures(nextSignature === '');
-              setSelectedSignature(nextSignature);
-            }}
-            disabled={signaturesLoading}
-          >
-            <option value="">All signatures</option>
-            {signatureOptions.map((signatureOption) => (
-              <option key={signatureOption.signature} value={signatureOption.signature}>
-                {signatureOption.label}
-              </option>
-            ))}
-          </select>
-        </div>
-        {availableModels.length > 0 && (
-          <details className="min-w-[210px]">
-            <summary className="cursor-pointer list-none">
-              <p className="mb-1 text-sm font-medium text-gray-700">Model filter</p>
-              <div className="inline-flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm min-h-[44px] hover:border-gray-400 sm:min-h-0">
-                <span>{modelSetSummary}</span>
-                <span className="ml-2 text-gray-400">▾</span>
-              </div>
-            </summary>
-            <div className="mt-1 space-y-2 rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-              <div className="flex flex-wrap gap-1.5">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setSelectedModelIds(defaultSelection)}
-                  className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
-                    isDefaultSelection
-                      ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
-                      : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
-                  }`}
-                >
-                  Default Models
-                </Button>
-                {availableModels.map((model) => {
-                  const isSelected = selectedModelIds.includes(model.modelId);
-                  return (
-                    <Button
-                      key={model.modelId}
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => toggleModelId(model.modelId)}
-                      className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
-                        isSelected
-                          ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
-                          : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
-                      }`}
-                      title={model.label}
-                    >
-                      {model.label}
-                    </Button>
-                  );
-                })}
-              </div>
-            </div>
-          </details>
+    const canonicalValues = data?.domainValueCoverage?.values ?? [];
+
+    const cellLookup = useMemo(() => {
+      const defaultCells = data?.domainValueCoverage?.cells ?? [];
+      const map = new Map<string, (typeof defaultCells)[0]>();
+      for (const cell of defaultCells) {
+        map.set([cell.valueA, cell.valueB].sort().join('::'), cell);
+      }
+      return map;
+    }, [data?.domainValueCoverage?.cells]);
+
+    const valueGroups = useMemo(() => {
+      const defaultCanonicalValues = data?.domainValueCoverage?.values ?? [];
+      if (defaultCanonicalValues.length === 0) return [];
+
+      const categories: Record<string, CategoryGroup> = {
+        Openness_to_Change: {
+          name: 'Openness',
+          color: 'bg-orange-100 border-orange-200 text-orange-800',
+          values: [],
+        },
+        Self_Enhancement: {
+          name: 'Enhancement',
+          color: 'bg-purple-100 border-purple-200 text-purple-800',
+          values: [],
+        },
+        Conservation: {
+          name: 'Conservation',
+          color: 'bg-blue-100 border-blue-200 text-blue-800',
+          values: [],
+        },
+        Self_Transcendence: {
+          name: 'Transcendence',
+          color: 'bg-emerald-100 border-emerald-200 text-emerald-800',
+          values: [],
+        },
+      };
+
+      defaultCanonicalValues.forEach((val) => {
+        const canonical = getCanonicalDimension(val);
+        if (canonical) {
+          categories[canonical.higherOrder]?.values.push(val);
+        }
+      });
+
+      return Object.values(categories).filter((c) => c.values.length > 0);
+    }, [data?.domainValueCoverage?.values]);
+
+    const displayValues = useMemo(
+      () => valueGroups.flatMap((group) => group.values),
+      [valueGroups],
+    );
+
+    return (
+      <div className="space-y-4">
+        {error && (
+          <ErrorMessage
+            message={`Failed to load coverage data: ${error.message}`}
+          />
         )}
-      </div>
+        {useLegacyQuery && signature !== '' && (
+          <ErrorMessage message="Coverage API does not yet support signature filtering in this environment. Showing all signatures." />
+        )}
 
-      {/* Matrix */}
-      {(signaturesLoading || (fetching && canonicalValues.length === 0)) ? (
-        <Loading size="lg" text="Loading coverage matrix..." />
-      ) : canonicalValues.length > 0 ? (
-        <div ref={ref} className="overflow-x-auto border border-gray-200 rounded-lg bg-white shadow-sm">
-          <table className="w-full min-w-full table-fixed border-collapse">
-            <thead>
-              <tr>
-                <th className="p-0 border-b border-gray-200 bg-gray-50/50" colSpan={2} rowSpan={2} />
-                {valueGroups.map((group) => (
-                  <th
-                    key={`col-group-${group.name}`}
-                    colSpan={group.values.length}
-                    className={cn(
-                      'p-1.5 text-[11px] font-semibold text-center border-b border-l border-gray-200 tracking-normal',
-                      group.color
-                    )}
-                  >
-                    {group.name}
-                  </th>
-                ))}
-              </tr>
-              <tr>
-                {valueGroups.flatMap((group, groupIndex) =>
-                  group.values.map((val, valIndex) => (
+        {/* Matrix */}
+        {fetching && canonicalValues.length === 0 ? (
+          <Loading size="lg" text="Loading coverage matrix..." />
+        ) : canonicalValues.length > 0 ? (
+          <div ref={ref} className="overflow-x-auto border border-gray-200 rounded-lg bg-white shadow-sm">
+            <table className="w-full min-w-full table-fixed border-collapse">
+              <thead>
+                <tr>
+                  <th className="p-0 border-b border-gray-200 bg-gray-50/50" colSpan={2} rowSpan={2} />
+                  {valueGroups.map((group) => (
                     <th
-                      key={`col-${val}`}
+                      key={`col-group-${group.name}`}
+                      colSpan={group.values.length}
                       className={cn(
-                        'w-[6.5rem] p-1.5 text-[11px] font-medium text-gray-600 border-b border-gray-200 align-top text-center leading-tight whitespace-normal break-words',
-                        valIndex === 0 && 'border-l',
-                        groupIndex % 2 === 0 ? 'bg-gray-50/30' : 'bg-white'
+                        'p-1.5 text-[11px] font-semibold text-center border-b border-l border-gray-200 tracking-normal',
+                        group.color,
                       )}
                     >
-                      <div className="mx-auto max-w-[6.5rem]">
-                        {VALUE_LABELS[val as keyof typeof VALUE_LABELS] ?? formatDisplayLabel(val)}
-                      </div>
+                      {group.name}
                     </th>
-                  ))
-                )}
-              </tr>
-            </thead>
-            <tbody>
-              {valueGroups.flatMap((rowGroup, rowGroupIdx) =>
-                rowGroup.values.map((rowVal, rowValIdx) => (
-                  <tr key={`row-${rowVal}`}>
-                    {rowValIdx === 0 && (
+                  ))}
+                </tr>
+                <tr>
+                  {valueGroups.flatMap((group, groupIndex) =>
+                    group.values.map((val, valIndex) => (
                       <th
-                        rowSpan={rowGroup.values.length}
+                        key={`col-${val}`}
                         className={cn(
-                          'w-[6.75rem] px-1 py-1.5 text-[11px] font-medium text-center border-t border-r border-gray-200 tracking-normal leading-tight whitespace-normal break-words overflow-hidden align-middle',
-                          rowGroup.color
+                          'w-[6.5rem] p-1.5 text-[11px] font-medium text-gray-600 border-b border-gray-200 align-top text-center leading-tight whitespace-normal break-words',
+                          valIndex === 0 && 'border-l',
+                          groupIndex % 2 === 0 ? 'bg-gray-50/30' : 'bg-white',
                         )}
                       >
-                        {rowGroup.name}
+                        <div className="mx-auto max-w-[6.5rem]">
+                          {VALUE_LABELS[val as keyof typeof VALUE_LABELS] ?? formatDisplayLabel(val)}
+                        </div>
                       </th>
-                    )}
-                    <th
-                      className={cn(
-                        'w-[8rem] px-0.5 py-1 text-[11px] font-medium text-gray-600 text-right border-t border-r border-gray-200 whitespace-normal break-words leading-tight',
-                        rowGroupIdx % 2 === 0 ? 'bg-gray-50/30' : 'bg-white'
-                      )}
-                    >
-                      {VALUE_LABELS[rowVal as keyof typeof VALUE_LABELS] ??
-                        formatDisplayLabel(rowVal)}
-                    </th>
-
-                    {displayValues.map((colVal) => {
-                      const keyA = [colVal, rowVal].sort().join('::');
-                      const cell = cellLookup.get(keyA);
-
-                      return (
-                        <td
-                          key={`cell-${rowVal}-${colVal}`}
-                          className="h-12 w-[3.5rem] border border-gray-100 p-0"
+                    )),
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {valueGroups.flatMap((rowGroup, rowGroupIdx) =>
+                  rowGroup.values.map((rowVal, rowValIdx) => (
+                    <tr key={`row-${rowVal}`}>
+                      {rowValIdx === 0 && (
+                        <th
+                          rowSpan={rowGroup.values.length}
+                          className={cn(
+                            'w-[6.75rem] px-1 py-1.5 text-[11px] font-medium text-center border-t border-r border-gray-200 tracking-normal leading-tight whitespace-normal break-words overflow-hidden align-middle',
+                            rowGroup.color,
+                          )}
                         >
-                          <CoverageCell
-                            valueA={rowVal}
-                            valueB={colVal}
-                            batchEquivalent={cell?.batchEquivalent ?? 0}
-                            aFirstBatchEquivalent={cell?.aFirstBatchEquivalent ?? 0}
-                            bFirstBatchEquivalent={cell?.bFirstBatchEquivalent ?? 0}
-                            aFirstDefinitionName={cell?.aFirstDefinitionName ?? null}
-                            bFirstDefinitionName={cell?.bFirstDefinitionName ?? null}
-                            weakestCondition={cell?.weakestCondition != null ? {
-                              conditionLabel: cell.weakestCondition.conditionLabel,
-                              modelCounts: cell.weakestCondition.modelCounts,
-                              otherConditionsCount: cell.weakestCondition.otherConditionsCount ?? null,
-                            } : null}
-                            contributingDefinitionIds={cell?.contributingDefinitionIds ?? []}
-                            definitionId={cell?.definitionId ?? null}
-                            aggregateRunId={cell?.aggregateRunId ?? null}
-                          />
-                        </td>
-                      );
-                    })}
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
-      ) : (
-        <div className="text-center py-12 text-gray-500 bg-gray-50 rounded-lg border border-dashed border-gray-300">
-          <p>No coverage data available for this domain yet.</p>
-          <p className="mt-1 text-sm">Create vignettes in the Vignettes tab, then run evaluations to see coverage here.</p>
-        </div>
-      )}
+                          {rowGroup.name}
+                        </th>
+                      )}
+                      <th
+                        className={cn(
+                          'w-[8rem] px-0.5 py-1 text-[11px] font-medium text-gray-600 text-right border-t border-r border-gray-200 whitespace-normal break-words leading-tight',
+                          rowGroupIdx % 2 === 0 ? 'bg-gray-50/30' : 'bg-white',
+                        )}
+                      >
+                        {VALUE_LABELS[rowVal as keyof typeof VALUE_LABELS] ??
+                          formatDisplayLabel(rowVal)}
+                      </th>
 
-      {!fetching && canonicalValues.length > 0 && (
-        <div className="px-1 pt-2 text-xs text-gray-500">
-          <p>
-            Batches per cell are{' '}
-            <span className="font-medium text-rose-700">red (&lt;3)</span>,{' '}
-            <span className="font-medium text-amber-700">yellow (3-9)</span>, or{' '}
-            <span className="font-medium text-emerald-700">green (10+)</span>. Click any cell to add a batch.
-          </p>
-        </div>
-      )}
-    </div>
-  );
-});
+                      {displayValues.map((colVal) => {
+                        const keyA = [colVal, rowVal].sort().join('::');
+                        const cell = cellLookup.get(keyA);
+
+                        return (
+                          <td
+                            key={`cell-${rowVal}-${colVal}`}
+                            className="h-12 w-[3.5rem] border border-gray-100 p-0"
+                          >
+                            <CoverageCell
+                              valueA={rowVal}
+                              valueB={colVal}
+                              batchEquivalent={cell?.batchEquivalent ?? 0}
+                              aFirstBatchEquivalent={cell?.aFirstBatchEquivalent ?? 0}
+                              bFirstBatchEquivalent={cell?.bFirstBatchEquivalent ?? 0}
+                              aFirstDefinitionName={cell?.aFirstDefinitionName ?? null}
+                              bFirstDefinitionName={cell?.bFirstDefinitionName ?? null}
+                              weakestCondition={cell?.weakestCondition != null ? {
+                                conditionLabel: cell.weakestCondition.conditionLabel,
+                                modelCounts: cell.weakestCondition.modelCounts,
+                                otherConditionsCount: cell.weakestCondition.otherConditionsCount ?? null,
+                              } : null}
+                              contributingDefinitionIds={cell?.contributingDefinitionIds ?? []}
+                              definitionId={cell?.definitionId ?? null}
+                              aggregateRunId={cell?.aggregateRunId ?? null}
+                            />
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  )),
+                )}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="text-center py-12 text-gray-500 bg-gray-50 rounded-lg border border-dashed border-gray-300">
+            <p>No coverage data available for this domain yet.</p>
+            <p className="mt-1 text-sm">Create vignettes in the Vignettes tab, then run evaluations to see coverage here.</p>
+          </div>
+        )}
+
+        {!fetching && canonicalValues.length > 0 && (
+          <div className="px-1 pt-2 text-xs text-gray-500">
+            <p>
+              Batches per cell are{' '}
+              <span className="font-medium text-rose-700">red (&lt;3)</span>,{' '}
+              <span className="font-medium text-amber-700">yellow (3-9)</span>, or{' '}
+              <span className="font-medium text-emerald-700">green (10+)</span>. Click any cell to add a batch.
+            </p>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
 
 CoverageMatrix.displayName = 'CoverageMatrix';

--- a/cloud/apps/web/src/pages/DomainCoverage.tsx
+++ b/cloud/apps/web/src/pages/DomainCoverage.tsx
@@ -1,92 +1,252 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { ErrorMessage } from '../components/ui/ErrorMessage';
+import { useQuery } from 'urql';
+import { AnalysisContextBar } from '../components/analysis/AnalysisContextBar';
 import { CopyVisualButton } from '../components/ui/CopyVisualButton';
-import { useDomains } from '../hooks/useDomains';
+import { ErrorMessage } from '../components/ui/ErrorMessage';
+import { Loading } from '../components/ui/Loading';
 import { CoverageMatrix } from '../components/domains/CoverageMatrix';
+import { useDomains } from '../hooks/useDomains';
+import {
+  DOMAIN_AVAILABLE_SIGNATURES_QUERY,
+  type DomainAvailableSignature,
+  type DomainAvailableSignaturesQueryResult,
+} from '../api/operations/domainAnalysis';
+import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
+import { selectPreferredSignature } from '../components/domains/coverageMatrixHelpers';
+import {
+  formatSignatureOptionLabel,
+  getSignaturePriority,
+} from '../utils/domainAnalysisUtils';
+
+type FolderKey = string;
+
+const LAST_DOMAIN_KEY = 'valuerank:lastSelectedDomainId';
 
 export function DomainCoverage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { domains, queryLoading: domainsLoading, error: domainsError } = useDomains();
+  const initialSelectedFolder = searchParams.get('domainId') ?? localStorage.getItem(LAST_DOMAIN_KEY) ?? '';
+  const signatureParam = searchParams.get('signature');
+  const [selectedFolder, setSelectedFolder] = useState<FolderKey>(initialSelectedFolder);
+  const [selectedSignature, setSelectedSignature] = useState<string>(signatureParam ?? '');
+  const [signatureSelectionResolved, setSignatureSelectionResolved] = useState(signatureParam != null);
+  const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
+  const initializedModelSelection = useRef(false);
   const coverageRef = useRef<HTMLDivElement>(null);
 
-  const [selectedDomainId, setSelectedDomainId] = useState<string>(
-    searchParams.get('domainId') ?? ''
+  const {
+    domains,
+    queryLoading: domainLoading,
+    error: domainError,
+  } = useDomains();
+  const resolvedDomainId = useMemo(() => {
+    if (selectedFolder !== '' && domains.some((domain) => domain.id === selectedFolder)) {
+      return selectedFolder;
+    }
+    return domains[0]?.id ?? '';
+  }, [domains, selectedFolder]);
+
+  const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
+    DomainAvailableSignaturesQueryResult,
+    { domainId: string }
+  >({
+    query: DOMAIN_AVAILABLE_SIGNATURES_QUERY,
+    variables: {
+      domainId: resolvedDomainId,
+    },
+    pause: resolvedDomainId === '',
+    requestPolicy: 'cache-and-network',
+  });
+
+  const [{ data: llmModelsData, fetching: llmModelsLoading, error: llmModelsError }] = useQuery<LlmModelsQueryResult>({
+    query: LLM_MODELS_QUERY,
+    variables: { status: 'ACTIVE' },
+    requestPolicy: 'cache-and-network',
+  });
+
+  const availableSignatures = useMemo(
+    () => signatureData?.domainAvailableSignatures ?? [],
+    [signatureData],
   );
 
-  // Ensure a domain is selected by default
+  const signatureOptions = useMemo<DomainAvailableSignature[]>(() => {
+    const options = availableSignatures
+      .map((option, index) => ({ option, index }))
+      .sort((left, right) => {
+        const priority = getSignaturePriority(left.option) - getSignaturePriority(right.option);
+        return priority !== 0 ? priority : left.index - right.index;
+      })
+      .map(({ option }) => option);
+
+    return options;
+  }, [availableSignatures]);
+
+  const activeModels = useMemo(
+    () => (llmModelsData?.llmModels ?? []).filter((model) => model.status === 'ACTIVE'),
+    [llmModelsData],
+  );
+  const defaultModelIds = useMemo(
+    () => {
+      const defaults = activeModels.filter((model) => model.isDefault).map((model) => model.modelId);
+      return defaults.length > 0 ? defaults : activeModels.map((model) => model.modelId);
+    },
+    [activeModels],
+  );
+  const modelOptions = useMemo(
+    () => activeModels.map((model) => ({
+      value: model.modelId,
+      label: model.displayName,
+      isDefault: defaultModelIds.includes(model.modelId),
+    })),
+    [activeModels, defaultModelIds],
+  );
+  const selectedModelSet = selectedModelIds ?? defaultModelIds;
+
+  const selectedDomain = domains.find((domain) => domain.id === resolvedDomainId) ?? null;
+
   useEffect(() => {
     if (domains.length === 0) return;
-    const selectedExists =
-      selectedDomainId !== '' && domains.some((domain) => domain.id === selectedDomainId);
-    if (selectedExists) return;
-    setSelectedDomainId(domains[0]?.id ?? '');
-  }, [domains, selectedDomainId]);
+    if (selectedFolder !== '' && domains.some((domain) => domain.id === selectedFolder)) return;
+    const lastId = localStorage.getItem(LAST_DOMAIN_KEY);
+    const lastDomain = lastId != null ? domains.find((domain) => domain.id === lastId) : null;
+    setSelectedFolder(lastDomain?.id ?? domains[0]?.id ?? '');
+  }, [domains, selectedFolder]);
 
-  // Sync URL state for domainId
   useEffect(() => {
-    if (selectedDomainId === '') return;
+    if (signatureOptions.length === 0) {
+      if (selectedSignature !== '') setSelectedSignature('');
+      if (!signatureSelectionResolved) setSignatureSelectionResolved(true);
+      return;
+    }
+
+    if (selectedSignature !== '' && signatureOptions.some((option) => option.signature === selectedSignature)) {
+      if (!signatureSelectionResolved) setSignatureSelectionResolved(true);
+      return;
+    }
+
+    if (selectedSignature === '' && signatureSelectionResolved) return;
+
+    setSelectedSignature(selectPreferredSignature(signatureOptions));
+    setSignatureSelectionResolved(true);
+  }, [selectedSignature, signatureOptions, signatureSelectionResolved]);
+
+  useEffect(() => {
+    if (initializedModelSelection.current) return;
+    if (llmModelsLoading || llmModelsData == null) return;
+    setSelectedModelIds(defaultModelIds);
+    initializedModelSelection.current = true;
+  }, [defaultModelIds, llmModelsData, llmModelsLoading]);
+
+  useEffect(() => {
     const next = new URLSearchParams(searchParams);
-    const currentDomain = searchParams.get('domainId');
-    if (currentDomain !== selectedDomainId) {
-      next.set('domainId', selectedDomainId);
+    if (selectedDomain != null) {
+      next.set('domainId', resolvedDomainId);
+    } else {
+      next.delete('domainId');
+    }
+    if (selectedSignature === '') next.delete('signature');
+    else next.set('signature', selectedSignature);
+    if (next.toString() !== searchParams.toString()) {
       setSearchParams(next, { replace: true });
     }
-  }, [searchParams, selectedDomainId, setSearchParams]);
+  }, [resolvedDomainId, searchParams, selectedDomain, selectedSignature, setSearchParams]);
+
+  const showPageLoader = domainLoading
+    || signaturesLoading
+    || llmModelsLoading
+    || !signatureSelectionResolved
+    || (resolvedDomainId !== '' && selectedDomain == null);
+
+  const coverageOptions = useMemo(
+    () => {
+      if (signatureOptions.length === 0) {
+        return [{ value: '', label: 'No signatures with completed runs', disabled: true }];
+      }
+
+      return [
+        { value: '', label: 'All signatures' },
+        ...signatureOptions.map((option) => ({
+          value: option.signature,
+          label: formatSignatureOptionLabel(option),
+        })),
+      ];
+    },
+    [signatureOptions],
+  );
+
+  if (domainError != null || signaturesError != null || llmModelsError != null) {
+    return (
+      <div className="space-y-6">
+        <ErrorMessage message={`Failed to load coverage page: ${(domainError ?? signaturesError ?? llmModelsError)?.message ?? 'Unknown error'}`} />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6 pb-12">
-      <div>
+      <AnalysisContextBar
+        domain={{
+          label: 'Domain',
+          value: resolvedDomainId,
+          options:
+            domains.length === 0
+              ? [{ value: '', label: 'No domains available', disabled: true }]
+              : domains.map((domain) => ({ value: domain.id, label: domain.name })),
+          onChange: (value) => {
+            setSelectedFolder(value);
+            localStorage.setItem(LAST_DOMAIN_KEY, value);
+          },
+          disabled: domainLoading || domains.length === 0,
+        }}
+        signature={{
+          label: 'Signature',
+          value: selectedSignature,
+          options: coverageOptions,
+          onChange: (value) => setSelectedSignature(value),
+          disabled: signaturesLoading || signatureOptions.length === 0,
+        }}
+        models={{
+          label: 'Models',
+          selectedModelIds,
+          defaultModelIds,
+          options: modelOptions,
+          onChange: (value) => {
+            if (value.length === 0) {
+              setSelectedModelIds(defaultModelIds);
+              return;
+            }
+            setSelectedModelIds(value);
+          },
+        }}
+      />
+
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Domains</p>
         <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Value Coverage</h1>
-        <p className="mt-1 text-sm text-gray-600">
+        <p className="max-w-3xl text-sm text-gray-600">
           Visualize batch density across the 10 canonical Schwartz value pairs for this domain.
         </p>
       </div>
 
-      {domainsError && (
-        <ErrorMessage message={`Failed to load domains: ${domainsError.message}`} />
-      )}
-
-      {/* Domain picker */}
-      <section className="rounded-lg border border-gray-200 bg-white p-4">
-        <div className="flex flex-col gap-2 md:flex-row md:items-center">
-          <h2 className="text-sm font-semibold text-gray-900 min-w-[140px]">Domain Selection</h2>
-          <select
-            aria-label="Domain Selection"
-            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 flex-1 max-w-sm"
-            value={selectedDomainId}
-            onChange={(event) => {
-              const newDomainId = event.target.value;
-              if (newDomainId !== selectedDomainId) {
-                setSelectedDomainId(newDomainId);
-              }
-            }}
-            disabled={domainsLoading || domains.length === 0}
-          >
-            {domains.length === 0 && <option value="">No domains available</option>}
-            {domains.map((domain) => (
-              <option key={domain.id} value={domain.id}>
-                {domain.name}
-              </option>
-            ))}
-          </select>
-        </div>
-      </section>
-
-      {selectedDomainId !== '' && (
+      {showPageLoader ? (
+        <Loading size="lg" text="Loading coverage page..." />
+      ) : (
         <section className="rounded-lg border border-gray-200 bg-white p-4">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <h2 className="text-base font-medium text-gray-900">Value coverage</h2>
-              <p className="mt-1 text-sm text-gray-600">
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <h2 className="text-base font-medium text-gray-900">Value Coverage</h2>
+              <p className="text-sm text-gray-600">
                 Batch density across Schwartz value pairs for this domain.
               </p>
             </div>
             <CopyVisualButton targetRef={coverageRef} label="coverage table" />
           </div>
-          <div className="mt-4">
-            <CoverageMatrix ref={coverageRef} domainId={selectedDomainId} />
-          </div>
+          <CoverageMatrix
+            ref={coverageRef}
+            domainId={resolvedDomainId}
+            signature={selectedSignature}
+            modelIds={selectedModelSet}
+          />
         </section>
       )}
     </div>

--- a/cloud/apps/web/src/pages/Domains.tsx
+++ b/cloud/apps/web/src/pages/Domains.tsx
@@ -1,9 +1,23 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { ErrorMessage } from '../components/ui/ErrorMessage';
+import { useQuery } from 'urql';
+import { AnalysisContextBar } from '../components/analysis/AnalysisContextBar';
 import { CopyVisualButton } from '../components/ui/CopyVisualButton';
+import { ErrorMessage } from '../components/ui/ErrorMessage';
+import { Loading } from '../components/ui/Loading';
 import { CoverageMatrix } from '../components/domains/CoverageMatrix';
 import { useDomains } from '../hooks/useDomains';
+import {
+  DOMAIN_AVAILABLE_SIGNATURES_QUERY,
+  type DomainAvailableSignature,
+  type DomainAvailableSignaturesQueryResult,
+} from '../api/operations/domainAnalysis';
+import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
+import { selectPreferredSignature } from '../components/domains/coverageMatrixHelpers';
+import {
+  formatSignatureOptionLabel,
+  getSignaturePriority,
+} from '../utils/domainAnalysisUtils';
 
 type FolderKey = string;
 
@@ -12,96 +26,239 @@ const LAST_DOMAIN_KEY = 'valuerank:lastSelectedDomainId';
 export function Domains() {
   const [searchParams, setSearchParams] = useSearchParams();
   const initialSelectedFolder = searchParams.get('domainId') ?? localStorage.getItem(LAST_DOMAIN_KEY) ?? '';
+  const signatureParam = searchParams.get('signature');
   const [selectedFolder, setSelectedFolder] = useState<FolderKey>(initialSelectedFolder);
+  const [selectedSignature, setSelectedSignature] = useState<string>(signatureParam ?? '');
+  const [signatureSelectionResolved, setSignatureSelectionResolved] = useState(signatureParam != null);
+  const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
+  const initializedModelSelection = useRef(false);
   const coverageRef = useRef<HTMLDivElement>(null);
 
   const {
     domains,
     error: domainError,
+    queryLoading: domainLoading,
   } = useDomains();
+  const resolvedDomainId = useMemo(() => {
+    if (selectedFolder !== '' && domains.some((domain) => domain.id === selectedFolder)) {
+      return selectedFolder;
+    }
+    return domains[0]?.id ?? '';
+  }, [domains, selectedFolder]);
 
-  const selectedDomain = domains.find((d) => d.id === selectedFolder) ?? null;
+  const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
+    DomainAvailableSignaturesQueryResult,
+    { domainId: string }
+  >({
+    query: DOMAIN_AVAILABLE_SIGNATURES_QUERY,
+    variables: { domainId: resolvedDomainId },
+    pause: resolvedDomainId === '',
+    requestPolicy: 'cache-and-network',
+  });
 
-  // Auto-select best domain when list loads: last picked > first in list
+  const [{ data: llmModelsData, fetching: llmModelsLoading, error: llmModelsError }] = useQuery<LlmModelsQueryResult>({
+    query: LLM_MODELS_QUERY,
+    variables: { status: 'ACTIVE' },
+    requestPolicy: 'cache-and-network',
+  });
+
+  const availableSignatures = useMemo(
+    () => signatureData?.domainAvailableSignatures ?? [],
+    [signatureData],
+  );
+  const signatureOptions = useMemo<DomainAvailableSignature[]>(() => {
+    return availableSignatures
+      .map((option, index) => ({ option, index }))
+      .sort((left, right) => {
+        const priority = getSignaturePriority(left.option) - getSignaturePriority(right.option);
+        return priority !== 0 ? priority : left.index - right.index;
+      })
+      .map(({ option }) => option);
+  }, [availableSignatures]);
+
+  const activeModels = useMemo(
+    () => (llmModelsData?.llmModels ?? []).filter((model) => model.status === 'ACTIVE'),
+    [llmModelsData],
+  );
+  const defaultModelIds = useMemo(() => {
+    const defaults = activeModels.filter((model) => model.isDefault).map((model) => model.modelId);
+    return defaults.length > 0 ? defaults : activeModels.map((model) => model.modelId);
+  }, [activeModels]);
+  const modelOptions = useMemo(
+    () => activeModels.map((model) => ({
+      value: model.modelId,
+      label: model.displayName,
+      isDefault: defaultModelIds.includes(model.modelId),
+    })),
+    [activeModels, defaultModelIds],
+  );
+  const selectedModelSet = selectedModelIds ?? defaultModelIds;
+  const selectedDomain = domains.find((domain) => domain.id === resolvedDomainId) ?? null;
+
   useEffect(() => {
     if (domains.length === 0) return;
-    if (selectedFolder !== '' && domains.some((d) => d.id === selectedFolder)) return;
+    if (selectedFolder !== '' && domains.some((domain) => domain.id === selectedFolder)) return;
     const lastId = localStorage.getItem(LAST_DOMAIN_KEY);
-    const lastDomain = lastId != null ? domains.find((d) => d.id === lastId) : null;
+    const lastDomain = lastId != null ? domains.find((domain) => domain.id === lastId) : null;
     setSelectedFolder(lastDomain?.id ?? domains[0]?.id ?? '');
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [domains]);
+  }, [domains, selectedFolder]);
 
-  // Sync domainId to URL
+  useEffect(() => {
+    if (signatureOptions.length === 0) {
+      if (selectedSignature !== '') setSelectedSignature('');
+      if (!signatureSelectionResolved) setSignatureSelectionResolved(true);
+      return;
+    }
+
+    if (selectedSignature !== '' && signatureOptions.some((option) => option.signature === selectedSignature)) {
+      if (!signatureSelectionResolved) setSignatureSelectionResolved(true);
+      return;
+    }
+
+    if (selectedSignature === '' && signatureSelectionResolved) return;
+
+    setSelectedSignature(selectPreferredSignature(signatureOptions));
+    setSignatureSelectionResolved(true);
+  }, [selectedSignature, signatureOptions, signatureSelectionResolved]);
+
+  useEffect(() => {
+    if (initializedModelSelection.current) return;
+    if (llmModelsLoading || llmModelsData == null) return;
+    setSelectedModelIds(defaultModelIds);
+    initializedModelSelection.current = true;
+  }, [defaultModelIds, llmModelsData, llmModelsLoading]);
+
   useEffect(() => {
     const next = new URLSearchParams(searchParams);
     if (selectedDomain != null) {
-      next.set('domainId', selectedFolder);
+      next.set('domainId', resolvedDomainId);
     } else {
       next.delete('domainId');
     }
+    if (selectedSignature === '') next.delete('signature');
+    else next.set('signature', selectedSignature);
     if (next.toString() !== searchParams.toString()) {
       setSearchParams(next, { replace: true });
     }
-  }, [searchParams, selectedDomain, selectedFolder, setSearchParams]);
+  }, [resolvedDomainId, searchParams, selectedDomain, selectedSignature, setSearchParams]);
+
+  const showPageLoader = domainLoading
+    || signaturesLoading
+    || llmModelsLoading
+    || !signatureSelectionResolved
+    || (resolvedDomainId !== '' && selectedDomain == null);
+
+  const coverageOptions = useMemo(
+    () => {
+      if (signatureOptions.length === 0) {
+        return [{ value: '', label: 'No signatures with completed runs', disabled: true }];
+      }
+
+      return [
+        { value: '', label: 'All signatures' },
+        ...signatureOptions.map((option) => ({
+          value: option.signature,
+          label: formatSignatureOptionLabel(option),
+        })),
+      ];
+    },
+    [signatureOptions],
+  );
+
+  if (domainError != null || signaturesError != null || llmModelsError != null) {
+    return (
+      <div className="space-y-6">
+        <ErrorMessage message={`Failed to load domains page: ${(domainError ?? signaturesError ?? llmModelsError)?.message ?? 'Unknown error'}`} />
+      </div>
+    );
+  }
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Domains</h1>
+    <div className="space-y-6 pb-12">
+      <AnalysisContextBar
+        domain={{
+          label: 'Domain',
+          value: resolvedDomainId,
+          options:
+            domains.length === 0
+              ? [{ value: '', label: 'No domains available', disabled: true }]
+              : domains.map((domain) => ({ value: domain.id, label: domain.name })),
+          onChange: (value) => {
+            setSelectedFolder(value);
+            localStorage.setItem(LAST_DOMAIN_KEY, value);
+          },
+          disabled: domainLoading || domains.length === 0,
+        }}
+        signature={{
+          label: 'Signature',
+          value: selectedSignature,
+          options: coverageOptions,
+          onChange: (value) => setSelectedSignature(value),
+          disabled: signaturesLoading || signatureOptions.length === 0,
+        }}
+        models={{
+          label: 'Models',
+          selectedModelIds,
+          defaultModelIds,
+          options: modelOptions,
+          onChange: (value) => {
+            if (value.length === 0) {
+              setSelectedModelIds(defaultModelIds);
+              return;
+            }
+            setSelectedModelIds(value);
+          },
+        }}
+      />
 
-      {domainError != null && (
-        <ErrorMessage message={`Failed to load domains: ${domainError.message}`} />
-      )}
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Domains</p>
+        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Domain Overview</h1>
+        <p className="max-w-3xl text-sm text-gray-600">
+          Browse the active domain overview, then inspect value-pair coverage for the selected domain and signature.
+        </p>
+      </div>
 
-      {domains.length > 0 && (
-        <div className="flex flex-col gap-3 md:flex-row md:items-center">
-          <div className="flex flex-col gap-2 md:flex-row md:items-center md:flex-1">
-            <select
-              value={selectedFolder}
-              onChange={(e) => {
-                setSelectedFolder(e.target.value);
-                localStorage.setItem(LAST_DOMAIN_KEY, e.target.value);
-              }}
-              className="min-w-[220px] border border-gray-300 rounded px-3 py-2 text-sm bg-white"
-            >
-              {domains.map((d) => (
-                <option key={d.id} value={d.id}>{d.name} ({d.definitionCount})</option>
-              ))}
-            </select>
-            {selectedDomain != null && (
+      {showPageLoader ? (
+        <Loading size="lg" text="Loading domains page..." />
+      ) : (
+        <div className="space-y-6">
+          {selectedDomain != null && (
+            <div className="flex items-center justify-end">
               <Link
                 to={`/domains/start/${selectedDomain.id}`}
-                className="inline-flex items-center justify-center rounded-lg border border-teal-600 bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 md:ml-auto"
+                className="inline-flex items-center justify-center rounded-lg border border-teal-600 bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2"
               >
                 Add Paired Batches for all Vignettes
               </Link>
-            )}
-          </div>
+            </div>
+          )}
+
+          {selectedDomain != null ? (
+            <section className="rounded-lg border border-gray-200 bg-white p-4">
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <h2 className="text-base font-medium text-gray-900">Value Coverage</h2>
+                  <p className="text-sm text-gray-600">
+                    Batch density across Schwartz value pairs.
+                  </p>
+                </div>
+                <CopyVisualButton targetRef={coverageRef} label="coverage table" />
+              </div>
+              <CoverageMatrix
+                ref={coverageRef}
+                domainId={resolvedDomainId}
+                signature={selectedSignature}
+                modelIds={selectedModelSet}
+              />
+            </section>
+          ) : (
+            <div className="rounded-lg border border-gray-200 bg-white p-8 text-center text-sm text-gray-500">
+              Select a domain to see its overview.
+            </div>
+          )}
         </div>
       )}
-
-      <div className="space-y-4">
-        {selectedDomain != null ? (
-          <div className="rounded-xl border border-gray-200 bg-white p-5">
-            <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2">
-              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                <h3 className="text-lg font-medium text-[#1A1A1A]">Value coverage</h3>
-                <p className="text-sm text-gray-600">
-                  Batch density across Schwartz value pairs.
-                </p>
-              </div>
-              <CopyVisualButton targetRef={coverageRef} label="coverage table" />
-            </div>
-            <div className="mt-4">
-              <CoverageMatrix ref={coverageRef} domainId={selectedDomain.id} />
-            </div>
-          </div>
-        ) : (
-          <div className="rounded-xl border border-gray-200 bg-white p-8 text-center text-sm text-gray-500">
-            Select a domain to see its overview.
-          </div>
-        )}
-      </div>
     </div>
   );
 }

--- a/cloud/apps/web/tests/pages/DomainCoverage.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainCoverage.test.tsx
@@ -137,7 +137,26 @@ describe('DomainCoverage Page', () => {
         }];
       }
       if (operationName === 'LlmModels') {
-        return [{ data: { llmModels: [] }, fetching: false, error: undefined }];
+        return [{
+          data: {
+            llmModels: [
+              {
+                modelId: 'model-a',
+                displayName: 'Model A',
+                status: 'ACTIVE',
+                isDefault: true,
+              },
+              {
+                modelId: 'model-b',
+                displayName: 'Model B',
+                status: 'ACTIVE',
+                isDefault: true,
+              },
+            ],
+          },
+          fetching: false,
+          error: undefined,
+        }];
       }
       if (operationName === 'DomainValueCoverageLegacy') {
         const legacyCoverage = coverageByDomain[args.variables.domainId];
@@ -155,9 +174,10 @@ describe('DomainCoverage Page', () => {
     });
 
     await waitFor(() => {
+      expect(screen.getByRole('button', { name: /domain: domain a/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /signature: temp 0/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /models: default — 2 models/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /copy coverage table as image/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Model A' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Model B' })).toBeInTheDocument();
     });
   });
 
@@ -167,8 +187,18 @@ describe('DomainCoverage Page', () => {
       renderCoveragePage();
     });
 
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /signature: temp 0/i })).toBeInTheDocument();
+    });
+
     await act(async () => {
-      await user.selectOptions(screen.getByRole('combobox', { name: 'Batch Signature' }), 'vnewt0.7');
+      await user.click(screen.getByRole('button', { name: /signature: temp 0/i }));
+    });
+
+    const signatureOption = await screen.findByRole('option', { name: 'Temp 0.7' });
+
+    await act(async () => {
+      await user.click(signatureOption);
     });
 
     await waitFor(() => {
@@ -177,6 +207,7 @@ describe('DomainCoverage Page', () => {
           variables: expect.objectContaining({
             domainId: 'domain-a',
             signature: 'vnewt0.7',
+            modelIds: ['model-a', 'model-b'],
           }),
         }),
       );
@@ -197,6 +228,7 @@ describe('DomainCoverage Page', () => {
           variables: expect.objectContaining({
             domainId: 'domain-a',
             signature: 'vnewt0',
+            modelIds: ['model-a', 'model-b'],
           }),
         }),
       );
@@ -210,6 +242,28 @@ describe('DomainCoverage Page', () => {
       if (operationName === 'DomainAvailableSignatures') {
         return [{
           data: { domainAvailableSignatures: signaturesByDomain[args.variables.domainId] },
+          fetching: false,
+          error: undefined,
+        }];
+      }
+      if (operationName === 'LlmModels') {
+        return [{
+          data: {
+            llmModels: [
+              {
+                modelId: 'model-a',
+                displayName: 'Model A',
+                status: 'ACTIVE',
+                isDefault: true,
+              },
+              {
+                modelId: 'model-b',
+                displayName: 'Model B',
+                status: 'ACTIVE',
+                isDefault: true,
+              },
+            ],
+          },
           fetching: false,
           error: undefined,
         }];
@@ -228,8 +282,18 @@ describe('DomainCoverage Page', () => {
       renderCoveragePage();
     });
 
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /signature: temp 0/i })).toBeInTheDocument();
+    });
+
     await act(async () => {
-      await user.selectOptions(screen.getByRole('combobox', { name: 'Batch Signature' }), 'vnewt0.7');
+      await user.click(screen.getByRole('button', { name: /signature: temp 0/i }));
+    });
+
+    const fallbackSignatureOption = await screen.findByRole('option', { name: 'Temp 0.7' });
+
+    await act(async () => {
+      await user.click(fallbackSignatureOption);
     });
 
     await waitFor(() => {

--- a/cloud/apps/web/tests/pages/Domains.test.tsx
+++ b/cloud/apps/web/tests/pages/Domains.test.tsx
@@ -66,6 +66,18 @@ describe('Domains page', () => {
           error: undefined,
         }];
       }
+      if (operationName === 'LlmModels') {
+        return [{
+          data: {
+            llmModels: [
+              { modelId: 'model-a', displayName: 'Model A', status: 'ACTIVE', isDefault: true },
+              { modelId: 'model-b', displayName: 'Model B', status: 'ACTIVE', isDefault: true },
+            ],
+          },
+          fetching: false,
+          error: undefined,
+        }];
+      }
       if (operationName === 'DomainValueCoverageLegacy' || operationName === 'DomainValueCoverage') {
         return [{
           data: {
@@ -95,16 +107,20 @@ describe('Domains page', () => {
     });
   });
 
-  it('shows the paired batch launch link for the selected domain', () => {
+  it('shows the paired batch launch link for the selected domain', async () => {
     renderDomainsPage();
 
-    const launchLink = screen.getByRole('link', { name: /add paired batches for all vignettes/i });
+    const launchLink = await screen.findByRole('link', { name: /add paired batches for all vignettes/i });
     expect(launchLink).toHaveAttribute('href', '/domains/start/domain-a');
   });
 
-  it('renders the coverage copy control beside the value coverage header', () => {
+  it('renders the coverage copy control beside the value coverage header', async () => {
     renderDomainsPage();
 
+    await screen.findByRole('button', { name: /domain: domain a/i });
+    expect(screen.getByRole('button', { name: /domain: domain a/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /signature: temp 0/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /models: default — 2 models/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /value coverage/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /copy coverage table as image/i })).toBeInTheDocument();
   });
@@ -113,7 +129,8 @@ describe('Domains page', () => {
     const user = userEvent.setup();
     renderDomainsPage();
 
-    await user.selectOptions(screen.getAllByRole('combobox')[0]!, 'domain-b');
+    await user.click(screen.getByRole('button', { name: /domain: domain a/i }));
+    await user.click(screen.getByRole('option', { name: 'Domain B' }));
 
     expect(screen.getByRole('link', { name: /add paired batches for all vignettes/i }))
       .toHaveAttribute('href', '/domains/start/domain-b');


### PR DESCRIPTION
# What changed
Updated the domain overview and value coverage pages to use the same shared context bar and title rhythm as the Model page.

The coverage matrix now receives its selected domain, signature, and model IDs from the page, so the page shell owns the controls and the matrix stays display-only.

# Why
This makes the domain overview feel consistent with the Model page and removes the extra card-heavy layout below the shared controls.

# Validation
- `npm run test -- --run tests/pages/DomainCoverage.test.tsx tests/pages/Domains.test.tsx` ✅
- `npm run typecheck` ✅
- `npx turbo lint --filter=@valuerank/web` ✅ with existing repo warnings, no errors
- `npx turbo build --filter=@valuerank/web` ✅
