### PR TITLE
Restore absolute value similarity and flatten linkage toggles

### DIFF
--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -172,26 +172,24 @@ export function ModelGroupsSection({
           {groupDisplayMode === 'groups' && (
             <>
               {onClusteringMethodChange != null && (
-                <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
-                  <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
-                    {LINKAGE_OPTIONS.map((option) => {
-                      const active = clusteringMethod === option.value;
-                      return (
-                        <Button
-                          key={option.value}
-                          type="button"
-                          variant={active ? 'primary' : 'ghost'}
-                          size="sm"
-                          onClick={() => onClusteringMethodChange(option.value)}
-                          className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
-                            active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-white hover:text-gray-900'
-                          }`}
-                        >
-                          {option.label}
-                        </Button>
-                      );
-                    })}
-                  </div>
+                <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+                  {LINKAGE_OPTIONS.map((option) => {
+                    const active = clusteringMethod === option.value;
+                    return (
+                      <Button
+                        key={option.value}
+                        type="button"
+                        variant={active ? 'primary' : 'ghost'}
+                        size="sm"
+                        onClick={() => onClusteringMethodChange(option.value)}
+                        className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
+                          active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-white hover:text-gray-900'
+                        }`}
+                      >
+                        {option.label}
+                      </Button>
+                    );
+                  })}
                 </div>
               )}
             </>

--- a/cloud/apps/web/src/components/models/ModelAnalysisSettingsBar.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelAnalysisSettingsBar.test.tsx
@@ -22,11 +22,12 @@ describe('ModelAnalysisSettingsBar', () => {
     expect(screen.getByText('Affects all reports on this page.')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Log Odds' }).className.includes('bg-teal-600')).toBe(true);
     expect(screen.getByRole('button', { name: 'Weighted Euclidean' }).className.includes('bg-teal-600')).toBe(true);
+    expect(screen.getByRole('button', { name: 'Absolute Value' })).toBeTruthy();
 
     await user.click(screen.getByRole('button', { name: 'Win Rate' }));
-    await user.click(screen.getByRole('button', { name: 'Kendall' }));
+    await user.click(screen.getByRole('button', { name: 'Absolute Value' }));
 
     expect(onDataSourceChange).toHaveBeenCalledWith('win-rate');
-    expect(onSimilarityMethodChange).toHaveBeenCalledWith('kendall');
+    expect(onSimilarityMethodChange).toHaveBeenCalledWith('absolute-value');
   });
 });

--- a/cloud/apps/web/src/components/models/ModelSimilarityMetrics.ts
+++ b/cloud/apps/web/src/components/models/ModelSimilarityMetrics.ts
@@ -1,6 +1,6 @@
 import { type ModelEntry, VALUES, VALUE_LABELS, type ValueKey } from '../../data/domainAnalysisData';
 
-export type CalculationMethod = 'weighted-euclidean' | 'cosine' | 'spearman' | 'kendall';
+export type CalculationMethod = 'weighted-euclidean' | 'absolute-value' | 'cosine' | 'spearman' | 'kendall';
 export type MetricView = 'distance' | 'similarity';
 
 export type PairStep = {
@@ -42,6 +42,7 @@ export type PairMetric = {
 
 export const CALCULATION_METHODS: Array<{ value: CalculationMethod; label: string }> = [
   { value: 'weighted-euclidean', label: 'Weighted Euclidean' },
+  { value: 'absolute-value', label: 'Absolute Value' },
   { value: 'cosine', label: 'Cosine' },
   { value: 'spearman', label: 'Spearman' },
   { value: 'kendall', label: 'Kendall' },
@@ -98,6 +99,12 @@ export function getMethodCopy(method: CalculationMethod) {
         summaryLabel: 'Weighted Euclidean distance',
         summaryNote: 'Smaller means the two models are closer.',
         helpCopy: 'We compare the win rate for each value, then use weighted Euclidean distance to see how close two models are.',
+      };
+    case 'absolute-value':
+      return {
+        summaryLabel: 'Mean absolute difference',
+        summaryNote: 'Smaller means the two models are closer.',
+        helpCopy: 'We take the absolute value of the win-rate difference for each value, then average them.',
       };
     case 'cosine':
       return {
@@ -189,7 +196,7 @@ function cosineSimilarity(xs: number[], ys: number[]): number | null {
 function buildDisplayScores(rawScore: number | null, method: CalculationMethod): { distance: number | null; similarity: number | null } {
   if (rawScore == null) return { distance: null, similarity: null };
 
-  if (method === 'weighted-euclidean') {
+  if (method === 'weighted-euclidean' || method === 'absolute-value') {
     return {
       distance: rawScore,
       similarity: clamp01(1 - rawScore / 100),
@@ -249,6 +256,45 @@ export function computePairMetric(left: ModelEntry, right: ModelEntry, method: C
         { label: 'Sum of weighted diff²', value: sumWeightedDiffSquared },
         { label: 'Divide by count', value: usedValueCount === 0 ? null : sumWeightedDiffSquared / usedValueCount },
         { label: 'Square root = distance', value: rawScore },
+      ],
+    };
+  }
+
+  if (method === 'absolute-value') {
+    const steps: PairStep[] = comparableValues.map((entry) => {
+      const diff = (entry.leftWinRate ?? 0) - (entry.rightWinRate ?? 0);
+      return {
+        ...entry,
+        leftDerived: null,
+        rightDerived: null,
+        diff,
+        diffSquared: null,
+        weight: null,
+        weightedDiffSquared: null,
+      };
+    });
+
+    const usedValueCount = steps.length;
+    const sumAbsDiff = steps.reduce((sum, step) => sum + Math.abs(step.diff ?? 0), 0);
+    const rawScore = usedValueCount === 0 ? null : sumAbsDiff / usedValueCount;
+    const displayScores = buildDisplayScores(rawScore, method);
+
+    return {
+      left,
+      right,
+      method,
+      steps,
+      kendallSteps: [],
+      usedValueCount,
+      rawScore,
+      distance: displayScores.distance,
+      similarity: displayScores.similarity,
+      summaryLabel: copy.summaryLabel,
+      summaryNote: copy.summaryNote,
+      summaryRows: [
+        { label: 'Sum of |diff|', value: sumAbsDiff },
+        { label: 'Divide by count', value: usedValueCount === 0 ? null : sumAbsDiff / usedValueCount },
+        { label: 'Mean absolute difference', value: rawScore },
       ],
     };
   }

--- a/cloud/apps/web/src/components/models/ModelSimilarityPairDetailDrawer.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityPairDetailDrawer.tsx
@@ -122,6 +122,12 @@ export function PairDetailDrawer({ open, metric, onClose }: PairDetailDrawerProp
                           <th className="px-4 py-3 text-right font-medium">diff²</th>
                           <th className="px-4 py-3 text-right font-medium">weight × diff²</th>
                         </>
+                      ) : metric.method === 'absolute-value' ? (
+                        <>
+                          <th className="px-4 py-3 text-right font-medium">diff</th>
+                          <th className="px-4 py-3 text-right font-medium">|diff|</th>
+                          <th className="px-4 py-3 text-right font-medium" />
+                        </>
                       ) : metric.method === 'cosine' ? (
                         <>
                           <th className="px-4 py-3 text-right font-medium">centered</th>
@@ -152,6 +158,14 @@ export function PairDetailDrawer({ open, metric, onClose }: PairDetailDrawerProp
                             <td className="px-4 py-3 text-right font-mono text-gray-900">
                               {step.weightedDiffSquared == null ? '—' : formatMetricNumber(step.weightedDiffSquared)}
                             </td>
+                          </>
+                        ) : metric.method === 'absolute-value' ? (
+                          <>
+                            <td className="px-4 py-3 text-right font-mono text-gray-900">{formatMetricNumber(step.diff)}</td>
+                            <td className="px-4 py-3 text-right font-mono text-gray-900">
+                              {step.diff == null ? '—' : formatMetricNumber(Math.abs(step.diff))}
+                            </td>
+                            <td className="px-4 py-3 text-right font-mono text-gray-900">—</td>
                           </>
                         ) : metric.method === 'cosine' ? (
                           <>


### PR DESCRIPTION
## Summary\n- Restore Absolute Value as a similarity method in the model similarity controls and pair detail drawer\n- Re-enable Absolute Value calculations in the shared similarity metrics helper\n- Flatten the UPGMA/Ward linkage control so it matches the other segmented toggles\n\n## Validation\n- npm run test --workspace @valuerank/web -- src/components/models/ModelAnalysisSettingsBar.test.tsx src/components/models/ModelSimilarityTableSection.test.tsx tests/components/ModelGroupsSection.test.tsx tests/pages/ModelsGroups.test.tsx ✅\n- npx turbo lint --filter=@valuerank/web ✅ (existing repo warnings only)\n- npx turbo build --filter=@valuerank/web ✅\n