### PR TITLE
[codex] confidence report screenshots and card shell

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -97,6 +97,7 @@ Once the above are resolved:
 - [x] Domain Shifts model picker now groups default models first and separates non-default models with `---` before alphabetical non-default options.
 - [x] Model Groups visualization now lives at `/models` under the Models dropdown first item, with the domain selection bar at the top of the page driving the report.
 - [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, and model rows no longer repeat the model ID line.
+- [x] Confidence by Values by Model now sits inside a bordered report card with the new intro copy, and the report headers now include screenshot buttons on the far right.
 - [x] Domain Shifts by Value now has an `All models` aggregate view, one-decimal formatting throughout, and content-fit Value / Avg Win Rate columns in the local branch.
 - [x] Model Value Preference overview report updated at `/models`; screenshot capture is available, the title now matches the report, the all-domains value priorities table now includes stability circles, and the comparison table stays below it.
 - [x] `/models` reporting now uses the canonical equal-vignette methodology in both tables, with one-decimal display, vignette-weighted cross-domain pooling, and no silent fallback to pooled raw counts when vignette-aware data is missing.

--- a/cloud/apps/web/src/components/models/ConfidenceDomainBreakout.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceDomainBreakout.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useClient } from 'urql';
 import gql from 'graphql-tag';
 import { Button } from '../ui/Button';
+import { ScreenshotButton } from '../ui/ScreenshotButton';
 import { cn } from '../../lib/utils';
 import { VALUES, VALUE_LABELS } from '../../data/domainAnalysisData';
 import { formatFullSchwartzValueName } from '../../utils/schwartz';
