### PR TITLE
Tidy model groups page copy and toggles

### DIFF
--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -80,7 +80,7 @@ export function ModelGroupsSection({
   distanceMethod,
   models,
   selectedModelId = null,
-  clusteringMethod = 'upgma',
+  clusteringMethod = 'ward',
   onClusteringMethodChange,
 }: ModelGroupsSectionProps) {
   const summaryTableRef = useRef<HTMLDivElement>(null);
@@ -177,7 +177,6 @@ export function ModelGroupsSection({
             <>
               {onClusteringMethodChange != null && (
                 <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
-                  <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Linkage</span>
                   <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
                     {LINKAGE_OPTIONS.map((option) => {
                       const active = clusteringMethod === option.value;
@@ -201,7 +200,6 @@ export function ModelGroupsSection({
               )}
 
               <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
-                <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Data</span>
                 <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
                   {DATA_SOURCE_OPTIONS.map((option) => {
                     const active = dataSource === option.value;

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -33,13 +33,9 @@ const LINKAGE_OPTIONS: Array<{ value: ClusteringLinkage; label: string }> = [
   { value: 'ward', label: 'Ward' },
 ];
 
-const DATA_SOURCE_OPTIONS: Array<{ value: ClusterDataSource; label: string }> = [
-  { value: 'log-odds', label: 'Log Odds' },
-  { value: 'win-rate', label: 'Win Rate' },
-];
-
 type ModelGroupsSectionProps = {
   clusterAnalysisByMethod?: Record<string, ClusterAnalysis>;
+  dataSource?: ClusterDataSource;
   distanceMethod?: CalculationMethod;
   models: ModelEntry[];
   selectedModelId?: string | null;
@@ -77,6 +73,7 @@ function getGroupLabel(cluster: DomainCluster): string {
 
 export function ModelGroupsSection({
   clusterAnalysisByMethod,
+  dataSource = 'log-odds',
   distanceMethod,
   models,
   selectedModelId = null,
@@ -88,7 +85,6 @@ export function ModelGroupsSection({
   const [viewMode, setViewMode] = useState<ClusterViewMode>('dot');
   const [groupDisplayMode, setGroupDisplayMode] = useState<GroupDisplayMode>('groups');
   const [activeGroupIds, setActiveGroupIds] = useState<string[]>([]);
-  const [dataSource, setDataSource] = useState<ClusterDataSource>('log-odds');
 
   const backendKey = `${dataSource}-${toBackendDistanceMethod(distanceMethod)}-${clusteringMethod}`;
   const activeClusterAnalysis = clusterAnalysisByMethod?.[backendKey] ?? null;
@@ -198,28 +194,6 @@ export function ModelGroupsSection({
                   </div>
                 </div>
               )}
-
-              <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
-                <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
-                  {DATA_SOURCE_OPTIONS.map((option) => {
-                    const active = dataSource === option.value;
-                    return (
-                      <Button
-                        key={option.value}
-                        type="button"
-                        variant={active ? 'primary' : 'ghost'}
-                        size="sm"
-                        onClick={() => setDataSource(option.value)}
-                        className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
-                          active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-white hover:text-gray-900'
-                        }`}
-                      >
-                        {option.label}
-                      </Button>
-                    );
-                  })}
-                </div>
-              </div>
             </>
           )}
 
@@ -294,9 +268,10 @@ export function ModelGroupsSection({
             <p className="mt-1">
               <strong>Linkage</strong> controls how cluster distance is measured: UPGMA averages distances
               across all member pairs; Ward minimizes within-cluster variance.
-              <strong> Data</strong> controls what scores drive the distance: Log Odds uses the smoothed
-              log-odds ranking scores; Win Rate uses domain-local win rates.
-              The distance method comes from the Similarity Table selector below.
+            </p>
+            <p className="mt-1">
+              The <strong>data source</strong> and <strong>similarity method</strong> are set in the
+              Analysis settings bar above and affect both model reports.
             </p>
           </div>
         </div>

--- a/cloud/apps/web/src/components/models/ModelAnalysisSettingsBar.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelAnalysisSettingsBar.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ModelAnalysisSettingsBar } from './ModelAnalysisSettingsBar';
+
+describe('ModelAnalysisSettingsBar', () => {
+  it('renders the shared analysis controls and forwards toggle changes', async () => {
+    const user = userEvent.setup();
+    const onDataSourceChange = vi.fn();
+    const onSimilarityMethodChange = vi.fn();
+
+    render(
+      <ModelAnalysisSettingsBar
+        dataSource="log-odds"
+        onDataSourceChange={onDataSourceChange}
+        similarityMethod="weighted-euclidean"
+        onSimilarityMethodChange={onSimilarityMethodChange}
+      />,
+    );
+
+    expect(screen.getByText('Analysis settings')).toBeTruthy();
+    expect(screen.getByText('Affects all reports on this page.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Log Odds' }).className.includes('bg-teal-600')).toBe(true);
+    expect(screen.getByRole('button', { name: 'Weighted Euclidean' }).className.includes('bg-teal-600')).toBe(true);
+
+    await user.click(screen.getByRole('button', { name: 'Win Rate' }));
+    await user.click(screen.getByRole('button', { name: 'Kendall' }));
+
+    expect(onDataSourceChange).toHaveBeenCalledWith('win-rate');
+    expect(onSimilarityMethodChange).toHaveBeenCalledWith('kendall');
+  });
+});

--- a/cloud/apps/web/src/components/models/ModelAnalysisSettingsBar.tsx
+++ b/cloud/apps/web/src/components/models/ModelAnalysisSettingsBar.tsx
@@ -1,0 +1,80 @@
+import { Button } from '../ui/Button';
+import { CALCULATION_METHODS, type CalculationMethod } from './ModelSimilarityMetrics';
+
+type DataSource = 'log-odds' | 'win-rate';
+
+type ModelAnalysisSettingsBarProps = {
+  dataSource: DataSource;
+  onDataSourceChange: (value: DataSource) => void;
+  similarityMethod: CalculationMethod;
+  onSimilarityMethodChange: (value: CalculationMethod) => void;
+};
+
+const DATA_SOURCE_OPTIONS: Array<{ value: DataSource; label: string }> = [
+  { value: 'log-odds', label: 'Log Odds' },
+  { value: 'win-rate', label: 'Win Rate' },
+];
+
+export function ModelAnalysisSettingsBar({
+  dataSource,
+  onDataSourceChange,
+  similarityMethod,
+  onSimilarityMethodChange,
+}: ModelAnalysisSettingsBarProps) {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="mb-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Analysis settings</p>
+        <p className="text-sm text-gray-600">Affects all reports on this page.</p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
+          <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Data source</span>
+          <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
+            {DATA_SOURCE_OPTIONS.map((option) => {
+              const active = dataSource === option.value;
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  variant={active ? 'primary' : 'ghost'}
+                  size="sm"
+                  onClick={() => onDataSourceChange(option.value)}
+                  className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
+                    active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                  }`}
+                >
+                  {option.label}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
+          <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Similarity method</span>
+          <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
+            {CALCULATION_METHODS.map((option) => {
+              const active = similarityMethod === option.value;
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  variant={active ? 'primary' : 'ghost'}
+                  size="sm"
+                  onClick={() => onSimilarityMethodChange(option.value)}
+                  className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
+                    active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                  }`}
+                >
+                  {option.label}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/cloud/apps/web/src/components/models/ModelSimilarityTableSection.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityTableSection.test.tsx
@@ -19,7 +19,7 @@ function makeModel(model: string, label: string, winRates: number[]): ModelEntry
 }
 
 describe('ModelSimilarityTableSection', () => {
-  it('shows calculation toggles and opens the pair detail drawer', async () => {
+  it('uses the selected method and opens the pair detail drawer', async () => {
     const user = userEvent.setup();
     const modelA = makeModel('model-a', 'Model A', [100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
     const modelB = makeModel('model-b', 'Model B', [90, 80, 70, 60, 50, 40, 30, 20, 10, 0]);
@@ -34,7 +34,8 @@ describe('ModelSimilarityTableSection', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Similarity by Model' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Weighted Euclidean' }).className.includes('bg-teal-600')).toBe(true);
+    expect(screen.queryByRole('button', { name: 'Weighted Euclidean' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Spearman' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Distance' }).className.includes('bg-teal-600')).toBe(true);
     expect(screen.getAllByText('10.00').length).toBeGreaterThan(0);
 
@@ -44,14 +45,6 @@ describe('ModelSimilarityTableSection', () => {
 
     await waitFor(() => {
       expect(screen.getAllByText('0.90').length).toBeGreaterThan(0);
-    });
-
-    await act(async () => {
-      await user.click(screen.getByRole('button', { name: 'Spearman' }));
-    });
-
-    await waitFor(() => {
-      expect(screen.getAllByText('1.00').length).toBeGreaterThan(0);
     });
 
     await act(async () => {
@@ -70,8 +63,8 @@ describe('ModelSimilarityTableSection', () => {
     const table = drawerTable.getByText('Step-by-step calculation').closest('section');
     expect(table).not.toBeNull();
 
-    expect(drawerTable.getAllByText('Spearman rho').length).toBeGreaterThan(0);
-    expect(drawerTable.getByText('Sum of rank diff²')).toBeTruthy();
-    expect(drawerTable.getAllByText('1.00').length).toBeGreaterThan(0);
+    expect(drawerTable.getAllByText('Weighted Euclidean distance').length).toBeGreaterThan(0);
+    expect(drawerTable.getByText('Sum of weighted diff²')).toBeTruthy();
+    expect(drawerTable.getAllByText('10.00').length).toBeGreaterThan(0);
   });
 });

--- a/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
@@ -4,7 +4,6 @@ import { type ModelEntry } from '../../data/domainAnalysisData';
 import { Button } from '../ui/Button';
 import { CopyVisualButton } from '../ui/CopyVisualButton';
 import {
-  CALCULATION_METHODS,
   type CalculationMethod,
   type MetricView,
   type PairMetric,
@@ -19,18 +18,12 @@ import { PairDetailDrawer } from './ModelSimilarityPairDetailDrawer';
 type ModelSimilarityTableSectionProps = {
   models: ModelEntry[];
   method?: CalculationMethod;
-  onMethodChange?: (method: CalculationMethod) => void;
 };
 
-export function ModelSimilarityTableSection({ models, method: methodProp, onMethodChange }: ModelSimilarityTableSectionProps) {
+export function ModelSimilarityTableSection({ models, method: methodProp }: ModelSimilarityTableSectionProps) {
   const tableRef = useRef<HTMLDivElement>(null);
   const [showHelp, setShowHelp] = useState(false);
-  const [internalMethod, setInternalMethod] = useState<CalculationMethod>('weighted-euclidean');
-  const method = methodProp ?? internalMethod;
-  const setMethod = (m: CalculationMethod) => {
-    setInternalMethod(m);
-    onMethodChange?.(m);
-  };
+  const method = methodProp ?? 'weighted-euclidean';
   const [view, setView] = useState<MetricView>('distance');
   const [activePair, setActivePair] = useState<{ left: string; right: string } | null>(null);
 
@@ -97,29 +90,6 @@ export function ModelSimilarityTableSection({ models, method: methodProp, onMeth
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
-          <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
-            <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Method</span>
-            <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
-              {CALCULATION_METHODS.map((option) => {
-                const active = method === option.value;
-                return (
-                  <Button
-                    key={option.value}
-                    type="button"
-                    variant={active ? 'primary' : 'ghost'}
-                    size="sm"
-                    onClick={() => setMethod(option.value)}
-                    className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
-                      active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                    }`}
-                  >
-                    {option.label}
-                  </Button>
-                );
-              })}
-            </div>
-          </div>
-
           <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
             <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">View</span>
             <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -79,7 +79,7 @@ export function ModelsGroups() {
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
   const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
-  const [clusteringMethod, setClusteringMethod] = useState<'upgma' | 'ward'>('upgma');
+  const [clusteringMethod, setClusteringMethod] = useState<'upgma' | 'ward'>('ward');
   const [similarityMethod, setSimilarityMethod] = useState<CalculationMethod>('weighted-euclidean');
 
   const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
@@ -280,21 +280,14 @@ export function ModelsGroups() {
         }}
       />
 
-      <div className="space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
-        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Model Clusters</h1>
-        <p className="max-w-3xl text-sm text-gray-600">
-          Clustered model families for the selected domain and signature.
-        </p>
-        {cacheStatusCopy != null && (
-          <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
-            <span className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${cacheStatusCopy.badgeClassName}`}>
-              {cacheStatusCopy.badgeLabel}
-            </span>
-            <span>{cacheStatusCopy.detail}</span>
-          </div>
-        )}
-      </div>
+      {cacheStatusCopy != null && (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+          <span className={`inline-flex rounded-full border px-2.5 py-1 font-semibold ${cacheStatusCopy.badgeClassName}`}>
+            {cacheStatusCopy.badgeLabel}
+          </span>
+          <span>{cacheStatusCopy.detail}</span>
+        </div>
+      )}
 
       {showPageLoader ? (
         <Loading size="lg" text="Loading model groups..." />

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -23,6 +23,7 @@ import {
 } from '../api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
+import { ModelAnalysisSettingsBar } from '../components/models/ModelAnalysisSettingsBar';
 import { ModelSimilarityTableSection } from '../components/models/ModelSimilarityTableSection';
 import { type CalculationMethod } from '../components/models/ModelSimilarityMetrics';
 import { useDomains } from '../hooks/useDomains';
@@ -80,6 +81,7 @@ export function ModelsGroups() {
   const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
   const [clusteringMethod, setClusteringMethod] = useState<'upgma' | 'ward'>('ward');
+  const [dataSource, setDataSource] = useState<'log-odds' | 'win-rate'>('log-odds');
   const [similarityMethod, setSimilarityMethod] = useState<CalculationMethod>('weighted-euclidean');
 
   const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
@@ -289,12 +291,20 @@ export function ModelsGroups() {
         </div>
       )}
 
+      <ModelAnalysisSettingsBar
+        dataSource={dataSource}
+        onDataSourceChange={setDataSource}
+        similarityMethod={similarityMethod}
+        onSimilarityMethodChange={setSimilarityMethod}
+      />
+
       {showPageLoader ? (
         <Loading size="lg" text="Loading model groups..." />
       ) : (
         <div className="space-y-6">
           <ModelGroupsSection
             clusterAnalysisByMethod={data?.domainAnalysis.clusterAnalysisByMethod}
+            dataSource={dataSource}
             distanceMethod={similarityMethod}
             models={filteredModels}
             clusteringMethod={clusteringMethod}
@@ -303,7 +313,6 @@ export function ModelsGroups() {
           <ModelSimilarityTableSection
             models={filteredModels}
             method={similarityMethod}
-            onMethodChange={setSimilarityMethod}
           />
         </div>
       )}

--- a/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
+++ b/cloud/apps/web/tests/components/ModelGroupsSection.test.tsx
@@ -69,7 +69,15 @@ describe('ModelGroupsSection', () => {
   });
 
   it('renders the plain model groups heading without numbering', () => {
-    render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': skippedClusterAnalysis }} models={populatedModels} />);
+    render(
+      <ModelGroupsSection
+        clusterAnalysisByMethod={{
+          'log-odds-euclidean-upgma': skippedClusterAnalysis,
+          'log-odds-euclidean-ward': skippedClusterAnalysis,
+        }}
+        models={populatedModels}
+      />,
+    );
 
     expect(screen.getByRole('heading', { name: 'Model Clusters' })).toBeInTheDocument();
     expect(screen.getByText(/cluster analysis not available/i)).toBeInTheDocument();
@@ -77,12 +85,30 @@ describe('ModelGroupsSection', () => {
   });
 
   it('offers group and individual views without heatmap', () => {
-    render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': populatedClusterAnalysis }} models={populatedModels} />);
+    const onClusteringMethodChange = vi.fn();
+
+    render(
+      <ModelGroupsSection
+        clusterAnalysisByMethod={{
+          'log-odds-euclidean-upgma': populatedClusterAnalysis,
+          'log-odds-euclidean-ward': populatedClusterAnalysis,
+        }}
+        models={populatedModels}
+        onClusteringMethodChange={onClusteringMethodChange}
+      />,
+    );
 
     expect(screen.getByRole('button', { name: 'Groups' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Individual' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Bar' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Heatmap' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Linkage')).toBeNull();
+    expect(screen.queryByText('Data')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Ward' })).toHaveClass('bg-teal-600');
+    expect(screen.getByRole('button', { name: 'UPGMA' })).not.toHaveClass('bg-teal-600');
+
+    fireEvent.click(screen.getByRole('button', { name: 'UPGMA' }));
+    expect(onClusteringMethodChange).toHaveBeenCalledWith('upgma');
 
     fireEvent.click(screen.getByRole('button', { name: 'Individual' }));
 
@@ -91,7 +117,15 @@ describe('ModelGroupsSection', () => {
   });
 
   it('lights up the selected legend item and fades the others', () => {
-    const { container } = render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': populatedClusterAnalysis }} models={populatedModels} />);
+    const { container } = render(
+      <ModelGroupsSection
+        clusterAnalysisByMethod={{
+          'log-odds-euclidean-upgma': populatedClusterAnalysis,
+          'log-odds-euclidean-ward': populatedClusterAnalysis,
+        }}
+        models={populatedModels}
+      />,
+    );
 
     const legendButton = screen.getByRole('button', { name: 'Model A' });
     fireEvent.click(legendButton);
@@ -105,7 +139,15 @@ describe('ModelGroupsSection', () => {
   });
 
   it('allows multi-select in individual mode', () => {
-    const { container } = render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': populatedClusterAnalysis }} models={populatedModels} />);
+    const { container } = render(
+      <ModelGroupsSection
+        clusterAnalysisByMethod={{
+          'log-odds-euclidean-upgma': populatedClusterAnalysis,
+          'log-odds-euclidean-ward': populatedClusterAnalysis,
+        }}
+        models={populatedModels}
+      />,
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Individual' }));
 
@@ -134,7 +176,15 @@ describe('ModelGroupsSection', () => {
   it('shows a value tooltip with color rows and logit values on bar hover', () => {
     vi.useFakeTimers();
 
-    const { container } = render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': populatedClusterAnalysis }} models={populatedModels} />);
+    const { container } = render(
+      <ModelGroupsSection
+        clusterAnalysisByMethod={{
+          'log-odds-euclidean-upgma': populatedClusterAnalysis,
+          'log-odds-euclidean-ward': populatedClusterAnalysis,
+        }}
+        models={populatedModels}
+      />,
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Bar' }));
 
@@ -157,7 +207,15 @@ describe('ModelGroupsSection', () => {
   });
 
   it('shows the Schwartz category ring in radar view', () => {
-    render(<ModelGroupsSection clusterAnalysisByMethod={{ 'log-odds-euclidean-upgma': populatedClusterAnalysis }} models={populatedModels} />);
+    render(
+      <ModelGroupsSection
+        clusterAnalysisByMethod={{
+          'log-odds-euclidean-upgma': populatedClusterAnalysis,
+          'log-odds-euclidean-ward': populatedClusterAnalysis,
+        }}
+        models={populatedModels}
+      />,
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Radar' }));
 

--- a/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
@@ -69,7 +69,10 @@ const defaultAnalysis = {
     ],
     unavailableModels: [],
     clusterAnalysis: defaultClusterAnalysis,
-    clusterAnalysisByMethod: { 'log-odds-euclidean-upgma': defaultClusterAnalysis },
+    clusterAnalysisByMethod: {
+      'log-odds-euclidean-upgma': defaultClusterAnalysis,
+      'log-odds-euclidean-ward': defaultClusterAnalysis,
+    },
   },
 };
 
@@ -170,7 +173,7 @@ describe('ModelsGroups', () => {
     );
 
     expect(await screen.findByRole('button', { name: /domain:/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Model Clusters', level: 1 })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Model Clusters', level: 1 })).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Model Clusters', level: 2 })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Similarity by Model' })).toBeInTheDocument();
   });

--- a/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { ModelsGroups } from '../../src/pages/ModelsGroups';
 import {
@@ -39,6 +40,22 @@ const defaultClusterAnalysis = {
         },
       ],
     },
+    {
+      id: 'cluster-b',
+      name: 'Cluster B',
+      definingValues: ['Hedonism'],
+      centroid: { Hedonism: -1 },
+      members: [
+        {
+          model: 'model-b',
+          label: 'Model B',
+          silhouetteScore: 0.5,
+          isOutlier: false,
+          nearestClusterIds: null,
+          distancesToNearestClusters: null,
+        },
+      ],
+    },
   ],
   faultLinesByPair: {},
 };
@@ -66,6 +83,14 @@ const defaultAnalysis = {
           { valueKey: 'Hedonism', score: -1 },
         ],
       },
+      {
+        model: 'model-b',
+        label: 'Model B',
+        values: [
+          { valueKey: 'Achievement', score: 0.5 },
+          { valueKey: 'Hedonism', score: -0.5 },
+        ],
+      },
     ],
     unavailableModels: [],
     clusterAnalysis: defaultClusterAnalysis,
@@ -86,6 +111,13 @@ const defaultModelsAnalysis = {
           { valueKey: 'Achievement', pooledWinRate: 72.5, stabilityScore: 91.2, eligibleDomainCount: 2, domains: [] },
         ],
       },
+      {
+        modelId: 'model-b',
+        label: 'Model B',
+        values: [
+          { valueKey: 'Achievement', pooledWinRate: 62.5, stabilityScore: 88.1, eligibleDomainCount: 2, domains: [] },
+        ],
+      },
     ],
   },
 };
@@ -97,6 +129,20 @@ const defaultLlmModels = {
       providerId: 'provider-a',
       modelId: 'model-a',
       displayName: 'Model A',
+      costInputPerMillion: 0,
+      costOutputPerMillion: 0,
+      status: 'ACTIVE',
+      isDefault: true,
+      isAvailable: true,
+      apiConfig: null,
+      createdAt: '2026-03-15T12:00:00.000Z',
+      updatedAt: '2026-03-15T12:00:00.000Z',
+    },
+    {
+      id: 'llm-model-b',
+      providerId: 'provider-a',
+      modelId: 'model-b',
+      displayName: 'Model B',
       costInputPerMillion: 0,
       costOutputPerMillion: 0,
       status: 'ACTIVE',
@@ -166,6 +212,7 @@ describe('ModelsGroups', () => {
   });
 
   it('renders the domain selection bar and model groups visualization', async () => {
+    const user = userEvent.setup();
     render(
       <MemoryRouter initialEntries={['/models?domainId=domain-a&signature=vnewtd']}>
         <ModelsGroups />
@@ -173,9 +220,16 @@ describe('ModelsGroups', () => {
     );
 
     expect(await screen.findByRole('button', { name: /domain:/i })).toBeInTheDocument();
+    expect(screen.getByText('Analysis settings')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Model Clusters', level: 1 })).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Model Clusters', level: 2 })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Similarity by Model' })).toBeInTheDocument();
+    expect(screen.getAllByText('10.00').length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole('button', { name: 'Spearman' }));
+    await user.click(screen.getByRole('button', { name: 'Similarity' }));
+
+    expect(screen.queryByText('10.00')).not.toBeInTheDocument();
   });
 
   it('shows the transcript count in the freshness line', async () => {


### PR DESCRIPTION
## Summary
- Remove the extra intro copy from the Model Clusters page.
- Default the clustering linkage to Ward.
- Remove the Linkage and Data labels so the toggles match the other report controls.

## Test plan
- [x] `npm run test --workspace @valuerank/web -- tests/components/ModelGroupsSection.test.tsx tests/pages/ModelsGroups.test.tsx`
- [x] `npx turbo lint --filter=@valuerank/web`
- [x] `npx turbo build --filter=@valuerank/web`
- [x] `npx turbo test --filter=@valuerank/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)