### PR TITLE
feat: Response Consistency by Model report (Win Rate page)

### DIFF
--- a/cloud/apps/api/src/graphql/queries/models-stability-math.ts
+++ b/cloud/apps/api/src/graphql/queries/models-stability-math.ts
@@ -1,0 +1,226 @@
+import type { VarianceStats } from '../../services/analysis/aggregate/contracts.js';
+
+export type RepeatPattern = 'stable' | 'softLean' | 'torn' | 'noisy';
+
+// Thresholds MUST stay identical to OverviewTabHelpers.ts; update both together.
+export function classifyRepeatPattern(
+  directionalAgreement: number | null | undefined,
+  medianSignedDistance: number | null | undefined,
+  neutralShare: number | null | undefined,
+  range: number | null | undefined,
+): RepeatPattern | null {
+  if (
+    directionalAgreement === null
+    || directionalAgreement === undefined
+    || medianSignedDistance === null
+    || medianSignedDistance === undefined
+    || neutralShare === null
+    || neutralShare === undefined
+    || range === null
+    || range === undefined
+  ) {
+    return null;
+  }
+
+  const absoluteDistance = Math.abs(medianSignedDistance);
+  if (directionalAgreement >= 0.80) {
+    return 'stable';
+  }
+  if (absoluteDistance >= 0.50 && range <= 1 && directionalAgreement >= 0.55) {
+    return 'softLean';
+  }
+  if (range >= 3) {
+    return 'noisy';
+  }
+  if (neutralShare >= 0.60 || absoluteDistance < 0.35) {
+    return 'torn';
+  }
+  return 'torn';
+}
+
+export type DimensionKeyResult =
+  | { keys: [string, string]; inconsistent: false }
+  | { inconsistent: true };
+
+export function resolveDimensionKeys(
+  scenarioDimensions: Record<string, Record<string, number | string>>,
+): DimensionKeyResult | null {
+  const entries = Object.values(scenarioDimensions);
+  if (entries.length === 0) return null;
+
+  // Get the sorted key set from the first entry
+  const firstKeys = Object.keys(entries[0]).sort();
+  if (firstKeys.length !== 2) return null;
+
+  // Check all entries share the same two keys
+  for (const dims of entries) {
+    const keys = Object.keys(dims).sort();
+    if (keys.length !== 2 || keys[0] !== firstKeys[0] || keys[1] !== firstKeys[1]) {
+      return { inconsistent: true };
+    }
+  }
+
+  return { keys: [firstKeys[0], firstKeys[1]], inconsistent: false };
+}
+
+export function buildConditionGroups(
+  scenarioDimensions: Record<string, Record<string, number | string>>,
+  keyA: string,
+  keyB: string,
+): Map<string, string[]> {
+  const groups = new Map<string, string[]>();
+  for (const [scenarioId, dims] of Object.entries(scenarioDimensions)) {
+    const aLevel = dims[keyA] != null ? String(dims[keyA]) : 'N/A';
+    const bLevel = dims[keyB] != null ? String(dims[keyB]) : 'N/A';
+    const conditionKey = `${aLevel}||${bLevel}`;
+    const existing = groups.get(conditionKey);
+    if (existing != null) {
+      existing.push(scenarioId);
+    } else {
+      groups.set(conditionKey, [scenarioId]);
+    }
+  }
+  return groups;
+}
+
+export function weightedMean(
+  entries: Array<{ sampleCount: number; value: number | null | undefined }>,
+): number | null {
+  const eligible = entries.filter((e): e is { sampleCount: number; value: number } => typeof e.value === 'number');
+  if (eligible.length === 0) return null;
+  const totalWeight = eligible.reduce((sum, e) => sum + e.sampleCount, 0);
+  if (totalWeight === 0) return null;
+  const weightedSum = eligible.reduce((sum, e) => sum + e.value * e.sampleCount, 0);
+  return weightedSum / totalWeight;
+}
+
+export type ConditionStats = {
+  directionalAgreement: number;
+  medianSignedDistance: number;
+  neutralShare: number;
+  maxRange: number;
+  totalSamples: number;
+};
+
+export function aggregateConditionStats(
+  scenarioIds: string[],
+  perScenario: Record<string, VarianceStats>,
+): ConditionStats | null {
+  const eligible = scenarioIds
+    .map((id) => perScenario[id])
+    .filter((s): s is VarianceStats => s != null && s.sampleCount >= 2);
+
+  if (eligible.length === 0) return null;
+
+  const totalSamples = eligible.reduce((sum, s) => sum + s.sampleCount, 0);
+
+  const wm = (key: keyof VarianceStats): number | null => {
+    const populated = eligible.filter((s) => typeof s[key] === 'number');
+    if (populated.length === 0) return null;
+    const weightedSum = populated.reduce((sum, s) => sum + (Number(s[key]) * s.sampleCount), 0);
+    const weightedCount = populated.reduce((sum, s) => sum + s.sampleCount, 0);
+    return weightedCount > 0 ? Number((weightedSum / weightedCount).toFixed(2)) : null;
+  };
+
+  const directionalAgreement = wm('directionalAgreement');
+  const medianSignedDistance = wm('medianSignedDistance');
+  const neutralShare = wm('neutralShare');
+
+  if (directionalAgreement == null || medianSignedDistance == null || neutralShare == null) {
+    return null;
+  }
+
+  const maxRange = eligible.reduce((max, s) => Math.max(max, s.range ?? 0), 0);
+
+  return { directionalAgreement, medianSignedDistance, neutralShare, maxRange, totalSamples };
+}
+
+export type VignetteStabilityStats = {
+  classifiedCount: number;
+  stableShare: number;
+  softLeanShare: number;
+  tornShare: number;
+  unstableShare: number;
+  avgDirectionalAgreement: number | null;
+};
+
+export function computeVignetteStability(
+  conditionGroups: Map<string, string[]>,
+  perScenario: Record<string, VarianceStats>,
+): VignetteStabilityStats | null {
+  let stable = 0;
+  let softLean = 0;
+  let torn = 0;
+  let unstable = 0;
+  const agreementValues: Array<{ value: number; weight: number }> = [];
+
+  for (const [, scenarioIds] of conditionGroups) {
+    const stats = aggregateConditionStats(scenarioIds, perScenario);
+    if (stats == null) continue;
+
+    const pattern = classifyRepeatPattern(
+      stats.directionalAgreement,
+      stats.medianSignedDistance,
+      stats.neutralShare,
+      stats.maxRange,
+    );
+    if (pattern == null) continue;
+
+    // 'noisy' maps to unstable bucket; UI label is "Unstable"
+    if (pattern === 'stable') stable++;
+    else if (pattern === 'softLean') softLean++;
+    else if (pattern === 'torn') torn++;
+    else if (pattern === 'noisy') unstable++;
+
+    agreementValues.push({ value: stats.directionalAgreement, weight: stats.totalSamples });
+  }
+
+  const classifiedCount = stable + softLean + torn + unstable;
+  if (classifiedCount === 0) return null;
+
+  const avgDirectionalAgreement = weightedMean(
+    agreementValues.map((v) => ({ sampleCount: v.weight, value: v.value })),
+  );
+
+  return {
+    classifiedCount,
+    stableShare: stable / classifiedCount,
+    softLeanShare: softLean / classifiedCount,
+    tornShare: torn / classifiedCount,
+    unstableShare: unstable / classifiedCount,
+    avgDirectionalAgreement,
+  };
+}
+
+export function averageVignetteStability(
+  vignetteStats: VignetteStabilityStats[],
+): {
+  stableShare: number;
+  softLeanShare: number;
+  tornShare: number;
+  unstableShare: number;
+  avgDirectionalAgreement: number | null;
+} | null {
+  if (vignetteStats.length === 0) return null;
+
+  const n = vignetteStats.length;
+  const sum = (key: keyof VignetteStabilityStats): number =>
+    vignetteStats.reduce((acc, s) => acc + (s[key] as number), 0);
+
+  const agreements = vignetteStats
+    .filter((s) => s.avgDirectionalAgreement != null)
+    .map((s) => s.avgDirectionalAgreement as number);
+
+  const avgDirectionalAgreement =
+    agreements.length > 0
+      ? agreements.reduce((a, b) => a + b, 0) / agreements.length
+      : null;
+
+  return {
+    stableShare: sum('stableShare') / n,
+    softLeanShare: sum('softLeanShare') / n,
+    tornShare: sum('tornShare') / n,
+    unstableShare: sum('unstableShare') / n,
+    avgDirectionalAgreement,
+  };
+}

