### PR TITLE
Add total trial column to value priorities table

### DIFF
--- a/cloud/apps/web/src/components/domains/ValuePrioritiesTable.tsx
+++ b/cloud/apps/web/src/components/domains/ValuePrioritiesTable.tsx
@@ -12,7 +12,12 @@ import { CopyVisualButton } from '../ui/CopyVisualButton';
 import { Tooltip } from '../ui/Tooltip';
 import { StabilityDots } from '../models/StabilityDotsView';
 import { getPriorityColor } from './domainAnalysisColors';
-import { formatMetricValue, getMetricValue, type DisplayMetric } from './valuePrioritiesMetric';
+import {
+  formatMetricValue,
+  formatTrialCount,
+  getMetricValue,
+  type DisplayMetric,
+} from './valuePrioritiesMetric';
 
 type SortState = {
   key: 'model' | ValueKey;
@@ -202,6 +207,12 @@ export function ValuePrioritiesTable({
                   {sortState.key === 'model' ? (sortState.direction === 'asc' ? '↑' : '↓') : ''}
                 </Button>
               </th>
+              <th
+                className="border-r-2 border-gray-300 px-2 py-2 text-right font-medium"
+                rowSpan={2}
+              >
+                Total
+              </th>
               {TOP_COLUMN_GROUPS.map((group, groupIndex) => {
                 const isOpennessGroup = group.label === 'Openness to Change';
                 return (
@@ -295,6 +306,9 @@ export function ValuePrioritiesTable({
                 <td className="border-r-2 border-gray-300 px-2 py-2">
                   <div className="font-medium text-gray-900">{model.label}</div>
                 </td>
+                <td className="border-r-2 border-gray-300 px-2 py-2 text-right font-medium text-gray-700 tabular-nums">
+                  {formatTrialCount(model.totalTrials)}
+                </td>
                 {COLUMN_VALUES.map((value) => {
                   const cellValue = getMetricValue(model, value, displayMetric);
                   const stabilityScore = model.stabilityScores?.[value] ?? null;
@@ -352,6 +366,9 @@ export function ValuePrioritiesTable({
               <tr className="border-t-2 border-gray-300">
                 <td className="border-r-2 border-gray-300 px-2 py-2">
                   <div className="text-xs font-medium italic text-gray-500">Avg</div>
+                </td>
+                <td className="border-r-2 border-gray-300 px-2 py-2 text-right text-xs text-gray-500">
+                  —
                 </td>
                 {COLUMN_VALUES.map((value) => {
                   const avg = avgMetricValues[value];

--- a/cloud/apps/web/src/components/domains/valuePrioritiesMetric.ts
+++ b/cloud/apps/web/src/components/domains/valuePrioritiesMetric.ts
@@ -1,6 +1,7 @@
 import { type ModelEntry, type ValueKey } from '../../data/domainAnalysisData';
 
 export type DisplayMetric = 'winRate' | 'logit';
+const trialCountFormatter = new Intl.NumberFormat('en-US');
 
 export const DISPLAY_METRICS: Array<{ value: DisplayMetric; label: string }> = [
   { value: 'winRate', label: 'Win rate' },
@@ -18,4 +19,9 @@ export function getMetricValue(
 export function formatMetricValue(value: number | null, metric: DisplayMetric): string {
   if (value == null) return 'n/a';
   return metric === 'winRate' ? `${value.toFixed(1)}%` : value.toFixed(2);
+}
+
+export function formatTrialCount(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return 'n/a';
+  return trialCountFormatter.format(value);
 }

--- a/cloud/apps/web/src/data/domainAnalysisData.ts
+++ b/cloud/apps/web/src/data/domainAnalysisData.ts
@@ -16,6 +16,7 @@ export type ModelEntry = {
   values: Record<ValueKey, number>;
   winRates?: Record<ValueKey, number | null>;
   stabilityScores?: Record<ValueKey, number | null>;
+  totalTrials?: number;
 };
 
 export type DomainAnalysisModelAvailability = {

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -254,12 +254,14 @@ export function DomainAnalysis() {
         acc[valueKey] = stabilityScoresByModel.get(model.model)?.get(valueKey) ?? null;
         return acc;
       }, {} as Record<ValueKey, number | null>);
+      const totalComparisons = model.values.reduce((sum, value) => sum + value.totalComparisons, 0);
       return {
         model: model.model,
         label: model.label,
         values,
         winRates,
         stabilityScores,
+        totalTrials: Math.round(totalComparisons / 2),
       };
     });
   }, [data, modelsAnalysisData]);

--- a/cloud/apps/web/tests/components/ValuePrioritiesSection.test.tsx
+++ b/cloud/apps/web/tests/components/ValuePrioritiesSection.test.tsx
@@ -17,6 +17,7 @@ function buildModel(label: string): ModelEntry {
     label,
     values,
     winRates,
+    totalTrials: 123,
   };
 }
 
@@ -32,8 +33,10 @@ describe('ValuePrioritiesSection', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('heading', { name: 'Win Rate by Values by Model' })).toBeInTheDocument();
-    expect(screen.queryByText(/model groups/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /full bt/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Win Rate by Values by Model' })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'Total' })).toBeTruthy();
+    expect(screen.getByText('123')).toBeTruthy();
+    expect(screen.queryByText(/model groups/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /full bt/i })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Add a `Total` column to the Win Rate by Values by Model table.
- Compute the total from the selected domain and signature data used to build each model row.
- Cover the new column in the component test.

## Validation
- `npm run lint --workspace @valuerank/web` ✅
- `npm run build --workspace @valuerank/web` ✅
- `npm run test --workspace @valuerank/web -- --environment jsdom tests/components/ValuePrioritiesSection.test.tsx` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)