### PR TITLE
fix: allow multiple vignettes per pair-direction in pair-detail resolver

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/analysis/pair-detail-types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/analysis/pair-detail-types.ts
@@ -27,25 +27,10 @@ export type DomainAnalysisPairDetailResult = {
   pooledMin: number | null;
   pooledMean: number | null;
   pooledMax: number | null;
-  iSquared: number | null;
+  pooledStdDev: number | null;
   vignetteCount: number;
   validEstimateCount: number;
 };
-
-export class MultipleVignettesPerDirectionError extends Error {
-  readonly code = 'MULTIPLE_VIGNETTES_PER_DIRECTION';
-
-  constructor(
-    public readonly pairKey: string,
-    public readonly direction: DomainAnalysisPairFramingDirection,
-    public readonly definitionIds: string[],
-  ) {
-    super(
-      `Multiple vignettes found for pair ${pairKey} direction ${direction}: ${definitionIds.join(', ')}. The data model assumes one vignette per (pair, direction); this is a hard invariant.`,
-    );
-    this.name = 'MultipleVignettesPerDirectionError';
-  }
-}
 
 export class PooledMeanDivergenceError extends Error {
   readonly code = 'POOLED_MEAN_DIVERGENCE';
@@ -106,7 +91,7 @@ builder.objectType(DomainAnalysisPairDetailResultRef, {
     pooledMin: t.exposeFloat('pooledMin', { nullable: true }),
     pooledMean: t.exposeFloat('pooledMean', { nullable: true }),
     pooledMax: t.exposeFloat('pooledMax', { nullable: true }),
-    iSquared: t.exposeFloat('iSquared', { nullable: true }),
+    pooledStdDev: t.exposeFloat('pooledStdDev', { nullable: true }),
     vignetteCount: t.exposeInt('vignetteCount'),
     validEstimateCount: t.exposeInt('validEstimateCount'),
   }),

--- a/cloud/apps/api/src/graphql/queries/domain/analysis/pair-detail.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/analysis/pair-detail.ts
@@ -10,7 +10,7 @@ import {
   resolveValuePairsInChunks,
   selectLatestDefinitionPerLineage,
 } from '../shared.js';
-import { computeISquared, computePairwiseWinRate } from '../../../../utils/pairwise-math.js';
+import { computePerVignetteStdDev, computePairwiseWinRate } from '../../../../utils/pairwise-math.js';
 import { wilsonCI95 } from '../../../../utils/binomial-ci.js';
 import {
   DomainAnalysisPairDetailResultRef,
@@ -122,7 +122,7 @@ builder.queryField('domainAnalysisPairDetail', (t) =>
           pooledMin: null,
           pooledMean: null,
           pooledMax: null,
-          iSquared: null,
+          pooledStdDev: null,
           vignetteCount: 0,
           validEstimateCount: 0,
         };
@@ -188,7 +188,7 @@ builder.queryField('domainAnalysisPairDetail', (t) =>
           pooledMin: null,
           pooledMean: null,
           pooledMax: null,
-          iSquared: null,
+          pooledStdDev: null,
           vignetteCount: 0,
           validEstimateCount: 0,
         };
@@ -304,7 +304,7 @@ builder.queryField('domainAnalysisPairDetail', (t) =>
         validEstimateCount === 0
           ? null
           : Math.max(...validVignettes.map((vignette) => vignette.selectedValueWinRate));
-      const iSquared = computeISquared(
+      const pooledStdDev = computePerVignetteStdDev(
         validVignettes.map((vignette) => ({
           winRate: vignette.selectedValueWinRate,
           totalTrials: vignette.totalTrials,
@@ -360,7 +360,7 @@ builder.queryField('domainAnalysisPairDetail', (t) =>
         pooledMin,
         pooledMean,
         pooledMax,
-        iSquared,
+        pooledStdDev,
         vignetteCount: vignettes.length,
         validEstimateCount,
       };

--- a/cloud/apps/api/src/graphql/queries/domain/analysis/pair-detail.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/analysis/pair-detail.ts
@@ -17,7 +17,6 @@ import {
   type DomainAnalysisPairDetailResult,
   type DomainAnalysisPairFramingDirection,
   type DomainAnalysisPairVignetteDetail,
-  MultipleVignettesPerDirectionError,
   PooledMeanDivergenceError,
 } from './pair-detail-types.js';
 
@@ -164,10 +163,15 @@ builder.queryField('domainAnalysisPairDetail', (t) =>
 
       for (const [direction, definitionIds] of definitionIdsByDirection.entries()) {
         if (definitionIds.length > 1) {
-          throw new MultipleVignettesPerDirectionError(
-            canonicalRequestedPairKey,
-            direction,
-            definitionIds,
+          ctx.log.warn(
+            {
+              pairKey: canonicalRequestedPairKey,
+              direction,
+              definitionIds,
+              modelId,
+              domainId,
+            },
+            'Multiple vignettes found for (pair, direction); aggregating across them. Original spec assumed 1:1 mapping; production data has cases where it does not hold.',
           );
         }
       }

--- a/cloud/apps/api/src/utils/pairwise-math.ts
+++ b/cloud/apps/api/src/utils/pairwise-math.ts
@@ -3,8 +3,6 @@
  * neutral outcomes in the denominator. Returns null when there are no
  * observations.
  */
-const EPSILON = 1e-6;
-
 export function computePairwiseWinRate(
   wins: number,
   losses: number,
@@ -16,68 +14,48 @@ export function computePairwiseWinRate(
 }
 
 /**
- * I² heterogeneity index for a set of per-vignette win-rate estimates.
- * Returns a number in [0, 100], or null when fewer than 2 valid estimates remain after filtering.
+ * Population standard deviation of per-vignette win-rate estimates,
+ * with each scenario counted equally regardless of trial count.
  *
- * Algorithm (per spec FR-011):
+ * ValueRank treats every vignette as a designed stimulus in a revealed-
+ * preference study; differences in trial count reflect data-collection
+ * choices, not differences in scenario importance. Weighting by trial count
+ * (as in textbook inverse-variance heterogeneity) would overrepresent
+ * heavily-sampled scenarios in the spread measure and contradict the
+ * unweighted arithmetic mean reported as `pooledMean`.
+ *
+ * `totalTrials` is used ONLY as a filter (drop zero-trial vignettes); it does
+ * NOT enter the spread calculation itself.
+ *
+ * Returns SD in [0, 1] (i.e., proportion units, the same unit as `winRate`),
+ * or null when fewer than 2 valid estimates remain after filtering.
+ *
+ * Algorithm:
  *   1. Filter out any input where totalTrials === 0 OR winRate === null
  *   2. If fewer than 2 valid estimates remain, return null
- *   3. For each estimate i:
- *        vi = max(p_i * (1 - p_i) / n_i, EPSILON)  with EPSILON = 1e-6
- *        wi = 1 / vi
- *   4. ybar_w = sum(wi * p_i) / sum(wi)
- *   5. Q = sum(wi * (p_i - ybar_w)^2)
- *   6. df = k - 1  where k = number of valid estimates
- *   7. If Q === 0 return 0
- *   8. Return max(0, (Q - df) / Q) * 100
+ *   3. mean = unweighted arithmetic mean of the per-vignette win rates
+ *   4. variance = sum((p_i - mean)^2) / k        (population variance, divisor k)
+ *   5. Return sqrt(variance)
  */
-export function computeISquared(
+export function computePerVignetteStdDev(
   estimates: Array<{ winRate: number | null; totalTrials: number }>,
 ): number | null {
-  const validEstimates = estimates.filter(
-    (
-      estimate,
-    ): estimate is {
-      winRate: number;
-      totalTrials: number;
-    } => estimate.totalTrials > 0 && estimate.winRate !== null,
-  );
+  const validRates = estimates
+    .filter(
+      (estimate) => estimate.totalTrials > 0 && estimate.winRate !== null,
+    )
+    .map((estimate) => estimate.winRate as number);
 
-  if (validEstimates.length < 2) {
+  if (validRates.length < 2) {
     return null;
   }
 
-  const weightedEstimates = validEstimates.map((estimate) => {
-    const variance = Math.max(
-      (estimate.winRate * (1 - estimate.winRate)) / estimate.totalTrials,
-      EPSILON,
-    );
-
-    return {
-      winRate: estimate.winRate,
-      weight: 1 / variance,
-    };
-  });
-
-  const totalWeight = weightedEstimates.reduce(
-    (sum, estimate) => sum + estimate.weight,
+  const mean =
+    validRates.reduce((sum, rate) => sum + rate, 0) / validRates.length;
+  const sumSquaredDeviations = validRates.reduce(
+    (sum, rate) => sum + (rate - mean) ** 2,
     0,
   );
-  const weightedMean =
-    weightedEstimates.reduce(
-      (sum, estimate) => sum + estimate.weight * estimate.winRate,
-      0,
-    ) / totalWeight;
-  const q = weightedEstimates.reduce(
-    (sum, estimate) =>
-      sum + estimate.weight * (estimate.winRate - weightedMean) ** 2,
-    0,
-  );
-
-  if (q === 0) {
-    return 0;
-  }
-
-  const degreesOfFreedom = validEstimates.length - 1;
-  return Math.max(0, (q - degreesOfFreedom) / q) * 100;
+  const variance = sumSquaredDeviations / validRates.length;
+  return Math.sqrt(variance);
 }

--- a/cloud/apps/api/tests/utils/pairwise-math.test.ts
+++ b/cloud/apps/api/tests/utils/pairwise-math.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeISquared } from '../../src/utils/pairwise-math.js';
+import { computePerVignetteStdDev } from '../../src/utils/pairwise-math.js';
 
-describe('computeISquared', () => {
+describe('computePerVignetteStdDev', () => {
   it('returns null for an empty set of estimates', () => {
-    expect(computeISquared([])).toBeNull();
+    expect(computePerVignetteStdDev([])).toBeNull();
   });
 
   it('returns null when fewer than two valid estimates remain', () => {
-    expect(computeISquared([{ winRate: 0.5, totalTrials: 100 }])).toBeNull();
+    expect(computePerVignetteStdDev([{ winRate: 0.5, totalTrials: 100 }])).toBeNull();
   });
 
   it('returns null when every estimate is filtered out', () => {
     expect(
-      computeISquared([
+      computePerVignetteStdDev([
         { winRate: null, totalTrials: 100 },
         { winRate: null, totalTrials: 100 },
       ]),
@@ -22,26 +22,42 @@ describe('computeISquared', () => {
 
   it('returns zero for identical estimates', () => {
     expect(
-      computeISquared([
+      computePerVignetteStdDev([
         { winRate: 0.5, totalTrials: 100 },
         { winRate: 0.5, totalTrials: 100 },
       ]),
     ).toBe(0);
   });
 
-  it('returns a high heterogeneity value for widely separated estimates', () => {
-    const result = computeISquared([
+  it('returns the population SD of widely separated estimates, ignoring trial counts', () => {
+    const result = computePerVignetteStdDev([
       { winRate: 0.1, totalTrials: 100 },
       { winRate: 0.9, totalTrials: 100 },
     ]);
 
+    // Population SD of [0.1, 0.9] with mean 0.5: sqrt(((0.1-0.5)^2 + (0.9-0.5)^2)/2) = 0.4
     expect(result).not.toBeNull();
-    expect(result).toBeGreaterThan(50);
+    expect(result).toBeCloseTo(0.4, 6);
   });
 
-  it('does not throw when estimates sit at the binomial extremes', () => {
+  it('weights every vignette equally regardless of trial count', () => {
+    // Same rates as above but with very different trial counts. SD must not change,
+    // because totalTrials is filter-only.
+    const balanced = computePerVignetteStdDev([
+      { winRate: 0.1, totalTrials: 100 },
+      { winRate: 0.9, totalTrials: 100 },
+    ]);
+    const skewed = computePerVignetteStdDev([
+      { winRate: 0.1, totalTrials: 5 },
+      { winRate: 0.9, totalTrials: 10000 },
+    ]);
+
+    expect(balanced).toBeCloseTo(skewed ?? -1, 9);
+  });
+
+  it('does not throw when estimates sit at the proportion extremes', () => {
     expect(() =>
-      computeISquared([
+      computePerVignetteStdDev([
         { winRate: 0.0, totalTrials: 100 },
         { winRate: 1.0, totalTrials: 100 },
       ]),

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -900,12 +900,12 @@ type DomainAnalysisPairDetailResult {
   columnValueKey: String!
   domainId: ID
   domainName: String
-  iSquared: Float
   modelId: String!
   modelLabel: String!
   pooledMax: Float
   pooledMean: Float
   pooledMin: Float
+  pooledStdDev: Float
   rowValueKey: String!
   validEstimateCount: Int!
   vignetteCount: Int!

--- a/cloud/apps/web/src/api/operations/domainAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.graphql
@@ -208,7 +208,7 @@ query DomainAnalysisPairDetail(
     pooledMin
     pooledMean
     pooledMax
-    iSquared
+    pooledStdDev
     vignetteCount
     validEstimateCount
   }

--- a/cloud/apps/web/src/components/domains/ForestPlot.tsx
+++ b/cloud/apps/web/src/components/domains/ForestPlot.tsx
@@ -26,7 +26,7 @@ export type ForestPlotProps = {
   pooledMin: number | null;
   pooledMean: number | null;
   pooledMax: number | null;
-  iSquared: number | null;
+  pooledStdDev: number | null;
   splitByDirection: boolean;
   onToggleSplit: () => void;
   onRowClick: (row: ForestPlotRow) => void;
@@ -183,7 +183,7 @@ export function ForestPlot({
   pooledMin,
   pooledMean,
   pooledMax,
-  iSquared,
+  pooledStdDev,
   splitByDirection,
   onToggleSplit,
   onRowClick,
@@ -199,7 +199,7 @@ export function ForestPlot({
   const rowsHeight = rows.length * ROW_HEIGHT;
   const summaryTop = rowsTop + rowsHeight + 10;
   const axisY = summaryTop + (summaryVisible ? SUMMARY_HEIGHT : 6);
-  const svgHeight = axisY + (iSquared != null ? 42 : 26);
+  const svgHeight = axisY + (pooledStdDev != null ? 42 : 26);
   const referenceLineBottom = summaryVisible ? summaryTop + 12 : rowsTop + rowsHeight - 4;
 
   return (
@@ -316,13 +316,13 @@ export function ForestPlot({
           </g>
         )}
 
-        {iSquared != null && (
+        {pooledStdDev != null && (
           <text
             x={PLOT_START_X}
             y={summaryTop + (summaryVisible ? 34 : 18)}
             className="fill-gray-600 text-[11px]"
           >
-            {`I² = ${Math.round(iSquared)}%`}
+            {`SD = ${(pooledStdDev * 100).toFixed(1)} pp`}
           </text>
         )}
 

--- a/cloud/apps/web/src/components/domains/PairwiseCellDrawer.tsx
+++ b/cloud/apps/web/src/components/domains/PairwiseCellDrawer.tsx
@@ -349,7 +349,7 @@ export function PairwiseCellDrawer({
           pooledMin={detail.pooledMin ?? null}
           pooledMean={detail.pooledMean ?? null}
           pooledMax={detail.pooledMax ?? null}
-          iSquared={detail.iSquared ?? null}
+          pooledStdDev={detail.pooledStdDev ?? null}
           splitByDirection={splitByDirection}
           onToggleSplit={handleToggleSplit}
           onRowClick={handleRowClick}

--- a/cloud/apps/web/src/components/domains/__tests__/PairwiseCellDrawer.test.tsx
+++ b/cloud/apps/web/src/components/domains/__tests__/PairwiseCellDrawer.test.tsx
@@ -26,7 +26,7 @@ function createResult(): DomainAnalysisPairDetailQueryResult {
       pooledMin: 0.4,
       pooledMean: 0.55,
       pooledMax: 0.7,
-      iSquared: 73,
+      pooledStdDev: 0.12,
       vignetteCount: 2,
       validEstimateCount: 2,
       vignettes: [

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -795,12 +795,12 @@ export type DomainAnalysisPairDetailResult = {
   columnValueKey: Scalars['String']['output'];
   domainId?: Maybe<Scalars['ID']['output']>;
   domainName?: Maybe<Scalars['String']['output']>;
-  iSquared?: Maybe<Scalars['Float']['output']>;
   modelId: Scalars['String']['output'];
   modelLabel: Scalars['String']['output'];
   pooledMax?: Maybe<Scalars['Float']['output']>;
   pooledMean?: Maybe<Scalars['Float']['output']>;
   pooledMin?: Maybe<Scalars['Float']['output']>;
+  pooledStdDev?: Maybe<Scalars['Float']['output']>;
   rowValueKey: Scalars['String']['output'];
   validEstimateCount: Scalars['Int']['output'];
   vignetteCount: Scalars['Int']['output'];
@@ -4388,7 +4388,7 @@ export type DomainAnalysisPairDetailQueryVariables = Exact<{
 }>;
 
 
-export type DomainAnalysisPairDetailQuery = { __typename?: 'Query', domainAnalysisPairDetail: { __typename?: 'DomainAnalysisPairDetailResult', rowValueKey: string, columnValueKey: string, modelId: string, modelLabel: string, domainId?: string | null, domainName?: string | null, pooledMin?: number | null, pooledMean?: number | null, pooledMax?: number | null, iSquared?: number | null, vignetteCount: number, validEstimateCount: number, vignettes: Array<{ __typename?: 'DomainAnalysisPairVignetteDetail', definitionId: string, definitionName: string, prioritized: number, deprioritized: number, neutral: number, totalTrials: number, selectedValueWinRate?: number | null, winRateCI95Low?: number | null, winRateCI95High?: number | null, refusalRate?: number | null, framingDirection: DomainAnalysisPairFramingDirection }> } };
+export type DomainAnalysisPairDetailQuery = { __typename?: 'Query', domainAnalysisPairDetail: { __typename?: 'DomainAnalysisPairDetailResult', rowValueKey: string, columnValueKey: string, modelId: string, modelLabel: string, domainId?: string | null, domainName?: string | null, pooledMin?: number | null, pooledMean?: number | null, pooledMax?: number | null, pooledStdDev?: number | null, vignetteCount: number, validEstimateCount: number, vignettes: Array<{ __typename?: 'DomainAnalysisPairVignetteDetail', definitionId: string, definitionName: string, prioritized: number, deprioritized: number, neutral: number, totalTrials: number, selectedValueWinRate?: number | null, winRateCI95Low?: number | null, winRateCI95High?: number | null, refusalRate?: number | null, framingDirection: DomainAnalysisPairFramingDirection }> } };
 
 export type DomainAnalysisConditionTranscriptsQueryVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -6289,7 +6289,7 @@ export const DomainAnalysisPairDetailDocument = gql`
     pooledMin
     pooledMean
     pooledMax
-    iSquared
+    pooledStdDev
     vignetteCount
     validEstimateCount
   }
@@ -7469,6 +7469,12 @@ export const PressureSensitivityDocument = gql`
         averageWinRate
         balancedWinRate
         highPressureOnThisValueWinRate
+        highPressureOnThisValueDomainRates {
+          domainId
+          domainName
+          rate
+          pairsMeasured
+        }
         highPressureOnOpposingValueWinRate
         pairsMeasured
       }


### PR DESCRIPTION
## Summary
Hotfix for PR #972, plus a methodological correction.

### Bug fix: drawer crash on multi-vignette pairs
Production data has multiple vignettes for the same `(value-pair, direction)` (e.g., Universalism vs Benevolence-Dependability has two A_TO_B vignettes). The new resolver enforced a 1:1 mapping as a hard runtime invariant and threw `MultipleVignettesPerDirectionError`, surfacing as **"Failed to load pair detail"** in the drawer. Replace the throw with a logged warning; emit all vignettes in the result. Forest plot already handles N rows per direction in both views.

### Methodological correction: drop trial-weighted I² for unit-weighted SD
Original implementation used inverse-variance weights (∝ trial count) for the I² heterogeneity index. This contradicted both the unweighted arithmetic mean shown as `pooledMean` AND the revealed-preference framing where each vignette is a designed stimulus, not a sample.

Replaced with standard deviation of per-vignette rates with unit weights:
- `computeISquared` → `computePerVignetteStdDev`
- Field `iSquared` → `pooledStdDev`
- UI label `"I² = X%"` → `"SD = X pp"`
- `totalTrials` now used ONLY as a filter (drop zero-trial vignettes); it does NOT enter the spread calculation

### Why this slipped past the original review
Two reviewers flagged Assumption 0 (one vignette per pair-direction) as UNVERIFIED in spec rounds 5 and 6. I confirmed it from one specific cell during spec authoring (Software Approach Choice, Benevolence vs others) and accepted the assumption as-designed. The Universalism pair specifically has 2 A→B vignettes; the runtime invariant was not safe to enforce.

The trial-weighted I² was also a defensible-looking textbook choice that nobody flagged at the time, but is wrong for revealed-preference data.

## Test plan
- [x] API lint, build clean
- [x] API tests: 32 passing including 7 for `computePerVignetteStdDev` (covers SD invariance to trial count)
- [x] Web lint, build clean
- [x] Drawer test passing (3/3)
- [x] Codegen run after schema changes
- [ ] Production smoke test: re-run `domainAnalysisPairDetail(valueA: "Benevolence_Dependability", valueB: "Universalism_Nature", modelId: "claude-sonnet-4-5", domainId: "cmnn9r7200000a4yaye4uh16j")` after deploy — should now return data instead of erroring
- [ ] Manual: open the Pairwise drawer in production for a cell that previously errored

🤖 Generated with [Claude Code](https://claude.com/claude-code)