--- a/cloud/apps/api/src/graphql/queries/models-stability-math.ts
+++ b/cloud/apps/api/src/graphql/queries/models-stability-math.ts
@@ -49,18 +49,22 @@ export function resolveDimensionKeys(
   if (entries.length === 0) return null;
 
   // Get the sorted key set from the first entry
-  const firstKeys = Object.keys(entries[0]).sort();
+  const firstEntry = entries[0];
+  if (firstEntry === undefined) return null;
+  const firstKeys = Object.keys(firstEntry).sort();
   if (firstKeys.length !== 2) return null;
+  const [keyA, keyB] = firstKeys;
+  if (keyA === undefined || keyB === undefined) return null;
 
   // Check all entries share the same two keys
   for (const dims of entries) {
     const keys = Object.keys(dims).sort();
-    if (keys.length !== 2 || keys[0] !== firstKeys[0] || keys[1] !== firstKeys[1]) {
+    if (keys.length !== 2 || keys[0] !== keyA || keys[1] !== keyB) {
       return { inconsistent: true };
     }
   }
 
-  return { keys: [firstKeys[0], firstKeys[1]], inconsistent: false };
+  return { keys: [keyA, keyB], inconsistent: false };
 }
 
 export function buildConditionGroups(

--- a/cloud/apps/api/src/graphql/queries/models-stability.ts
+++ b/cloud/apps/api/src/graphql/queries/models-stability.ts
@@ -1,0 +1,227 @@
+import { db } from '@valuerank/db';
+import { getModelsFromDatabase } from '../../config/models.js';
+import { zAnalysisOutput } from '../../services/analysis/aggregate/contracts.js';
+import { normalizeAnalysisArtifacts } from '../../services/analysis/normalize-analysis-output.js';
+import { builder } from '../builder.js';
+import { ModelsStabilityResultRef, type ModelsStabilityResultShape } from '../types/models-stability.js';
+import { formatRunSignature, runMatchesSignature } from './domain-coverage-gql-types.js';
+import {
+  resolveDimensionKeys,
+  buildConditionGroups,
+  computeVignetteStability,
+  averageVignetteStability,
+  type VignetteStabilityStats,
+} from './models-stability-math.js';
+
+type RunRow = {
+  id: string;
+  definitionId: string;
+  createdAt: Date;
+  config: unknown;
+  definition: { name: string };
+  analysisResults: Array<{ analysisType: string; output: unknown }>;
+};
+
+type VignetteEntry = {
+  definitionId: string;
+  vignetteName: string;
+  stats: VignetteStabilityStats;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function extractScenarioDimensions(
+  visualizationData: Record<string, unknown> | null,
+): Record<string, Record<string, number | string>> {
+  if (visualizationData == null) return {};
+  const raw = visualizationData.scenarioDimensions;
+  if (!isPlainObject(raw)) return {};
+  const result: Record<string, Record<string, number | string>> = {};
+  for (const [scenarioId, dims] of Object.entries(raw)) {
+    if (!isPlainObject(dims)) continue;
+    const sanitized: Record<string, number | string> = {};
+    for (const [key, value] of Object.entries(dims)) {
+      if (typeof value === 'number' || typeof value === 'string') {
+        sanitized[key] = value;
+      }
+    }
+    if (Object.keys(sanitized).length > 0) {
+      result[scenarioId] = sanitized;
+    }
+  }
+  return result;
+}
+
+function extractPerScenario(
+  varianceAnalysis: Record<string, unknown> | null,
+  modelId: string,
+): Record<string, unknown> | null {
+  if (varianceAnalysis == null) return null;
+  const perModel = varianceAnalysis.perModel;
+  if (!isPlainObject(perModel)) return null;
+  const modelStats = perModel[modelId];
+  if (!isPlainObject(modelStats)) return null;
+  const perScenario = modelStats.perScenario;
+  if (!isPlainObject(perScenario)) return null;
+  return perScenario;
+}
+
+builder.queryField('modelsWinRateStability', (t) =>
+  t.field({
+    type: ModelsStabilityResultRef,
+    args: {
+      signature: t.arg.string({ required: false }),
+      domainId: t.arg.id({ required: false }),
+    },
+    resolve: async (_root, args) => {
+      const signature = args.signature != null ? String(args.signature) : null;
+      const domainId = args.domainId != null ? String(args.domainId) : null;
+
+      const activeModels = await getModelsFromDatabase({ activeOnly: true, availableOnly: false });
+
+      const runs = await db.run.findMany({
+        where: {
+          status: 'COMPLETED',
+          deletedAt: null,
+          tags: { some: { tag: { name: 'Aggregate' } } },
+          ...(domainId != null ? { definition: { domainId } } : {}),
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        select: {
+          id: true,
+          definitionId: true,
+          createdAt: true,
+          config: true,
+          definition: { select: { name: true } },
+          analysisResults: {
+            where: { status: 'CURRENT' },
+            select: { analysisType: true, output: true },
+          },
+        },
+      }) as RunRow[];
+
+      const scopedRuns = signature != null
+        ? runs.filter((run) => runMatchesSignature(run.config, signature))
+        : runs;
+
+      // Dedup: keep most-recent run per (definitionId, resolvedSignature)
+      const seenKeys = new Set<string>();
+      const dedupedRuns: RunRow[] = [];
+      for (const run of scopedRuns) {
+        const resolvedSignature = signature ?? formatRunSignature(run.config);
+        const key = `${run.definitionId}::${resolvedSignature}`;
+        if (seenKeys.has(key)) continue;
+        seenKeys.add(key);
+        dedupedRuns.push(run);
+      }
+
+      if (dedupedRuns.length === 0) {
+        return { models: [], skippedVignettes: [] };
+      }
+
+      // Batch-fetch scenarios for all unique definitionIds
+      const definitionIds = [...new Set(dedupedRuns.map((r) => r.definitionId))];
+      const allScenarios = await db.scenario.findMany({
+        where: { definitionId: { in: definitionIds }, deletedAt: null },
+        select: { id: true, name: true, content: true, definitionId: true },
+      });
+      const scenariosByDefinition = new Map<string, typeof allScenarios>();
+      for (const scenario of allScenarios) {
+        const list = scenariosByDefinition.get(scenario.definitionId) ?? [];
+        list.push(scenario);
+        scenariosByDefinition.set(scenario.definitionId, list);
+      }
+
+      const skippedVignettes: ModelsStabilityResultShape['skippedVignettes'] = [];
+      const vignetteEntriesByModel = new Map<string, VignetteEntry[]>();
+      let validRunCount = 0;
+
+      for (const run of dedupedRuns) {
+        const vignetteName = run.definition.name;
+        const definitionId = run.definitionId;
+
+        const analysis = run.analysisResults.find((ar) => ar.analysisType === 'AGGREGATE');
+        if (analysis == null) continue;
+
+        try {
+          const parsed = zAnalysisOutput.safeParse(analysis.output);
+          if (!parsed.success) {
+            skippedVignettes.push({ definitionId, vignetteName, reason: 'normalization-failed' });
+            continue;
+          }
+
+          const scenarios = scenariosByDefinition.get(definitionId) ?? [];
+          const normalized = normalizeAnalysisArtifacts({
+            visualizationData: parsed.data.visualizationData ?? null,
+            varianceAnalysis: parsed.data.varianceAnalysis ?? null,
+            scenarios,
+          });
+
+          const scenarioDimensions = extractScenarioDimensions(normalized.visualizationData);
+          const dimKeys = resolveDimensionKeys(scenarioDimensions);
+
+          if (dimKeys == null) continue;
+          if (dimKeys.inconsistent) {
+            skippedVignettes.push({ definitionId, vignetteName, reason: 'inconsistent-dimension-keys' });
+            continue;
+          }
+
+          validRunCount++;
+          const conditionGroups = buildConditionGroups(scenarioDimensions, dimKeys.keys[0], dimKeys.keys[1]);
+
+          for (const model of activeModels) {
+            const rawPerScenario = extractPerScenario(normalized.varianceAnalysis, model.modelId);
+            if (rawPerScenario == null) continue;
+
+            // Safe cast: data was validated by zAnalysisOutput above
+            const vignetteStability = computeVignetteStability(
+              conditionGroups,
+              rawPerScenario as Parameters<typeof computeVignetteStability>[1],
+            );
+            if (vignetteStability == null) continue;
+
+            const list = vignetteEntriesByModel.get(model.modelId) ?? [];
+            list.push({ definitionId, vignetteName, stats: vignetteStability });
+            vignetteEntriesByModel.set(model.modelId, list);
+          }
+        } catch (err) {
+          skippedVignettes.push({ definitionId, vignetteName, reason: 'unexpected-error' });
+        }
+      }
+
+      if (validRunCount === 0) {
+        return { models: [], skippedVignettes };
+      }
+
+      const outputModels: ModelsStabilityResultShape['models'] = activeModels.map((model) => {
+        const entries = vignetteEntriesByModel.get(model.modelId) ?? [];
+        const avg = averageVignetteStability(entries.map((e) => e.stats));
+
+        return {
+          modelId: model.modelId,
+          label: model.displayName,
+          qualifyingVignetteCount: entries.length,
+          avgDirectionalAgreement: avg?.avgDirectionalAgreement ?? null,
+          stableShare: avg?.stableShare ?? null,
+          softLeanShare: avg?.softLeanShare ?? null,
+          tornShare: avg?.tornShare ?? null,
+          unstableShare: avg?.unstableShare ?? null,
+          vignettes: entries.map((entry) => ({
+            definitionId: entry.definitionId,
+            vignetteName: entry.vignetteName,
+            classifiedConditionCount: entry.stats.classifiedCount,
+            stableShare: entry.stats.stableShare,
+            softLeanShare: entry.stats.softLeanShare,
+            tornShare: entry.stats.tornShare,
+            unstableShare: entry.stats.unstableShare,
+            avgDirectionalAgreement: entry.stats.avgDirectionalAgreement,
+          })),
+        };
+      });
+
+      return { models: outputModels, skippedVignettes };
+    },
+  }),
+);

--- a/cloud/apps/api/src/graphql/types/index.ts
+++ b/cloud/apps/api/src/graphql/types/index.ts
@@ -31,6 +31,7 @@ import './models-analysis.js';
 import './models-confidence.js';
 import './confidence-value-detail.js';
 import './models-consistency.js';
+import './models-stability.js';
 import './pressure-sensitivity.js';
 import './circumplex.js';
 import './pairwise-win-rates.js';

--- a/cloud/apps/api/src/graphql/types/models-stability.ts
+++ b/cloud/apps/api/src/graphql/types/models-stability.ts
@@ -1,0 +1,82 @@
+import { builder } from '../builder.js';
+
+export type ModelsStabilitySkippedVignetteShape = {
+  definitionId: string;
+  vignetteName: string;
+  reason: string;
+};
+
+export type ModelsStabilityVignetteResultShape = {
+  definitionId: string;
+  vignetteName: string;
+  classifiedConditionCount: number;
+  stableShare: number;
+  softLeanShare: number;
+  tornShare: number;
+  unstableShare: number;
+  avgDirectionalAgreement: number | null;
+};
+
+export type ModelsStabilityModelResultShape = {
+  modelId: string;
+  label: string;
+  qualifyingVignetteCount: number;
+  avgDirectionalAgreement: number | null;
+  stableShare: number | null;
+  softLeanShare: number | null;
+  tornShare: number | null;
+  unstableShare: number | null;
+  vignettes: ModelsStabilityVignetteResultShape[];
+};
+
+export type ModelsStabilityResultShape = {
+  models: ModelsStabilityModelResultShape[];
+  skippedVignettes: ModelsStabilitySkippedVignetteShape[];
+};
+
+const ModelsStabilitySkippedVignetteRef = builder.objectRef<ModelsStabilitySkippedVignetteShape>('ModelsStabilitySkippedVignette');
+const ModelsStabilityVignetteResultRef = builder.objectRef<ModelsStabilityVignetteResultShape>('ModelsStabilityVignetteResult');
+const ModelsStabilityModelResultRef = builder.objectRef<ModelsStabilityModelResultShape>('ModelsStabilityModelResult');
+export const ModelsStabilityResultRef = builder.objectRef<ModelsStabilityResultShape>('ModelsStabilityResult');
+
+builder.objectType(ModelsStabilitySkippedVignetteRef, {
+  fields: (t) => ({
+    definitionId: t.exposeString('definitionId'),
+    vignetteName: t.exposeString('vignetteName'),
+    reason: t.exposeString('reason'),
+  }),
+});
+
+builder.objectType(ModelsStabilityVignetteResultRef, {
+  fields: (t) => ({
+    definitionId: t.exposeString('definitionId'),
+    vignetteName: t.exposeString('vignetteName'),
+    classifiedConditionCount: t.exposeInt('classifiedConditionCount'),
+    stableShare: t.exposeFloat('stableShare'),
+    softLeanShare: t.exposeFloat('softLeanShare'),
+    tornShare: t.exposeFloat('tornShare'),
+    unstableShare: t.exposeFloat('unstableShare'),
+    avgDirectionalAgreement: t.exposeFloat('avgDirectionalAgreement', { nullable: true }),
+  }),
+});
+
+builder.objectType(ModelsStabilityModelResultRef, {
+  fields: (t) => ({
+    modelId: t.exposeString('modelId'),
+    label: t.exposeString('label'),
+    qualifyingVignetteCount: t.exposeInt('qualifyingVignetteCount'),
+    avgDirectionalAgreement: t.exposeFloat('avgDirectionalAgreement', { nullable: true }),
+    stableShare: t.exposeFloat('stableShare', { nullable: true }),
+    softLeanShare: t.exposeFloat('softLeanShare', { nullable: true }),
+    tornShare: t.exposeFloat('tornShare', { nullable: true }),
+    unstableShare: t.exposeFloat('unstableShare', { nullable: true }),
+    vignettes: t.expose('vignettes', { type: [ModelsStabilityVignetteResultRef] }),
+  }),
+});
+
+builder.objectType(ModelsStabilityResultRef, {
+  fields: (t) => ({
+    models: t.expose('models', { type: [ModelsStabilityModelResultRef] }),
+    skippedVignettes: t.expose('skippedVignettes', { type: [ModelsStabilitySkippedVignetteRef] }),
+  }),
+});

--- a/cloud/apps/api/tests/graphql/queries/models-stability-math.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/models-stability-math.test.ts
@@ -1,0 +1,479 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyRepeatPattern,
+  resolveDimensionKeys,
+  buildConditionGroups,
+  aggregateConditionStats,
+  computeVignetteStability,
+  averageVignetteStability,
+  weightedMean,
+} from '../../../src/graphql/queries/models-stability-math.js';
+
+describe('classifyRepeatPattern', () => {
+  it('returns stable at the exact directional agreement threshold', () => {
+    expect(classifyRepeatPattern(0.80, 0.5, 0.1, 0)).toBe('stable');
+  });
+
+  it('returns softLean when the absolute distance and agreement thresholds are met', () => {
+    expect(classifyRepeatPattern(0.79, 0.6, 0.1, 0)).not.toBe('stable');
+    expect(classifyRepeatPattern(0.79, 0.6, 0.1, 1)).toBe('softLean');
+  });
+
+  it('returns noisy when range is 3', () => {
+    expect(classifyRepeatPattern(0.5, 0.2, 0.1, 3)).toBe('noisy');
+  });
+
+  it('returns torn when the pattern falls through', () => {
+    expect(classifyRepeatPattern(0.5, 0.2, 0.1, 2)).toBe('torn');
+  });
+
+  it('returns null when any input is null or undefined', () => {
+    expect(classifyRepeatPattern(null, 0.5, 0.1, 0)).toBeNull();
+    expect(classifyRepeatPattern(undefined, 0.5, 0.1, 0)).toBeNull();
+  });
+});
+
+describe('resolveDimensionKeys', () => {
+  it('returns the shared sorted keys when all scenarios match', () => {
+    expect(
+      resolveDimensionKeys({
+        a: { fairness: 1, security: 2 },
+        b: { fairness: 3, security: 4 },
+      }),
+    ).toEqual({ keys: ['fairness', 'security'], inconsistent: false });
+  });
+
+  it('returns inconsistent when one scenario has a different key set', () => {
+    expect(
+      resolveDimensionKeys({
+        a: { fairness: 1, security: 2 },
+        b: { fairness: 3, loyalty: 4 },
+      }),
+    ).toEqual({ inconsistent: true });
+  });
+
+  it('returns null for an empty scenario map', () => {
+    expect(resolveDimensionKeys({})).toBeNull();
+  });
+
+  it('returns null when a scenario has only one key', () => {
+    expect(
+      resolveDimensionKeys({
+        a: { fairness: 1 },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('buildConditionGroups', () => {
+  it('groups scenarios with the same levels into the same condition key', () => {
+    const groups = buildConditionGroups(
+      {
+        a: { fairness: 1, security: 2 },
+        b: { fairness: 1, security: 2 },
+      },
+      'fairness',
+      'security',
+    );
+
+    expect(groups.get('1||2')).toEqual(['a', 'b']);
+  });
+
+  it('uses N/A when a key is missing', () => {
+    const groups = buildConditionGroups(
+      {
+        a: { security: 2 },
+      },
+      'fairness',
+      'security',
+    );
+
+    expect(groups.get('N/A||2')).toEqual(['a']);
+  });
+
+  it('creates multiple entries for distinct level combinations', () => {
+    const groups = buildConditionGroups(
+      {
+        a: { fairness: 1, security: 2 },
+        b: { fairness: 1, security: 3 },
+        c: { fairness: 2, security: 2 },
+      },
+      'fairness',
+      'security',
+    );
+
+    expect(groups.size).toBe(3);
+    expect(groups.get('1||2')).toEqual(['a']);
+    expect(groups.get('1||3')).toEqual(['b']);
+    expect(groups.get('2||2')).toEqual(['c']);
+  });
+});
+
+describe('weightedMean', () => {
+  it('returns null when no eligible entries are present', () => {
+    expect(
+      weightedMean([
+        { sampleCount: 1, value: null },
+        { sampleCount: 2, value: undefined },
+      ]),
+    ).toBeNull();
+  });
+
+  it('computes a weighted average using sampleCount as the weight', () => {
+    expect(
+      weightedMean([
+        { sampleCount: 2, value: 0.6 },
+        { sampleCount: 4, value: 0.9 },
+      ]),
+    ).toBeCloseTo(0.8, 10);
+  });
+
+  it('returns null when the total weight is zero', () => {
+    expect(
+      weightedMean([
+        { sampleCount: 0, value: 0.9 },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe('aggregateConditionStats', () => {
+  it('returns null when all scenarios are below the repeat threshold', () => {
+    expect(
+      aggregateConditionStats(
+        ['a', 'b'],
+        {
+          a: {
+            sampleCount: 1,
+            mean: 0,
+            stdDev: 0,
+            variance: 0,
+            min: 0,
+            max: 0,
+            range: 1,
+            directionalAgreement: 0.8,
+            medianSignedDistance: 0.5,
+            neutralShare: 0.1,
+          },
+          b: {
+            sampleCount: 1,
+            mean: 0,
+            stdDev: 0,
+            variance: 0,
+            min: 0,
+            max: 0,
+            range: 2,
+            directionalAgreement: 0.9,
+            medianSignedDistance: 0.4,
+            neutralShare: 0.2,
+          },
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it('includes only scenarios with sampleCount at least 2', () => {
+    expect(
+      aggregateConditionStats(
+        ['a', 'b'],
+        {
+          a: {
+            sampleCount: 1,
+            mean: 0,
+            stdDev: 0,
+            variance: 0,
+            min: 0,
+            max: 0,
+            range: 1,
+            directionalAgreement: 0.2,
+            medianSignedDistance: 0.1,
+            neutralShare: 0.8,
+          },
+          b: {
+            sampleCount: 3,
+            mean: 0,
+            stdDev: 0,
+            variance: 0,
+            min: 0,
+            max: 0,
+            range: 4,
+            directionalAgreement: 0.7,
+            medianSignedDistance: 0.5,
+            neutralShare: 0.2,
+          },
+        },
+      ),
+    ).toEqual({
+      directionalAgreement: 0.7,
+      medianSignedDistance: 0.5,
+      neutralShare: 0.2,
+      maxRange: 4,
+      totalSamples: 3,
+    });
+  });
+
+  it('computes weighted means and rounds to two decimals', () => {
+    expect(
+      aggregateConditionStats(
+        ['a', 'b'],
+        {
+          a: {
+            sampleCount: 2,
+            mean: 0,
+            stdDev: 0,
+            variance: 0,
+            min: 0,
+            max: 0,
+            range: 2,
+            directionalAgreement: 0.6,
+            medianSignedDistance: 0.4,
+            neutralShare: 0.1,
+          },
+          b: {
+            sampleCount: 4,
+            mean: 0,
+            stdDev: 0,
+            variance: 0,
+            min: 0,
+            max: 0,
+            range: 5,
+            directionalAgreement: 0.9,
+            medianSignedDistance: 0.8,
+            neutralShare: 0.3,
+          },
+        },
+      ),
+    ).toEqual({
+      directionalAgreement: Number((0.8).toFixed(2)),
+      medianSignedDistance: Number(((0.4 * 2 + 0.8 * 4) / 6).toFixed(2)),
+      neutralShare: Number(((0.1 * 2 + 0.3 * 4) / 6).toFixed(2)),
+      maxRange: 5,
+      totalSamples: 6,
+    });
+  });
+
+  it('uses the maximum range across eligible scenarios', () => {
+    const stats = aggregateConditionStats(
+      ['a', 'b'],
+      {
+        a: {
+          sampleCount: 2,
+          mean: 0,
+          stdDev: 0,
+          variance: 0,
+          min: 0,
+          max: 0,
+          range: 2,
+          directionalAgreement: 0.6,
+          medianSignedDistance: 0.4,
+          neutralShare: 0.1,
+        },
+        b: {
+          sampleCount: 3,
+          mean: 0,
+          stdDev: 0,
+          variance: 0,
+          min: 0,
+          max: 0,
+          range: 7,
+          directionalAgreement: 0.9,
+          medianSignedDistance: 0.8,
+          neutralShare: 0.3,
+        },
+      },
+    );
+
+    expect(stats?.maxRange).toBe(7);
+  });
+});
+
+describe('computeVignetteStability', () => {
+  it('returns null when all grouped conditions are null after aggregation', () => {
+    expect(
+      computeVignetteStability(
+        new Map([['c1', ['a']], ['c2', ['b']]]),
+        {
+          a: {
+            sampleCount: 1,
+            mean: 0,
+            stdDev: 0,
+            variance: 0,
+            min: 0,
+            max: 0,
+            range: 0,
+            directionalAgreement: 0.9,
+            medianSignedDistance: 0.6,
+            neutralShare: 0.1,
+          },
+          b: {
+            sampleCount: 1,
+            mean: 0,
+            stdDev: 0,
+            variance: 0,
+            min: 0,
+            max: 0,
+            range: 3,
+            directionalAgreement: 0.2,
+            medianSignedDistance: 0.1,
+            neutralShare: 0.9,
+          },
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it('counts stable and noisy conditions and maps noisy to unstable', () => {
+    const stability = computeVignetteStability(
+      new Map([
+        ['c1', ['stable-a', 'stable-b']],
+        ['c2', ['noisy-a', 'noisy-b']],
+      ]),
+      {
+        'stable-a': {
+          sampleCount: 2,
+          mean: 0,
+          stdDev: 0,
+          variance: 0,
+          min: 0,
+          max: 0,
+          range: 0,
+          directionalAgreement: 0.8,
+          medianSignedDistance: 0.2,
+          neutralShare: 0.1,
+        },
+        'stable-b': {
+          sampleCount: 2,
+          mean: 0,
+          stdDev: 0,
+          variance: 0,
+          min: 0,
+          max: 0,
+          range: 1,
+          directionalAgreement: 0.8,
+          medianSignedDistance: 0.1,
+          neutralShare: 0.1,
+        },
+        'noisy-a': {
+          sampleCount: 2,
+          mean: 0,
+          stdDev: 0,
+          variance: 0,
+          min: 0,
+          max: 0,
+          range: 3,
+          directionalAgreement: 0.4,
+          medianSignedDistance: 0.1,
+          neutralShare: 0.7,
+        },
+        'noisy-b': {
+          sampleCount: 2,
+          mean: 0,
+          stdDev: 0,
+          variance: 0,
+          min: 0,
+          max: 0,
+          range: 4,
+          directionalAgreement: 0.4,
+          medianSignedDistance: 0.2,
+          neutralShare: 0.8,
+        },
+      },
+    );
+
+    expect(stability).toEqual({
+      classifiedCount: 2,
+      stableShare: 0.5,
+      softLeanShare: 0,
+      tornShare: 0,
+      unstableShare: 0.5,
+      avgDirectionalAgreement: stability?.avgDirectionalAgreement ?? null,
+    });
+    expect(stability?.avgDirectionalAgreement).toBeCloseTo(0.6, 10);
+  });
+
+  it('returns null when no grouped conditions can be classified', () => {
+    expect(
+      computeVignetteStability(
+        new Map([['c1', ['a']]]),
+        {
+          a: {
+            sampleCount: 1,
+            mean: 0,
+            stdDev: 0,
+            variance: 0,
+            min: 0,
+            max: 0,
+            range: 0,
+            directionalAgreement: 0.9,
+            medianSignedDistance: 0.2,
+            neutralShare: 0.1,
+          },
+        },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('averageVignetteStability', () => {
+  it('returns null for an empty array', () => {
+    expect(averageVignetteStability([])).toBeNull();
+  });
+
+  it('averages stability shares across vignettes', () => {
+    expect(
+      averageVignetteStability([
+        {
+          classifiedCount: 10,
+          stableShare: 1,
+          softLeanShare: 0,
+          tornShare: 0,
+          unstableShare: 0,
+          avgDirectionalAgreement: 0.9,
+        },
+        {
+          classifiedCount: 2,
+          stableShare: 0,
+          softLeanShare: 1,
+          tornShare: 0,
+          unstableShare: 0,
+          avgDirectionalAgreement: 0.5,
+        },
+      ]),
+    ).toEqual({
+      stableShare: 0.5,
+      softLeanShare: 0.5,
+      tornShare: 0,
+      unstableShare: 0,
+      avgDirectionalAgreement: 0.7,
+    });
+  });
+
+  it('gives each vignette equal weight regardless of classifiedCount', () => {
+    expect(
+      averageVignetteStability([
+        {
+          classifiedCount: 10,
+          stableShare: 1,
+          softLeanShare: 0,
+          tornShare: 0,
+          unstableShare: 0,
+          avgDirectionalAgreement: 1,
+        },
+        {
+          classifiedCount: 2,
+          stableShare: 0,
+          softLeanShare: 1,
+          tornShare: 0,
+          unstableShare: 0,
+          avgDirectionalAgreement: 0,
+        },
+      ]),
+    ).toEqual({
+      stableShare: 0.5,
+      softLeanShare: 0.5,
+      tornShare: 0,
+      unstableShare: 0,
+      avgDirectionalAgreement: 0.5,
+    });
+  });
+});

--- a/cloud/apps/api/tests/graphql/queries/models-stability-math.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/models-stability-math.test.ts
@@ -380,13 +380,13 @@ describe('computeVignetteStability', () => {
       },
     );
 
-    expect(stability).toEqual({
+    expect(stability).not.toBeNull();
+    expect(stability).toMatchObject({
       classifiedCount: 2,
       stableShare: 0.5,
       softLeanShare: 0,
       tornShare: 0,
       unstableShare: 0.5,
-      avgDirectionalAgreement: stability?.avgDirectionalAgreement ?? null,
     });
     expect(stability?.avgDirectionalAgreement).toBeCloseTo(0.6, 10);
   });

--- a/cloud/apps/api/tests/graphql/queries/models-stability.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/models-stability.test.ts
@@ -1,0 +1,581 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import { db } from '@valuerank/db';
+import { createServer } from '../../../src/server.js';
+import { TEST_USER, getAuthHeader } from '../../test-utils.js';
+
+const app = createServer();
+
+const TS = Date.now();
+const PROVIDER_NAME = `stab-prov-${TS}`;
+const MODEL_A_ID = `stab-model-a-${TS}`;
+const MODEL_B_ID = `stab-model-b-${TS}`;
+const DOMAIN_A_NAME = `stab-domain-a-${TS}`;
+const DOMAIN_B_NAME = `stab-domain-b-${TS}`;
+
+// Definitions (one per vignette scenario)
+const DEF_MAIN = `stab-def-main-${TS}`;
+const DEF_SECOND = `stab-def-second-${TS}`;
+const DEF_DOMAIN_B = `stab-def-domainb-${TS}`;
+const DEF_DEDUP = `stab-def-dedup-${TS}`;
+const DEF_INCONS = `stab-def-incons-${TS}`;
+const DEF_NORM_FAIL = `stab-def-fail-${TS}`;
+const DEF_NO_VA = `stab-def-nova-${TS}`;
+const DEF_LEGACY = `stab-def-legacy-${TS}`;
+
+// Run IDs
+const RUN_MAIN = `stab-run-main-${TS}`;
+const RUN_SECOND = `stab-run-second-${TS}`;
+const RUN_DOMAIN_B = `stab-run-domainb-${TS}`;
+const RUN_DEDUP_OLD = `stab-run-dedup-old-${TS}`;
+const RUN_DEDUP_NEW = `stab-run-dedup-new-${TS}`;
+const RUN_INCONS = `stab-run-incons-${TS}`;
+const RUN_NORM_FAIL = `stab-run-fail-${TS}`;
+const RUN_NO_VA = `stab-run-nova-${TS}`;
+const RUN_LEGACY = `stab-run-legacy-${TS}`;
+
+// Config producing a deterministic signature v1td (version=1, temperature=null)
+const CONFIG_V1TD = { temperature: null, definitionSnapshot: { version: 1 } };
+// Config producing v?td (no version, temperature=null) — excluded by v1td filter
+const CONFIG_NO_VERSION = { temperature: null };
+
+// A valid zAnalysisOutput blob with varianceAnalysis for MODEL_A over the given perScenario map.
+// visualizationData: {} is required so normalizeAnalysisArtifacts runs normalizeScenarioDimensions
+// from scenario.content.dimensions (content-based approach takes priority over rawDimensions).
+function buildAnalysisOutput(
+  modelAPerScenario: Record<string, object>,
+): object {
+  return {
+    perModel: {},
+    visualizationData: {},
+    varianceAnalysis: {
+      isMultiSample: true,
+      samplesPerScenario: 3,
+      perModel: {
+        [MODEL_A_ID]: {
+          totalSamples: Object.keys(modelAPerScenario).length * 3,
+          uniqueScenarios: Object.keys(modelAPerScenario).length,
+          samplesPerScenario: 3,
+          avgWithinScenarioVariance: 0.1,
+          maxWithinScenarioVariance: 0.2,
+          consistencyScore: 0.9,
+          perScenario: modelAPerScenario,
+        },
+        // MODEL_B intentionally omitted — tests case 1 (no-data model)
+      },
+    },
+  };
+}
+
+// A VarianceStats blob for a "stable" scenario (directionalAgreement=0.9 >= 0.80)
+function stableStats(): object {
+  return {
+    sampleCount: 3,
+    mean: 0.5,
+    stdDev: 0.1,
+    variance: 0.01,
+    min: 0.4,
+    max: 0.6,
+    range: 0,
+    directionalAgreement: 0.9,
+    medianSignedDistance: 0.6,
+    neutralShare: 0.05,
+  };
+}
+
+// A VarianceStats blob for a "noisy" scenario (range=3 → noisy → unstableShare)
+function noisyStats(): object {
+  return {
+    sampleCount: 3,
+    mean: 0.5,
+    stdDev: 0.5,
+    variance: 0.25,
+    min: 0.0,
+    max: 1.0,
+    range: 3,
+    directionalAgreement: 0.3,
+    medianSignedDistance: 0.1,
+    neutralShare: 0.6,
+  };
+}
+
+// Scenario content with two named dimensions (for grouping)
+function scenarioContent(dimA: string, valA: number, dimB: string, valB: number): object {
+  return { dimensions: { [dimA]: valA, [dimB]: valB } };
+}
+
+const STABLE_GQL_QUERY = `
+  query ModelsWinRateStability($signature: String, $domainId: ID) {
+    modelsWinRateStability(signature: $signature, domainId: $domainId) {
+      models {
+        modelId
+        label
+        qualifyingVignetteCount
+        avgDirectionalAgreement
+        stableShare
+        softLeanShare
+        tornShare
+        unstableShare
+      }
+      skippedVignettes {
+        definitionId
+        vignetteName
+        reason
+      }
+    }
+  }
+`;
+
+describe('GraphQL modelsWinRateStability', () => {
+  let domainAId: string;
+  let domainBId: string;
+
+  beforeAll(async () => {
+    await db.user.upsert({
+      where: { id: TEST_USER.id },
+      create: { id: TEST_USER.id, email: TEST_USER.email, passwordHash: 'test-hash' },
+      update: {},
+    });
+
+    const [domainA, domainB] = await Promise.all([
+      db.domain.create({ data: { name: DOMAIN_A_NAME, normalizedName: DOMAIN_A_NAME } }),
+      db.domain.create({ data: { name: DOMAIN_B_NAME, normalizedName: DOMAIN_B_NAME } }),
+    ]);
+    domainAId = domainA.id;
+    domainBId = domainB.id;
+
+    const provider = await db.llmProvider.create({
+      data: { name: PROVIDER_NAME, displayName: 'Stability Test Provider' },
+    });
+
+    await Promise.all([
+      db.llmModel.create({
+        data: {
+          providerId: provider.id,
+          modelId: MODEL_A_ID,
+          displayName: 'Stability Model A',
+          status: 'ACTIVE',
+          isDefault: false,
+          costInputPerMillion: 1,
+          costOutputPerMillion: 1,
+        },
+      }),
+      db.llmModel.create({
+        data: {
+          providerId: provider.id,
+          modelId: MODEL_B_ID,
+          displayName: 'Stability Model B',
+          status: 'ACTIVE',
+          isDefault: false,
+          costInputPerMillion: 1,
+          costOutputPerMillion: 1,
+        },
+      }),
+    ]);
+
+    // Create all definitions
+    const defData = [
+      { id: DEF_MAIN, domainId: domainAId, name: 'Vignette Main' },
+      { id: DEF_SECOND, domainId: domainAId, name: 'Vignette Second' },
+      { id: DEF_DOMAIN_B, domainId: domainBId, name: 'Vignette Domain B' },
+      { id: DEF_DEDUP, domainId: domainAId, name: 'Vignette Dedup' },
+      { id: DEF_INCONS, domainId: domainAId, name: 'Vignette Inconsistent' },
+      { id: DEF_NORM_FAIL, domainId: domainAId, name: 'Vignette Norm Fail' },
+      { id: DEF_NO_VA, domainId: domainAId, name: 'Vignette No VarianceAnalysis' },
+      { id: DEF_LEGACY, domainId: domainAId, name: 'Vignette Legacy' },
+    ];
+    for (const def of defData) {
+      await db.definition.create({
+        data: { id: def.id, domainId: def.domainId, name: def.name, content: {} },
+      });
+    }
+
+    // Scenarios for DEF_MAIN (2 scenarios in same condition: fairness=1, security=2)
+    const scMainA = `stab-sc-main-a-${TS}`;
+    const scMainB = `stab-sc-main-b-${TS}`;
+    await db.scenario.createMany({
+      data: [
+        { id: scMainA, definitionId: DEF_MAIN, name: 'Main A', content: scenarioContent('fairness', 1, 'security', 2) },
+        { id: scMainB, definitionId: DEF_MAIN, name: 'Main B', content: scenarioContent('fairness', 1, 'security', 2) },
+      ],
+    });
+
+    // Scenarios for DEF_SECOND:
+    //   Condition X (fairness=1, security=2): 2 scenarios → stable (stableShare=1.0, classifiedCount=1)
+    //   Condition Y (fairness=2, security=2): 2 scenarios → stable (stableShare=1.0, classifiedCount=2 total)
+    const scSecA = `stab-sc-sec-a-${TS}`;
+    const scSecB = `stab-sc-sec-b-${TS}`;
+    const scSecC = `stab-sc-sec-c-${TS}`;
+    const scSecD = `stab-sc-sec-d-${TS}`;
+    await db.scenario.createMany({
+      data: [
+        { id: scSecA, definitionId: DEF_SECOND, name: 'Sec A', content: scenarioContent('fairness', 1, 'security', 2) },
+        { id: scSecB, definitionId: DEF_SECOND, name: 'Sec B', content: scenarioContent('fairness', 1, 'security', 2) },
+        { id: scSecC, definitionId: DEF_SECOND, name: 'Sec C', content: scenarioContent('fairness', 2, 'security', 2) },
+        { id: scSecD, definitionId: DEF_SECOND, name: 'Sec D', content: scenarioContent('fairness', 2, 'security', 2) },
+      ],
+    });
+
+    // Scenario for DEF_DOMAIN_B (2 scenarios, 1 stable condition)
+    const scDomB1 = `stab-sc-domB-1-${TS}`;
+    const scDomB2 = `stab-sc-domB-2-${TS}`;
+    await db.scenario.createMany({
+      data: [
+        { id: scDomB1, definitionId: DEF_DOMAIN_B, name: 'DomB 1', content: scenarioContent('fairness', 1, 'security', 2) },
+        { id: scDomB2, definitionId: DEF_DOMAIN_B, name: 'DomB 2', content: scenarioContent('fairness', 1, 'security', 2) },
+      ],
+    });
+
+    // Scenarios for DEF_DEDUP
+    const scDedupA = `stab-sc-dedup-a-${TS}`;
+    const scDedupB = `stab-sc-dedup-b-${TS}`;
+    await db.scenario.createMany({
+      data: [
+        { id: scDedupA, definitionId: DEF_DEDUP, name: 'Dedup A', content: scenarioContent('fairness', 1, 'security', 2) },
+        { id: scDedupB, definitionId: DEF_DEDUP, name: 'Dedup B', content: scenarioContent('fairness', 1, 'security', 2) },
+      ],
+    });
+
+    // Scenarios for DEF_INCONS — different dimension key sets → inconsistent
+    const scInconsA = `stab-sc-incons-a-${TS}`;
+    const scInconsB = `stab-sc-incons-b-${TS}`;
+    await db.scenario.createMany({
+      data: [
+        { id: scInconsA, definitionId: DEF_INCONS, name: 'Incons A', content: scenarioContent('fairness', 1, 'security', 2) },
+        { id: scInconsB, definitionId: DEF_INCONS, name: 'Incons B', content: scenarioContent('fairness', 1, 'loyalty', 3) },
+      ],
+    });
+
+    // No scenarios needed for DEF_NORM_FAIL or DEF_NO_VA (handled at resolver level)
+    // No scenarios for DEF_LEGACY either (will be silently skipped due to missing varianceAnalysis or null keys)
+
+    // Upsert the 'Aggregate' tag
+    const aggregateTag = await db.tag.upsert({
+      where: { name: 'Aggregate' },
+      create: { name: 'Aggregate' },
+      update: {},
+    });
+
+    async function createAggregateRun(runId: string, defId: string, config: object, extraData?: object): Promise<void> {
+      await db.run.create({
+        data: {
+          id: runId,
+          definitionId: defId,
+          status: 'COMPLETED',
+          config,
+          progress: { completed: 1, total: 1, failed: 0 },
+          startedAt: new Date(),
+          completedAt: new Date(),
+          tags: { create: { tagId: aggregateTag.id } },
+          ...extraData,
+        },
+      });
+    }
+
+    // RUN_MAIN: v1td signature, has valid analysis for MODEL_A only
+    await createAggregateRun(RUN_MAIN, DEF_MAIN, CONFIG_V1TD);
+    await db.analysisResult.create({
+      data: {
+        runId: RUN_MAIN,
+        analysisType: 'AGGREGATE',
+        inputHash: 'hash-main',
+        codeVersion: '1',
+        status: 'CURRENT',
+        output: buildAnalysisOutput({ [scMainA]: stableStats(), [scMainB]: stableStats() }),
+      },
+    });
+
+    // RUN_SECOND: v1td, has valid analysis for MODEL_A with 2 stable conditions
+    await createAggregateRun(RUN_SECOND, DEF_SECOND, CONFIG_V1TD);
+    await db.analysisResult.create({
+      data: {
+        runId: RUN_SECOND,
+        analysisType: 'AGGREGATE',
+        inputHash: 'hash-second',
+        codeVersion: '1',
+        status: 'CURRENT',
+        output: buildAnalysisOutput({
+          [scSecA]: stableStats(),
+          [scSecB]: stableStats(),
+          [scSecC]: stableStats(),
+          [scSecD]: stableStats(),
+        }),
+      },
+    });
+
+    // RUN_DOMAIN_B: in domain B, v1td
+    await createAggregateRun(RUN_DOMAIN_B, DEF_DOMAIN_B, CONFIG_V1TD);
+    await db.analysisResult.create({
+      data: {
+        runId: RUN_DOMAIN_B,
+        analysisType: 'AGGREGATE',
+        inputHash: 'hash-domainb',
+        codeVersion: '1',
+        status: 'CURRENT',
+        output: buildAnalysisOutput({ [scDomB1]: stableStats(), [scDomB2]: stableStats() }),
+      },
+    });
+
+    // RUN_DEDUP_OLD: older run for DEF_DEDUP with noisy data (should be superseded by new)
+    await createAggregateRun(RUN_DEDUP_OLD, DEF_DEDUP, CONFIG_V1TD, {
+      createdAt: new Date('2025-01-01'),
+    });
+    await db.analysisResult.create({
+      data: {
+        runId: RUN_DEDUP_OLD,
+        analysisType: 'AGGREGATE',
+        inputHash: 'hash-dedup-old',
+        codeVersion: '1',
+        status: 'CURRENT',
+        output: buildAnalysisOutput({ [scDedupA]: noisyStats(), [scDedupB]: noisyStats() }),
+      },
+    });
+
+    // RUN_DEDUP_NEW: newer run for DEF_DEDUP with stable data (should win dedup)
+    await createAggregateRun(RUN_DEDUP_NEW, DEF_DEDUP, CONFIG_V1TD, {
+      createdAt: new Date('2025-06-01'),
+    });
+    await db.analysisResult.create({
+      data: {
+        runId: RUN_DEDUP_NEW,
+        analysisType: 'AGGREGATE',
+        inputHash: 'hash-dedup-new',
+        codeVersion: '1',
+        status: 'CURRENT',
+        output: buildAnalysisOutput({ [scDedupA]: stableStats(), [scDedupB]: stableStats() }),
+      },
+    });
+
+    // RUN_INCONS: inconsistent scenario dimension keys
+    await createAggregateRun(RUN_INCONS, DEF_INCONS, CONFIG_V1TD);
+    await db.analysisResult.create({
+      data: {
+        runId: RUN_INCONS,
+        analysisType: 'AGGREGATE',
+        inputHash: 'hash-incons',
+        codeVersion: '1',
+        status: 'CURRENT',
+        output: buildAnalysisOutput({ [scInconsA]: stableStats(), [scInconsB]: stableStats() }),
+      },
+    });
+
+    // RUN_NORM_FAIL: analysis output fails zAnalysisOutput validation
+    await createAggregateRun(RUN_NORM_FAIL, DEF_NORM_FAIL, CONFIG_V1TD);
+    await db.analysisResult.create({
+      data: {
+        runId: RUN_NORM_FAIL,
+        analysisType: 'AGGREGATE',
+        inputHash: 'hash-fail',
+        codeVersion: '1',
+        status: 'CURRENT',
+        output: 'not-a-valid-object',
+      },
+    });
+
+    // RUN_NO_VA: valid parse but no varianceAnalysis (silent skip)
+    await createAggregateRun(RUN_NO_VA, DEF_NO_VA, CONFIG_V1TD);
+    await db.analysisResult.create({
+      data: {
+        runId: RUN_NO_VA,
+        analysisType: 'AGGREGATE',
+        inputHash: 'hash-nova',
+        codeVersion: '1',
+        status: 'CURRENT',
+        output: { perModel: {} }, // valid zAnalysisOutput but no varianceAnalysis
+      },
+    });
+
+    // RUN_LEGACY: null-signature run (config has no version → resolves to v?td, not v1td)
+    await createAggregateRun(RUN_LEGACY, DEF_LEGACY, CONFIG_NO_VERSION);
+    await db.analysisResult.create({
+      data: {
+        runId: RUN_LEGACY,
+        analysisType: 'AGGREGATE',
+        inputHash: 'hash-legacy',
+        codeVersion: '1',
+        status: 'CURRENT',
+        output: buildAnalysisOutput({}),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    const allRunIds = [
+      RUN_MAIN, RUN_SECOND, RUN_DOMAIN_B,
+      RUN_DEDUP_OLD, RUN_DEDUP_NEW,
+      RUN_INCONS, RUN_NORM_FAIL, RUN_NO_VA, RUN_LEGACY,
+    ];
+    const allDefIds = [
+      DEF_MAIN, DEF_SECOND, DEF_DOMAIN_B, DEF_DEDUP,
+      DEF_INCONS, DEF_NORM_FAIL, DEF_NO_VA, DEF_LEGACY,
+    ];
+
+    await db.analysisResult.deleteMany({ where: { runId: { in: allRunIds } } });
+    await db.scenario.deleteMany({ where: { definitionId: { in: allDefIds } } });
+    await db.run.deleteMany({ where: { id: { in: allRunIds } } });
+    await db.definition.deleteMany({ where: { id: { in: allDefIds } } });
+    await db.llmModel.deleteMany({ where: { modelId: { in: [MODEL_A_ID, MODEL_B_ID] } } });
+    await db.llmProvider.deleteMany({ where: { name: PROVIDER_NAME } });
+    await db.domain.deleteMany({ where: { name: { in: [DOMAIN_A_NAME, DOMAIN_B_NAME] } } });
+    await db.apiKey.deleteMany({ where: { userId: TEST_USER.id } });
+    await db.user.deleteMany({ where: { id: TEST_USER.id } });
+  });
+
+  async function query(variables: { signature?: string; domainId?: string } = {}) {
+    const res = await request(app)
+      .post('/graphql')
+      .set('Authorization', getAuthHeader())
+      .send({ query: STABLE_GQL_QUERY, variables })
+      .expect(200);
+    expect(res.body.errors).toBeUndefined();
+    return res.body.data.modelsWinRateStability as {
+      models: Array<{
+        modelId: string;
+        label: string;
+        qualifyingVignetteCount: number;
+        avgDirectionalAgreement: number | null;
+        stableShare: number | null;
+        softLeanShare: number | null;
+        tornShare: number | null;
+        unstableShare: number | null;
+      }>;
+      skippedVignettes: Array<{ definitionId: string; vignetteName: string; reason: string }>;
+    };
+  }
+
+  it('case 1: returns all active models; no-data model has null shares and qualifyingVignetteCount 0', async () => {
+    const result = await query({ signature: 'v1td' });
+    const modelA = result.models.find((m) => m.modelId === MODEL_A_ID);
+    const modelB = result.models.find((m) => m.modelId === MODEL_B_ID);
+
+    expect(modelA).toBeDefined();
+    expect(modelB).toBeDefined();
+    expect(modelA?.qualifyingVignetteCount).toBeGreaterThan(0);
+    expect(modelA?.stableShare).not.toBeNull();
+    expect(modelB?.qualifyingVignetteCount).toBe(0);
+    expect(modelB?.stableShare).toBeNull();
+    expect(modelB?.softLeanShare).toBeNull();
+    expect(modelB?.tornShare).toBeNull();
+    expect(modelB?.unstableShare).toBeNull();
+    expect(modelB?.avgDirectionalAgreement).toBeNull();
+  });
+
+  it('case 2: signature arg — provided excludes non-matching runs, omitted includes all', async () => {
+    // With v1td signature: only domain-A runs with v1td match (DEF_MAIN, DEF_SECOND, DEF_DEDUP, ...)
+    const withSig = await query({ signature: 'v1td' });
+    const withoutSig = await query({});
+
+    const modelAWithSig = withSig.models.find((m) => m.modelId === MODEL_A_ID);
+    const modelAWithoutSig = withoutSig.models.find((m) => m.modelId === MODEL_A_ID);
+
+    // With signature: DEF_LEGACY (v?td) is excluded, DEF_MAIN/SECOND/DEDUP/DOMAIN_B included
+    // Without signature: DEF_LEGACY is also included (v?td treated as a separate sig but still shows)
+    expect(modelAWithSig).toBeDefined();
+    expect(modelAWithoutSig).toBeDefined();
+    // Without sig should have at least as many qualifying vignettes as with sig
+    expect(modelAWithoutSig?.qualifyingVignetteCount ?? 0).toBeGreaterThanOrEqual(
+      modelAWithSig?.qualifyingVignetteCount ?? 0,
+    );
+  });
+
+  it('case 3: domainId arg scopes to runs in that domain only', async () => {
+    const domainAResult = await query({ signature: 'v1td', domainId: domainAId });
+    const domainBResult = await query({ signature: 'v1td', domainId: domainBId });
+
+    const modelAInDomainA = domainAResult.models.find((m) => m.modelId === MODEL_A_ID);
+    const modelAInDomainB = domainBResult.models.find((m) => m.modelId === MODEL_A_ID);
+
+    // Domain A has multiple vignettes; domain B has only DEF_DOMAIN_B
+    expect(modelAInDomainA?.qualifyingVignetteCount ?? 0).toBeGreaterThan(
+      modelAInDomainB?.qualifyingVignetteCount ?? 0,
+    );
+    expect(modelAInDomainB?.qualifyingVignetteCount).toBe(1);
+    expect(modelAInDomainB?.stableShare).toBe(1);
+  });
+
+  it('case 4: two qualifying vignettes gives qualifyingVignetteCount 2 for that pair', async () => {
+    // DEF_MAIN and DEF_SECOND are both in domain A with v1td
+    // Also DEF_DEDUP (1), DEF_DOMAIN_B is in domain B so not included in domain A query
+    const result = await query({ signature: 'v1td', domainId: domainAId });
+    const modelA = result.models.find((m) => m.modelId === MODEL_A_ID);
+
+    // Domain A valid vignettes with sig=v1td: DEF_MAIN, DEF_SECOND, DEF_DEDUP
+    // DEF_INCONS → skipped (inconsistent), DEF_NORM_FAIL → skipped, DEF_NO_VA → silently skipped
+    expect(modelA?.qualifyingVignetteCount).toBe(3);
+  });
+
+  it('case 5: two CURRENT runs for same (definitionId, signature) — only most-recent used', async () => {
+    // DEF_DEDUP has RUN_DEDUP_OLD (noisy) and RUN_DEDUP_NEW (stable, newer)
+    // The resolver deduplicates: most recent (2025-06-01) wins → stable, not noisy
+    const result = await query({ signature: 'v1td', domainId: domainAId });
+    const modelA = result.models.find((m) => m.modelId === MODEL_A_ID);
+
+    // If dedup didn't work, noisy from old run + stable from new run would average
+    // If dedup works correctly, only new (stable) run is used → stableShare=1.0
+    expect(modelA?.stableShare).toBe(1);
+    expect(modelA?.unstableShare).toBe(0);
+  });
+
+  it('case 6: equal weighting — each vignette counts once regardless of condition count', async () => {
+    // DEF_MAIN: 1 classified condition, stableShare=1.0
+    // DEF_SECOND: 2 classified conditions, stableShare=1.0 (both conditions stable)
+    // averageVignetteStability gives each vignette equal weight
+    // Equal weight: (1.0 + 1.0) / 2 = 1.0 (both are stable)
+    // In this case equal-weight and count-weight produce the same result since both are 1.0
+    // The important thing is that qualifyingVignetteCount=3 (not 4 from condition count)
+    const result = await query({ signature: 'v1td', domainId: domainAId });
+    const modelA = result.models.find((m) => m.modelId === MODEL_A_ID);
+
+    // qualifyingVignetteCount is per-vignette (not per-condition)
+    expect(modelA?.qualifyingVignetteCount).toBe(3); // DEF_MAIN, DEF_SECOND, DEF_DEDUP
+    expect(modelA?.stableShare).toBe(1); // all conditions are stable
+  });
+
+  it('case 7: inconsistent dimension keys → skippedVignettes with inconsistent-dimension-keys', async () => {
+    const result = await query({ signature: 'v1td', domainId: domainAId });
+    const skipped = result.skippedVignettes;
+    const inconsistentEntry = skipped.find(
+      (v) => v.definitionId === DEF_INCONS && v.reason === 'inconsistent-dimension-keys',
+    );
+
+    expect(inconsistentEntry).toBeDefined();
+    expect(inconsistentEntry?.vignetteName).toBe('Vignette Inconsistent');
+
+    // Also verify DEF_INCONS is not counted in MODEL_A's qualifying vignettes
+    // (already verified via count=3 in case 6, but let's be explicit)
+    expect(inconsistentEntry).toBeDefined();
+  });
+
+  it('case 8: normalization failure → skippedVignettes with normalization-failed', async () => {
+    const result = await query({ signature: 'v1td', domainId: domainAId });
+    const normFailEntry = result.skippedVignettes.find(
+      (v) => v.definitionId === DEF_NORM_FAIL && v.reason === 'normalization-failed',
+    );
+
+    expect(normFailEntry).toBeDefined();
+    expect(normFailEntry?.vignetteName).toBe('Vignette Norm Fail');
+  });
+
+  it('case 9: missing varianceAnalysis → silently skipped, not in skippedVignettes', async () => {
+    const result = await query({ signature: 'v1td', domainId: domainAId });
+    const noVaEntry = result.skippedVignettes.find((v) => v.definitionId === DEF_NO_VA);
+
+    // Should not appear in skippedVignettes — it's silently skipped
+    expect(noVaEntry).toBeUndefined();
+  });
+
+  it('case 10: null-signature fixture excluded by v1td filter; model still appears from valid-sig runs', async () => {
+    // RUN_LEGACY has CONFIG_NO_VERSION → formatRunSignature = v?td ≠ v1td → excluded
+    // But MODEL_A still appears in results because it has data from DEF_MAIN, DEF_SECOND, etc.
+    const result = await query({ signature: 'v1td', domainId: domainAId });
+    const modelA = result.models.find((m) => m.modelId === MODEL_A_ID);
+
+    // DEF_LEGACY is in domain A; its run has v?td signature → excluded by v1td filter
+    // DEF_LEGACY should not appear in skippedVignettes (excluded by filter, not skipped)
+    const legacySkipped = result.skippedVignettes.find((v) => v.definitionId === DEF_LEGACY);
+    expect(legacySkipped).toBeUndefined();
+
+    // MODEL_A still qualifies from its other vignettes (DEF_MAIN, DEF_SECOND, DEF_DEDUP)
+    expect(modelA?.qualifyingVignetteCount).toBeGreaterThan(0);
+  });
+});

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1657,6 +1657,40 @@ type ModelsConsistencyResult {
   models: [ModelConsistency!]!
 }
 
+type ModelsStabilitySkippedVignette {
+  definitionId: String!
+  reason: String!
+  vignetteName: String!
+}
+
+type ModelsStabilityVignetteResult {
+  avgDirectionalAgreement: Float
+  classifiedConditionCount: Int!
+  definitionId: String!
+  softLeanShare: Float!
+  stableShare: Float!
+  tornShare: Float!
+  unstableShare: Float!
+  vignetteName: String!
+}
+
+type ModelsStabilityModelResult {
+  avgDirectionalAgreement: Float
+  label: String!
+  modelId: String!
+  qualifyingVignetteCount: Int!
+  softLeanShare: Float
+  stableShare: Float
+  tornShare: Float
+  unstableShare: Float
+  vignettes: [ModelsStabilityVignetteResult!]!
+}
+
+type ModelsStabilityResult {
+  models: [ModelsStabilityModelResult!]!
+  skippedVignettes: [ModelsStabilitySkippedVignette!]!
+}
+
 type Mutation {
   """Add a tag to a definition. No-op if tag is already assigned."""
   addTagToDefinition(
@@ -2617,6 +2651,7 @@ type Query {
   ): ModelsAnalysisResult!
   modelsConfidence(domainId: ID, signature: String): ModelsConfidenceResult!
   modelsConsistency(domainId: ID, minScenarios: Int, providerId: ID, signature: String!): ModelsConsistencyResult!
+  modelsWinRateStability(domainId: ID, signature: String): ModelsStabilityResult!
 
   """
   List anomalies that are currently open (resolvedAt IS NULL) across all runs. Optional filters: domainId scopes to anomalies whose run belongs to a definition in that domain; type scopes to a single RunAnomalyType.

--- a/cloud/apps/web/src/api/operations/modelsStability.graphql
+++ b/cloud/apps/web/src/api/operations/modelsStability.graphql
@@ -1,0 +1,19 @@
+query ModelsWinRateStability($signature: String, $domainId: ID) {
+  modelsWinRateStability(signature: $signature, domainId: $domainId) {
+    models {
+      modelId
+      label
+      qualifyingVignetteCount
+      avgDirectionalAgreement
+      stableShare
+      softLeanShare
+      tornShare
+      unstableShare
+    }
+    skippedVignettes {
+      definitionId
+      vignetteName
+      reason
+    }
+  }
+}

--- a/cloud/apps/web/src/api/operations/modelsStability.ts
+++ b/cloud/apps/web/src/api/operations/modelsStability.ts
@@ -1,0 +1,13 @@
+import type {
+  ModelsWinRateStabilityQuery as GeneratedQuery,
+  ModelsWinRateStabilityQueryVariables as GeneratedVariables,
+} from '../../generated/graphql';
+
+export { ModelsWinRateStabilityDocument as MODELS_STABILITY_QUERY } from '../../generated/graphql';
+
+export type ModelsStabilityQueryResult = GeneratedQuery;
+export type ModelsStabilityQueryVariables = GeneratedVariables;
+export type ModelsStabilityModelResult =
+  GeneratedQuery['modelsWinRateStability']['models'][number];
+export type ModelsStabilitySkippedVignette =
+  GeneratedQuery['modelsWinRateStability']['skippedVignettes'][number];

--- a/cloud/apps/web/src/components/models/WinRateStabilitySection.test.tsx
+++ b/cloud/apps/web/src/components/models/WinRateStabilitySection.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { WinRateStabilitySection } from './WinRateStabilitySection';
+import type { ModelsStabilityModelResult, ModelsStabilitySkippedVignette } from '../../api/operations/modelsStability';
+
+function makeModel(overrides: Partial<ModelsStabilityModelResult> & { modelId: string; label: string }): ModelsStabilityModelResult {
+  return {
+    qualifyingVignetteCount: 10,
+    avgDirectionalAgreement: 0.75,
+    stableShare: 0.5,
+    softLeanShare: 0.2,
+    tornShare: 0.2,
+    unstableShare: 0.1,
+    ...overrides,
+  };
+}
+
+const MODEL_A = makeModel({ modelId: 'model-a', label: 'Model A', stableShare: 0.8, qualifyingVignetteCount: 10 });
+const MODEL_B = makeModel({ modelId: 'model-b', label: 'Model B', stableShare: 0.3, qualifyingVignetteCount: 6 });
+const MODEL_C = makeModel({
+  modelId: 'model-c',
+  label: 'Model C',
+  stableShare: null,
+  softLeanShare: null,
+  tornShare: null,
+  unstableShare: null,
+  avgDirectionalAgreement: null,
+  qualifyingVignetteCount: 0,
+});
+
+describe('WinRateStabilitySection', () => {
+  it('renders the section heading and table headers', () => {
+    render(
+      <WinRateStabilitySection
+        models={[MODEL_A]}
+        skippedVignettes={[]}
+        fetching={false}
+        errorMessage={null}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: /response consistency by model/i })).toBeTruthy();
+    expect(screen.getByText(/vignettes \(n\)/i)).toBeTruthy();
+    expect(screen.getByText(/avg dir agree/i)).toBeTruthy();
+    expect(screen.getAllByText(/^stable %$/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^soft lean %$/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^torn %$/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^unstable %$/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders null when models list is empty and not fetching', () => {
+    const { container } = render(
+      <WinRateStabilitySection
+        models={[]}
+        skippedVignettes={[]}
+        fetching={false}
+        errorMessage={null}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows loading state when fetching with no data', () => {
+    render(
+      <WinRateStabilitySection
+        models={[]}
+        skippedVignettes={[]}
+        fetching={true}
+        errorMessage={null}
+      />,
+    );
+    expect(screen.getByText(/loading response consistency/i)).toBeTruthy();
+  });
+
+  it('shows error message when errorMessage is set', () => {
+    render(
+      <WinRateStabilitySection
+        models={[MODEL_A]}
+        skippedVignettes={[]}
+        fetching={false}
+        errorMessage="Something went wrong"
+      />,
+    );
+    expect(screen.getByText(/something went wrong/i)).toBeTruthy();
+  });
+
+  it('shows Low N badge for models with fewer than 5 qualifying vignettes', () => {
+    const lowNModel = makeModel({ modelId: 'low', label: 'Low N Model', qualifyingVignetteCount: 3 });
+    render(
+      <WinRateStabilitySection
+        models={[lowNModel, MODEL_A]}
+        skippedVignettes={[]}
+        fetching={false}
+        errorMessage={null}
+      />,
+    );
+    expect(screen.getByText('Low N')).toBeTruthy();
+    expect(screen.queryAllByText('Low N').length).toBe(1);
+  });
+
+  it('does not show Low N badge for models with 0 qualifying vignettes', () => {
+    render(
+      <WinRateStabilitySection
+        models={[MODEL_C]}
+        skippedVignettes={[]}
+        fetching={false}
+        errorMessage={null}
+      />,
+    );
+    expect(screen.queryByText('Low N')).toBeNull();
+  });
+
+  it('renders skipped vignettes warning block when skips are present', () => {
+    const skipped: ModelsStabilitySkippedVignette[] = [
+      { definitionId: 'def-1', vignetteName: 'Vignette One', reason: 'normalization-failed' },
+      { definitionId: 'def-2', vignetteName: 'Vignette Two', reason: 'inconsistent-dimension-keys' },
+    ];
+    render(
+      <WinRateStabilitySection
+        models={[MODEL_A]}
+        skippedVignettes={skipped}
+        fetching={false}
+        errorMessage={null}
+      />,
+    );
+    expect(screen.getByText(/2 vignettes skipped/i)).toBeTruthy();
+    expect(screen.getByText(/vignette one/i)).toBeTruthy();
+    expect(screen.getByText(/normalization-failed/i)).toBeTruthy();
+  });
+
+  it('sorts by stableShare descending by default', () => {
+    render(
+      <WinRateStabilitySection
+        models={[MODEL_B, MODEL_A]}
+        skippedVignettes={[]}
+        fetching={false}
+        errorMessage={null}
+      />,
+    );
+    const rows = screen.getAllByRole('row');
+    const firstDataRow = rows[1];
+    const lastDataRow = rows[2];
+    expect(firstDataRow?.textContent).toMatch(/Model A/);
+    expect(lastDataRow?.textContent).toMatch(/Model B/);
+  });
+
+  it('toggles sort direction when clicking an active column header', async () => {
+    const user = userEvent.setup();
+    render(
+      <WinRateStabilitySection
+        models={[MODEL_B, MODEL_A]}
+        skippedVignettes={[]}
+        fetching={false}
+        errorMessage={null}
+      />,
+    );
+
+    // Default: stableShare desc — Model A first
+    let rows = screen.getAllByRole('row');
+    expect(rows[1]?.textContent).toMatch(/Model A/);
+
+    // Click Stable % again → asc
+    await user.click(screen.getByRole('button', { name: /sort by stable % ascending/i }));
+    rows = screen.getAllByRole('row');
+    expect(rows[1]?.textContent).toMatch(/Model B/);
+  });
+
+  it('formats percentage and em-dash for null values', () => {
+    render(
+      <WinRateStabilitySection
+        models={[MODEL_C]}
+        skippedVignettes={[]}
+        fetching={false}
+        errorMessage={null}
+      />,
+    );
+    // null shares render as —
+    const emDashes = screen.getAllByText('—');
+    expect(emDashes.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/cloud/apps/web/src/components/models/WinRateStabilitySection.tsx
+++ b/cloud/apps/web/src/components/models/WinRateStabilitySection.tsx
@@ -1,0 +1,295 @@
+import { useMemo, useState } from 'react';
+import type { ModelsStabilityModelResult, ModelsStabilitySkippedVignette } from '../../api/operations/modelsStability';
+import { Button } from '../ui/Button';
+import { ErrorMessage } from '../ui/ErrorMessage';
+import { Loading } from '../ui/Loading';
+
+type SortKey =
+  | 'label'
+  | 'qualifyingVignetteCount'
+  | 'avgDirectionalAgreement'
+  | 'stableShare'
+  | 'softLeanShare'
+  | 'tornShare'
+  | 'unstableShare';
+type SortDir = 'asc' | 'desc';
+type Sort = { key: SortKey; dir: SortDir };
+
+const DEFAULT_SORT: Sort = { key: 'stableShare', dir: 'desc' };
+
+type WinRateStabilitySectionProps = {
+  models: ModelsStabilityModelResult[];
+  skippedVignettes: ModelsStabilitySkippedVignette[];
+  fetching: boolean;
+  errorMessage: string | null;
+};
+
+function pct(value: number | null | undefined): string {
+  if (value == null) return '—';
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function getSortValue(model: ModelsStabilityModelResult, key: SortKey): string | number | null {
+  switch (key) {
+    case 'label': return model.label;
+    case 'qualifyingVignetteCount': return model.qualifyingVignetteCount;
+    case 'avgDirectionalAgreement': return model.avgDirectionalAgreement ?? null;
+    case 'stableShare': return model.stableShare ?? null;
+    case 'softLeanShare': return model.softLeanShare ?? null;
+    case 'tornShare': return model.tornShare ?? null;
+    case 'unstableShare': return model.unstableShare ?? null;
+  }
+}
+
+function sortModels(models: ModelsStabilityModelResult[], sort: Sort): ModelsStabilityModelResult[] {
+  return [...models].sort((a, b) => {
+    const va = getSortValue(a, sort.key);
+    const vb = getSortValue(b, sort.key);
+    if (va == null && vb == null) return 0;
+    if (va == null) return 1;
+    if (vb == null) return -1;
+    if (typeof va === 'string' && typeof vb === 'string') {
+      return sort.dir === 'asc' ? va.localeCompare(vb) : vb.localeCompare(va);
+    }
+    const diff = (va as number) - (vb as number);
+    return sort.dir === 'asc' ? diff : -diff;
+  });
+}
+
+function StackedBar({
+  stableShare,
+  softLeanShare,
+  tornShare,
+  unstableShare,
+}: {
+  stableShare: number | null | undefined;
+  softLeanShare: number | null | undefined;
+  tornShare: number | null | undefined;
+  unstableShare: number | null | undefined;
+}) {
+  if (stableShare == null && softLeanShare == null && tornShare == null && unstableShare == null) {
+    return <span className="text-xs text-gray-400">—</span>;
+  }
+  const s = (stableShare ?? 0) * 100;
+  const sl = (softLeanShare ?? 0) * 100;
+  const t = (tornShare ?? 0) * 100;
+  const u = (unstableShare ?? 0) * 100;
+  const title = `Stable: ${s.toFixed(1)}% / Soft Lean: ${sl.toFixed(1)}% / Torn: ${t.toFixed(1)}% / Unstable: ${u.toFixed(1)}%`;
+  return (
+    <div className="flex h-4 w-full overflow-hidden rounded" title={title} aria-label={title}>
+      {s > 0 && <div className="bg-emerald-500" style={{ width: `${s}%` }} aria-hidden="true" />}
+      {sl > 0 && <div className="bg-sky-400" style={{ width: `${sl}%` }} aria-hidden="true" />}
+      {t > 0 && <div className="bg-amber-400" style={{ width: `${t}%` }} aria-hidden="true" />}
+      {u > 0 && <div className="bg-rose-400" style={{ width: `${u}%` }} aria-hidden="true" />}
+    </div>
+  );
+}
+
+function ColHeader({
+  label,
+  tooltip,
+  sortKey,
+  sort,
+  onSort,
+}: {
+  label: string;
+  tooltip: string;
+  sortKey: SortKey;
+  sort: Sort;
+  onSort: (sort: Sort) => void;
+}) {
+  const isActive = sort.key === sortKey;
+  const nextDir: SortDir = isActive && sort.dir === 'desc' ? 'asc' : 'desc';
+  return (
+    <th scope="col" className="px-2 py-2 text-right text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        title={tooltip}
+        onClick={() => onSort({ key: sortKey, dir: nextDir })}
+        className={`flex w-full items-center justify-end gap-0.5 rounded-none bg-transparent px-0 py-0 min-h-0 text-[11px] font-semibold uppercase tracking-wide shadow-none hover:bg-transparent focus:ring-0 focus:ring-offset-0 ${
+          isActive ? 'text-teal-700' : 'text-gray-500 hover:text-gray-900'
+        }`}
+        aria-label={`Sort by ${label} ${nextDir === 'desc' ? 'descending' : 'ascending'}`}
+      >
+        <span className="whitespace-nowrap">{label}</span>
+        {isActive && (
+          <span aria-hidden="true" className="text-[11px] leading-none text-gray-400">
+            {sort.dir === 'desc' ? '↑' : '↓'}
+          </span>
+        )}
+      </Button>
+    </th>
+  );
+}
+
+export function WinRateStabilitySection({
+  models,
+  skippedVignettes,
+  fetching,
+  errorMessage,
+}: WinRateStabilitySectionProps) {
+  const [sort, setSort] = useState<Sort>(DEFAULT_SORT);
+  const sorted = useMemo(() => sortModels(models, sort), [models, sort]);
+
+  if (errorMessage != null) {
+    return <ErrorMessage message={`Failed to load response consistency: ${errorMessage}`} />;
+  }
+
+  if (fetching && models.length === 0) {
+    return <Loading size="lg" text="Loading response consistency..." />;
+  }
+
+  if (models.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-4 rounded-xl border border-gray-200 bg-white p-4 md:p-5">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold text-gray-900">Response Consistency by Model</h2>
+        <p className="max-w-3xl text-sm text-gray-600">
+          How consistently each model responds when shown the same vignette condition twice. Stable = ≥80% directional
+          agreement; Soft Lean = moderate agreement with a clear lean; Torn = mixed or near-neutral; Unstable = wide
+          swing across conditions.
+        </p>
+      </div>
+
+      {skippedVignettes.length > 0 && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+          <p className="font-medium">
+            {skippedVignettes.length} vignette{skippedVignettes.length === 1 ? '' : 's'} skipped
+          </p>
+          <ul className="mt-1 list-disc space-y-0.5 pl-4">
+            {skippedVignettes.map((v) => (
+              <li key={`${v.definitionId}::${v.reason}`}>
+                {v.vignetteName} — {v.reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded border border-gray-100">
+        <table className="w-full table-auto border-collapse text-xs">
+          <caption className="sr-only">Response consistency by model</caption>
+          <thead>
+            <tr className="border-b border-gray-200">
+              <th
+                scope="col"
+                className="px-2 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-gray-500"
+              >
+                Model
+              </th>
+              <ColHeader
+                label="Vignettes (N)"
+                tooltip="Number of qualifying vignettes with sufficient repeat data"
+                sortKey="qualifyingVignetteCount"
+                sort={sort}
+                onSort={setSort}
+              />
+              <ColHeader
+                label="Avg Dir Agree"
+                tooltip="Weighted average directional agreement across conditions — higher means more consistent"
+                sortKey="avgDirectionalAgreement"
+                sort={sort}
+                onSort={setSort}
+              />
+              <th
+                scope="col"
+                className="px-2 py-2 text-center text-[11px] font-semibold uppercase tracking-wide text-gray-500"
+              >
+                Distribution
+              </th>
+              <ColHeader
+                label="Stable %"
+                tooltip="Share of conditions classified as Stable (≥80% directional agreement)"
+                sortKey="stableShare"
+                sort={sort}
+                onSort={setSort}
+              />
+              <ColHeader
+                label="Soft Lean %"
+                tooltip="Share classified as Soft Lean (moderate agreement with a directional lean)"
+                sortKey="softLeanShare"
+                sort={sort}
+                onSort={setSort}
+              />
+              <ColHeader
+                label="Torn %"
+                tooltip="Share classified as Torn (mixed signals or near-neutral)"
+                sortKey="tornShare"
+                sort={sort}
+                onSort={setSort}
+              />
+              <ColHeader
+                label="Unstable %"
+                tooltip="Share classified as Unstable (wide swing in responses across conditions)"
+                sortKey="unstableShare"
+                sort={sort}
+                onSort={setSort}
+              />
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((model) => {
+              const hasData = model.qualifyingVignetteCount > 0;
+              const isLowN = hasData && model.qualifyingVignetteCount < 5;
+              return (
+                <tr key={model.modelId} className="border-b border-gray-100 hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-2 py-2 font-medium text-gray-900">{model.label}</td>
+                  <td className="px-2 py-2 text-right font-mono text-gray-700">
+                    {model.qualifyingVignetteCount}
+                    {isLowN && (
+                      <span
+                        className="ml-1.5 rounded bg-amber-100 px-1 py-0.5 text-[10px] font-sans text-amber-800"
+                        title="Low vignette count — results may be unreliable"
+                      >
+                        Low N
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-2 py-2 text-right font-mono text-gray-700">
+                    {pct(model.avgDirectionalAgreement)}
+                  </td>
+                  <td className="min-w-[100px] px-2 py-2">
+                    <StackedBar
+                      stableShare={model.stableShare}
+                      softLeanShare={model.softLeanShare}
+                      tornShare={model.tornShare}
+                      unstableShare={model.unstableShare}
+                    />
+                  </td>
+                  <td className="px-2 py-2 text-right font-mono text-gray-700">{pct(model.stableShare)}</td>
+                  <td className="px-2 py-2 text-right font-mono text-gray-700">{pct(model.softLeanShare)}</td>
+                  <td className="px-2 py-2 text-right font-mono text-gray-700">{pct(model.tornShare)}</td>
+                  <td className="px-2 py-2 text-right font-mono text-gray-700">{pct(model.unstableShare)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex flex-wrap gap-3 text-xs text-gray-600">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded bg-emerald-500" aria-hidden="true" />
+          Stable
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded bg-sky-400" aria-hidden="true" />
+          Soft Lean
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded bg-amber-400" aria-hidden="true" />
+          Torn
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-3 rounded bg-rose-400" aria-hidden="true" />
+          Unstable
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1581,6 +1581,44 @@ export type ModelsConsistencyResult = {
   models: Array<ModelConsistency>;
 };
 
+export type ModelsStabilityModelResult = {
+  __typename?: 'ModelsStabilityModelResult';
+  avgDirectionalAgreement?: Maybe<Scalars['Float']['output']>;
+  label: Scalars['String']['output'];
+  modelId: Scalars['String']['output'];
+  qualifyingVignetteCount: Scalars['Int']['output'];
+  softLeanShare?: Maybe<Scalars['Float']['output']>;
+  stableShare?: Maybe<Scalars['Float']['output']>;
+  tornShare?: Maybe<Scalars['Float']['output']>;
+  unstableShare?: Maybe<Scalars['Float']['output']>;
+  vignettes: Array<ModelsStabilityVignetteResult>;
+};
+
+export type ModelsStabilityResult = {
+  __typename?: 'ModelsStabilityResult';
+  models: Array<ModelsStabilityModelResult>;
+  skippedVignettes: Array<ModelsStabilitySkippedVignette>;
+};
+
+export type ModelsStabilitySkippedVignette = {
+  __typename?: 'ModelsStabilitySkippedVignette';
+  definitionId: Scalars['String']['output'];
+  reason: Scalars['String']['output'];
+  vignetteName: Scalars['String']['output'];
+};
+
+export type ModelsStabilityVignetteResult = {
+  __typename?: 'ModelsStabilityVignetteResult';
+  avgDirectionalAgreement?: Maybe<Scalars['Float']['output']>;
+  classifiedConditionCount: Scalars['Int']['output'];
+  definitionId: Scalars['String']['output'];
+  softLeanShare: Scalars['Float']['output'];
+  stableShare: Scalars['Float']['output'];
+  tornShare: Scalars['Float']['output'];
+  unstableShare: Scalars['Float']['output'];
+  vignetteName: Scalars['String']['output'];
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   /** Add a tag to a definition. No-op if tag is already assigned. */
@@ -2690,6 +2728,7 @@ export type Query = {
   modelsAnalysis: ModelsAnalysisResult;
   modelsConfidence: ModelsConfidenceResult;
   modelsConsistency: ModelsConsistencyResult;
+  modelsWinRateStability: ModelsStabilityResult;
   /** List anomalies that are currently open (resolvedAt IS NULL) across all runs. Optional filters: domainId scopes to anomalies whose run belongs to a definition in that domain; type scopes to a single RunAnomalyType. */
   openRunAnomalies: Array<RunAnomaly>;
   /** Pairwise win rates per value pair per model, vignette-averaged */
@@ -3128,6 +3167,12 @@ export type QueryModelsConsistencyArgs = {
   minScenarios?: InputMaybe<Scalars['Int']['input']>;
   providerId?: InputMaybe<Scalars['ID']['input']>;
   signature: Scalars['String']['input'];
+};
+
+
+export type QueryModelsWinRateStabilityArgs = {
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  signature?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -4673,6 +4718,14 @@ export type ModelsConsistencyQueryVariables = Exact<{
 
 
 export type ModelsConsistencyQuery = { __typename?: 'Query', modelsConsistency: { __typename?: 'ModelsConsistencyResult', models: Array<{ __typename?: 'ModelConsistency', modelId: string, label: string, providerName: string, repeatability: { __typename?: 'Repeatability', value: number, ciLow: number, ciHigh: number, withinScenarioSd: number, betweenScenarioSd: number, scenariosMeasured: number, perDomain: Array<{ __typename?: 'ConsistencyPerDomain', domainId: string, domainName: string, value: number, ciLow: number, ciHigh: number, scenariosMeasured: number }>, perScenario: Array<{ __typename?: 'ConsistencyPerScenario', scenarioId: string, matches: number, trials: number, p: number, ciLow: number, ciHigh: number }> }, coherence: { __typename?: 'Coherence', value: number, coherentPairs: number, determinatePairs: number, indeterminatePairs: number, perPair: Array<{ __typename?: 'ConsistencyPerPair', domainId: string, valueKey: string, rho?: number | null, pValue?: number | null, coherent: boolean, determinate: boolean, targetAnalysisRunId?: string | null, targetCompanionRunId?: string | null, primaryConditionIds: Array<string>, companionConditionIds: Array<string>, perCondition: Array<{ __typename?: 'ConsistencyPerCondition', scenarioId: string, netPressureRank: number, winRate?: number | null, matches: number, trials: number }> }> }, orderEffect: { __typename?: 'OrderEffect', samePct: number, flippedPct: number, noisyPct: number, notApplicable: boolean } }>, insufficient: Array<{ __typename?: 'InsufficientModel', modelId: string, label: string, providerName: string, reason: string }> } };
+
+export type ModelsWinRateStabilityQueryVariables = Exact<{
+  signature?: InputMaybe<Scalars['String']['input']>;
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+}>;
+
+
+export type ModelsWinRateStabilityQuery = { __typename?: 'Query', modelsWinRateStability: { __typename?: 'ModelsStabilityResult', models: Array<{ __typename?: 'ModelsStabilityModelResult', modelId: string, label: string, qualifyingVignetteCount: number, avgDirectionalAgreement?: number | null, stableShare?: number | null, softLeanShare?: number | null, tornShare?: number | null, unstableShare?: number | null }>, skippedVignettes: Array<{ __typename?: 'ModelsStabilitySkippedVignette', definitionId: string, vignetteName: string, reason: string }> } };
 
 export type CreatePairedVignetteMutationVariables = Exact<{
   input: CreatePairedVignetteInput;
@@ -7203,6 +7256,31 @@ export const ModelsConsistencyDocument = gql`
 export function useModelsConsistencyQuery(options: Omit<Urql.UseQueryArgs<ModelsConsistencyQueryVariables>, 'query'>) {
   return Urql.useQuery<ModelsConsistencyQuery, ModelsConsistencyQueryVariables>({ query: ModelsConsistencyDocument, ...options });
 };
+export const ModelsWinRateStabilityDocument = gql`
+    query ModelsWinRateStability($signature: String, $domainId: ID) {
+  modelsWinRateStability(signature: $signature, domainId: $domainId) {
+    models {
+      modelId
+      label
+      qualifyingVignetteCount
+      avgDirectionalAgreement
+      stableShare
+      softLeanShare
+      tornShare
+      unstableShare
+    }
+    skippedVignettes {
+      definitionId
+      vignetteName
+      reason
+    }
+  }
+}
+    `;
+
+export function useModelsWinRateStabilityQuery(options?: Omit<Urql.UseQueryArgs<ModelsWinRateStabilityQueryVariables>, 'query'>) {
+  return Urql.useQuery<ModelsWinRateStabilityQuery, ModelsWinRateStabilityQueryVariables>({ query: ModelsWinRateStabilityDocument, ...options });
+};
 export const CreatePairedVignetteDocument = gql`
     mutation CreatePairedVignette($input: CreatePairedVignetteInput!) {
   createPairedVignette(input: $input) {
@@ -7293,12 +7371,6 @@ export const PressureSensitivityDocument = gql`
         averageWinRate
         balancedWinRate
         highPressureOnThisValueWinRate
-        highPressureOnThisValueDomainRates {
-          domainId
-          domainName
-          rate
-          pairsMeasured
-        }
         highPressureOnOpposingValueWinRate
         pairsMeasured
       }

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -24,10 +24,16 @@ import {
   type ModelsAnalysisQueryVariables,
 } from '../api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
+import {
+  MODELS_STABILITY_QUERY,
+  type ModelsStabilityQueryResult,
+  type ModelsStabilityQueryVariables,
+} from '../api/operations/modelsStability';
 import { DominanceSection } from '../components/domains/DominanceSection';
 import { PairwiseWinRateMatrix } from '../components/domains/PairwiseWinRateMatrix';
 import { ValuePrioritiesSection } from '../components/domains/ValuePrioritiesSection';
 import { DomainShiftsReportSection } from '../components/models/DomainShiftsReportSection';
+import { WinRateStabilitySection } from '../components/models/WinRateStabilitySection';
 import {
   VALUES,
   type ModelEntry,
@@ -159,6 +165,18 @@ export function DomainAnalysis() {
   const [{ data: llmModelsData }] = useQuery<LlmModelsQueryResult>({
     query: LLM_MODELS_QUERY,
     variables: { status: 'ACTIVE' },
+    requestPolicy: 'cache-and-network',
+  });
+  const [{ data: modelsStabilityData, fetching: modelsStabilityFetching, error: modelsStabilityError }] = useQuery<
+    ModelsStabilityQueryResult,
+    ModelsStabilityQueryVariables
+  >({
+    query: MODELS_STABILITY_QUERY,
+    variables: {
+      ...(selectedScope === 'DOMAIN' && selectedDomainId !== '' ? { domainId: selectedDomainId } : {}),
+      ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
+    },
+    pause: selectedScope === 'DOMAIN' && selectedDomainId === '',
     requestPolicy: 'cache-and-network',
   });
   const [{ fetching: refreshFetching }, refreshDomainAnalysis] = useMutation<
@@ -457,6 +475,12 @@ export function DomainAnalysis() {
             defaultModelIds={defaultSelection}
             fetching={modelsAnalysisFetching}
             errorMessage={modelsAnalysisError?.message ?? null}
+          />
+          <WinRateStabilitySection
+            models={modelsStabilityData?.modelsWinRateStability.models ?? []}
+            skippedVignettes={modelsStabilityData?.modelsWinRateStability.skippedVignettes ?? []}
+            fetching={modelsStabilityFetching}
+            errorMessage={modelsStabilityError?.message ?? null}
           />
         </>
       )}

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../src/api/operations/domainAnalysis';
 import { MODELS_ANALYSIS_QUERY } from '../../src/api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY } from '../../src/api/operations/llm';
+import { MODELS_STABILITY_QUERY } from '../../src/api/operations/modelsStability';
 
 const useQueryMock = vi.fn();
 const useMutationMock = vi.fn();
@@ -80,6 +81,13 @@ const defaultModelsAnalysis = {
 
 const valuePrioritiesSectionMock = vi.fn(() => <div>Mock value priorities section</div>);
 
+const defaultModelsStability = {
+  modelsWinRateStability: {
+    models: [],
+    skippedVignettes: [],
+  },
+};
+
 function installQueryResponses(options?: {
   findingsData?: typeof defaultFindingsEligibility | undefined;
   findingsFetching?: boolean;
@@ -91,6 +99,7 @@ function installQueryResponses(options?: {
   analysisFetching?: boolean;
   analysisError?: Error | undefined;
   modelsAnalysisData?: typeof defaultModelsAnalysis | undefined;
+  modelsStabilityData?: typeof defaultModelsStability | undefined;
   llmModelsData?: { llmModels: Array<{ modelId: string; isDefault: boolean }> } | undefined;
 }) {
   const findingsData = options && 'findingsData' in options ? options.findingsData : defaultFindingsEligibility;
@@ -103,6 +112,7 @@ function installQueryResponses(options?: {
   const analysisFetching = options?.analysisFetching ?? false;
   const analysisError = options?.analysisError;
   const modelsAnalysisData = options && 'modelsAnalysisData' in options ? options.modelsAnalysisData : defaultModelsAnalysis;
+  const modelsStabilityData = options && 'modelsStabilityData' in options ? options.modelsStabilityData : defaultModelsStability;
   const llmModelsData = options && 'llmModelsData' in options ? options.llmModelsData : { llmModels: [] };
 
   useQueryMock.mockImplementation((args: { query: unknown }) => {
@@ -130,6 +140,13 @@ function installQueryResponses(options?: {
     if (args.query === MODELS_ANALYSIS_QUERY) {
       return [{
         data: modelsAnalysisData,
+        fetching: false,
+        error: undefined,
+      }];
+    }
+    if (args.query === MODELS_STABILITY_QUERY) {
+      return [{
+        data: modelsStabilityData,
         fetching: false,
         error: undefined,
       }];
@@ -174,6 +191,10 @@ vi.mock('../../src/components/models/DomainShiftsReportSection', () => ({
   DomainShiftsReportSection: () => <div>Mock domain shifts section</div>,
 }));
 
+vi.mock('../../src/components/models/WinRateStabilitySection', () => ({
+  WinRateStabilitySection: () => <div>Mock win rate stability section</div>,
+}));
+
 describe('DomainAnalysis', () => {
   beforeEach(() => {
     useQueryMock.mockReset();
@@ -213,10 +234,12 @@ describe('DomainAnalysis', () => {
     const valuePriorities = screen.getByText(/mock value priorities section/i);
     const dominance = screen.getByText(/mock dominance section/i);
     const domainShifts = screen.getByText(/mock domain shifts section/i);
+    const winRateStability = screen.getByText(/mock win rate stability section/i);
 
     expect(domainSelection.compareDocumentPosition(valuePriorities) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(valuePriorities.compareDocumentPosition(dominance) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(dominance.compareDocumentPosition(domainShifts) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(domainShifts.compareDocumentPosition(winRateStability) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('defaults the scope dropdown to all domains when no domain is selected', async () => {
@@ -359,6 +382,26 @@ describe('DomainAnalysis', () => {
         }),
       }),
     ]);
+  });
+
+  it('issues the stability query with domainId and signature variables', async () => {
+    render(
+      <MemoryRouter initialEntries={['/models/win-rate?domainId=domain-a&signature=vnewt0']}>
+        <DomainAnalysis />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(useQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: MODELS_STABILITY_QUERY,
+          variables: expect.objectContaining({
+            domainId: 'domain-a',
+            signature: 'vnewt0',
+          }),
+        }),
+      );
+    });
   });
 
   it('does not fall back to pooled counts when canonical models-analysis data is missing', async () => {

--- a/docs/workflow/feature-runs/winrate-response-consistency/state.json
+++ b/docs/workflow/feature-runs/winrate-response-consistency/state.json
@@ -1,0 +1,56 @@
+{
+  "review_policy": {
+    "sensitive": false,
+    "large_structural": false,
+    "performance_sensitive": false,
+    "extra_gemini_lenses": []
+  },
+  "blocked": {
+    "active": false,
+    "reason": "",
+    "updated_at": 0
+  },
+  "discovery": {
+    "version": 2,
+    "required": false,
+    "complete": true,
+    "question_count": 0,
+    "asked_count": 0,
+    "questions": [],
+    "assumptions": [],
+    "summary": "",
+    "updated_at": 0,
+    "answers": {},
+    "non_goals": [],
+    "acceptance_criteria": [],
+    "unresolved": []
+  },
+  "delivery": {},
+  "dirty_overrides": {},
+  "checkpoint_fallback": {},
+  "parallel_analysis": {
+    "reviewed": false,
+    "found": false,
+    "note": "",
+    "updated_at": 0
+  },
+  "init_head_sha": "",
+  "token_usage": [],
+  "command_telemetry": [
+    {
+      "command": "checkpoint",
+      "stage": "spec",
+      "ts": "2026-05-06T20:18:07Z",
+      "wall_seconds": 0.021,
+      "input_bytes_read": 2565,
+      "output_bytes_written": 2565,
+      "files_read": 3,
+      "files_written": 3,
+      "subprocess_invocations": 2,
+      "ttl_crossed": false
+    }
+  ],
+  "stages": {},
+  "invariant_warnings": [],
+  "schema_version": 1
+}


### PR DESCRIPTION
## Summary

Adds a **Response Consistency by Model** section to the Win Rate page showing how consistently each AI model responds when presented with the same vignette condition twice.

- **Backend math** (`models-stability-math.ts`): `classifyRepeatPattern`, `aggregateConditionStats`, `computeVignetteStability`, `averageVignetteStability` — classifies each condition as Stable / Soft Lean / Torn / Unstable based on directional agreement, signed distance, neutral share, and range
- **GraphQL resolver** (`modelsWinRateStability` query): fetches Aggregate runs, deduplicates per `(definitionId, signature)`, resolves dimension keys, builds condition groups, and aggregates stability stats per model
- **Frontend** (`WinRateStabilitySection`): sortable 8-column table (Model | Vignettes N | Avg Dir Agree | Distribution bar | Stable% | Soft Lean% | Torn% | Unstable%), Low-N badge for < 5 vignettes, skipped-vignette warning block, legend
- **Page integration** (`DomainAnalysis`): 4th `useQuery` for `MODELS_STABILITY_QUERY` with matching domainId/signature variables; section rendered after `DomainShiftsReportSection`

## Validation

| Step | Result |
|------|--------|
| `npm run lint @valuerank/api` | ✅ 0 errors |
| `npm run build @valuerank/api` | ✅ clean |
| `npm run test @valuerank/api` | ✅ 206 files, 2364 tests pass |
| `npm run lint @valuerank/web` | ✅ 0 errors (159 pre-existing warnings) |
| `npm run test @valuerank/web` | ✅ 153 files, 1421 tests pass |
| `npm run build @valuerank/web` | ⚠️ pre-existing `highPressureOnThisValueDomainRates` TS errors exist on main; no new errors from this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)