### PR TITLE
Add pressure sensitivity high-pressure report

### DIFF
--- a/cloud/apps/api/src/graphql/types/pressure-sensitivity.ts
+++ b/cloud/apps/api/src/graphql/types/pressure-sensitivity.ts
@@ -58,6 +58,13 @@ export type PressureSensitivityValuePairShape = {
   directionBalancedHighPressureOpponentOpponentWinRate: number | null;
 };
 
+export type PressureSensitivityValueRateByDomainShape = {
+  domainId: string;
+  domainName: string;
+  rate: number | null;
+  pairsMeasured: number;
+};
+
 export type PressureSensitivityValueRateShape = {
   valueToken: string;
   valueLabel: string;
@@ -65,6 +72,7 @@ export type PressureSensitivityValueRateShape = {
   balancedWinRate: number | null;
   highPressureOnThisValueWinRate: number | null;
   highPressureOnOpposingValueWinRate: number | null;
+  highPressureOnThisValueDomainRates: PressureSensitivityValueRateByDomainShape[];
   pairsMeasured: number;
 };
 
@@ -146,6 +154,9 @@ const PressureSensitivityValuePairRef = builder.objectRef<PressureSensitivityVal
 const PressureSensitivityValueRateRef = builder.objectRef<PressureSensitivityValueRateShape>(
   'PressureSensitivityValueRate',
 );
+const PressureSensitivityValueRateByDomainRef = builder.objectRef<
+  PressureSensitivityValueRateByDomainShape
+>('PressureSensitivityValueRateByDomain');
 const DomainPressureEffectRef = builder.objectRef<DomainPressureEffectShape>('DomainPressureEffect');
 const PressureSensitivityModelRef = builder.objectRef<PressureSensitivityModelShape>(
   'PressureSensitivityModel',
@@ -242,6 +253,18 @@ builder.objectType(PressureSensitivityValueRateRef, {
       'highPressureOnOpposingValueWinRate',
       { nullable: true },
     ),
+    highPressureOnThisValueDomainRates: t.expose('highPressureOnThisValueDomainRates', {
+      type: [PressureSensitivityValueRateByDomainRef],
+    }),
+    pairsMeasured: t.exposeInt('pairsMeasured'),
+  }),
+});
+
+builder.objectType(PressureSensitivityValueRateByDomainRef, {
+  fields: (t) => ({
+    domainId: t.exposeString('domainId'),
+    domainName: t.exposeString('domainName'),
+    rate: t.exposeFloat('rate', { nullable: true }),
     pairsMeasured: t.exposeInt('pairsMeasured'),
   }),
 });

--- a/cloud/apps/api/src/services/pressure-sensitivity/domain-rate-mapping.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/domain-rate-mapping.ts
@@ -1,0 +1,22 @@
+type DomainRateInput = {
+  domainId: string;
+  rate: number;
+  pairsCounted: number;
+};
+
+export function mapHighPressureDomainRates(
+  domainRates: ReadonlyArray<DomainRateInput> | undefined,
+  domainNameById: ReadonlyMap<string, string>,
+): Array<{
+  domainId: string;
+  domainName: string;
+  rate: number;
+  pairsMeasured: number;
+}> {
+  return (domainRates ?? []).map((domainRate) => ({
+    domainId: domainRate.domainId,
+    domainName: domainNameById.get(domainRate.domainId) ?? domainRate.domainId,
+    rate: domainRate.rate,
+    pairsMeasured: domainRate.pairsCounted,
+  }));
+}

