### PR TITLE
feat: remove component model pickers; use page-level selection

### DIFF
--- a/cloud/apps/web/src/components/domains/DominanceSection.tsx
+++ b/cloud/apps/web/src/components/domains/DominanceSection.tsx
@@ -7,16 +7,10 @@ import {
 import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { DominanceSectionChart, type DominanceSectionThemeColors } from './DominanceSectionChart';
 import { DominanceSectionSummary } from './DominanceSectionSummary';
-import {
-  DISPLAY_VALUES,
-  NODE_ANIMATION_BASE_DURATION_MS,
-  NODE_ANIMATION_PER_NODE_SLOWDOWN_MS,
-  useDominanceGraph,
-} from './useDominanceGraph';
+import { useDominanceGraph } from './useDominanceGraph';
 
 type DominanceSectionProps = {
   models: ModelEntry[];
-  defaultModelIds: Set<string>;
 };
 
 const THEME_COLORS: DominanceSectionThemeColors = {
@@ -37,13 +31,12 @@ const THEME_COLORS: DominanceSectionThemeColors = {
   idleRingColor: '#38bdf8',
 };
 
-export function DominanceSection({ models, defaultModelIds }: DominanceSectionProps) {
+export function DominanceSection({ models }: DominanceSectionProps) {
   const chartRef = useRef<HTMLDivElement>(null);
   const [focusedValue, setFocusedValue] = useState<ValueKey | null>(null);
   const [hoveredValue, setHoveredValue] = useState<ValueKey | null>(null);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const [animationPhase, setAnimationPhase] = useState<'idle' | 'collapse' | 'expand'>('idle');
-  const [pickedModelId, setPickedModelId] = useState<string>(''); // '' = All models
+  const animationPhase = 'idle' as const;
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
@@ -53,15 +46,6 @@ export function DominanceSection({ models, defaultModelIds }: DominanceSectionPr
     mediaQuery.addEventListener('change', updatePreference);
     return () => mediaQuery.removeEventListener('change', updatePreference);
   }, []);
-
-  const slowestDuration =
-    NODE_ANIMATION_BASE_DURATION_MS +
-    (DISPLAY_VALUES.length - 1) * NODE_ANIMATION_PER_NODE_SLOWDOWN_MS;
-
-  const pickerModels = useMemo(
-    () => models.filter((m) => defaultModelIds.has(m.model)),
-    [models, defaultModelIds],
-  );
 
   const allModelsEntry = useMemo<ModelEntry>(() => {
     const modelsWithRates = models.filter((m) =>
@@ -98,22 +82,7 @@ export function DominanceSection({ models, defaultModelIds }: DominanceSectionPr
     [models, allModelsEntry],
   );
 
-  const effectiveModelId = pickedModelId !== '' ? pickedModelId : '__all__';
-  const selectedModel = modelById.get(effectiveModelId);
-
-  const prevActiveId = useRef(effectiveModelId);
-  useEffect(() => {
-    if (effectiveModelId === prevActiveId.current) return;
-    prevActiveId.current = effectiveModelId;
-    if (prefersReducedMotion) return;
-    setAnimationPhase('collapse');
-    const expandTimer = setTimeout(() => setAnimationPhase('expand'), slowestDuration);
-    const idleTimer = setTimeout(() => setAnimationPhase('idle'), 2 * slowestDuration);
-    return () => {
-      clearTimeout(expandTimer);
-      clearTimeout(idleTimer);
-    };
-  }, [effectiveModelId, prefersReducedMotion, slowestDuration]);
+  const selectedModel = modelById.get('__all__');
 
   const {
     contestedPairs,
@@ -134,27 +103,10 @@ export function DominanceSection({ models, defaultModelIds }: DominanceSectionPr
         <div>
           <h2 className={`text-base font-medium ${THEME_COLORS.panelText}`}>Dominance Graph</h2>
           <p className={`text-sm ${THEME_COLORS.panelMutedText}`}>
-            Directed value graph for one selected AI: arrows point from stronger value to weaker value.
+            Directed value graph averaged across selected models: arrows point from stronger value to weaker value.
           </p>
         </div>
         <CopyVisualButton targetRef={chartRef} label="ranking and cycles chart" />
-      </div>
-
-      <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">
-        <label htmlFor="dominance-model-picker" className={`font-medium ${THEME_COLORS.panelMutedText}`}>
-          Model focus:
-        </label>
-        <select
-          id="dominance-model-picker"
-          className="rounded border border-gray-300 px-1.5 py-0.5 text-xs text-gray-800"
-          value={pickedModelId}
-          onChange={(e) => setPickedModelId(e.target.value)}
-        >
-          <option value="">All models (average)</option>
-          {pickerModels.map((m) => (
-            <option key={m.model} value={m.model}>{m.label}</option>
-          ))}
-        </select>
       </div>
 
       {models.length === 0 && (

--- a/cloud/apps/web/src/components/domains/PairwiseWinRateMatrix.tsx
+++ b/cloud/apps/web/src/components/domains/PairwiseWinRateMatrix.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useMemo } from 'react';
+import { useRef, useMemo } from 'react';
 import { VALUE_LABELS, VALUE_DESCRIPTIONS, type ValueKey } from '../../data/domainAnalysisData';
 import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { Tooltip } from '../ui/Tooltip';
@@ -47,40 +47,53 @@ type PairwiseWinRateMatrixProps = {
 
 export function PairwiseWinRateMatrix({ models }: PairwiseWinRateMatrixProps) {
   const tableRef = useRef<HTMLDivElement>(null);
-  const [pickedModelId, setPickedModelId] = useState<string>('');
 
-  const effectiveModelId =
-    pickedModelId !== '' && models.some((m) => m.modelId === pickedModelId)
-      ? pickedModelId
-      : (models[0]?.modelId ?? '');
-
-  const selectedModel = useMemo(
-    () => models.find((m) => m.modelId === effectiveModelId) ?? null,
-    [models, effectiveModelId],
-  );
-
+  const firstModel = models[0];
   const valueIndexMap = useMemo<Map<string, number>>(
     () =>
-      selectedModel != null
-        ? new Map(selectedModel.valueOrder.map((key, i) => [key, i]))
+      firstModel != null
+        ? new Map(firstModel.valueOrder.map((key, i) => [key, i]))
         : new Map(),
-    [selectedModel],
+    [firstModel],
   );
 
+  const averagedMatrix = useMemo<(number | null)[][]>(() => {
+    if (models.length === 0 || firstModel == null) return [];
+    const n = firstModel.valueOrder.length;
+    return Array.from({ length: n }, (_, r) =>
+      Array.from({ length: n }, (_, c) => {
+        const rates = models
+          .map((m) => m.winRateMatrix[r]?.[c] ?? null)
+          .filter((v): v is number => v != null);
+        return rates.length > 0 ? rates.reduce((a, b) => a + b, 0) / rates.length : null;
+      }),
+    );
+  }, [models, firstModel]);
+
+  const totalTrialMatrix = useMemo<number[][]>(() => {
+    if (models.length === 0 || firstModel == null) return [];
+    const n = firstModel.valueOrder.length;
+    return Array.from({ length: n }, (_, r) =>
+      Array.from({ length: n }, (_, c) =>
+        models.reduce((sum, m) => sum + (m.trialCountMatrix[r]?.[c] ?? 0), 0),
+      ),
+    );
+  }, [models, firstModel]);
+
   function getCellWinRate(rowKey: ValueKey, colKey: ValueKey): number | null {
-    if (selectedModel == null || rowKey === colKey) return null;
+    if (rowKey === colKey) return null;
     const rowIdx = valueIndexMap.get(rowKey);
     const colIdx = valueIndexMap.get(colKey);
     if (rowIdx == null || colIdx == null) return null;
-    return selectedModel.winRateMatrix[rowIdx]?.[colIdx] ?? null;
+    return averagedMatrix[rowIdx]?.[colIdx] ?? null;
   }
 
   function getCellTrials(rowKey: ValueKey, colKey: ValueKey): number {
-    if (selectedModel == null || rowKey === colKey) return 0;
+    if (rowKey === colKey) return 0;
     const rowIdx = valueIndexMap.get(rowKey);
     const colIdx = valueIndexMap.get(colKey);
     if (rowIdx == null || colIdx == null) return 0;
-    return selectedModel.trialCountMatrix[rowIdx]?.[colIdx] ?? 0;
+    return totalTrialMatrix[rowIdx]?.[colIdx] ?? 0;
   }
 
   return (
@@ -89,32 +102,14 @@ export function PairwiseWinRateMatrix({ models }: PairwiseWinRateMatrixProps) {
         <div>
           <h2 className="text-base font-medium text-gray-900">Pairwise Win Rate Matrix</h2>
           <p className="text-sm text-gray-600">
-            Win rate of the row value over the column value, averaged across vignettes.
+            Win rate of the row value over the column value, averaged across vignettes and selected models.
             Green = row wins more often; red = row loses more often. Centered at 50%.
           </p>
         </div>
         <CopyVisualButton targetRef={tableRef} label="pairwise win rate matrix" />
       </div>
 
-      <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">
-        <label htmlFor="pairwise-model-picker" className="font-medium text-gray-600">
-          Model:
-        </label>
-        <select
-          id="pairwise-model-picker"
-          className="rounded border border-gray-300 px-1.5 py-0.5 text-xs text-gray-800"
-          value={effectiveModelId}
-          onChange={(e) => setPickedModelId(e.target.value)}
-        >
-          {models.map((m) => (
-            <option key={m.modelId} value={m.modelId}>
-              {m.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {selectedModel == null ? (
+      {models.length === 0 ? (
         <p className="text-xs text-gray-500">No pairwise data available.</p>
       ) : (
         <div ref={tableRef} className="overflow-x-auto">

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -459,8 +459,7 @@ export function DomainAnalysis() {
             showStabilityDots
           />
           <DominanceSection
-            models={models}
-            defaultModelIds={defaultModelIds}
+            models={visibleModels}
           />
           <PairwiseWinRateMatrix
             models={pairwiseData?.pairwiseWinRates.models ?? []}

--- a/cloud/apps/web/tests/components/DominanceSection.test.tsx
+++ b/cloud/apps/web/tests/components/DominanceSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import type {
   ModelEntry,
 } from '../../src/data/domainAnalysisData';
@@ -64,10 +64,8 @@ const models: ModelEntry[] = [
   },
 ];
 
-const defaultModelIds = new Set(['model-a', 'model-b']);
-
 describe('DominanceSection', () => {
-  it('renders shell, model picker, and updates summary when model changes', async () => {
+  it('renders shell with averaged model data and no model picker', async () => {
     vi.spyOn(window, 'matchMedia').mockImplementation(
       (query) =>
         ({
@@ -82,39 +80,21 @@ describe('DominanceSection', () => {
         }) as MediaQueryList,
     );
 
-    render(
-      <DominanceSection
-        models={models}
-        defaultModelIds={defaultModelIds}
-      />,
-    );
+    render(<DominanceSection models={models} />);
 
-    let container: HTMLElement;
     await act(async () => {
-      container = screen.getByRole('img', { name: 'Value dominance graph' }).parentElement!.parentElement!;
       await Promise.resolve();
     });
 
     expect(screen.getByRole('heading', { name: 'Dominance Graph' })).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Directed value graph for one selected AI: arrows point from stronger value to weaker value.',
+        'Directed value graph averaged across selected models: arrows point from stronger value to weaker value.',
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'Value dominance graph' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Most Contestable Value Pairs' })).toBeInTheDocument();
 
-    const picker = screen.getByLabelText('Model focus:');
-    expect(picker).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'All models (average)' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Model A' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Model B' })).toBeInTheDocument();
-
-    const summaryList = container!.querySelector('ol');
-    expect(summaryList?.textContent).toBeTruthy();
-    const initialSummary = summaryList?.textContent ?? '';
-
-    fireEvent.change(picker, { target: { value: 'model-a' } });
-    expect(summaryList?.textContent).not.toEqual(initialSummary);
+    expect(screen.queryByLabelText('Model focus:')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Removed the internal model picker from the Dominance Graph — it now always shows the average across the page-level selected models
- Removed the internal model picker from the Pairwise Win Rate Matrix — it now averages matrices client-side across all page-level selected models
- Both components respond to changes in the domain/signature/models page picker without any extra UI

## Changes
- `DominanceSection`: dropped `defaultModelIds` prop and `pickedModelId` state; always renders the average of `visibleModels` passed from parent; removed dead animation logic
- `PairwiseWinRateMatrix`: removed `pickedModelId` state and picker; computes averaged win rates and summed trial counts across all models in the prop
- `DomainAnalysis`: passes `visibleModels` (filtered to `selectedModelIds`) to `DominanceSection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)