### PR TITLE
[codex] win rate report cleanup

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -37,6 +37,7 @@
 
 | Feature | Branch | Status | Notes |
 |---------|--------|--------|-------|
+| **win-rate-report-cleanup** | `—` | 🟢 Done locally | Cleaned up the Win Rate pages: removed the extra intro copy, moved Export CSV into the freshness row, simplified the Win Rate by Domain by Value header, put Cell metric inline with its toggle, removed the percent-change note, and narrowed screenshot capture to the table only. |
 | **status-page-pending-launches** | `—` | 🟢 Done locally | Status page active-evaluation query now includes PENDING, RUNNING, PAUSED, and SUMMARIZING launches so stuck-but-working runs show up again. Added API regression coverage and updated the section copy to match. |
 | **pressure-response-by-value-direct-rates** | `codex/value-priorities-logit-toggle` | 🟢 Done locally | Pressure Response by Value now uses direct win rates for both sides of each pair, instead of flipping the first value's rate for the second value. The table also keeps the vignette-level weighting rule so repeated measurements do not overcount a vignette. |
 | **model-groups-visualization-toggle** | `codex/pressure-response-tooltip-grid` | 🟢 Done locally | Domain Analysis model groups now support radar, dot map, and heatmap views with a view toggle, shared cluster ordering, and a fixed symmetric dot-map axis. |

