### PR TITLE
fix: include neutral outcomes in pairwise win rate denominator

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
@@ -17,7 +17,7 @@ export type DomainAnalysisCacheStatus =
   (typeof DOMAIN_ANALYSIS_CACHE_STATUS)[keyof typeof DOMAIN_ANALYSIS_CACHE_STATUS];
 
 export const DOMAIN_ANALYSIS_SNAPSHOT_TYPE = 'domain_overview';
-export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.8.0';
+export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.9.0';
 export const DOMAIN_ANALYSIS_ASSUMPTION_PREFIX = 'domain-analysis';
 export const DOMAIN_ANALYSIS_NONE_SIGNATURE = '__none__';
 
@@ -27,6 +27,9 @@ export type DomainAnalysisSnapshotModel = {
   model: string;
   counts: Record<string, DomainAnalysisValueCounts>;
   pairwiseWins: Record<string, Record<string, number>>;
+  // Per-pair neutral counts keyed by [winner][loser] (only stored from valueA side to avoid
+  // double-counting). Optional for backward compat with snapshots built before v1.9.0.
+  pairwiseNeutrals?: Record<string, Record<string, number>>;
   // Equal-weight per-vignette win rates (0–100) and vignette counts per value key.
   // Optional for backward compatibility with snapshots built before v1.3.0.
   valueWinRates?: Record<string, number>;

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -71,7 +71,10 @@ function extractWinRates(snapshotModel: DomainAnalysisSnapshotModel, valueKeys: 
   return result;
 }
 
-function buildPairwiseWinRateModel(pairwiseWins: Record<string, Record<string, number>>): PairwiseWinRateModel {
+function buildPairwiseWinRateModel(
+  pairwiseWins: Record<string, Record<string, number>>,
+  pairwiseNeutrals?: Record<string, Record<string, number>>,
+): PairwiseWinRateModel {
   const order = [...SCHWARTZ_CIRCULAR_ORDER];
   const n = order.length;
   const winRateMatrix: Array<Array<number | null>> = [];
@@ -85,7 +88,12 @@ function buildPairwiseWinRateModel(pairwiseWins: Record<string, Record<string, n
       const keyJ = order[j] as string;
       const winsIJ = pairwiseWins[keyI]?.[keyJ] ?? 0;
       const winsJI = pairwiseWins[keyJ]?.[keyI] ?? 0;
-      const total = winsIJ + winsJI;
+      // Neutrals are stored from the valueA side only: keyI vs keyJ → neutrals[keyI][keyJ] when keyI < keyJ alphabetically is NOT guaranteed,
+      // so check both directions and take whichever has data.
+      const neutralsIJ = pairwiseNeutrals != null
+        ? (pairwiseNeutrals[keyI]?.[keyJ] ?? pairwiseNeutrals[keyJ]?.[keyI] ?? 0)
+        : 0;
+      const total = winsIJ + winsJI + neutralsIJ;
       winRateRow.push(total > 0 ? winsIJ / total : null);
       trialRow.push(total);
     }
@@ -125,7 +133,7 @@ function buildDomainAnalysisResultFromSnapshot(params: {
       model: model.model,
       label: activeModelLabelById.get(model.model) ?? model.model,
       values,
-      pairwiseWinRateModel: buildPairwiseWinRateModel(model.pairwiseWins),
+      pairwiseWinRateModel: buildPairwiseWinRateModel(model.pairwiseWins, model.pairwiseNeutrals),
     };
   });
 

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cell-win-rates.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cell-win-rates.ts
@@ -13,6 +13,7 @@ export type CellWeightedDomainModel = {
   model: string;
   counts: Record<string, DomainAnalysisValueCounts>;
   pairwiseWins: Record<string, Record<string, number>>;
+  pairwiseNeutrals: Record<string, Record<string, number>>;
   valueWinRates: Record<string, number>;
   vignetteCount: Record<string, number>;
 };
@@ -48,6 +49,20 @@ function addPairwiseWin(
   pairwiseWins.set(winner, winnerMap);
 }
 
+// Adds neutral counts for pair (valueA, valueB). Only called from the valueA side of each
+// vignette to avoid double-counting — a neutral outcome is shared by both values in the pair.
+function addPairwiseNeutral(
+  pairwiseNeutrals: Map<DomainAnalysisValueKey, Map<DomainAnalysisValueKey, number>>,
+  valueA: DomainAnalysisValueKey,
+  valueB: DomainAnalysisValueKey,
+  count: number,
+): void {
+  if (count <= 0) return;
+  const aMap = pairwiseNeutrals.get(valueA) ?? new Map<DomainAnalysisValueKey, number>();
+  aMap.set(valueB, (aMap.get(valueB) ?? 0) + count);
+  pairwiseNeutrals.set(valueA, aMap);
+}
+
 function getOrCreateCounts(
   countsByModel: Map<string, Map<DomainAnalysisValueKey, DomainAnalysisValueCounts>>,
   modelId: string,
@@ -80,6 +95,7 @@ export function computeCellWeightedDomainRates(params: {
 }): { models: CellWeightedDomainModel[]; analyzedDefinitionIds: Set<string> } {
   const countsByModel = new Map<string, Map<DomainAnalysisValueKey, DomainAnalysisValueCounts>>();
   const pairwiseWinsByModel = new Map<string, Map<DomainAnalysisValueKey, Map<DomainAnalysisValueKey, number>>>();
+  const pairwiseNeutralsByModel = new Map<string, Map<DomainAnalysisValueKey, Map<DomainAnalysisValueKey, number>>>();
   const ratesByModelDefinitionValue = new Map<string, Map<string, Map<DomainAnalysisValueKey, number[]>>>();
   const analyzedDefinitionIds = new Set<string>();
   const modelsById = new Set<string>();
@@ -116,8 +132,13 @@ export function computeCellWeightedDomainRates(params: {
     rates.push(rate);
     valueRatesByDefinition.set(decoded.valueKey, rates);
 
-    if (counts.wins <= 0) continue;
     const pair = params.definitionValuePairById.get(decoded.definitionId);
+    if (pair != null && decoded.valueKey === pair.valueA && counts.neutrals > 0) {
+      const pairwiseNeutrals = getOrCreatePairwise(pairwiseNeutralsByModel, decoded.modelId);
+      addPairwiseNeutral(pairwiseNeutrals, pair.valueA, pair.valueB, counts.neutrals);
+    }
+
+    if (counts.wins <= 0) continue;
     if (pair == null) continue;
 
     const pairwiseWins = getOrCreatePairwise(pairwiseWinsByModel, decoded.modelId);
@@ -167,6 +188,7 @@ export function computeCellWeightedDomainRates(params: {
         model: modelId,
         counts: toCountsRecord(valueCounts),
         pairwiseWins: toPairwiseRecord(pairwiseWinsByModel.get(modelId) ?? new Map<DomainAnalysisValueKey, Map<DomainAnalysisValueKey, number>>()),
+        pairwiseNeutrals: toPairwiseRecord(pairwiseNeutralsByModel.get(modelId) ?? new Map<DomainAnalysisValueKey, Map<DomainAnalysisValueKey, number>>()),
         valueWinRates,
         vignetteCount,
       };


### PR DESCRIPTION
## Summary
- Adds `pairwiseNeutrals` tracking to the domain analysis snapshot (stored from the `valueA` side of each vignette to avoid double-counting)
- `buildPairwiseWinRateModel` now uses `wins / (wins + losses + neutrals)` — matching the formula used in all other reports
- Previously the matrix used `wins_A / (wins_A + wins_B)` which excluded neutrals and would produce slightly different numbers
- Bumps snapshot version to `1.9.0` to trigger snapshot rebuilds on next request

## Why neutrals must be tracked from one side only
Each vignette tests two values (A, B). A neutral outcome is shared — both values see the same neutral count. Processing each cell independently would double-count if we added neutrals for both the A-cell and the B-cell. By only adding when `decoded.valueKey === pair.valueA`, each vignette's neutrals are counted exactly once.

## Backward compat
Old snapshots (pre-v1.9.0) have no `pairwiseNeutrals` field. `buildPairwiseWinRateModel` treats missing neutrals as 0 — same behavior as before until snapshots rebuild.

## Test plan
- [ ] CI passes
- [ ] Win Rate page pairwise matrix numbers match values shown in other reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)