@@ -287,6 +288,7 @@ export function ConfidenceDomainBreakout({
   const [displayMode, setDisplayMode] = useState<DomainShiftDisplayMode>('winRate');
   const [sort, setSort] = useState<BreakoutSort>(DEFAULT_SORT);
   const [domainStates, setDomainStates] = useState<Record<string, DomainQueryState>>({});
+  const sectionRef = useRef<HTMLElement>(null);
   const effectiveModelIds = selectedModelIds ?? defaultModelIds;
   const selectedModelSet = useMemo(() => new Set(effectiveModelIds), [effectiveModelIds]);
   const noModelsSelected = effectiveModelIds.length === 0;
@@ -440,13 +442,14 @@ export function ConfidenceDomainBreakout({
   }
 
   return (
-    <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+    <section ref={sectionRef} className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
       <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-        <div>
+        <div className="min-w-0">
           <h2 className="text-lg font-semibold text-gray-900">Confidence by Value &amp; Domain</h2>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <DisplayModeToggle displayMode={displayMode} onChange={setDisplayMode} />
+          <ScreenshotButton targetRef={sectionRef} label="confidence by value and domain report" />
         </div>
       </div>
 

--- a/cloud/apps/web/src/components/models/ConfidenceModelDomainBreakout.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceModelDomainBreakout.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useClient } from 'urql';
 import gql from 'graphql-tag';
 import { Button } from '../ui/Button';
+import { ScreenshotButton } from '../ui/ScreenshotButton';
 import { cn } from '../../lib/utils';
 import {
   formatPercent,
@@ -314,6 +315,7 @@ export function ConfidenceModelDomainBreakout({
   const [displayMode, setDisplayMode] = useState<DomainShiftDisplayMode>('winRate');
   const [sort, setSort] = useState<ModelBreakoutSort>(DEFAULT_MODEL_SORT);
   const [domainStates, setDomainStates] = useState<Record<string, DomainQueryState>>({});
+  const sectionRef = useRef<HTMLElement>(null);
   const effectiveModelIds = selectedModelIds ?? defaultModelIds;
   const noModelsSelected = effectiveModelIds.length === 0;
 
@@ -413,13 +415,14 @@ export function ConfidenceModelDomainBreakout({
   }
 
   return (
-    <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+    <section ref={sectionRef} className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
       <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-        <div>
+        <div className="min-w-0">
           <h2 className="text-lg font-semibold text-gray-900">Confidence by Model &amp; Domain</h2>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <DisplayModeToggle displayMode={displayMode} onChange={setDisplayMode} />
+          <ScreenshotButton targetRef={sectionRef} label="confidence by model and domain report" />
         </div>
       </div>
 

--- a/cloud/apps/web/src/pages/ModelsConfidence.tsx
+++ b/cloud/apps/web/src/pages/ModelsConfidence.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'urql';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
@@ -17,6 +17,7 @@ import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/l
 import { ConfidenceHeatmap } from '../components/models/ConfidenceHeatmap';
 import { ConfidenceDomainBreakout } from '../components/models/ConfidenceDomainBreakout';
 import { ConfidenceModelDomainBreakout } from '../components/models/ConfidenceModelDomainBreakout';
+import { ScreenshotButton } from '../components/ui/ScreenshotButton';
 import {
   buildDomainShiftSignatureOptions,
   getDefaultDomainShiftSignature,
@@ -27,6 +28,7 @@ export function ModelsConfidence() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const signatureParam = searchParams.get('signature');
+  const reportRef = useRef<HTMLDivElement>(null);
 
   const { domains } = useDomains();
   const [selectedDomainId, setSelectedDomainId] = useState<string | null>(null);
@@ -163,25 +165,32 @@ export function ModelsConfidence() {
         }}
       />
 
-      <div className="space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
-        <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Confidence by Values by Model</h1>
-        <p className="max-w-3xl text-sm text-gray-600">
-          How often each model responds with strong conviction vs. a lean.
-          Strong% = strongly support / (strongly support + somewhat support).
-        </p>
-      </div>
-
       {error != null && <ErrorMessage message={error.message} />}
-      {loading ? (
-        <Loading />
-      ) : (
-        <ConfidenceHeatmap
-          models={models}
-          selectedModelIds={filteredModelIds ?? undefined}
-          onCellClick={handleCellClick}
-        />
-      )}
+
+      <section ref={reportRef} className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-700">Models</p>
+            <h1 className="text-lg font-semibold text-gray-900">
+              Confidence by Values by Model
+            </h1>
+            <p className="max-w-3xl text-sm text-gray-600">
+              Shows how often each model responds with strong conviction when it picks a value.
+            </p>
+          </div>
+          <ScreenshotButton targetRef={reportRef} label="confidence by values by model report" />
+        </div>
+
+        {loading ? (
+          <Loading />
+        ) : (
+          <ConfidenceHeatmap
+            models={models}
+            selectedModelIds={filteredModelIds ?? undefined}
+            onCellClick={handleCellClick}
+          />
+        )}
+      </section>
 
       {domains.length > 0 && (
         <ConfidenceDomainBreakout


### PR DESCRIPTION
## What changed
- Wrapped `Confidence by Values by Model` in a standard bordered report card.
- Updated the intro copy to: `Shows how often each model responds with strong conviction when it picks a value.`
- Added screenshot buttons to the far right of the main report header and the two breakout report headers.

## Why
- This keeps the confidence report visually consistent with the rest of the reporting page.
- It also makes screenshot capture available from each report section instead of only some of them.

## Validation
- `npx eslint src/pages/ModelsConfidence.tsx src/components/models/ConfidenceDomainBreakout.tsx src/components/models/ConfidenceModelDomainBreakout.tsx` ✅ ran clean, with only existing max-lines warnings in the two breakout files.
- `npx tsc --noEmit --skipLibCheck --target ES2020 --module ESNext --moduleResolution bundler --jsx react-jsx --lib ES2020,DOM,DOM.Iterable --types vite/client,node src/pages/ModelsConfidence.tsx src/components/models/ConfidenceDomainBreakout.tsx src/components/models/ConfidenceModelDomainBreakout.tsx` ✅
- `npx turbo lint --filter=@valuerank/web` ⚠️ fails on pre-existing unrelated lint errors in other web files.
- `npm run typecheck --workspace=@valuerank/web` ⚠️ fails on a pre-existing unrelated error in `DomainValueShiftHeatmap.tsx`.
