### PR TITLE
fix: remove pairwiseWinRates from Win Rate page to fix API OOM

### DIFF
--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -24,12 +24,7 @@ import {
   type ModelsAnalysisQueryVariables,
 } from '../api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
-import {
-  usePairwiseWinRatesQuery,
-  type PairwiseWinRatesQueryVariables,
-} from '../api/operations/pairwiseWinRates';
 import { DominanceSection } from '../components/domains/DominanceSection';
-import { PairwiseWinRateMatrix } from '../components/domains/PairwiseWinRateMatrix';
 import { ValuePrioritiesSection } from '../components/domains/ValuePrioritiesSection';
 import { DomainShiftsReportSection } from '../components/models/DomainShiftsReportSection';
 import {
@@ -165,20 +160,6 @@ export function DomainAnalysis() {
     variables: { status: 'ACTIVE' },
     requestPolicy: 'cache-and-network',
   });
-  const pairwiseVars = useMemo<PairwiseWinRatesQueryVariables>(
-    () => ({
-      ...(selectedScope === 'DOMAIN' && selectedDomainId !== '' ? { domainId: selectedDomainId } : {}),
-      ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
-      ...(selectedModelIds.length > 0 ? { modelIds: selectedModelIds } : {}),
-    }),
-    [selectedDomainId, selectedScope, selectedSignature, selectedModelIds],
-  );
-  const [{ data: pairwiseData }] = usePairwiseWinRatesQuery({
-    variables: pairwiseVars,
-    pause: selectedModelIds.length === 0,
-    requestPolicy: 'cache-and-network',
-  });
-
   const [{ fetching: refreshFetching }, refreshDomainAnalysis] = useMutation<
     RefreshDomainAnalysisMutationResult,
     RefreshDomainAnalysisMutationVariables
@@ -460,9 +441,6 @@ export function DomainAnalysis() {
           />
           <DominanceSection
             models={visibleModels}
-          />
-          <PairwiseWinRateMatrix
-            models={pairwiseData?.pairwiseWinRates.models ?? []}
           />
           <DomainShiftsReportSection
             models={modelsAnalysisData?.modelsAnalysis.models ?? []}


### PR DESCRIPTION
## Summary
- Removes `PairwiseWinRateMatrix` component and `usePairwiseWinRatesQuery` hook from `DomainAnalysis.tsx`
- The `pairwiseWinRates` resolver fans out one `transcript.findMany` per model in parallel, loading large JSON blobs — exhausts Railway API memory with 20+ models
- The component and resolver stay in the codebase for a future reimplementation using pre-computed data

## Test plan
- [ ] Win Rate page loads without API OOM
- [ ] DominanceSection still renders (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)