### PR TITLE
feat: serve pairwise win rate matrix from domain analysis snapshot

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/types.ts
@@ -37,11 +37,18 @@ export {
   DomainAnalysisValueDetailResultRef,
 } from './types-detail.js';
 
+export type PairwiseWinRateModel = {
+  valueOrder: string[];
+  winRateMatrix: Array<Array<number | null>>;
+  trialCountMatrix: number[][];
+};
+
 export type DomainAnalysisModel = {
   model: string;
   label: string;
   values: DomainAnalysisValueScore[];
   rankingShape: RankingShape;
+  pairwiseWinRateModel: PairwiseWinRateModel | null;
 };
 
 export type DomainAnalysisCacheStatus = 'FRESH' | 'UPDATING' | 'OUT_OF_DATE';
@@ -74,6 +81,7 @@ export const ValueFaultLineRef = builder.objectRef<ValueFaultLine>('ValueFaultLi
 export const ClusterPairFaultLinesRef = builder.objectRef<ClusterPairFaultLines>('ClusterPairFaultLines');
 export const ClusterAnalysisRef = builder.objectRef<ClusterAnalysis>('ClusterAnalysis');
 export const DomainAnalysisValueScoreRef = builder.objectRef<DomainAnalysisValueScore>('DomainAnalysisValueScore');
+export const PairwiseWinRateModelRef = builder.objectRef<PairwiseWinRateModel>('PairwiseWinRateModel');
 export const DomainAnalysisModelRef = builder.objectRef<DomainAnalysisModel>('DomainAnalysisModel');
 export const DomainAnalysisUnavailableModelRef = builder.objectRef<DomainAnalysisUnavailableModel>('DomainAnalysisUnavailableModel');
 export const DomainAnalysisMissingDefinitionRef = builder.objectRef<DomainAnalysisMissingDefinition>('DomainAnalysisMissingDefinition');
@@ -185,6 +193,20 @@ builder.objectType(DomainAnalysisValueScoreRef, {
   }),
 });
 
