### PR TITLE
[codex] pressure sensitivity copy cleanup

### DIFF
--- a/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.test.tsx
@@ -186,4 +186,12 @@ describe('PressureDirectionalBreakdown', () => {
     expect(screen.getByRole('tooltip').textContent ?? '').toContain('Ethics');
     fireEvent.blur(ethicsTrigger);
   });
+
+  it('renders the standard copy button for the report capture control', () => {
+    renderBreakdown([createModel('alpha', 'Alpha', 0.2, DOMAINS)]);
+
+    expect(
+      screen.getByRole('button', { name: /copy pressure sensitivity by domain as image/i }),
+    ).toBeDefined();
+  });
 });

--- a/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.tsx
+++ b/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/Table';
 import { HeaderTooltip } from '../ui/HeaderTooltip';
-import { ScreenshotButton } from '../ui/ScreenshotButton';
+import { CopyVisualButton } from '../ui/CopyVisualButton';
 import type { PressureSensitivityModel } from '../../api/operations/pressureSensitivity';
 import { formatSignedPoints } from './pressureSensitivityFormatting';
 
@@ -95,7 +95,7 @@ export function PressureDirectionalBreakdown({ models }: Props) {
             balanced win rate. Domain cells show the deviation from each model&apos;s overall pressure sensitivity.
           </p>
         </div>
-        <ScreenshotButton targetRef={tableRef} label="pressure sensitivity by domain" />
+        <CopyVisualButton targetRef={tableRef} label="pressure sensitivity by domain" />
       </div>
       <Table variant="bordered">
         <TableHeader variant="bordered">

--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
@@ -225,7 +225,6 @@ describe('PressureResponseByValueTable', () => {
     }
 
     const cells = within(row).getAllByRole('cell');
-    expect(screen.getByText(/Averaged across 2 selected models/)).toBeDefined();
     expect(cells[1]?.textContent ?? '').toBe('60.0%');
     expect(cells[2]?.textContent ?? '').toBe('30.0%');
     expect(cells[3]?.textContent ?? '').toBe('80.0%');

--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.tsx
@@ -159,7 +159,7 @@ function SortHeaderContent({
   tooltip,
   numeric,
 }: {
-  label: string;
+  label: ReactNode;
   ariaLabel: string;
   sortKey: SortKey;
   activeSortKey: SortKey;
@@ -195,7 +195,7 @@ function SortHeaderContent({
 }
 
 function SortHeaderCell(props: {
-  label: string;
+  label: ReactNode;
   ariaLabel: string;
   sortKey: SortKey;
   activeSortKey: SortKey;
@@ -233,6 +233,15 @@ function EffectCell({ value }: { value: number | null }) {
     <TableCell className="text-right text-sm">
       <span className={`font-mono ${colorClass}`}>{formatSignedPoints(value)}</span>
     </TableCell>
+  );
+}
+
+function WrappedHighPressureLabel({ suffix }: { suffix: string }) {
+  return (
+    <span className="inline-flex flex-col items-end leading-tight text-right">
+      <span className="whitespace-nowrap">High pressure</span>
+      <span>{suffix}</span>
+    </span>
   );
 }
 
@@ -280,10 +289,7 @@ export function PressureResponseByValueTable({ models }: Props) {
   if (models.length === 0) {
     return (
       <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
-        <div className="space-y-1">
-          <h2 className="text-lg font-semibold text-gray-900">Win Rate by Pressure Conditions by Value</h2>
-          <p className="text-sm text-gray-600">No by-value data is available for the selected models.</p>
-        </div>
+        <h2 className="text-lg font-semibold text-gray-900">Win Rate by Pressure Conditions by Value</h2>
       </section>
     );
   }
@@ -293,13 +299,6 @@ export function PressureResponseByValueTable({ models }: Props) {
       <div className="mb-3 flex items-start justify-between gap-3">
         <div className="space-y-1">
           <h2 className="text-lg font-semibold text-gray-900">Win Rate by Pressure Conditions by Value</h2>
-          <p className="text-sm text-gray-600">
-            Averaged across {models.length} selected model{models.length === 1 ? '' : 's'} in the page filter.
-          </p>
-          <p className="text-sm text-gray-600">
-            Each row is one value. The columns show how often the selected model set picks that value across
-            its 9 pairings, broken down by what the prompt was doing.
-          </p>
           <p className="text-xs text-gray-500">
             Each pressure cell is pooled from its vignette-level observations, then counted once in the row summary.
             The pair rows are averaged equally across the 9 pairs containing this value.
@@ -364,7 +363,7 @@ export function PressureResponseByValueTable({ models }: Props) {
                 numeric
               />
               <SortHeaderCell
-                label="High pressure on value"
+                label={<WrappedHighPressureLabel suffix="on value" />}
                 ariaLabel="High pressure on value win rate"
                 sortKey="highPressureOnThisValue"
                 activeSortKey={sortKey}
@@ -380,7 +379,7 @@ export function PressureResponseByValueTable({ models }: Props) {
                 numeric
               />
               <SortHeaderCell
-                label="High pressure on value effect"
+                label={<WrappedHighPressureLabel suffix="on value effect" />}
                 ariaLabel="High pressure on value effect"
                 sortKey="highPressureOnValueEffect"
                 activeSortKey={sortKey}
@@ -389,7 +388,7 @@ export function PressureResponseByValueTable({ models }: Props) {
                 numeric
               />
               <SortHeaderCell
-                label="High pressure on opposing value"
+                label={<WrappedHighPressureLabel suffix="on opposing value" />}
                 ariaLabel="High pressure on opposing value win rate"
                 sortKey="highPressureOnOpposingValue"
                 activeSortKey={sortKey}
@@ -405,7 +404,7 @@ export function PressureResponseByValueTable({ models }: Props) {
                 numeric
               />
               <SortHeaderCell
-                label="High pressure on opposing value effect"
+                label={<WrappedHighPressureLabel suffix="on opposing value effect" />}
                 ariaLabel="High pressure on opposing value effect"
                 sortKey="highPressureOnOpposingValueEffect"
                 activeSortKey={sortKey}
@@ -433,10 +432,7 @@ export function PressureResponseByValueTable({ models }: Props) {
 
       <div className="mt-4 space-y-3 text-sm text-gray-600">
         <h3 className="text-sm font-semibold text-gray-900">Reading this table</h3>
-        <p>
-          Each row is one value. The columns show how often the selected model set picks that value across its
-          9 pairings, broken down by what the prompt was doing.
-        </p>
+        <p>Compare the average, balanced, and pressure-skewed rates to see where the selected models shift most.</p>
         <p>
           The two push columns are most informative when compared against the balanced rate. If &quot;high pressure on
           value&quot; is well above balanced, the prompt successfully pushes the model toward this value. If

--- a/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
@@ -356,7 +356,6 @@ describe('PressureSensitivity page', () => {
     );
 
     expect(screen.getByText('Win Rate by Pressure Conditions by Value')).toBeDefined();
-    expect(screen.getByText(/Averaged across 2 selected models/)).toBeDefined();
   });
 
   it('defaults to the shared bar and removes the provider filter copy', () => {
@@ -432,6 +431,5 @@ describe('PressureSensitivity page', () => {
 
     valueCells = within(valueRow).getAllByRole('cell');
     expect(valueCells[1]?.textContent ?? '').toBe('80.0%');
-    expect(screen.getByText(/Averaged across 1 selected model/)).toBeDefined();
   });
 });

--- a/cloud/apps/web/src/pages/PressureSensitivity.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.tsx
@@ -277,14 +277,6 @@ export function PressureSensitivity() {
         }}
       />
 
-      <div className="space-y-2">
-        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Pressure Sensitivity</h1>
-        <p className="max-w-3xl text-sm text-gray-600">
-          Compare how pressure changes model choices across value pairs. Use the bar above to scope the report by
-          domain, signature, and model set. The pair grid below needs exactly one model selected in the bar.
-        </p>
-      </div>
-
       {transcriptCapHit && (
         <section className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
           Coverage warning: this report scanned the maximum 500,000 transcripts and stopped before reaching the end of the data. Win rates and CIs may be biased toward earlier transcripts in the corpus.


### PR DESCRIPTION
## Summary
- Remove the top Pressure Sensitivity intro copy.
- Switch the domain report capture control to the standard copy-style button.
- Trim the by-value report copy and wrap the high-pressure column headers.

## Validation
- `npm run lint --filter=@valuerank/web`
- `npm run test --filter=@valuerank/web`
- `npm run build --filter=@valuerank/web`
- `npm run test -- --run src/components/models/PressureDirectionalBreakdown.test.tsx src/components/models/PressureResponseByValueTable.test.tsx src/pages/PressureSensitivity.test.tsx`
- `npm run typecheck`

🤖 Generated with [Codex](https://openai.com/codex)
