### PR TITLE
[codex] fix empty model filter

### DIFF
--- a/cloud/apps/web/src/pages/DomainAnalysis.test.ts
+++ b/cloud/apps/web/src/pages/DomainAnalysis.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { filterSelectedModels } from './DomainAnalysis';
+import { VALUES, type ModelEntry, type ValueKey } from '../data/domainAnalysisData';
+
+function createModel(model: string, label: string): ModelEntry {
+  const values = Object.fromEntries(VALUES.map((valueKey, index) => [valueKey, index + 1])) as Record<ValueKey, number>;
+  return {
+    model,
+    label,
+    values,
+  };
+}
+
+describe('filterSelectedModels', () => {
+  it('returns no models when the selection is empty', () => {
+    expect(filterSelectedModels([createModel('model-a', 'Model A')], [], (model) => model.model)).toEqual([]);
+  });
+
+  it('returns only the selected models in the original order', () => {
+    const models = [
+      createModel('model-a', 'Model A'),
+      createModel('model-b', 'Model B'),
+      createModel('model-c', 'Model C'),
+    ];
+
+    expect(filterSelectedModels(models, ['model-c', 'model-a'], (model) => model.model)).toEqual([
+      models[0],
+      models[2],
+    ]);
+  });
+});

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -52,6 +52,19 @@ import {
 
 const ALL_DOMAINS_SCOPE = 'all-domains';
 
+export function filterSelectedModels<T>(
+  models: T[],
+  selectedModelIds: string[],
+  getModelId: (model: T) => string,
+): T[] {
+  if (selectedModelIds.length === 0) {
+    return [];
+  }
+
+  const selected = new Set(selectedModelIds);
+  return models.filter((model) => selected.has(getModelId(model)));
+}
+
 export function DomainAnalysis() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -288,8 +301,8 @@ export function DomainAnalysis() {
     [defaultSelection, models],
   );
 
-  const visibleModels = useMemo(
-    () => selectedModelIds.length === 0 ? models : models.filter((model) => selectedModelIds.includes(model.model)),
+  const selectedModels = useMemo(
+    () => filterSelectedModels(models, selectedModelIds, (model) => model.model),
     [models, selectedModelIds],
   );
   const selectedModelId = selectedModelIds.length === 1 ? (selectedModelIds[0] ?? null) : null;
@@ -300,12 +313,14 @@ export function DomainAnalysis() {
     setOpenPair(null);
   }, [selectedDomainIdForDrawer, selectedModelId, selectedSignatureForDrawer]);
 
-  const visiblePairwiseModels = useMemo(() => {
-    const sourceModels = data?.domainAnalysis.models ?? [];
-    return selectedModelIds.length === 0
-      ? sourceModels
-      : sourceModels.filter((m) => selectedModelIds.includes(m.model));
-  }, [data?.domainAnalysis.models, selectedModelIds]);
+  const visiblePairwiseModels = useMemo(
+    () => filterSelectedModels(data?.domainAnalysis.models ?? [], selectedModelIds, (model) => model.model),
+    [data?.domainAnalysis.models, selectedModelIds],
+  );
+  const visibleStabilityModels = useMemo(
+    () => filterSelectedModels(modelsStabilityData?.modelsWinRateStability.models ?? [], selectedModelIds, (model) => model.modelId),
+    [modelsStabilityData?.modelsWinRateStability.models, selectedModelIds],
+  );
 
   const missingDefinitionCount = data?.domainAnalysis.missingDefinitions?.length ?? 0;
   const allMissingDefinitionIds = useMemo(
@@ -468,14 +483,14 @@ export function DomainAnalysis() {
       ) : (
         <>
           <ValuePrioritiesSection
-            models={visibleModels}
+            models={selectedModels}
             selectedDomainId={selectedDomainId}
             selectedSignature={selectedSignature === '' ? null : selectedSignature}
             isReadOnly={isAllDomains}
             showStabilityDots
           />
           <DominanceSection
-            models={visibleModels}
+            models={selectedModels}
           />
           <PairwiseWinRateMatrix
             models={visiblePairwiseModels}
@@ -493,7 +508,7 @@ export function DomainAnalysis() {
             errorMessage={modelsAnalysisError?.message ?? null}
           />
           <WinRateStabilitySection
-            models={modelsStabilityData?.modelsWinRateStability.models ?? []}
+            models={visibleStabilityModels}
             skippedVignettes={modelsStabilityData?.modelsWinRateStability.skippedVignettes ?? []}
             fetching={modelsStabilityFetching}
             errorMessage={modelsStabilityError?.message ?? null}


### PR DESCRIPTION
## What changed

- The win-rate page now treats an empty model selection as empty for every table on the page.
- `DomainAnalysis` filters the selected models once and passes that filtered list to the value priorities, dominance, pairwise win rate, and win-rate stability sections.
- Added a small regression test for the model-filter helper.

## Why

Clearing the model filter used to fall back to showing all models in part of the page. That made the UI say no models were selected while the tables still rendered results.

## Root cause

The page-level wiring treated an empty selection as `all models` instead of `no models` for some sections.

## Validation

- `npm run test --workspace=@valuerank/web -- --run src/pages/DomainAnalysis.test.ts`
- `npm run build --workspace=@valuerank/web`