+builder.objectType(PairwiseWinRateModelRef, {
+  fields: (t) => ({
+    valueOrder: t.exposeStringList('valueOrder'),
+    winRateMatrix: t.field({
+      type: [t.listRef('Float', { nullable: true })],
+      resolve: (parent) => parent.winRateMatrix,
+    }),
+    trialCountMatrix: t.field({
+      type: [t.listRef('Int')],
+      resolve: (parent) => parent.trialCountMatrix,
+    }),
+  }),
+});
+
 builder.objectType(DomainAnalysisModelRef, {
   fields: (t) => ({
     model: t.exposeString('model'),
@@ -196,6 +218,11 @@ builder.objectType(DomainAnalysisModelRef, {
     rankingShape: t.field({
       type: RankingShapeRef,
       resolve: (parent) => parent.rankingShape,
+    }),
+    pairwiseWinRateModel: t.field({
+      type: PairwiseWinRateModelRef,
+      nullable: true,
+      resolve: (parent) => parent.pairwiseWinRateModel,
     }),
   }),
 });

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -13,7 +13,9 @@ import { computeClusterAnalysis, computeAllClusterAnalyses } from '../../graphql
 import type {
   DomainAnalysisModel,
   DomainAnalysisResult,
+  PairwiseWinRateModel,
 } from '../../graphql/queries/domain/types.js';
+import { SCHWARTZ_CIRCULAR_ORDER } from '@valuerank/shared/schwartz';
 import {
   DOMAIN_ANALYSIS_CACHE_STATUS,
   DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
@@ -69,6 +71,30 @@ function extractWinRates(snapshotModel: DomainAnalysisSnapshotModel, valueKeys: 
   return result;
 }
 
+function buildPairwiseWinRateModel(pairwiseWins: Record<string, Record<string, number>>): PairwiseWinRateModel {
+  const order = [...SCHWARTZ_CIRCULAR_ORDER];
+  const n = order.length;
+  const winRateMatrix: Array<Array<number | null>> = [];
+  const trialCountMatrix: number[][] = [];
+  for (let i = 0; i < n; i++) {
+    const winRateRow: Array<number | null> = [];
+    const trialRow: number[] = [];
+    for (let j = 0; j < n; j++) {
+      if (i === j) { winRateRow.push(null); trialRow.push(0); continue; }
+      const keyI = order[i] as string;
+      const keyJ = order[j] as string;
+      const winsIJ = pairwiseWins[keyI]?.[keyJ] ?? 0;
+      const winsJI = pairwiseWins[keyJ]?.[keyI] ?? 0;
+      const total = winsIJ + winsJI;
+      winRateRow.push(total > 0 ? winsIJ / total : null);
+      trialRow.push(total);
+    }
+    winRateMatrix.push(winRateRow);
+    trialCountMatrix.push(trialRow);
+  }
+  return { valueOrder: order, winRateMatrix, trialCountMatrix };
+}
+
 function buildDomainAnalysisResultFromSnapshot(params: {
   snapshot: DomainAnalysisSnapshotOutput;
   activeModels: Array<{ modelId: string; displayName: string; isDefault: boolean }>;
@@ -99,6 +125,7 @@ function buildDomainAnalysisResultFromSnapshot(params: {
       model: model.model,
       label: activeModelLabelById.get(model.model) ?? model.model,
       values,
+      pairwiseWinRateModel: buildPairwiseWinRateModel(model.pairwiseWins),
     };
   });
 

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -848,8 +848,15 @@ type DomainAnalysisMissingDefinition {
 type DomainAnalysisModel {
   label: String!
   model: String!
+  pairwiseWinRateModel: PairwiseWinRateModel
   rankingShape: RankingShape!
   values: [DomainAnalysisValueScore!]!
+}
+
+type PairwiseWinRateModel {
+  trialCountMatrix: [[Int!]!]!
+  valueOrder: [String!]!
+  winRateMatrix: [[Float]!]!
 }
 
 type DomainAnalysisRefreshResult {

--- a/cloud/apps/web/src/api/operations/domainAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.graphql
@@ -50,6 +50,11 @@ query DomainAnalysis($domainId: ID!, $scope: String, $signature: String) {
         steepness
         dominanceZScore
       }
+      pairwiseWinRateModel {
+        valueOrder
+        winRateMatrix
+        trialCountMatrix
+      }
     }
     unavailableModels {
       model

--- a/cloud/apps/web/src/components/domains/PairwiseWinRateMatrix.tsx
+++ b/cloud/apps/web/src/components/domains/PairwiseWinRateMatrix.tsx
@@ -3,7 +3,18 @@ import { VALUE_LABELS, VALUE_DESCRIPTIONS, type ValueKey } from '../../data/doma
 import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { Tooltip } from '../ui/Tooltip';
 import { getHeatmapColor } from './domainAnalysisColors';
-import type { ModelPairwiseWinRates } from '../../api/operations/pairwiseWinRates';
+
+type PairwiseWinRateModelData = {
+  valueOrder: Array<string>;
+  winRateMatrix: Array<Array<number | null>>;
+  trialCountMatrix: Array<Array<number>>;
+};
+
+export type PairwiseMatrixModel = {
+  model: string;
+  label: string;
+  pairwiseWinRateModel?: PairwiseWinRateModelData | null;
+};
 
 const COLUMN_VALUES: ValueKey[] = [
   'Universalism_Nature',
@@ -42,43 +53,50 @@ function winRateCellColor(winRate: number): string {
 }
 
 type PairwiseWinRateMatrixProps = {
-  models: ModelPairwiseWinRates[];
+  models: PairwiseMatrixModel[];
 };
 
 export function PairwiseWinRateMatrix({ models }: PairwiseWinRateMatrixProps) {
   const tableRef = useRef<HTMLDivElement>(null);
 
-  const firstModel = models[0];
+  const modelsWithData = useMemo(
+    () => models.filter((m): m is PairwiseMatrixModel & { pairwiseWinRateModel: PairwiseWinRateModelData } =>
+      m.pairwiseWinRateModel != null,
+    ),
+    [models],
+  );
+
+  const firstModel = modelsWithData[0];
   const valueIndexMap = useMemo<Map<string, number>>(
     () =>
       firstModel != null
-        ? new Map(firstModel.valueOrder.map((key, i) => [key, i]))
+        ? new Map(firstModel.pairwiseWinRateModel.valueOrder.map((key, i) => [key, i]))
         : new Map(),
     [firstModel],
   );
 
   const averagedMatrix = useMemo<(number | null)[][]>(() => {
-    if (models.length === 0 || firstModel == null) return [];
-    const n = firstModel.valueOrder.length;
+    if (modelsWithData.length === 0 || firstModel == null) return [];
+    const n = firstModel.pairwiseWinRateModel.valueOrder.length;
     return Array.from({ length: n }, (_, r) =>
       Array.from({ length: n }, (_, c) => {
-        const rates = models
-          .map((m) => m.winRateMatrix[r]?.[c] ?? null)
+        const rates = modelsWithData
+          .map((m) => m.pairwiseWinRateModel.winRateMatrix[r]?.[c] ?? null)
           .filter((v): v is number => v != null);
         return rates.length > 0 ? rates.reduce((a, b) => a + b, 0) / rates.length : null;
       }),
     );
-  }, [models, firstModel]);
+  }, [modelsWithData, firstModel]);
 
   const totalTrialMatrix = useMemo<number[][]>(() => {
-    if (models.length === 0 || firstModel == null) return [];
-    const n = firstModel.valueOrder.length;
+    if (modelsWithData.length === 0 || firstModel == null) return [];
+    const n = firstModel.pairwiseWinRateModel.valueOrder.length;
     return Array.from({ length: n }, (_, r) =>
       Array.from({ length: n }, (_, c) =>
-        models.reduce((sum, m) => sum + (m.trialCountMatrix[r]?.[c] ?? 0), 0),
+        modelsWithData.reduce((sum, m) => sum + (m.pairwiseWinRateModel.trialCountMatrix[r]?.[c] ?? 0), 0),
       ),
     );
-  }, [models, firstModel]);
+  }, [modelsWithData, firstModel]);
 
   function getCellWinRate(rowKey: ValueKey, colKey: ValueKey): number | null {
     if (rowKey === colKey) return null;
@@ -109,7 +127,7 @@ export function PairwiseWinRateMatrix({ models }: PairwiseWinRateMatrixProps) {
         <CopyVisualButton targetRef={tableRef} label="pairwise win rate matrix" />
       </div>
 
-      {models.length === 0 ? (
+      {modelsWithData.length === 0 ? (
         <p className="text-xs text-gray-500">No pairwise data available.</p>
       ) : (
         <div ref={tableRef} className="overflow-x-auto">

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -785,6 +785,7 @@ export type DomainAnalysisModel = {
   __typename?: 'DomainAnalysisModel';
   label: Scalars['String']['output'];
   model: Scalars['String']['output'];
+  pairwiseWinRateModel?: Maybe<PairwiseWinRateModel>;
   rankingShape: RankingShape;
   values: Array<DomainAnalysisValueScore>;
 };
@@ -2319,6 +2320,13 @@ export type OrderEffect = {
   noisyPct: Scalars['Float']['output'];
   notApplicable: Scalars['Boolean']['output'];
   samePct: Scalars['Float']['output'];
+};
+
+export type PairwiseWinRateModel = {
+  __typename?: 'PairwiseWinRateModel';
+  trialCountMatrix: Array<Array<Scalars['Int']['output']>>;
+  valueOrder: Array<Scalars['String']['output']>;
+  winRateMatrix: Array<Array<Maybe<Scalars['Float']['output']>>>;
 };
 
 export type PairwiseWinRatesResult = {
@@ -4253,7 +4261,7 @@ export type DomainAnalysisQueryVariables = Exact<{
 }>;
 
 
-export type DomainAnalysisQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, definitionsWithAnalysis: number, cacheStatus: string, generatedAt: string, clusterAnalysisByMethod: unknown, contributionSummary: Array<{ __typename?: 'DomainAnalysisContributionSummary', domainId: string, domainName: string, rawTrialCount: number, share: number }>, excludedDataSummary: Array<{ __typename?: 'DomainAnalysisExcludedDataSummary', domainId: string, domainName: string, reasonCode: string, count: number }>, missingDefinitions: Array<{ __typename?: 'DomainAnalysisMissingDefinition', definitionId: string, definitionName: string, reasonCode: string, reasonLabel: string, missingAllModels: boolean, missingModelIds: Array<string>, missingModelLabels: Array<string> }>, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number }>, rankingShape: { __typename?: 'RankingShape', topStructure: string, bottomStructure: string, topGap: number, bottomGap: number, spread: number, steepness: number, dominanceZScore?: number | null } }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }>, rankingShapeBenchmarks: { __typename?: 'RankingShapeBenchmarks', domainMeanTopGap: number, domainStdTopGap?: number | null, medianSpread: number }, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } } };
+export type DomainAnalysisQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, definitionsWithAnalysis: number, cacheStatus: string, generatedAt: string, clusterAnalysisByMethod: unknown, contributionSummary: Array<{ __typename?: 'DomainAnalysisContributionSummary', domainId: string, domainName: string, rawTrialCount: number, share: number }>, excludedDataSummary: Array<{ __typename?: 'DomainAnalysisExcludedDataSummary', domainId: string, domainName: string, reasonCode: string, count: number }>, missingDefinitions: Array<{ __typename?: 'DomainAnalysisMissingDefinition', definitionId: string, definitionName: string, reasonCode: string, reasonLabel: string, missingAllModels: boolean, missingModelIds: Array<string>, missingModelLabels: Array<string> }>, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number }>, rankingShape: { __typename?: 'RankingShape', topStructure: string, bottomStructure: string, topGap: number, bottomGap: number, spread: number, steepness: number, dominanceZScore?: number | null }, pairwiseWinRateModel?: { __typename?: 'PairwiseWinRateModel', valueOrder: Array<string>, winRateMatrix: Array<Array<number | null>>, trialCountMatrix: Array<Array<number>> } | null }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }>, rankingShapeBenchmarks: { __typename?: 'RankingShapeBenchmarks', domainMeanTopGap: number, domainStdTopGap?: number | null, medianSpread: number }, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } } };
 
 export type RefreshDomainAnalysisMutationVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -5993,6 +6001,11 @@ export const DomainAnalysisDocument = gql`
         spread
         steepness
         dominanceZScore
+      }
+      pairwiseWinRateModel {
+        valueOrder
+        winRateMatrix
+        trialCountMatrix
       }
     }
     unavailableModels {

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -25,6 +25,7 @@ import {
 } from '../api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { DominanceSection } from '../components/domains/DominanceSection';
+import { PairwiseWinRateMatrix } from '../components/domains/PairwiseWinRateMatrix';
 import { ValuePrioritiesSection } from '../components/domains/ValuePrioritiesSection';
 import { DomainShiftsReportSection } from '../components/models/DomainShiftsReportSection';
 import {
@@ -272,6 +273,13 @@ export function DomainAnalysis() {
     [models, selectedModelIds],
   );
 
+  const visiblePairwiseModels = useMemo(() => {
+    const sourceModels = data?.domainAnalysis.models ?? [];
+    return selectedModelIds.length === 0
+      ? sourceModels
+      : sourceModels.filter((m) => selectedModelIds.includes(m.model));
+  }, [data?.domainAnalysis.models, selectedModelIds]);
+
   const missingDefinitionCount = data?.domainAnalysis.missingDefinitions?.length ?? 0;
   const allMissingDefinitionIds = useMemo(
     () => (data?.domainAnalysis.missingDefinitions ?? []).map((m) => m.definitionId),
@@ -442,6 +450,7 @@ export function DomainAnalysis() {
           <DominanceSection
             models={visibleModels}
           />
+          <PairwiseWinRateMatrix models={visiblePairwiseModels} />
           <DomainShiftsReportSection
             models={modelsAnalysisData?.modelsAnalysis.models ?? []}
             selectedModelIds={selectedModelIds}


### PR DESCRIPTION
## Summary
- Adds `pairwiseWinRateModel` field to `DomainAnalysisModel` (API + schema), built from the pre-computed `pairwiseWins` counts already in the `AssumptionAnalysisSnapshot` — zero extra DB queries
- Restores `PairwiseWinRateMatrix` on the Win Rate page using this snapshot-backed field instead of the OOM-prone `pairwiseWinRates` top-level query (removed in #968)
- `PairwiseWinRateMatrix` now accepts `PairwiseMatrixModel[]` (the raw `domainAnalysis` query models) so no transformation layer is needed

## How it works
`buildPairwiseWinRateModel()` converts the snapshot's `pairwiseWins: Record<valueKey, Record<valueKey, winCount>>` into a 10×10 matrix ordered by `SCHWARTZ_CIRCULAR_ORDER`. Win rate = `wins_A_over_B / (wins_A_over_B + wins_B_over_A)`. Trial count = sum of both directions.

## Test plan
- [ ] Preflight passed (lint + build API + build web)
- [ ] Win Rate page loads and shows the pairwise matrix
- [ ] Matrix averages correctly across selected models

🤖 Generated with [Claude Code](https://claude.com/claude-code)