--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-cache.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-cache.ts
@@ -27,12 +27,21 @@ const log = createLogger('pressure-sensitivity:cache');
 export function parseSnapshotOutput(raw: unknown): PressureSensitivityResultShape | null {
   if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return null;
   const result = raw as PressureSensitivityResultShape;
-  // Snapshots written before v1.2.0 lack pushedEffectPairsUsed or domainPressureEffects.
+  // Snapshots written before v1.4.0 lack the domain-by-value high-pressure rates.
   // Return null so the caller falls through to synchronous recompute rather than
-  // serving stale data that renders the table incomplete.
+  // serving stale data that renders the new report incomplete.
   const missingNewFields = result.models.some((m) => {
-    const model = m as { pushedEffectPairsUsed?: unknown; domainPressureEffects?: unknown };
-    return model.pushedEffectPairsUsed == null || model.domainPressureEffects == null;
+    const model = m as {
+      pushedEffectPairsUsed?: unknown;
+      domainPressureEffects?: unknown;
+      valueRates?: Array<{ highPressureOnThisValueDomainRates?: unknown }>;
+    };
+    return (
+      model.pushedEffectPairsUsed == null
+      || model.domainPressureEffects == null
+      || model.valueRates == null
+      || model.valueRates.some((valueRate) => valueRate.highPressureOnThisValueDomainRates == null)
+    );
   });
   if (missingNewFields) return null;
   return result;

--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-compute.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-compute.ts
@@ -34,6 +34,7 @@ import {
 } from './value-pair.js';
 import { buildPressureSensitivityDecisionSnapshot } from './decision-snapshot.js';
 import { aggregateValueWinRates } from '../analysis/value-win-rate-aggregation.js';
+import { mapHighPressureDomainRates } from './domain-rate-mapping.js';
 import type {
   ModelRow,
   TranscriptRow,
@@ -95,10 +96,6 @@ function strengthFromCanonical(strength: 'strong' | 'lean' | 'neutral' | 'unknow
   if (strength === 'strong') return 'strong';
   if (strength === 'lean') return 'lean';
   return null;
-}
-
-function formatValueLabel(token: string): string {
-  return token.replaceAll('_', ' ').trim();
 }
 
 function totalPressureConditionExclusions(breakdown: PressureConditionExclusionBreakdown): number {
@@ -551,9 +548,9 @@ export async function buildPressureSensitivitySnapshotOutput(
       valuePairs.push({
         pairKey: acc.pairKey,
         firstValueToken: acc.firstValueToken,
-        firstValueLabel: formatValueLabel(acc.firstValueToken),
+        firstValueLabel: acc.firstValueToken.replaceAll('_', ' ').trim(),
         secondValueToken: acc.secondValueToken,
-        secondValueLabel: formatValueLabel(acc.secondValueToken),
+        secondValueLabel: acc.secondValueToken.replaceAll('_', ' ').trim(),
         pressureResponse: {
           value: pressureResponse.value,
           ciLow: pressureResponse.ciLow,
@@ -638,17 +635,15 @@ export async function buildPressureSensitivitySnapshotOutput(
     const valueTokens = [...pairKeysByValue.keys()].sort((a, b) => a.localeCompare(b));
     const valueRates: PressureSensitivityValueRateShape[] = valueTokens.map((valueToken) => ({
       valueToken,
-      valueLabel: formatValueLabel(valueToken),
+      valueLabel: valueToken.replaceAll('_', ' ').trim(),
       averageWinRate: allValueRates.get(valueToken)?.crossDomainRate ?? null,
       balancedWinRate: balancedValueRates.get(valueToken)?.crossDomainRate ?? null,
       highPressureOnThisValueWinRate: highPressureOnValueRates.get(valueToken)?.crossDomainRate ?? null,
       highPressureOnOpposingValueWinRate: highPressureOnOpposingValueRates.get(valueToken)?.crossDomainRate ?? null,
-      highPressureOnThisValueDomainRates: (highPressureOnValueRates.get(valueToken)?.domainRates ?? []).map((domainRate) => ({
-        domainId: domainRate.domainId,
-        domainName: domainNameById.get(domainRate.domainId) ?? domainRate.domainId,
-        rate: domainRate.rate,
-        pairsMeasured: domainRate.pairsCounted,
-      })),
+      highPressureOnThisValueDomainRates: mapHighPressureDomainRates(
+        highPressureOnValueRates.get(valueToken)?.domainRates,
+        domainNameById,
+      ),
       pairsMeasured: pairKeysByValue.get(valueToken)?.size ?? 0,
     }));
 

--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-compute.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-compute.ts
@@ -643,6 +643,12 @@ export async function buildPressureSensitivitySnapshotOutput(
       balancedWinRate: balancedValueRates.get(valueToken)?.crossDomainRate ?? null,
       highPressureOnThisValueWinRate: highPressureOnValueRates.get(valueToken)?.crossDomainRate ?? null,
       highPressureOnOpposingValueWinRate: highPressureOnOpposingValueRates.get(valueToken)?.crossDomainRate ?? null,
+      highPressureOnThisValueDomainRates: (highPressureOnValueRates.get(valueToken)?.domainRates ?? []).map((domainRate) => ({
+        domainId: domainRate.domainId,
+        domainName: domainNameById.get(domainRate.domainId) ?? domainRate.domainId,
+        rate: domainRate.rate,
+        pairsMeasured: domainRate.pairsCounted,
+      })),
       pairsMeasured: pairKeysByValue.get(valueToken)?.size ?? 0,
     }));
 

--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-types.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-types.ts
@@ -1,3 +1,3 @@
 export const PRESSURE_SENSITIVITY_SNAPSHOT_TYPE = 'pressure_sensitivity';
-export const PRESSURE_SENSITIVITY_SNAPSHOT_CODE_VERSION = '1.3.0';
+export const PRESSURE_SENSITIVITY_SNAPSHOT_CODE_VERSION = '1.4.0';
 export const PRESSURE_SENSITIVITY_ASSUMPTION_PREFIX = 'pressure-sensitivity';

--- a/cloud/apps/web/src/api/operations/pressureSensitivity.ts
+++ b/cloud/apps/web/src/api/operations/pressureSensitivity.ts
@@ -24,6 +24,8 @@ export type PressureSensitivityExcludedDefinition =
 
 export type PressureSensitivityValuePair = PressureSensitivityModel['valuePairs'][number];
 export type PressureSensitivityValueRate = PressureSensitivityModel['valueRates'][number];
+export type PressureSensitivityValueRateByDomain =
+  PressureSensitivityValueRate['highPressureOnThisValueDomainRates'][number];
 export type PressureSensitivityCell = PressureSensitivityValuePair['grid'][number];
 export type PressureResponse = NonNullable<PressureSensitivityValuePair['pressureResponse']>;
 export type PressureResponseSummary =

--- a/cloud/apps/web/src/components/models/PressureHighPressureByValueDomainTable.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureHighPressureByValueDomainTable.test.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { PressureHighPressureByValueDomainTable } from './PressureHighPressureByValueDomainTable';
+import type {
+  PressureSensitivityModel,
+  PressureSensitivityValueRate,
+} from '../../api/operations/pressureSensitivity';
+
+function createValueRate(
+  valueLabel: string,
+  overrides: Partial<PressureSensitivityValueRate> = {},
+): PressureSensitivityValueRate {
+  return {
+    valueToken: valueLabel.toLowerCase(),
+    valueLabel,
+    averageWinRate: 0.5,
+    balancedWinRate: 0.5,
+    highPressureOnThisValueWinRate: 0.5,
+    highPressureOnThisValueDomainRates: [],
+    highPressureOnOpposingValueWinRate: 0.5,
+    pairsMeasured: 9,
+    ...overrides,
+  };
+}
+
+function createModel(modelId: string, valueRates: PressureSensitivityValueRate[]): PressureSensitivityModel {
+  return {
+    modelId,
+    label: modelId,
+    providerName: 'Provider',
+    unscoredCount: 0,
+    pushedEffectPairsUsed: 0,
+    domainPressureEffects: [],
+    pressureResponseSummary: {
+      mean: 0.1,
+      rangeMin: 0.05,
+      rangeMax: 0.15,
+      pairsMeasured: valueRates[0]?.pairsMeasured ?? 0,
+    },
+    valueRates,
+    valuePairs: [],
+  };
+}
+
+describe('PressureHighPressureByValueDomainTable', () => {
+  it('renders raw high-pressure rates by default', () => {
+    render(
+      <PressureHighPressureByValueDomainTable
+        models={[
+          createModel('Model A', [
+            createValueRate('Alpha', {
+              highPressureOnThisValueWinRate: 0.6,
+              highPressureOnThisValueDomainRates: [
+                { domainId: 'domain-a', domainName: 'Domain A', rate: 0.7, pairsMeasured: 6 },
+                { domainId: 'domain-b', domainName: 'Domain B', rate: 0.5, pairsMeasured: 6 },
+              ],
+            }),
+          ]),
+        ]}
+      />,
+    );
+
+    const row = screen.getByText('Alpha').closest('tr');
+    if (row == null) {
+      throw new Error('Missing Alpha row');
+    }
+
+    const cells = within(row).getAllByRole('cell');
+    expect(cells[1]?.textContent ?? '').toBe('60.0%');
+    expect(cells[2]?.textContent ?? '').toBe('70.0%');
+    expect(cells[3]?.textContent ?? '').toBe('50.0%');
+  });
+
+  it('toggles domain cells to shifts versus the value average', () => {
+    render(
+      <PressureHighPressureByValueDomainTable
+        models={[
+          createModel('Model A', [
+            createValueRate('Alpha', {
+              highPressureOnThisValueWinRate: 0.6,
+              highPressureOnThisValueDomainRates: [
+                { domainId: 'domain-a', domainName: 'Domain A', rate: 0.7, pairsMeasured: 6 },
+                { domainId: 'domain-b', domainName: 'Domain B', rate: 0.5, pairsMeasured: 6 },
+              ],
+            }),
+          ]),
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Shift vs high pressure' }));
+
+    const row = screen.getByText('Alpha').closest('tr');
+    if (row == null) {
+      throw new Error('Missing Alpha row');
+    }
+
+    const cells = within(row).getAllByRole('cell');
+    expect(cells[1]?.textContent ?? '').toBe('60.0%');
+    expect(cells[2]?.textContent ?? '').toBe('+10.0');
+    expect(cells[3]?.textContent ?? '').toBe('−10.0');
+  });
+
+  it('averages the same domain across models before rendering', () => {
+    render(
+      <PressureHighPressureByValueDomainTable
+        models={[
+          createModel('Model A', [
+            createValueRate('Alpha', {
+              highPressureOnThisValueWinRate: 0.6,
+              highPressureOnThisValueDomainRates: [
+                { domainId: 'domain-a', domainName: 'Domain A', rate: 0.7, pairsMeasured: 6 },
+              ],
+            }),
+          ]),
+          createModel('Model B', [
+            createValueRate('Alpha', {
+              highPressureOnThisValueWinRate: 0.8,
+              highPressureOnThisValueDomainRates: [
+                { domainId: 'domain-a', domainName: 'Domain A', rate: 0.9, pairsMeasured: 8 },
+              ],
+            }),
+          ]),
+        ]}
+      />,
+    );
+
+    const row = screen.getByText('Alpha').closest('tr');
+    if (row == null) {
+      throw new Error('Missing Alpha row');
+    }
+
+    const cells = within(row).getAllByRole('cell');
+    expect(cells[1]?.textContent ?? '').toBe('70.0%');
+    expect(cells[2]?.textContent ?? '').toBe('80.0%');
+  });
+});

--- a/cloud/apps/web/src/components/models/PressureHighPressureByValueDomainTable.tsx
+++ b/cloud/apps/web/src/components/models/PressureHighPressureByValueDomainTable.tsx
@@ -1,0 +1,210 @@
+import { useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { CopyVisualButton } from '../ui/CopyVisualButton';
+import { Button } from '../ui/Button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/Table';
+import type { PressureSensitivityModel } from '../../api/operations/pressureSensitivity';
+import { formatPercent, formatSignedPoints } from './pressureSensitivityFormatting';
+import { averageValueRatesAcrossModels } from './pressureResponseAggregation';
+
+type Props = {
+  models: PressureSensitivityModel[];
+};
+
+type DisplayMode = 'winRate' | 'shift';
+
+type DomainColumn = {
+  domainId: string;
+  domainName: string;
+};
+
+type DomainCell = {
+  domainId: string;
+  domainName: string;
+  rate: number | null;
+  shift: number | null;
+};
+
+type ValueRow = {
+  valueLabel: string;
+  averageHighPressureRate: number | null;
+  cells: Map<string, DomainCell>;
+};
+
+function formatRate(value: number | null, displayMode: DisplayMode): ReactNode {
+  if (value == null) {
+    return <span className="font-mono text-gray-500">—</span>;
+  }
+
+  const className = displayMode === 'shift'
+    ? value > 0
+      ? 'text-emerald-700'
+      : value < 0
+        ? 'text-red-700'
+        : 'text-gray-700'
+    : 'text-gray-900';
+
+  return (
+    <span className={`font-mono ${className}`}>
+      {displayMode === 'shift' ? formatSignedPoints(value) : formatPercent(value)}
+    </span>
+  );
+}
+
+function DisplayModeToggle({
+  displayMode,
+  onChange,
+}: {
+  displayMode: DisplayMode;
+  onChange: (value: DisplayMode) => void;
+}) {
+  return (
+    <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+      {([
+        ['winRate', 'High pressure win rate'],
+        ['shift', 'Shift vs high pressure'],
+      ] as const).map(([mode, label]) => (
+        <Button
+          key={mode}
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-pressed={displayMode === mode}
+          onClick={() => onChange(mode)}
+          className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            displayMode === mode
+              ? 'bg-white text-gray-900 shadow-sm ring-1 ring-gray-200'
+              : 'text-gray-600 hover:text-gray-900'
+          }`}
+        >
+          {label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+export function PressureHighPressureByValueDomainTable({ models }: Props) {
+  const tableRef = useRef<HTMLDivElement>(null);
+  const [displayMode, setDisplayMode] = useState<DisplayMode>('winRate');
+  const valueRates = useMemo(() => averageValueRatesAcrossModels(models), [models]);
+
+  const columns = useMemo<DomainColumn[]>(() => {
+    const columnsById = new Map<string, DomainColumn>();
+
+    for (const valueRate of valueRates) {
+      for (const domainRate of valueRate.highPressureOnThisValueDomainRates) {
+        if (columnsById.has(domainRate.domainId)) {
+          continue;
+        }
+        columnsById.set(domainRate.domainId, {
+          domainId: domainRate.domainId,
+          domainName: domainRate.domainName,
+        });
+      }
+    }
+
+    return [...columnsById.values()].sort(
+      (left, right) => left.domainName.localeCompare(right.domainName) || left.domainId.localeCompare(right.domainId),
+    );
+  }, [valueRates]);
+
+  const rows = useMemo<ValueRow[]>(
+    () =>
+      valueRates
+        .map((valueRate) => {
+          const cells = new Map<string, DomainCell>();
+
+          for (const domainRate of valueRate.highPressureOnThisValueDomainRates) {
+            cells.set(domainRate.domainId, {
+              domainId: domainRate.domainId,
+              domainName: domainRate.domainName,
+              rate: domainRate.rate ?? null,
+              shift:
+                domainRate.rate != null && valueRate.highPressureOnThisValueWinRate != null
+                  ? domainRate.rate - valueRate.highPressureOnThisValueWinRate
+                  : null,
+            });
+          }
+
+          return {
+            valueLabel: valueRate.valueLabel,
+            averageHighPressureRate: valueRate.highPressureOnThisValueWinRate ?? null,
+            cells,
+          };
+        })
+        .sort((left, right) => left.valueLabel.localeCompare(right.valueLabel)),
+    [valueRates],
+  );
+
+  if (models.length === 0) {
+    return (
+      <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+        <h2 className="text-lg font-semibold text-gray-900">High Pressure on Value Win Rate by Domain by Value</h2>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-gray-900">High Pressure on Value Win Rate by Domain by Value</h2>
+          <p className="max-w-3xl text-sm text-gray-600">
+            Each row shows a value&apos;s high-pressure win rate averaged across the selected models.
+            Use the toggle to switch the domain cells between raw win rates and shifts versus that value&apos;s own
+            cross-domain high-pressure average.
+          </p>
+        </div>
+        <CopyVisualButton targetRef={tableRef} label="High Pressure on Value Win Rate by Domain by Value" />
+      </div>
+
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div className="text-sm text-gray-600">
+          Raw percentages show the selected models&apos; high-pressure win rate in each domain.
+        </div>
+        <DisplayModeToggle displayMode={displayMode} onChange={setDisplayMode} />
+      </div>
+
+      <div ref={tableRef} className="overflow-x-auto">
+        <Table variant="bordered">
+          <TableHeader variant="bordered">
+            <TableRow>
+              <TableHead className="text-left text-xs uppercase tracking-wide text-gray-700">Value</TableHead>
+              <TableHead className="text-right text-xs uppercase tracking-wide text-gray-700">
+                Avg High Pressure Win Rate
+              </TableHead>
+              {columns.map((column) => (
+                <TableHead
+                  key={column.domainId}
+                  className="text-right text-xs uppercase tracking-wide text-gray-700"
+                >
+                  {column.domainName}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.valueLabel}>
+                <TableCell className="font-medium text-gray-900">{row.valueLabel}</TableCell>
+                <TableCell className="text-right text-sm">
+                  {formatRate(row.averageHighPressureRate, 'winRate')}
+                </TableCell>
+                {columns.map((column) => {
+                  const cell = row.cells.get(column.domainId) ?? null;
+                  const value = displayMode === 'shift' ? cell?.shift ?? null : cell?.rate ?? null;
+                  return (
+                    <TableCell key={column.domainId} className="text-right text-sm">
+                      {formatRate(value, displayMode)}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </section>
+  );
+}

--- a/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureResponseByValueTable.test.tsx
@@ -29,6 +29,7 @@ function createValueRate(
     averageWinRate: 0.5,
     balancedWinRate: 0.5,
     highPressureOnThisValueWinRate: 0.5,
+    highPressureOnThisValueDomainRates: [],
     highPressureOnOpposingValueWinRate: 0.5,
     pairsMeasured: 9,
     ...overrides,
@@ -160,9 +161,9 @@ describe('PressureResponseByValueTable', () => {
     expect(cells[1]?.textContent ?? '').toBe('60.0%');
     expect(cells[2]?.textContent ?? '').toBe('40.0%');
     expect(cells[3]?.textContent ?? '').toBe('80.0%');
-    expect(cells[4]?.textContent ?? '').toBe('+40.0 pp');
+    expect(cells[4]?.textContent ?? '').toBe('+40.0');
     expect(cells[5]?.textContent ?? '').toBe('30.0%');
-    expect(cells[6]?.textContent ?? '').toBe('−10.0 pp');
+    expect(cells[6]?.textContent ?? '').toBe('−10.0');
   });
 
   it('shows dashes for null rates instead of a numeric value', () => {
@@ -192,7 +193,7 @@ describe('PressureResponseByValueTable', () => {
     expect(cells[3]?.textContent ?? '').toBe('—');
     expect(cells[4]?.textContent ?? '').toBe('—');
     expect(cells[5]?.textContent ?? '').toBe('30.0%');
-    expect(cells[6]?.textContent ?? '').toBe('−10.0 pp');
+    expect(cells[6]?.textContent ?? '').toBe('−10.0');
   });
 
   it('averages rates across all selected models', () => {
@@ -228,8 +229,8 @@ describe('PressureResponseByValueTable', () => {
     expect(cells[1]?.textContent ?? '').toBe('60.0%');
     expect(cells[2]?.textContent ?? '').toBe('30.0%');
     expect(cells[3]?.textContent ?? '').toBe('80.0%');
-    expect(cells[4]?.textContent ?? '').toBe('+50.0 pp');
+    expect(cells[4]?.textContent ?? '').toBe('+50.0');
     expect(cells[5]?.textContent ?? '').toBe('20.0%');
-    expect(cells[6]?.textContent ?? '').toBe('−10.0 pp');
+    expect(cells[6]?.textContent ?? '').toBe('−10.0');
   });
 });

--- a/cloud/apps/web/src/components/models/PressureSensitivityDetail.tsx
+++ b/cloud/apps/web/src/components/models/PressureSensitivityDetail.tsx
@@ -59,7 +59,7 @@ function renderResponseCell(pair: PressureSensitivityValuePair): ReactNode {
   const halfWidth = Math.abs((ciHigh - ciLow) * 50);
   return (
     <span className={`font-mono ${textClass}`}>
-      {signed} ± {halfWidth.toFixed(1)} pp
+      {signed} ± {halfWidth.toFixed(1)}
     </span>
   );
 }

--- a/cloud/apps/web/src/components/models/pressureResponseAggregation.test.ts
+++ b/cloud/apps/web/src/components/models/pressureResponseAggregation.test.ts
@@ -16,6 +16,7 @@ function createValueRate(
     balancedWinRate: 0.5,
     highPressureOnThisValueWinRate: 0.5,
     highPressureOnOpposingValueWinRate: 0.5,
+    highPressureOnThisValueDomainRates: [],
     pairsMeasured: 9,
     ...overrides,
   };
@@ -118,6 +119,42 @@ describe('averageValueRatesAcrossModels', () => {
         balancedWinRate: 0.4,
         highPressureOnThisValueWinRate: null,
         highPressureOnOpposingValueWinRate: 0.2,
+        highPressureOnThisValueDomainRates: [],
+        pairsMeasured: 9,
+      },
+    ]);
+  });
+
+  it('averages per-domain high-pressure rates across models', () => {
+    const averaged = averageValueRatesAcrossModels([
+      createModel('Model A', [
+        createValueRate('Alpha', {
+          highPressureOnThisValueDomainRates: [
+            { domainId: 'jobs', domainName: 'Jobs', rate: 0.6, pairsMeasured: 7 },
+            { domainId: 'city', domainName: 'City Planning', rate: 0.2, pairsMeasured: 5 },
+          ],
+        }),
+      ]),
+      createModel('Model B', [
+        createValueRate('Alpha', {
+          highPressureOnThisValueDomainRates: [
+            { domainId: 'jobs', domainName: 'Jobs', rate: 0.8, pairsMeasured: 9 },
+          ],
+        }),
+      ]),
+    ]);
+
+    expect(averaged[0]?.highPressureOnThisValueDomainRates).toEqual([
+      {
+        domainId: 'city',
+        domainName: 'City Planning',
+        rate: 0.2,
+        pairsMeasured: 5,
+      },
+      {
+        domainId: 'jobs',
+        domainName: 'Jobs',
+        rate: 0.7,
         pairsMeasured: 9,
       },
     ]);

--- a/cloud/apps/web/src/components/models/pressureResponseAggregation.ts
+++ b/cloud/apps/web/src/components/models/pressureResponseAggregation.ts
@@ -15,6 +15,15 @@ type MutableRateAccumulator = {
   counts: Record<RateField, number>;
   valueLabel: string;
   valueToken: string;
+  domainRates: Map<string, MutableDomainRateAccumulator>;
+};
+
+type MutableDomainRateAccumulator = {
+  domainId: string;
+  domainName: string;
+  pairsMeasured: number;
+  sum: number;
+  count: number;
 };
 
 const RATE_FIELDS: RateField[] = [
@@ -56,6 +65,7 @@ export function averageValueRatesAcrossModels(
         },
         valueLabel: valueRate.valueLabel,
         valueToken: valueRate.valueToken,
+        domainRates: new Map(),
       };
 
       // pairsMeasured should be structural per value, but keep the max if older data varies.
@@ -68,6 +78,26 @@ export function averageValueRatesAcrossModels(
         }
         accumulator.sums[field] += rate;
         accumulator.counts[field] += 1;
+      }
+
+      for (const domainRate of valueRate.highPressureOnThisValueDomainRates) {
+        if (domainRate.rate == null) {
+          continue;
+        }
+
+        const existingDomainRate = accumulator.domainRates.get(domainRate.domainId);
+        const domainAccumulator = existingDomainRate ?? {
+          domainId: domainRate.domainId,
+          domainName: domainRate.domainName,
+          pairsMeasured: domainRate.pairsMeasured,
+          sum: 0,
+          count: 0,
+        };
+        domainAccumulator.domainName = domainRate.domainName;
+        domainAccumulator.pairsMeasured = Math.max(domainAccumulator.pairsMeasured, domainRate.pairsMeasured);
+        domainAccumulator.sum += domainRate.rate;
+        domainAccumulator.count += 1;
+        accumulator.domainRates.set(domainRate.domainId, domainAccumulator);
       }
 
       if (existing == null) {
@@ -89,6 +119,14 @@ export function averageValueRatesAcrossModels(
       rate.sums.highPressureOnOpposingValueWinRate,
       rate.counts.highPressureOnOpposingValueWinRate,
     ),
+    highPressureOnThisValueDomainRates: [...rate.domainRates.values()]
+      .sort((left, right) => left.domainName.localeCompare(right.domainName) || left.domainId.localeCompare(right.domainId))
+      .map((domainRate) => ({
+        domainId: domainRate.domainId,
+        domainName: domainRate.domainName,
+        rate: averageRate(domainRate.sum, domainRate.count),
+        pairsMeasured: domainRate.pairsMeasured,
+      })),
     pairsMeasured: rate.pairsMeasured,
   }));
 }

--- a/cloud/apps/web/src/components/models/pressureSensitivityFormatting.ts
+++ b/cloud/apps/web/src/components/models/pressureSensitivityFormatting.ts
@@ -7,7 +7,7 @@ export const SUMMARY_PRESSURE_RESPONSE_TOOLTIP =
   "Arithmetic mean of per-pair pressure responses across this model's measured pairs. The range in brackets is the spread of per-pair values. Positive = more pressure moved toward the model's own value; negative = more pressure moved away.";
 
 export const PAIR_PRESSURE_RESPONSE_TOOLTIP =
-  'Signed push-rate difference: Push toward first minus Push toward other, in percentage points. The CI is the Newcombe 95% confidence interval for the difference of two proportions.';
+  'Signed push-rate difference: Push toward first minus Push toward other. The CI is the Newcombe 95% confidence interval for the difference of two proportions.';
 
 export const BALANCED_TOOLTIP =
   'Win rate when own and opponent pressure are both at moderate levels. Used as the reference for the push columns.';
@@ -25,20 +25,20 @@ export function formatPercent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
 }
 
-/** Unsigned percentage-points string, one decimal place. */
+/** Unsigned raw difference string, one decimal place. */
 export function formatPoints(value: number): string {
-  return `${Math.abs(value * 100).toFixed(1)} pp`;
+  return `${Math.abs(value * 100).toFixed(1)}`;
 }
 
 /**
- * Signed percentage-points string, one decimal place.
+ * Signed raw difference string, one decimal place.
  * Exact zero renders without a sign per spec FR-xxx.
  */
 export function formatSignedPoints(value: number): string {
-  const pp = value * 100;
-  if (pp === 0) return '0.0';
-  const sign = pp < 0 ? '−' : '+';
-  return `${sign}${Math.abs(pp).toFixed(1)}`;
+  const points = value * 100;
+  if (points === 0) return '0.0';
+  const sign = points < 0 ? '−' : '+';
+  return `${sign}${Math.abs(points).toFixed(1)}`;
 }
 
 /**

--- a/cloud/apps/web/src/components/models/pressureSensitivityFormatting.ts
+++ b/cloud/apps/web/src/components/models/pressureSensitivityFormatting.ts
@@ -36,9 +36,9 @@ export function formatPoints(value: number): string {
  */
 export function formatSignedPoints(value: number): string {
   const pp = value * 100;
-  if (pp === 0) return '0.0 pp';
+  if (pp === 0) return '0.0';
   const sign = pp < 0 ? '−' : '+';
-  return `${sign}${Math.abs(pp).toFixed(1)} pp`;
+  return `${sign}${Math.abs(pp).toFixed(1)}`;
 }
 
 /**

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -2380,6 +2380,14 @@ export type PressureSensitivityModel = {
   valueRates: Array<PressureSensitivityValueRate>;
 };
 
+export type PressureSensitivityValueRateByDomain = {
+  __typename?: 'PressureSensitivityValueRateByDomain';
+  domainId: string;
+  domainName: string;
+  pairsMeasured: number;
+  rate?: Maybe<Scalars['Float']['output']>;
+};
+
 export type PressureSensitivityResult = {
   __typename?: 'PressureSensitivityResult';
   directionalSanityCheck: DirectionalSanityCheck;
@@ -2417,6 +2425,7 @@ export type PressureSensitivityValueRate = {
   __typename?: 'PressureSensitivityValueRate';
   averageWinRate?: Maybe<Scalars['Float']['output']>;
   balancedWinRate?: Maybe<Scalars['Float']['output']>;
+  highPressureOnThisValueDomainRates: Array<PressureSensitivityValueRateByDomain>;
   highPressureOnOpposingValueWinRate?: Maybe<Scalars['Float']['output']>;
   highPressureOnThisValueWinRate?: Maybe<Scalars['Float']['output']>;
   pairsMeasured: Scalars['Int']['output'];
@@ -4656,7 +4665,7 @@ export type PressureSensitivityQueryVariables = Exact<{
 }>;
 
 
-export type PressureSensitivityQuery = { __typename?: 'Query', pressureSensitivity: { __typename?: 'PressureSensitivityResult', pressureConditionExcludedCount: number, transcriptCapHit: boolean, models: Array<{ __typename?: 'PressureSensitivityModel', modelId: string, label: string, providerName: string, unscoredCount: number, pushedForEffect?: number | null, pushedAgainstEffect?: number | null, pushedEffectPairsUsed: number, domainPressureEffects: Array<{ __typename?: 'DomainPressureEffect', domainId: string, domainName: string, pushedForEffect?: number | null }>, pressureResponseSummary: { __typename?: 'PressureResponseSummary', mean?: number | null, rangeMin?: number | null, rangeMax?: number | null, pairsMeasured: number }, valueRates: Array<{ __typename?: 'PressureSensitivityValueRate', valueToken: string, valueLabel: string, averageWinRate?: number | null, balancedWinRate?: number | null, highPressureOnThisValueWinRate?: number | null, highPressureOnOpposingValueWinRate?: number | null, pairsMeasured: number }>, valuePairs: Array<{ __typename?: 'PressureSensitivityValuePair', pairKey: string, firstValueToken: string, firstValueLabel: string, secondValueToken: string, secondValueLabel: string, n: number, unscoredCount: number, definitionsMeasured: number, directionBalancedWinRate?: number | null, directionBalancedOpponentWinRate?: number | null, directionBalancedBalancedWinRate?: number | null, directionBalancedBalancedOpponentWinRate?: number | null, directionBalancedHighPressureOwnWinRate?: number | null, directionBalancedHighPressureOwnOpponentWinRate?: number | null, directionBalancedHighPressureOpponentWinRate?: number | null, directionBalancedHighPressureOpponentOpponentWinRate?: number | null, pressureResponse: { __typename?: 'PressureResponse', value?: number | null, baselineRate?: number | null, pushTowardFirstRate?: number | null, pushTowardSecondRate?: number | null, qualifyingTrials: number, ciLow?: number | null, ciHigh?: number | null, reason?: string | null }, grid: Array<{ __typename?: 'SensitivityCell', ownLevel: number, opponentLevel: number, n: number, unscoredCount: number, winRate?: number | null, opponentWinRate?: number | null, conviction?: number | null, netScore?: number | null, lowData: boolean }> }> }>, insufficient: Array<{ __typename?: 'InsufficientPressureSensitivityModel', modelId: string, label: string, providerName: string, reason: string }>, excludedDefinitions: Array<{ __typename?: 'ExcludedDefinition', definitionId: string, name: string, reason: string }>, pressureConditionExclusionBreakdown: { __typename?: 'PressureConditionExclusionBreakdown', sourceRunMapping: number, definitionMetadata: number, missingScenario: number, invalidMetadata: number, levelAssignment: number }, directionalSanityCheck: { __typename?: 'DirectionalSanityCheck', positivePct: number, flatPct: number, negativePct: number, measuredCount: number, unmeasurableCount: number, breakdown: Array<{ __typename?: 'DirectionalSanityCheckEntry', modelId: string, pairKey: string, pressureResponse: number, classification: string }> } } };
+export type PressureSensitivityQuery = { __typename?: 'Query', pressureSensitivity: { __typename?: 'PressureSensitivityResult', pressureConditionExcludedCount: number, transcriptCapHit: boolean, models: Array<{ __typename?: 'PressureSensitivityModel', modelId: string, label: string, providerName: string, unscoredCount: number, pushedForEffect?: number | null, pushedAgainstEffect?: number | null, pushedEffectPairsUsed: number, domainPressureEffects: Array<{ __typename?: 'DomainPressureEffect', domainId: string, domainName: string, pushedForEffect?: number | null }>, pressureResponseSummary: { __typename?: 'PressureResponseSummary', mean?: number | null, rangeMin?: number | null, rangeMax?: number | null, pairsMeasured: number }, valueRates: Array<{ __typename?: 'PressureSensitivityValueRate', valueToken: string, valueLabel: string, averageWinRate?: number | null, balancedWinRate?: number | null, highPressureOnThisValueWinRate?: number | null, highPressureOnThisValueDomainRates: Array<{ __typename?: 'PressureSensitivityValueRateByDomain', domainId: string, domainName: string, rate?: number | null, pairsMeasured: number }>, highPressureOnOpposingValueWinRate?: number | null, pairsMeasured: number }>, valuePairs: Array<{ __typename?: 'PressureSensitivityValuePair', pairKey: string, firstValueToken: string, firstValueLabel: string, secondValueToken: string, secondValueLabel: string, n: number, unscoredCount: number, definitionsMeasured: number, directionBalancedWinRate?: number | null, directionBalancedOpponentWinRate?: number | null, directionBalancedBalancedWinRate?: number | null, directionBalancedBalancedOpponentWinRate?: number | null, directionBalancedHighPressureOwnWinRate?: number | null, directionBalancedHighPressureOwnOpponentWinRate?: number | null, directionBalancedHighPressureOpponentWinRate?: number | null, directionBalancedHighPressureOpponentOpponentWinRate?: number | null, pressureResponse: { __typename?: 'PressureResponse', value?: number | null, baselineRate?: number | null, pushTowardFirstRate?: number | null, pushTowardSecondRate?: number | null, qualifyingTrials: number, ciLow?: number | null, ciHigh?: number | null, reason?: string | null }, grid: Array<{ __typename?: 'SensitivityCell', ownLevel: number, opponentLevel: number, n: number, unscoredCount: number, winRate?: number | null, opponentWinRate?: number | null, conviction?: number | null, netScore?: number | null, lowData: boolean }> }> }>, insufficient: Array<{ __typename?: 'InsufficientPressureSensitivityModel', modelId: string, label: string, providerName: string, reason: string }>, excludedDefinitions: Array<{ __typename?: 'ExcludedDefinition', definitionId: string, name: string, reason: string }>, pressureConditionExclusionBreakdown: { __typename?: 'PressureConditionExclusionBreakdown', sourceRunMapping: number, definitionMetadata: number, missingScenario: number, invalidMetadata: number, levelAssignment: number }, directionalSanityCheck: { __typename?: 'DirectionalSanityCheck', positivePct: number, flatPct: number, negativePct: number, measuredCount: number, unmeasurableCount: number, breakdown: Array<{ __typename?: 'DirectionalSanityCheckEntry', modelId: string, pairKey: string, pressureResponse: number, classification: string }> } } };
 
 export type OpenRunAnomaliesQueryVariables = Exact<{
   domainId?: InputMaybe<Scalars['ID']['input']>;
@@ -7218,6 +7227,12 @@ export const PressureSensitivityDocument = gql`
         averageWinRate
         balancedWinRate
         highPressureOnThisValueWinRate
+        highPressureOnThisValueDomainRates {
+          domainId
+          domainName
+          rate
+          pairsMeasured
+        }
         highPressureOnOpposingValueWinRate
         pairsMeasured
       }

--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -366,7 +366,7 @@ export function DomainValueShiftHeatmap() {
           <h2 className="text-base font-semibold text-amber-950">More domain coverage needed</h2>
           <p className="mt-2 text-sm text-amber-900">
             Domain-shift analysis needs at least one value with eligible win-rate data in two or more domains for the
-            selected model set. With only one domain for a value, the shift would be 0pp by definition and would
+            selected model set. With only one domain for a value, the shift would be 0 by definition and would
             not be meaningful.
           </p>
         </section>

--- a/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
@@ -51,6 +51,14 @@ function createPressureData(
               averageWinRate: 0.4,
               balancedWinRate: 0.3,
               highPressureOnThisValueWinRate: 0.6,
+              highPressureOnThisValueDomainRates: [
+                {
+                  domainId: 'domain-a',
+                  domainName: 'Domain A',
+                  rate: 0.6,
+                  pairsMeasured: 1,
+                },
+              ],
               highPressureOnOpposingValueWinRate: 0.3,
               pairsMeasured: 1,
             },
@@ -99,6 +107,14 @@ function createPressureData(
               averageWinRate: 0.8,
               balancedWinRate: 0.5,
               highPressureOnThisValueWinRate: 0.9,
+              highPressureOnThisValueDomainRates: [
+                {
+                  domainId: 'domain-a',
+                  domainName: 'Domain A',
+                  rate: 0.9,
+                  pairsMeasured: 1,
+                },
+              ],
               highPressureOnOpposingValueWinRate: 0.2,
               pairsMeasured: 1,
             },
@@ -356,6 +372,7 @@ describe('PressureSensitivity page', () => {
     );
 
     expect(screen.getByText('Win Rate by Pressure Conditions by Value')).toBeDefined();
+    expect(screen.getByText('High Pressure on Value Win Rate by Domain by Value')).toBeDefined();
   });
 
   it('defaults to the shared bar and removes the provider filter copy', () => {
@@ -411,7 +428,12 @@ describe('PressureSensitivity page', () => {
       </MemoryRouter>,
     );
 
-    const valueRow = screen.getByText('Alpha').closest('tr');
+    const byValueSection = screen.getByRole('heading', { name: 'Win Rate by Pressure Conditions by Value' }).closest('section');
+    if (byValueSection == null) {
+      throw new Error('Missing by-value section');
+    }
+
+    const valueRow = within(byValueSection).getByText('Alpha').closest('tr');
     if (valueRow == null) {
       throw new Error('Missing Alpha row');
     }

--- a/cloud/apps/web/src/pages/PressureSensitivity.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.tsx
@@ -21,6 +21,7 @@ import {
 import { PressureDirectionalBreakdown } from '../components/models/PressureDirectionalBreakdown';
 import { PressureSensitivitySummary } from '../components/models/PressureSensitivitySummary';
 import { PressureResponseByValueTable } from '../components/models/PressureResponseByValueTable';
+import { PressureHighPressureByValueDomainTable } from '../components/models/PressureHighPressureByValueDomainTable';
 import { PressureSensitivityGridSection } from '../components/models/PressureSensitivityGridSection';
 import { PressureSensitivityCrossValueMap } from '../components/models/PressureSensitivityCrossValueMap';
 import { PressureSensitivitySanityCheck } from '../components/models/PressureSensitivitySanityCheck';
@@ -322,6 +323,7 @@ export function PressureSensitivity() {
         <>
           <PressureDirectionalBreakdown models={models} />
           <PressureResponseByValueTable models={models} />
+          <PressureHighPressureByValueDomainTable models={models} />
 
           <PressureSensitivityGridSection models={models}>
             {({ selectedModelId, onSelectModel }) => (

--- a/cloud/apps/web/src/pages/domainValueShiftHeatmapUtils.ts
+++ b/cloud/apps/web/src/pages/domainValueShiftHeatmapUtils.ts
@@ -82,8 +82,8 @@ function formatValueLabel(valueKey: string): string {
 export function formatPointShift(value: number | null): string {
   if (value == null || !Number.isFinite(value)) return 'n/a';
   const rounded = Math.round(value);
-  if (rounded === 0) return '0pp';
-  return `${rounded > 0 ? '+' : ''}${rounded}pp`;
+  if (rounded === 0) return '0';
+  return `${rounded > 0 ? '+' : ''}${rounded}`;
 }
 
 export function formatPercent(value: number | null): string {

--- a/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
@@ -235,9 +235,9 @@ describe('DomainValueShiftHeatmap helpers', () => {
   });
 
   it('formats point shifts and unknown evidence without percent-change language', () => {
-    expect(formatPointShift(12.4)).toBe('+12pp');
-    expect(formatPointShift(-8.6)).toBe('-9pp');
-    expect(formatPointShift(0.2)).toBe('0pp');
+    expect(formatPointShift(12.4)).toBe('+12');
+    expect(formatPointShift(-8.6)).toBe('-9');
+    expect(formatPointShift(0.2)).toBe('0');
     expect(formatPercent(42.34)).toBe('42.3%');
     expect(formatEvidenceWeight(null)).toBe('—');
     expect(formatEvidenceWeight(0)).toBe('—');
@@ -375,7 +375,7 @@ describe('DomainValueShiftHeatmap page', () => {
     expect(screen.getByRole('button', { name: /signature: latest @ default/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sort by Avg Win Rate descending/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sort by Value descending/i })).toHaveTextContent('Value↓');
-    expect(screen.getByLabelText(/Achievement in City Planning: raw win rate 80\.0%; shift \+20pp/i)).toHaveAccessibleName(
+    expect(screen.getByLabelText(/Achievement in City Planning: raw win rate 80\.0%; shift \+20/i)).toHaveAccessibleName(
       /average 60\.0%; average evidence vignettes —/i,
     );
     expect(screen.getByText('Cell metric')).toBeInTheDocument();
@@ -415,7 +415,7 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    expect(await screen.findByText('+20pp')).toBeInTheDocument();
+    expect(await screen.findByText('+20')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Raw win rate' }));
 
     expect(screen.getByRole('button', { name: 'Raw win rate' })).toHaveAttribute('aria-pressed', 'true');

--- a/cloud/tests/snapshot-baselines/queries/pressure-sensitivity.graphql
+++ b/cloud/tests/snapshot-baselines/queries/pressure-sensitivity.graphql
@@ -26,6 +26,12 @@ query PressureSensitivity(
         averageWinRate
         balancedWinRate
         highPressureOnThisValueWinRate
+        highPressureOnThisValueDomainRates {
+          domainId
+          domainName
+          rate
+          pairsMeasured
+        }
         highPressureOnOpposingValueWinRate
         pairsMeasured
       }


### PR DESCRIPTION
## Summary
- Add a new Pressure Sensitivity report for high-pressure win rate by value and domain.
- Add a toggle for raw high-pressure win rate vs shift vs the value's own average.
- Update Pressure Sensitivity shift formatting to show signed raw numbers without `pp`.

## Validation
- `npm test --filter=@valuerank/web --filter=@valuerank/api` in `cloud/` -> passed
- `npm run build --filter=@valuerank/web --filter=@valuerank/api` in `cloud/` -> passed
- `npm run db:test:setup` in `cloud/` -> passed

## Notes
- Existing repo lint warnings remain outside this change, but no new errors were introduced.