### PR TITLE
fix: scope pairwiseWinRates to selected models

### DIFF
--- a/cloud/apps/api/src/graphql/queries/pairwise-win-rates.ts
+++ b/cloud/apps/api/src/graphql/queries/pairwise-win-rates.ts
@@ -17,6 +17,10 @@ builder.queryField('pairwiseWinRates', (t) =>
         required: false,
         description: 'Batch signature to filter runs (e.g. vnewtd)',
       }),
+      modelIds: t.arg.stringList({
+        required: false,
+        description: 'Model IDs to include. Defaults to all active models when omitted.',
+      }),
     },
     resolve: async (_root, args) => {
       const domainId = args.domainId != null ? String(args.domainId) : null;
@@ -27,7 +31,11 @@ builder.queryField('pairwiseWinRates', (t) =>
         availableOnly: false,
       });
 
-      const modelIds = activeModels.map((m) => m.modelId);
+      const requestedIds = args.modelIds != null ? new Set(args.modelIds) : null;
+      const filteredModels = requestedIds != null
+        ? activeModels.filter((m) => requestedIds.has(m.modelId))
+        : activeModels;
+      const modelIds = filteredModels.map((m) => m.modelId);
 
       let domainDefinitionIds: Set<string> | null = null;
       if (domainId != null) {
@@ -48,7 +56,7 @@ builder.queryField('pairwiseWinRates', (t) =>
         domainDefinitionIds,
       });
 
-      const models = activeModels.map((model) => {
+      const models = filteredModels.map((model) => {
         const matrix = pairwiseMap.get(model.modelId);
         const winRateMatrix = (matrix ?? []).map((row) => row.map((cell) => cell.winRate));
         const trialCountMatrix = (matrix ?? []).map((row) => row.map((cell) => cell.trials));

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -2617,7 +2617,7 @@ type Query {
   openRunAnomalies(domainId: ID, type: RunAnomalyType): [RunAnomaly!]!
 
   """Pairwise win rates per value pair per model, vignette-averaged"""
-  pairwiseWinRates(domainId: ID, signature: String): PairwiseWinRatesResult!
+  pairwiseWinRates(domainId: ID, modelIds: [String!], signature: String): PairwiseWinRatesResult!
 
   """Get a specific preamble by ID"""
   preamble(id: ID!): Preamble

--- a/cloud/apps/web/src/api/operations/pairwiseWinRates.graphql
+++ b/cloud/apps/web/src/api/operations/pairwiseWinRates.graphql
@@ -1,5 +1,5 @@
-query PairwiseWinRates($domainId: ID, $signature: String) {
-  pairwiseWinRates(domainId: $domainId, signature: $signature) {
+query PairwiseWinRates($domainId: ID, $modelIds: [String!], $signature: String) {
+  pairwiseWinRates(domainId: $domainId, modelIds: $modelIds, signature: $signature) {
     models {
       modelId
       label

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -3131,6 +3131,7 @@ export type QueryOpenRunAnomaliesArgs = {
 
 export type QueryPairwiseWinRatesArgs = {
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  modelIds?: InputMaybe<Array<Scalars['String']['input']>>;
   signature?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -4681,6 +4682,7 @@ export type UpdatePairedVignetteMutation = { __typename?: 'Mutation', updatePair
 
 export type PairwiseWinRatesQueryVariables = Exact<{
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  modelIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
   signature?: InputMaybe<Scalars['String']['input']>;
 }>;
 
@@ -7225,8 +7227,12 @@ export function useUpdatePairedVignetteMutation() {
   return Urql.useMutation<UpdatePairedVignetteMutation, UpdatePairedVignetteMutationVariables>(UpdatePairedVignetteDocument);
 };
 export const PairwiseWinRatesDocument = gql`
-    query PairwiseWinRates($domainId: ID, $signature: String) {
-  pairwiseWinRates(domainId: $domainId, signature: $signature) {
+    query PairwiseWinRates($domainId: ID, $modelIds: [String!], $signature: String) {
+  pairwiseWinRates(
+    domainId: $domainId
+    modelIds: $modelIds
+    signature: $signature
+  ) {
     models {
       modelId
       label

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -169,11 +169,13 @@ export function DomainAnalysis() {
     () => ({
       ...(selectedScope === 'DOMAIN' && selectedDomainId !== '' ? { domainId: selectedDomainId } : {}),
       ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
+      ...(selectedModelIds.length > 0 ? { modelIds: selectedModelIds } : {}),
     }),
-    [selectedDomainId, selectedScope, selectedSignature],
+    [selectedDomainId, selectedScope, selectedSignature, selectedModelIds],
   );
   const [{ data: pairwiseData }] = usePairwiseWinRatesQuery({
     variables: pairwiseVars,
+    pause: selectedModelIds.length === 0,
     requestPolicy: 'cache-and-network',
   });
 


### PR DESCRIPTION
## Summary
- The `pairwiseWinRates` resolver was querying ALL active models simultaneously (one parallel transcript DB query per model), exhausting the connection pool and causing unrelated queries like `domainAnalysis` to hang
- Added a `modelIds` argument to the resolver so only the requested models are queried
- The web now passes `selectedModelIds` (the user's current model picker selection) to the query, and pauses the query until models are selected

## Root cause
`aggregatePairwiseWinRates` fans out one `transcript.findMany` per model in parallel. With 20+ active models this fires 20+ large concurrent queries, consuming all PgBouncer connections and starving the rest of the page.

## Test plan
- [ ] Win Rate page loads normally
- [ ] Pairwise matrix renders data for selected models
- [ ] Switching models in the page picker updates the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)