### PR TITLE
[codex] scope confidence reports to header filters

### DIFF
--- a/cloud/apps/web/src/components/models/ConfidenceDomainBreakout.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceDomainBreakout.tsx
@@ -291,12 +291,19 @@ export function ConfidenceDomainBreakout({
   const sectionRef = useRef<HTMLElement>(null);
   const effectiveModelIds = selectedModelIds ?? defaultModelIds;
   const selectedModelSet = useMemo(() => new Set(effectiveModelIds), [effectiveModelIds]);
+  const visibleDomains = useMemo(
+    () =>
+      selectedDomainId != null
+        ? domains.filter((domain) => domain.id === selectedDomainId)
+        : domains,
+    [domains, selectedDomainId],
+  );
   const noModelsSelected = effectiveModelIds.length === 0;
 
   useEffect(() => {
     let cancelled = false;
 
-    if (domains.length === 0) {
+    if (visibleDomains.length === 0) {
       setDomainStates({});
       return () => {
         cancelled = true;
@@ -305,14 +312,14 @@ export function ConfidenceDomainBreakout({
 
     setDomainStates(() => {
       const next: Record<string, DomainQueryState> = {};
-      for (const domain of domains) {
+      for (const domain of visibleDomains) {
         next[domain.id] = { status: 'loading', models: [], error: null };
       }
       return next;
     });
 
     void Promise.allSettled(
-      domains.map(async (domain) => {
+      visibleDomains.map(async (domain) => {
         try {
           const result = await client
             .query<ModelsConfidenceQueryResult, ConfidenceDomainBreakoutModelsConfidenceQueryVariables>(
@@ -360,7 +367,7 @@ export function ConfidenceDomainBreakout({
     return () => {
       cancelled = true;
     };
-  }, [client, domains, signature]);
+  }, [client, signature, visibleDomains]);
 
   const rows = useMemo<RowData[]>(() => {
     return VALUES.map((valueKey) => {
@@ -368,7 +375,7 @@ export function ConfidenceDomainBreakout({
       let pooledLean = 0;
       const cells = new Map<string, CellData>();
 
-      for (const domain of domains) {
+      for (const domain of visibleDomains) {
         const state = domainStates[domain.id];
         if (state == null || state.status === 'loading') {
           cells.set(domain.id, {
@@ -418,17 +425,17 @@ export function ConfidenceDomainBreakout({
         cells,
       };
     });
-  }, [domains, domainStates, selectedModelSet]);
+  }, [domainStates, selectedModelSet, visibleDomains]);
 
   const sortedRows = useMemo(
     () => sortRows(rows, sort, displayMode),
     [displayMode, rows, sort],
   );
 
-  if (domains.length === 0) {
+  if (visibleDomains.length === 0) {
     return (
       <section className="rounded-xl border border-gray-200 bg-white p-6">
-        <p className="text-sm text-gray-600">No domains are available yet.</p>
+        <p className="text-sm text-gray-600">No domains are available for the selected filters.</p>
       </section>
     );
   }
@@ -473,7 +480,7 @@ export function ConfidenceDomainBreakout({
                 align="right"
                 className="border-r-2 border-gray-300"
               />
-              {domains.map((domain) => {
+              {visibleDomains.map((domain) => {
                 const isSelected = selectedDomainId === domain.id;
                 const domainSortKey: BreakoutSortKey = `domain:${domain.id}`;
                 return (
@@ -499,7 +506,7 @@ export function ConfidenceDomainBreakout({
                   <td className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 whitespace-nowrap text-right font-mono text-gray-700">
                     {formatPercent(row.averageStrongPct)}
                   </td>
-                  {domains.map((domain) => {
+                  {visibleDomains.map((domain) => {
                     const cell = row.cells.get(domain.id);
                     const isSelected = selectedDomainId === domain.id;
                     const isLoading = cell == null || cell.status === 'loading';

--- a/cloud/apps/web/src/components/models/ConfidenceModelDomainBreakout.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceModelDomainBreakout.tsx
@@ -317,12 +317,19 @@ export function ConfidenceModelDomainBreakout({
   const [domainStates, setDomainStates] = useState<Record<string, DomainQueryState>>({});
   const sectionRef = useRef<HTMLElement>(null);
   const effectiveModelIds = selectedModelIds ?? defaultModelIds;
+  const visibleDomains = useMemo(
+    () =>
+      selectedDomainId != null
+        ? domains.filter((domain) => domain.id === selectedDomainId)
+        : domains,
+    [domains, selectedDomainId],
+  );
   const noModelsSelected = effectiveModelIds.length === 0;
 
   useEffect(() => {
     let cancelled = false;
 
-    if (domains.length === 0) {
+    if (visibleDomains.length === 0) {
       setDomainStates({});
       return () => {
         cancelled = true;
@@ -331,14 +338,14 @@ export function ConfidenceModelDomainBreakout({
 
     setDomainStates(() => {
       const next: Record<string, DomainQueryState> = {};
-      for (const domain of domains) {
+      for (const domain of visibleDomains) {
         next[domain.id] = { status: 'loading', models: [], error: null };
       }
       return next;
     });
 
     void Promise.allSettled(
-      domains.map(async (domain) => {
+      visibleDomains.map(async (domain) => {
         try {
           const result = await client
             .query<ModelsConfidenceQueryResult, ConfidenceModelBreakoutModelsConfidenceQueryVariables>(
@@ -386,7 +393,7 @@ export function ConfidenceModelDomainBreakout({
     return () => {
       cancelled = true;
     };
-  }, [client, domains, signature]);
+  }, [client, signature, visibleDomains]);
 
   const rows = useMemo(
     () => buildModelRows(domains, domainStates, effectiveModelIds),
@@ -398,10 +405,10 @@ export function ConfidenceModelDomainBreakout({
     [displayMode, rows, sort],
   );
 
-  if (domains.length === 0) {
+  if (visibleDomains.length === 0) {
     return (
       <section className="rounded-xl border border-gray-200 bg-white p-6">
-        <p className="text-sm text-gray-600">No domains are available yet.</p>
+        <p className="text-sm text-gray-600">No domains are available for the selected filters.</p>
       </section>
     );
   }
@@ -446,7 +453,7 @@ export function ConfidenceModelDomainBreakout({
                 align="right"
                 className="border-r-2 border-gray-300"
               />
-              {domains.map((domain) => {
+              {visibleDomains.map((domain) => {
                 const isSelected = selectedDomainId === domain.id;
                 const domainSortKey: ModelBreakoutSortKey = `domain:${domain.id}`;
                 return (
@@ -472,7 +479,7 @@ export function ConfidenceModelDomainBreakout({
                   <td className="border-b border-r-2 border-gray-300 bg-white px-2 py-2 whitespace-nowrap text-right font-mono text-gray-700">
                     {formatPercent(row.averageStrongPct)}
                   </td>
-                  {domains.map((domain) => {
+                  {visibleDomains.map((domain) => {
                     const cell = row.cells.get(domain.id);
                     const isSelected = selectedDomainId === domain.id;
                     const isLoading = cell == null || cell.status === 'loading';


### PR DESCRIPTION
## Summary
- Scope the confidence breakout reports to the selected domain from the header filters.
- Keep the main confidence heatmap and both breakout reports aligned on the same model/domain slice.

## Validation
- `npx eslint src/pages/ModelsConfidence.tsx src/components/models/ConfidenceDomainBreakout.tsx src/components/models/ConfidenceModelDomainBreakout.tsx` ✅
- `npx tsc --noEmit --skipLibCheck --target ES2020 --module ESNext --moduleResolution bundler --jsx react-jsx --lib ES2020,DOM,DOM.Iterable --types vite/client,node src/pages/ModelsConfidence.tsx src/components/models/ConfidenceDomainBreakout.tsx src/components/models/ConfidenceModelDomainBreakout.tsx` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