--- a/cloud/apps/web/src/components/models/DomainShiftsReportSection.tsx
+++ b/cloud/apps/web/src/components/models/DomainShiftsReportSection.tsx
@@ -123,8 +123,8 @@ function DisplayModeToggle({
   onChange: (displayMode: DomainShiftDisplayMode) => void;
 }) {
   return (
-    <fieldset className="space-y-2">
-      <legend className="block text-sm font-medium text-gray-700">Cell metric</legend>
+    <div className="flex flex-wrap items-center gap-3">
+      <span className="text-sm font-medium text-gray-700">Cell metric</span>
       <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
         {([
           ['shift', 'Shift vs avg'],
@@ -148,7 +148,7 @@ function DisplayModeToggle({
           </Button>
         ))}
       </div>
-    </fieldset>
+    </div>
   );
 }
 
@@ -208,11 +208,6 @@ export function DomainShiftsReportSection({
     () => sortHeatmapRows(heatmap.rows, sort, displayMode),
     [displayMode, heatmap.rows, sort],
   );
-  const selectedModelsLabel = useMemo(() => {
-    if (selectedModels.length === 0) return 'No models selected';
-    if (selectedModels.length === 1) return selectedModels[0]?.label ?? 'Selected model';
-    return isDefaultSelection ? 'Default models' : `${selectedModels.length} selected models`;
-  }, [isDefaultSelection, selectedModels]);
 
   if (errorMessage != null) {
     return <ErrorMessage message={`Failed to load domain shifts: ${errorMessage}`} />;
@@ -261,29 +256,21 @@ export function DomainShiftsReportSection({
 
   return (
     <section className="space-y-6 rounded-xl border border-gray-200 bg-white p-4 md:p-5">
-      <div className="space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
-        <h2 className="text-2xl font-serif font-medium text-[#1A1A1A]">Win Rate by Domain by Value</h2>
-        <p className="max-w-3xl text-sm text-gray-600">
-          Exploratory heatmap for domain-associated value shifts, using the current Win Rate filters above.
-        </p>
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold text-gray-900">Win Rate by Domain by Value</h2>
+          <p className="max-w-3xl text-sm text-gray-600">
+            Exploratory heatmap for domain-associated value shifts, using the current Win Rate filters above.
+          </p>
+        </div>
+        <CopyVisualButton targetRef={tableRef} label="Win Rate by Domain by Value" />
       </div>
 
-      <div ref={tableRef} className="space-y-4">
-        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <h3 className="text-lg font-semibold text-gray-900">{selectedModelsLabel}</h3>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <DisplayModeToggle displayMode={displayMode} onChange={setDisplayMode} />
-            <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
-              <span className="font-semibold text-gray-800">Metric:</span>{' '}
-              {displayMode === 'shift' ? 'percentage-point shift, not percent change' : 'raw domain win rate'}
-            </div>
-            <CopyVisualButton targetRef={tableRef} label="Win Rate by Domain by Value" />
-          </div>
-        </div>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <DisplayModeToggle displayMode={displayMode} onChange={setDisplayMode} />
+      </div>
 
+      <div ref={tableRef}>
         <div className="overflow-x-auto rounded border border-gray-100 bg-white p-2">
           <table className="w-full table-auto border-collapse text-xs">
             <colgroup>

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -364,23 +364,8 @@ export function DomainAnalysis() {
         }}
       />
 
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="space-y-2">
-          <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Win Rate</h1>
-          <p className="text-sm text-gray-600">
-            Structured win-rate interpretation across priorities, ranking behavior, and similarity for the selected domain.
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={handleExport}
-          disabled={selectedDomainId === '' || exportLoading || isAllDomains}
-          title={isAllDomains ? 'CSV export is unavailable in All domains mode' : undefined}
-        >
-          {exportLoading ? 'Exporting…' : 'Export CSV'}
-        </Button>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Win Rate</h1>
       </div>
 
       {exportError !== null && <p className="mt-1 text-xs text-amber-700">{exportError}</p>}
@@ -423,6 +408,16 @@ export function DomainAnalysis() {
                 {refreshFetching ? 'Refreshing\u2026' : 'Refresh now'}
               </Button>
             )}
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleExport}
+              disabled={selectedDomainId === '' || exportLoading || isAllDomains}
+              title={isAllDomains ? 'CSV export is unavailable in All domains mode' : undefined}
+            >
+              {exportLoading ? 'Exporting…' : 'Export CSV'}
+            </Button>
           </div>
           {refreshNotice !== null && <p className="text-green-700">{refreshNotice}</p>}
           {refreshError !== null && <p className="text-amber-700">{refreshError}</p>}

--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -456,8 +456,8 @@ export function DomainValueShiftHeatmap() {
                           cell == null
                             ? 'border-gray-100 bg-gray-50 text-gray-400'
                             : displayMode === 'shift'
-                              ? getCellToneClass(cell.shift)
-                              : getWinRateToneClass(cell.winRate),
+                              ? getCellTone(cell.shift)
+                              : getWinRateTone(cell.winRate),
                         );
 
                         return (

--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -107,8 +107,8 @@ function DisplayModeToggle({
   onChange: (displayMode: DomainShiftDisplayMode) => void;
 }) {
   return (
-    <fieldset className="space-y-2">
-      <legend className="block text-sm font-medium text-gray-700">Cell metric</legend>
+    <div className="flex flex-wrap items-center gap-3">
+      <span className="text-sm font-medium text-gray-700">Cell metric</span>
       <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
         {([
           ['shift', 'Shift vs avg'],
@@ -132,7 +132,7 @@ function DisplayModeToggle({
           </Button>
         ))}
       </div>
-    </fieldset>
+    </div>
   );
 }
 
@@ -289,11 +289,6 @@ export function DomainValueShiftHeatmap() {
     () => [{ value: 'all', label: 'All domains' }, ...domains.map((domain) => ({ value: domain.id, label: domain.name }))],
     [domains],
   );
-  const selectedModelsLabel = selectedModels.length === 1
-    ? selectedModels[0]?.label ?? 'Selected model'
-    : isDefaultSelection
-      ? 'Default models'
-      : `${selectedModels.length} selected models`;
 
   if (domainsError != null || signatureError != null || llmModelsError != null || error != null) {
     return (
@@ -345,7 +340,6 @@ export function DomainValueShiftHeatmap() {
       />
 
       <div className="space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
         <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Domain shifts</h1>
         <p className="max-w-3xl text-sm text-gray-600">
           Exploratory heatmap for domain-associated value shifts. Toggle between percentage-point shifts and raw win
@@ -377,105 +371,111 @@ export function DomainValueShiftHeatmap() {
           </p>
         </section>
       ) : (
-        <section ref={tableRef} className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+        <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
           <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <h2 className="text-lg font-semibold text-gray-900">{selectedModelsLabel}</h2>
+            <div className="space-y-2">
+              <h2 className="text-lg font-semibold text-gray-900">Win Rate by Domain by Value</h2>
+              <p className="max-w-3xl text-sm text-gray-600">
+                Exploratory heatmap for domain-associated value shifts. Toggle between percentage-point shifts and raw win
+                rates, then click any column header to sort.
+              </p>
             </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <DisplayModeToggle displayMode={displayMode} onChange={setDisplayMode} />
-              <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
-                <span className="font-semibold text-gray-800">Metric:</span>{' '}
-                {displayMode === 'shift' ? 'percentage-point shift, not percent change' : 'raw domain win rate'}
-              </div>
-              <CopyVisualButton targetRef={tableRef} label="domain shifts table" />
-            </div>
+            <CopyVisualButton targetRef={tableRef} label="Win Rate by Domain by Value" />
           </div>
 
-          <div className="overflow-x-auto rounded border border-gray-100 bg-white p-2">
-            <table className="w-full table-auto border-collapse text-xs">
-              <colgroup>
-                <col className="w-max" />
-                <col className="w-max" />
-                {heatmap.columns.map((domain) => (
-                  <col key={domain.domainId} style={{ width: domainColumnWidth }} />
-                ))}
-              </colgroup>
-              <thead>
-                <tr className="border-b border-gray-200 text-gray-600">
-                  <SortableHeader
-                    label="Value"
-                    sortKey="value"
-                    sort={sort}
-                    onSort={setSort}
-                    align="left"
-                    className="border-r-2 border-gray-300"
-                  />
-                  <SortableHeader
-                    label="Avg Win Rate"
-                    sortKey="average"
-                    sort={sort}
-                    onSort={setSort}
-                    align="right"
-                    className="border-r-2 border-gray-300"
-                  />
-                  {heatmap.columns.map((domain) => {
-                    const domainSortKey: DomainShiftSortKey = `domain:${domain.domainId}`;
-                    return (
-                      <SortableHeader
-                        key={domain.domainId}
-                        label={domain.domainName}
-                        sortKey={domainSortKey}
-                        sort={sort}
-                        onSort={setSort}
-                      />
-                    );
-                  })}
-                </tr>
-              </thead>
-              <tbody>
-                {sortedRows.map((row) => (
-                  <tr key={row.valueKey} className="border-b border-gray-100">
-                    <th scope="row" className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 whitespace-nowrap text-left font-medium text-gray-900">
-                      {row.valueLabel}
-                    </th>
-                    <td className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 whitespace-nowrap text-right font-mono text-gray-700">
-                      {formatPercent(row.averageWinRate)}
-                      {row.averageMatchesPooled === false && (
-                        <span
-                          className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-xs font-sans text-amber-800"
-                          title="Computed average differs from the API pooled win rate by more than the allowed tolerance."
-                        >
-                          check
-                        </span>
-                      )}
-                    </td>
-                    {heatmap.columns.map((domain) => {
-                      const cell = row.cells.get(domain.domainId) ?? null;
-                      const tdClassName = cn(
-                        'border-b border-gray-100 px-2 py-2 text-center align-middle transition-colors',
-                        cell == null
-                          ? 'border-gray-100 bg-gray-50 text-gray-400'
-                          : displayMode === 'shift'
-                            ? getCellTone(cell.shift)
-                            : getWinRateTone(cell.winRate),
-                      );
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <DisplayModeToggle displayMode={displayMode} onChange={setDisplayMode} />
+          </div>
 
+          <div ref={tableRef}>
+            <div className="overflow-x-auto rounded border border-gray-100 bg-white p-2">
+              <table className="w-full table-auto border-collapse text-xs">
+                <colgroup>
+                  <col className="w-max" />
+                  <col className="w-max" />
+                  {heatmap.columns.map((domain) => (
+                    <col key={domain.domainId} style={{ width: domainColumnWidth }} />
+                  ))}
+                </colgroup>
+                <thead>
+                  <tr className="border-b border-gray-200 text-gray-600">
+                    <SortableHeader
+                      label="Value"
+                      sortKey="value"
+                      sort={sort}
+                      onSort={setSort}
+                      align="left"
+                      className="border-r-2 border-gray-300"
+                    />
+                    <SortableHeader
+                      label="Avg Win Rate"
+                      sortKey="average"
+                      sort={sort}
+                      onSort={setSort}
+                      align="right"
+                      className="border-r-2 border-gray-300"
+                    />
+                    {heatmap.columns.map((domain) => {
+                      const domainSortKey: DomainShiftSortKey = `domain:${domain.domainId}`;
                       return (
-                        <td key={domain.domainId} className={tdClassName}>
-                          <Cell
-                            cell={cell}
-                            valueLabel={row.valueLabel}
-                            displayMode={displayMode}
-                            evidenceLabel={isDefaultSelection ? 'average evidence vignettes' : 'evidence vignettes'}
-                          />
-                        </td>
+                        <SortableHeader
+                          key={domain.domainId}
+                          label={domain.domainName}
+                          sortKey={domainSortKey}
+                          sort={sort}
+                          onSort={setSort}
+                        />
                       );
                     })}
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {sortedRows.map((row) => (
+                    <tr key={row.valueKey} className="border-b border-gray-100">
+                      <th
+                        scope="row"
+                        className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 whitespace-nowrap text-left font-medium text-gray-900"
+                      >
+                        {row.valueLabel}
+                      </th>
+                      <td className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 whitespace-nowrap text-right font-mono text-gray-700">
+                        {formatPercent(row.averageWinRate)}
+                        {row.averageMatchesPooled === false && (
+                          <span
+                            className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-xs font-sans text-amber-800"
+                            title="Computed average differs from the API pooled win rate by more than the allowed tolerance."
+                          >
+                            check
+                          </span>
+                        )}
+                      </td>
+                      {heatmap.columns.map((domain) => {
+                        const cell = row.cells.get(domain.domainId) ?? null;
+                        const tdClassName = cn(
+                          'border-b border-gray-100 px-2 py-2 text-center align-middle transition-colors',
+                          cell == null
+                            ? 'border-gray-100 bg-gray-50 text-gray-400'
+                            : displayMode === 'shift'
+                              ? getCellToneClass(cell.shift)
+                              : getWinRateToneClass(cell.winRate),
+                        );
+
+                        return (
+                          <td key={domain.domainId} className={tdClassName}>
+                            <Cell
+                              cell={cell}
+                              valueLabel={row.valueLabel}
+                              displayMode={displayMode}
+                              evidenceLabel={isDefaultSelection ? 'average evidence vignettes' : 'evidence vignettes'}
+                            />
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         </section>
       )}

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -199,6 +199,7 @@ describe('DomainAnalysis', () => {
     expect(await screen.findByText(/^Fresh$/)).toBeInTheDocument();
     expect(screen.getByText(/updated 3\/15\/2026/i)).toBeInTheDocument();
     expect(screen.getByText(/0 transcripts analyzed/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeInTheDocument();
   });
 
   it('renders the report sections in the requested order', async () => {

--- a/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import {
@@ -368,9 +368,7 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Model A' })).toBeInTheDocument();
-    });
+    expect(await screen.findByRole('heading', { name: 'Win Rate by Domain by Value' })).toBeInTheDocument();
     expect(screen.getByRole('table')).toHaveClass('table-auto');
     await user.click(screen.getByRole('button', { name: /default — 1 model/i }));
     expect(screen.getByRole('button', { name: /default models/i })).toBeInTheDocument();
@@ -380,8 +378,9 @@ describe('DomainValueShiftHeatmap page', () => {
     expect(screen.getByLabelText(/Achievement in City Planning: raw win rate 80\.0%; shift \+20pp/i)).toHaveAccessibleName(
       /average 60\.0%; average evidence vignettes —/i,
     );
-    expect(screen.getByText('Metric:')).toBeInTheDocument();
-    expect(screen.getByText(/percentage-point shift, not percent change/i)).toBeInTheDocument();
+    expect(screen.getByText('Cell metric')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Copy Win Rate by Domain by Value as image/i })).toBeInTheDocument();
+    expect(screen.queryByText(/percentage-point shift, not percent change/i)).not.toBeInTheDocument();
 
     const firstDataRow = screen.getAllByRole('row')[1];
     expect(within(firstDataRow).getAllByRole('rowheader')[0]).toHaveTextContent('Achievement');
@@ -421,7 +420,7 @@ describe('DomainValueShiftHeatmap page', () => {
 
     expect(screen.getByRole('button', { name: 'Raw win rate' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByText('80.0%')).toBeInTheDocument();
-    expect(screen.getByText(/raw domain win rate/i)).toBeInTheDocument();
+    expect(screen.queryByText(/raw domain win rate/i)).not.toBeInTheDocument();
   });
 
   it('sorts table rows when a domain column header is clicked', async () => {
@@ -464,7 +463,7 @@ describe('DomainValueShiftHeatmap page', () => {
     await user.click(screen.getByRole('button', { name: /default — 2 models/i }));
     await user.click(screen.getByRole('button', { name: 'Alpha' }));
 
-    expect(screen.getByRole('heading', { name: 'Zulu' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /models: 1 of 2 selected/i })).toBeInTheDocument();
   });
 
   it('groups default models ahead of non-default models with a divider', async () => {


### PR DESCRIPTION
## What changed
- Removed the extra Win Rate intro copy on the analysis page.
- Moved `Export CSV` into the freshness row next to `Fresh` / `Refresh now`.
- Standardized the `Win Rate by Domain by Value` title size and removed the extra `Models` label.
- Put `Cell metric` inline with the toggle and removed the percent-change note.
- Kept the screenshot control scoped to the table content.
- Updated the affected tests and the local status dashboard.

## Why
The Win Rate pages had too much surrounding copy and control clutter, and the screenshot button was capturing more than the table itself.

## Validation
- `npm run test -- tests/pages/DomainValueShiftHeatmap.test.tsx tests/pages/DomainAnalysis.test.tsx`
- `npm run typecheck -- --pretty false`
