### PR TITLE
[codex] Add model grouping significance report

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -38,6 +38,9 @@
 | Feature | Branch | Status | Notes |
 |---------|--------|--------|-------|
 | **forest-plot-pairwise-drawer** | `—` | 🟢 Done locally | Pairwise Win Rate Matrix cells now open a right-side drawer for single-model, single-domain, signed selections. The drawer fetches pair detail data, renders a forest plot with split-by-direction toggle, summary band, I² label, inline expansion for averaged rows, and loading/error/empty states. Focused web test added; local web lint, full vitest, and build checks pass. |
+| **model-grouping-pairwise-significance-tasks** | `—` | 🟢 Done locally | Added the implementation task list for the bottom-of-page `/models` pairwise significance report, with backend-owned paired permutation tests, page-scope wiring, and heatmap/table UI slices. |
+| **model-grouping-pairwise-significance-plan** | `—` | 🟢 Done locally | Drafted the implementation plan for the new bottom-of-page `/models` pairwise significance report, with backend-owned paired permutation tests, Holm-Bonferroni correction, and a heatmap + sortable table UI. |
+| **model-grouping-pairwise-significance-spec** | `—` | 🟢 Done locally | Drafted the spec for a bottom-of-page `/models` report that compares selected models pairwise with paired permutation tests, Holm-Bonferroni correction, a scan heatmap, and a sortable source-of-truth table. |
 | **win-rate-domain-shift-decimals** | `—` | 🟢 Done locally | Win Rate by Domain by Value now shows shift values with one decimal place in the report page and the shared report section. The shared whole-point formatter stays intact for the other model tables. |
 | **win-rate-report-cleanup** | `—` | 🟢 Done locally | Cleaned up the Win Rate pages: removed the extra intro copy, moved Export CSV into the freshness row, simplified the Win Rate by Domain by Value header, put Cell metric inline with its toggle, removed the percent-change note, and narrowed screenshot capture to the table only. |
 | **status-page-pending-launches** | `—` | 🟢 Done locally | Status page active-evaluation query now includes PENDING, RUNNING, PAUSED, and SUMMARIZING launches so stuck-but-working runs show up again. Added API regression coverage and updated the section copy to match. |
@@ -107,6 +110,7 @@ Once the above are resolved:
 - [x] Win Rate findings controls now live at the top of the page, and the model focus selector applies across the model groups, value priorities, dominance, similarity, and embedded Domain Shifts sections.
 - [x] Value Priorities now uses win rate only, with the retired Full BT toggle removed and the cell dots rendered under the numbers.
 - [x] Pressure Sensitivity page now includes a **Pressure Directional Breakdown** cross-model table showing pushed-for effect, pushed-against effect, gap, and pairs per model. Answers: "Does pressure work equally in both directions?" PR #834.
+- [x] Pressure Directional Breakdown now labels the overall column as **High Pressure on Value Effect** for consistency with the pressure value tables.
 - [x] Pressure Sensitivity now uses the standard default-model multi-select, keeps the tooltip anchored while scrolling, and moves the cross-model response table to the bottom of the report.
 - [x] Pressure Response by Value now weights each vignette once and uses pooled directional coverage, so sparse cells no longer trip the "below coverage thresholds" error when the report has enough total vignette coverage.
 - [ ] Review the new pairwise forest drawer copy and capture screenshots for the AAPOR deck now that the drilldown is available.

--- a/cloud/apps/api/src/graphql/queries/model-grouping-significance.ts
+++ b/cloud/apps/api/src/graphql/queries/model-grouping-significance.ts
@@ -1,0 +1,214 @@
+import { db } from '@valuerank/db';
+import { ValidationError } from '@valuerank/shared';
+import { builder } from '../builder.js';
+import { buildAssumptionKey, parseSnapshotOutput } from '../../services/analysis/domain-analysis-snapshot-builder.js';
+import { DOMAIN_ANALYSIS_SNAPSHOT_TYPE } from '../../services/analysis/domain-analysis-cache-types.js';
+import { DOMAIN_ANALYSIS_VALUE_KEYS } from './domain-analysis-values.js';
+import { getModelsFromDatabase } from '../../config/models.js';
+import { ModelGroupingSignificanceResultRef } from '../types/model-grouping-significance.js';
+import {
+  classifyEffectSize,
+  classifyVerdict,
+  holmBonferroni,
+  pairedCohensD,
+  pairedMeanConfidenceInterval,
+  pairedPermutationPValue,
+} from '../../services/model-grouping-significance/math.js';
+import type { DomainAnalysisSnapshotOutput } from '../../services/analysis/domain-analysis-cache-types.js';
+
+type SnapshotModel = NonNullable<DomainAnalysisSnapshotOutput['models'][number]>;
+
+function sortModelIds(modelIds: string[]): string[] {
+  return [...new Set(modelIds.map((modelId) => modelId.trim()).filter((modelId) => modelId.length > 0))]
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function getScopeAssumptionKey(scope: string, domainId: string | null): string {
+  if (scope === 'ALL_DOMAINS') {
+    return buildAssumptionKey('ALL_DOMAINS', domainId ?? 'all-domains');
+  }
+  return buildAssumptionKey('DOMAIN', domainId ?? '');
+}
+
+function toFiniteRecord(values: SnapshotModel['valueWinRates']): Record<string, number> | null {
+  if (values == null) return null;
+  const record: Record<string, number> = {};
+  for (const valueKey of DOMAIN_ANALYSIS_VALUE_KEYS) {
+    const value = values[valueKey];
+    if (value == null || !Number.isFinite(value)) return null;
+    record[valueKey] = value;
+  }
+  return record;
+}
+
+builder.queryField('modelGroupingSignificance', (t) =>
+  t.field({
+    type: ModelGroupingSignificanceResultRef,
+    args: {
+      modelIds: t.arg.stringList({ required: true }),
+      domainId: t.arg.id({ required: false }),
+      scope: t.arg.string({ required: true }),
+      signature: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      const scope = String(args.scope);
+      if (scope !== 'DOMAIN' && scope !== 'ALL_DOMAINS') {
+        throw new ValidationError(`Unsupported scope: ${scope}`);
+      }
+
+      const selectedModelIds = sortModelIds(args.modelIds.map(String));
+      if (selectedModelIds.length < 2) {
+        return { models: [], rows: [] };
+      }
+
+      const domainId = args.domainId != null ? String(args.domainId) : null;
+      if (scope === 'DOMAIN' && (domainId == null || domainId.trim() === '')) {
+        throw new ValidationError('domainId is required when scope is DOMAIN');
+      }
+
+      const signature = String(args.signature).trim();
+      if (signature.length === 0) {
+        throw new ValidationError('signature is required');
+      }
+
+      const assumptionKey = getScopeAssumptionKey(scope, domainId);
+      const currentSnapshot = await db.assumptionAnalysisSnapshot.findFirst({
+        where: {
+          assumptionKey,
+          analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
+          configSignature: signature,
+          status: 'CURRENT',
+          deletedAt: null,
+        },
+        orderBy: [
+          { createdAt: 'desc' },
+          { id: 'desc' },
+        ],
+        select: {
+          output: true,
+        },
+      });
+
+      if (currentSnapshot == null) {
+        throw new ValidationError('Pairwise significance could not be computed because no cached analysis snapshot was found for the selected scope.');
+      }
+
+      const parsed = parseSnapshotOutput(currentSnapshot.output);
+      if (parsed == null) {
+        throw new ValidationError('Pairwise significance could not be computed because the cached analysis snapshot could not be parsed.');
+      }
+
+      const activeModels = await getModelsFromDatabase({
+        activeOnly: true,
+        availableOnly: false,
+      });
+      const labelByModelId = new Map(activeModels.map((model) => [model.modelId, model.displayName] as const));
+
+      const availableModelMap = new Map<string, SnapshotModel>();
+      for (const snapshotModel of parsed.models) {
+        availableModelMap.set(snapshotModel.model, snapshotModel);
+      }
+
+      const selectedModels = selectedModelIds.map((modelId) => {
+        const label = labelByModelId.get(modelId) ?? modelId;
+        const snapshotModel = availableModelMap.get(modelId) ?? null;
+        return { modelId, label, snapshotModel };
+      });
+
+      const missingModels = selectedModels.filter((model) => model.snapshotModel == null);
+      if (missingModels.length > 0) {
+        throw new ValidationError(
+          `Pairwise significance could not be computed because ${missingModels.map((model) => model.label).join(', ')} is missing analysis data in the selected scope.`,
+        );
+      }
+
+      const normalizedModels = selectedModels.map((model) => {
+        const values = toFiniteRecord(model.snapshotModel?.valueWinRates);
+        if (values == null) {
+          throw new ValidationError(
+            `Pairwise significance could not be computed because ${model.label} is missing equal-vignette win-rate data in the selected scope.`,
+          );
+        }
+        return {
+          modelId: model.modelId,
+          label: model.label,
+          values,
+        };
+      });
+
+      const rows = [];
+      for (let leftIndex = 0; leftIndex < normalizedModels.length; leftIndex += 1) {
+        for (let rightIndex = leftIndex + 1; rightIndex < normalizedModels.length; rightIndex += 1) {
+          const left = normalizedModels[leftIndex]!;
+          const right = normalizedModels[rightIndex]!;
+          const differences = DOMAIN_ANALYSIS_VALUE_KEYS.map(
+            (valueKey) => {
+              const leftValue = left.values[valueKey];
+              const rightValue = right.values[valueKey];
+              if (leftValue == null || rightValue == null) {
+                throw new ValidationError('Pairwise significance could not be computed because the selected scope has incomplete vignette coverage.');
+              }
+              return leftValue - rightValue;
+            },
+          );
+          const rawPValue = pairedPermutationPValue(differences);
+          const { mean: meanDifference, ciLow, ciHigh, n } = pairedMeanConfidenceInterval(differences);
+          const effectSize = pairedCohensD(differences);
+          rows.push({
+            modelAId: left.modelId,
+            modelALabel: left.label,
+            modelBId: right.modelId,
+            modelBLabel: right.label,
+            n,
+            meanDifference,
+            rawPValue,
+            holmCorrectedPValue: null,
+            effectSize,
+            effectLabel: classifyEffectSize(effectSize),
+            confidenceIntervalLow: ciLow,
+            confidenceIntervalHigh: ciHigh,
+            verdict: 'Not significant' as const,
+          });
+        }
+      }
+
+      const corrected = holmBonferroni(rows.map((row) => row.rawPValue));
+      const finalRows = rows.map((row, index) => {
+        const holmCorrectedPValue = corrected[index] ?? null;
+        return {
+          ...row,
+          holmCorrectedPValue,
+          verdict: classifyVerdict({
+            correctedPValue: holmCorrectedPValue,
+            effectSize: row.effectSize,
+            alpha: 0.05,
+          }),
+        };
+      });
+
+      const sortedModels = normalizedModels.slice().sort((left, right) => {
+        const labelDelta = left.label.localeCompare(right.label);
+        return labelDelta !== 0 ? labelDelta : left.modelId.localeCompare(right.modelId);
+      });
+
+      const sortedRows = finalRows.slice().sort((left, right) => {
+        const leftKey = `${left.modelALabel}::${left.modelBLabel}`;
+        const rightKey = `${right.modelALabel}::${right.modelBLabel}`;
+        return leftKey.localeCompare(rightKey);
+      });
+
+      ctx.log.debug(
+        { scope, domainId, signature, modelCount: sortedModels.length, pairCount: sortedRows.length },
+        'Computed model grouping significance report',
+      );
+
+      return {
+        models: sortedModels.map((model) => ({
+          modelId: model.modelId,
+          label: model.label,
+        })),
+        rows: sortedRows,
+      };
+    },
+  }),
+);

--- a/cloud/apps/api/src/graphql/types/index.ts
+++ b/cloud/apps/api/src/graphql/types/index.ts
@@ -32,6 +32,7 @@ import './models-confidence.js';
 import './confidence-value-detail.js';
 import './models-consistency.js';
 import './models-stability.js';
+import './model-grouping-significance.js';
 import './pressure-sensitivity.js';
 import './circumplex.js';
 import './pairwise-win-rates.js';

--- a/cloud/apps/api/src/graphql/types/model-grouping-significance.ts
+++ b/cloud/apps/api/src/graphql/types/model-grouping-significance.ts
@@ -1,0 +1,70 @@
+import { builder } from '../builder.js';
+
+export type ModelGroupingSignificanceModelShape = {
+  modelId: string;
+  label: string;
+};
+
+export type ModelGroupingSignificanceRowShape = {
+  modelAId: string;
+  modelALabel: string;
+  modelBId: string;
+  modelBLabel: string;
+  n: number;
+  meanDifference: number | null;
+  rawPValue: number | null;
+  holmCorrectedPValue: number | null;
+  effectSize: number | null;
+  effectLabel: 'Weak' | 'Strong';
+  confidenceIntervalLow: number | null;
+  confidenceIntervalHigh: number | null;
+  verdict: 'Significant' | 'Weak' | 'Not significant';
+};
+
+export type ModelGroupingSignificanceResultShape = {
+  models: ModelGroupingSignificanceModelShape[];
+  rows: ModelGroupingSignificanceRowShape[];
+};
+
+const ModelGroupingSignificanceModelRef = builder.objectRef<ModelGroupingSignificanceModelShape>(
+  'ModelGroupingSignificanceModel',
+);
+const ModelGroupingSignificanceRowRef = builder.objectRef<ModelGroupingSignificanceRowShape>(
+  'ModelGroupingSignificanceRow',
+);
+
+export const ModelGroupingSignificanceResultRef = builder.objectRef<ModelGroupingSignificanceResultShape>(
+  'ModelGroupingSignificanceResult',
+);
+
+builder.objectType(ModelGroupingSignificanceModelRef, {
+  fields: (t) => ({
+    modelId: t.exposeString('modelId'),
+    label: t.exposeString('label'),
+  }),
+});
+
+builder.objectType(ModelGroupingSignificanceRowRef, {
+  fields: (t) => ({
+    modelAId: t.exposeString('modelAId'),
+    modelALabel: t.exposeString('modelALabel'),
+    modelBId: t.exposeString('modelBId'),
+    modelBLabel: t.exposeString('modelBLabel'),
+    n: t.exposeInt('n'),
+    meanDifference: t.exposeFloat('meanDifference', { nullable: true }),
+    rawPValue: t.exposeFloat('rawPValue', { nullable: true }),
+    holmCorrectedPValue: t.exposeFloat('holmCorrectedPValue', { nullable: true }),
+    effectSize: t.exposeFloat('effectSize', { nullable: true }),
+    effectLabel: t.exposeString('effectLabel'),
+    confidenceIntervalLow: t.exposeFloat('confidenceIntervalLow', { nullable: true }),
+    confidenceIntervalHigh: t.exposeFloat('confidenceIntervalHigh', { nullable: true }),
+    verdict: t.exposeString('verdict'),
+  }),
+});
+
+builder.objectType(ModelGroupingSignificanceResultRef, {
+  fields: (t) => ({
+    models: t.expose('models', { type: [ModelGroupingSignificanceModelRef] }),
+    rows: t.expose('rows', { type: [ModelGroupingSignificanceRowRef] }),
+  }),
+});

--- a/cloud/apps/api/src/services/model-grouping-significance/math.ts
+++ b/cloud/apps/api/src/services/model-grouping-significance/math.ts
@@ -1,0 +1,175 @@
+const STUDENT_T_975 = [
+  12.706204736174694,
+  4.302652729749462,
+  3.182446305283708,
+  2.776445105197793,
+  2.570581835636315,
+  2.446911851144979,
+  2.364624251592784,
+  2.306004135204166,
+  2.262157162798205,
+  2.228138851986274,
+  2.200985160091638,
+  2.178812829667228,
+  2.160368656462791,
+  2.144786687917804,
+  2.131449545559776,
+  2.119905299221255,
+  2.109815577833316,
+  2.100922040241038,
+  2.093024054408309,
+  2.085963447265864,
+  2.07961384472768,
+  2.073873067904025,
+  2.068657610419049,
+  2.063898561628024,
+  2.059538552753298,
+  2.055529438642874,
+  2.051830516480285,
+  2.048407141795245,
+  2.045229642132704,
+  2.042272456301238,
+] as const;
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function mean(values: ReadonlyArray<number>): number | null {
+  const usable = values.filter(isFiniteNumber);
+  if (usable.length === 0) return null;
+  return usable.reduce((sum, value) => sum + value, 0) / usable.length;
+}
+
+export function sampleStandardDeviation(values: ReadonlyArray<number>, center: number): number | null {
+  const usable = values.filter(isFiniteNumber);
+  if (usable.length < 2) return null;
+  const sumSquares = usable.reduce((sum, value) => {
+    const delta = value - center;
+    return sum + (delta * delta);
+  }, 0);
+  return Math.sqrt(sumSquares / (usable.length - 1));
+}
+
+function studentTQuantile(p: number, df: number): number {
+  if (!Number.isFinite(p) || !Number.isFinite(df) || p <= 0 || p >= 1 || df <= 0) return NaN;
+  if (df >= 120) return 1.96;
+  const roundedDf = Math.round(df);
+  if (roundedDf <= 0) return NaN;
+  if (roundedDf <= STUDENT_T_975.length && Math.abs(p - 0.975) < 1e-6) {
+    return STUDENT_T_975[roundedDf - 1] ?? 1.96;
+  }
+  if (roundedDf <= STUDENT_T_975.length && Math.abs(p - 0.025) < 1e-6) {
+    return -(STUDENT_T_975[roundedDf - 1] ?? 1.96);
+  }
+  return 1.96;
+}
+
+export function pairedMeanConfidenceInterval(
+  differences: ReadonlyArray<number>,
+  alpha = 0.05,
+): { mean: number | null; ciLow: number | null; ciHigh: number | null; n: number } {
+  const usable = differences.filter(isFiniteNumber);
+  const n = usable.length;
+  if (n === 0) {
+    return { mean: null, ciLow: null, ciHigh: null, n: 0 };
+  }
+
+  const center = mean(usable);
+  if (center == null || n < 2 || !Number.isFinite(alpha) || alpha <= 0 || alpha >= 1) {
+    return { mean: center, ciLow: null, ciHigh: null, n };
+  }
+
+  const sd = sampleStandardDeviation(usable, center);
+  if (sd == null) {
+    return { mean: center, ciLow: null, ciHigh: null, n };
+  }
+
+  const t = studentTQuantile(1 - alpha / 2, n - 1);
+  if (!Number.isFinite(t)) {
+    return { mean: center, ciLow: null, ciHigh: null, n };
+  }
+
+  const margin = (t * sd) / Math.sqrt(n);
+  return {
+    mean: center,
+    ciLow: center - margin,
+    ciHigh: center + margin,
+    n,
+  };
+}
+
+export function pairedCohensD(differences: ReadonlyArray<number>): number | null {
+  const usable = differences.filter(isFiniteNumber);
+  if (usable.length === 0) return null;
+  const center = mean(usable);
+  if (center == null) return null;
+  const sd = sampleStandardDeviation(usable, center);
+  if (sd == null || sd === 0) {
+    return center === 0 ? 0 : null;
+  }
+  return center / sd;
+}
+
+export function pairedPermutationPValue(differences: ReadonlyArray<number>): number | null {
+  const usable = differences.filter(isFiniteNumber);
+  const n = usable.length;
+  if (n === 0) return null;
+
+  const observed = Math.abs(mean(usable) ?? 0);
+  const total = 2 ** n;
+  let extreme = 0;
+
+  for (let mask = 0; mask < total; mask += 1) {
+    let sum = 0;
+    for (let index = 0; index < n; index += 1) {
+      const value = usable[index] ?? 0;
+      sum += (mask & (1 << index)) !== 0 ? value : -value;
+    }
+    const permutedMean = Math.abs(sum / n);
+    if (permutedMean >= observed - 1e-12) {
+      extreme += 1;
+    }
+  }
+
+  return extreme / total;
+}
+
+export function holmBonferroni(values: ReadonlyArray<number | null>): Array<number | null> {
+  const indexed = values
+    .map((value, index) => ({ value, index }))
+    .filter((entry): entry is { value: number; index: number } => entry.value != null && Number.isFinite(entry.value))
+    .sort((left, right) => left.value - right.value);
+
+  const adjusted = new Array<number | null>(values.length).fill(null);
+  let runningMax = 0;
+
+  for (let rank = 0; rank < indexed.length; rank += 1) {
+    const entry = indexed[rank]!;
+    const multiplier = indexed.length - rank;
+    const rawAdjusted = Math.min(1, entry.value * multiplier);
+    runningMax = Math.max(runningMax, rawAdjusted);
+    adjusted[entry.index] = runningMax;
+  }
+
+  return adjusted;
+}
+
+export function classifyEffectSize(effectSize: number | null): 'Weak' | 'Strong' {
+  if (effectSize == null || !Number.isFinite(effectSize)) return 'Weak';
+  return Math.abs(effectSize) < 0.5 ? 'Weak' : 'Strong';
+}
+
+export function classifyVerdict(params: {
+  correctedPValue: number | null;
+  effectSize: number | null;
+  alpha?: number;
+}): 'Significant' | 'Weak' | 'Not significant' {
+  const alpha = params.alpha ?? 0.05;
+  if (params.correctedPValue == null || !Number.isFinite(params.correctedPValue) || params.correctedPValue >= alpha) {
+    return 'Not significant';
+  }
+  return params.effectSize != null && Number.isFinite(params.effectSize) && Math.abs(params.effectSize) < 0.5
+    ? 'Weak'
+    : 'Significant';
+}

--- a/cloud/apps/api/tests/services/model-grouping-significance/math.test.ts
+++ b/cloud/apps/api/tests/services/model-grouping-significance/math.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyEffectSize,
+  classifyVerdict,
+  holmBonferroni,
+  pairedCohensD,
+  pairedMeanConfidenceInterval,
+  pairedPermutationPValue,
+} from '../../../src/services/model-grouping-significance/math.js';
+
+describe('model-grouping-significance math', () => {
+  it('computes an exact paired permutation p-value', () => {
+    expect(pairedPermutationPValue([1, 1, 1, 1])).toBe(0.125);
+  });
+
+  it('returns a neutral p-value when the paired differences cancel out', () => {
+    expect(pairedPermutationPValue([1, -1, 1, -1])).toBe(1);
+  });
+
+  it('applies Holm-Bonferroni correction in ascending order', () => {
+    expect(holmBonferroni([0.01, 0.03, 0.04])).toEqual([0.03, 0.06, 0.06]);
+  });
+
+  it('computes a t-based confidence interval for the mean difference', () => {
+    const ci = pairedMeanConfidenceInterval([1, 1, 1, 1]);
+    expect(ci.mean).toBe(1);
+    expect(ci.ciLow).toBe(1);
+    expect(ci.ciHigh).toBe(1);
+    expect(ci.n).toBe(4);
+  });
+
+  it('computes a paired Cohen d and classifies the result', () => {
+    expect(pairedCohensD([1, 1, 1, 1])).toBeNull();
+    expect(pairedCohensD([1, -1, 1, -1])).toBe(0);
+    expect(classifyEffectSize(0.2)).toBe('Weak');
+    expect(classifyEffectSize(0.8)).toBe('Strong');
+    expect(classifyVerdict({ correctedPValue: 0.01, effectSize: 0.2 })).toBe('Weak');
+    expect(classifyVerdict({ correctedPValue: 0.01, effectSize: 0.8 })).toBe('Significant');
+    expect(classifyVerdict({ correctedPValue: 0.2, effectSize: 0.8 })).toBe('Not significant');
+  });
+});

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1617,6 +1617,32 @@ type ModelCostEstimate {
   totalCost: Float!
 }
 
+type ModelGroupingSignificanceModel {
+  label: String!
+  modelId: String!
+}
+
+type ModelGroupingSignificanceResult {
+  models: [ModelGroupingSignificanceModel!]!
+  rows: [ModelGroupingSignificanceRow!]!
+}
+
+type ModelGroupingSignificanceRow {
+  confidenceIntervalHigh: Float
+  confidenceIntervalLow: Float
+  effectLabel: String!
+  effectSize: Float
+  holmCorrectedPValue: Float
+  meanDifference: Float
+  modelAId: String!
+  modelALabel: String!
+  modelBId: String!
+  modelBLabel: String!
+  n: Int!
+  rawPValue: Float
+  verdict: String!
+}
+
 """Token usage statistics for a model, used for cost prediction"""
 type ModelTokenStats {
   """Average input tokens per probe based on historical data"""
@@ -2204,11 +2230,18 @@ type PressureSensitivityValueRate {
   averageWinRate: Float
   balancedWinRate: Float
   highPressureOnOpposingValueWinRate: Float
-  highPressureOnThisValueDomainRates: [HighPressureDomainRate!]!
+  highPressureOnThisValueDomainRates: [PressureSensitivityValueRateByDomain!]!
   highPressureOnThisValueWinRate: Float
   pairsMeasured: Int!
   valueLabel: String!
   valueToken: String!
+}
+
+type PressureSensitivityValueRateByDomain {
+  domainId: String!
+  domainName: String!
+  pairsMeasured: Int!
+  rate: Float
 }
 
 """Result of a probe job execution"""
@@ -2346,11 +2379,6 @@ type Query {
   List DomainEvaluations that have at least one member run currently in PENDING, RUNNING, PAUSED, or SUMMARIZING status. Optional domainId filter scopes to one domain. Used by the cross-domain /status page.
   """
   activeEvaluations(domainId: ID): [DomainEvaluation!]!
-
-  """
-  List runs in PENDING, RUNNING, PAUSED, or SUMMARIZING status that are not members of any DomainEvaluation. Used by the /status page to surface ad-hoc runs.
-  """
-  standaloneActiveRuns: [Run!]!
 
   """
   Get the average token statistics across all models. Used as fallback when model-specific stats are unavailable.
@@ -2670,6 +2698,7 @@ type Query {
 
   "\n      Get the currently authenticated user.\n      Returns null if not authenticated.\n    "
   me: User
+  modelGroupingSignificance(domainId: ID, modelIds: [String!]!, scope: String!, signature: String!): ModelGroupingSignificanceResult!
 
   """
   Get token statistics for specific models. Useful for understanding prediction quality.
@@ -2822,6 +2851,11 @@ type Query {
     """Number of results to skip for pagination (default: 0)"""
     offset: Int
   ): [Scenario!]!
+
+  """
+  List runs in PENDING, RUNNING, PAUSED, or SUMMARIZING status that are not members of any DomainEvaluation. Used by the /status page to surface ad-hoc runs.
+  """
+  standaloneActiveRuns: [Run!]!
 
   """Fetch a survey by experiment ID."""
   survey(

--- a/cloud/apps/web/src/api/operations/modelGroupingSignificance.graphql
+++ b/cloud/apps/web/src/api/operations/modelGroupingSignificance.graphql
@@ -1,0 +1,23 @@
+query ModelGroupingSignificance($modelIds: [String!]!, $domainId: ID, $scope: String!, $signature: String!) {
+  modelGroupingSignificance(modelIds: $modelIds, domainId: $domainId, scope: $scope, signature: $signature) {
+    models {
+      modelId
+      label
+    }
+    rows {
+      modelAId
+      modelALabel
+      modelBId
+      modelBLabel
+      n
+      meanDifference
+      rawPValue
+      holmCorrectedPValue
+      effectSize
+      effectLabel
+      confidenceIntervalLow
+      confidenceIntervalHigh
+      verdict
+    }
+  }
+}

--- a/cloud/apps/web/src/api/operations/modelGroupingSignificance.ts
+++ b/cloud/apps/web/src/api/operations/modelGroupingSignificance.ts
@@ -1,0 +1,14 @@
+import type {
+  ModelGroupingSignificanceQuery as GeneratedModelGroupingSignificanceQuery,
+  ModelGroupingSignificanceQueryVariables as GeneratedModelGroupingSignificanceQueryVariables,
+} from '../../generated/graphql';
+
+export { ModelGroupingSignificanceDocument as MODEL_GROUPING_SIGNIFICANCE_QUERY } from '../../generated/graphql';
+
+export type ModelGroupingSignificanceQueryResult = GeneratedModelGroupingSignificanceQuery;
+export type ModelGroupingSignificanceQueryVariables = GeneratedModelGroupingSignificanceQueryVariables;
+
+export type ModelGroupingSignificanceResult =
+  GeneratedModelGroupingSignificanceQuery['modelGroupingSignificance'];
+export type ModelGroupingSignificanceModel = ModelGroupingSignificanceResult['models'][number];
+export type ModelGroupingSignificanceRow = ModelGroupingSignificanceResult['rows'][number];

--- a/cloud/apps/web/src/api/operations/pressureSensitivity.graphql
+++ b/cloud/apps/web/src/api/operations/pressureSensitivity.graphql
@@ -42,6 +42,12 @@ query PressureSensitivity(
           pairsMeasured
         }
         highPressureOnOpposingValueWinRate
+        highPressureOnThisValueDomainRates {
+          domainId
+          domainName
+          rate
+          pairsMeasured
+        }
         pairsMeasured
       }
       valuePairs {

--- a/cloud/apps/web/src/components/models/ConfidenceModelDomainBreakout.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceModelDomainBreakout.tsx
@@ -6,7 +6,7 @@ import { ScreenshotButton } from '../ui/ScreenshotButton';
 import { cn } from '../../lib/utils';
 import {
   formatPercent,
-  formatPointShift,
+  formatReportPointShift,
   getCellTone,
   getWinRateTone,
   type DomainShiftDisplayMode,
@@ -24,7 +24,6 @@ type DomainOption = {
 
 export interface ConfidenceModelDomainBreakoutProps {
   domains: DomainOption[];
-  referenceModels: ModelsConfidenceModelResult[];
   signature: string;
   selectedModelIds: string[] | null;
   defaultModelIds: string[];
@@ -156,7 +155,6 @@ function buildModelRows(
   domains: DomainOption[],
   domainStates: Record<string, DomainQueryState>,
   effectiveModelIds: readonly string[],
-  overallConfidenceByModelId: ReadonlyMap<string, number | null>,
 ): ModelRowData[] {
   const modelLabels = new Map<string, string>();
 
@@ -172,6 +170,8 @@ function buildModelRows(
   }
 
   return effectiveModelIds.map((modelId) => {
+    let pooledStrong = 0;
+    let pooledLean = 0;
     const cells = new Map<string, ModelCellData>();
 
     for (const domain of domains) {
@@ -212,6 +212,8 @@ function buildModelRows(
 
       const total = model.overallStrongCount + model.overallLeanCount;
       const strongPct = total > 0 ? (model.overallStrongCount / total) * 100 : null;
+      pooledStrong += model.overallStrongCount;
+      pooledLean += model.overallLeanCount;
       cells.set(domain.id, {
         strongCount: model.overallStrongCount,
         leanCount: model.overallLeanCount,
@@ -221,7 +223,8 @@ function buildModelRows(
       });
     }
 
-    const averageStrongPct = overallConfidenceByModelId.get(modelId) ?? null;
+    const total = pooledStrong + pooledLean;
+    const averageStrongPct = total > 0 ? (pooledStrong / total) * 100 : null;
 
     for (const [domainId, cell] of cells.entries()) {
       if (cell.status !== 'ready' || cell.strongPct == null) continue;
@@ -243,7 +246,7 @@ function buildModelRows(
 function getCellValue(cell: ModelCellData, displayMode: DomainShiftDisplayMode): string {
   if (cell.status === 'loading') return '…';
   if (cell.status === 'error' || cell.strongPct == null) return '—';
-  if (displayMode === 'shift') return cell.shift == null ? '—' : formatPointShift(cell.shift);
+  if (displayMode === 'shift') return cell.shift == null ? '—' : formatReportPointShift(cell.shift);
   return formatPercent(cell.strongPct);
 }
 
@@ -305,7 +308,6 @@ function SortableHeader({
 
 export function ConfidenceModelDomainBreakout({
   domains,
-  referenceModels,
   signature,
   selectedModelIds,
   defaultModelIds,
@@ -323,13 +325,6 @@ export function ConfidenceModelDomainBreakout({
         ? domains.filter((domain) => domain.id === selectedDomainId)
         : domains,
     [domains, selectedDomainId],
-  );
-  const overallConfidenceByModelId = useMemo(
-    () =>
-      new Map<string, number | null>(
-        referenceModels.map((model) => [model.modelId, model.overallConfidence ?? null] as const),
-      ),
-    [referenceModels],
   );
   const noModelsSelected = effectiveModelIds.length === 0;
 
@@ -403,8 +398,8 @@ export function ConfidenceModelDomainBreakout({
   }, [client, signature, visibleDomains]);
 
   const rows = useMemo(
-    () => buildModelRows(visibleDomains, domainStates, effectiveModelIds, overallConfidenceByModelId),
-    [domainStates, effectiveModelIds, overallConfidenceByModelId, visibleDomains],
+    () => buildModelRows(visibleDomains, domainStates, effectiveModelIds),
+    [domainStates, effectiveModelIds, visibleDomains],
   );
 
   const sortedRows = useMemo(

--- a/cloud/apps/web/src/components/models/ConfidenceModelDomainBreakout.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceModelDomainBreakout.tsx
@@ -6,7 +6,7 @@ import { ScreenshotButton } from '../ui/ScreenshotButton';
 import { cn } from '../../lib/utils';
 import {
   formatPercent,
-  formatReportPointShift,
+  formatPointShift,
   getCellTone,
   getWinRateTone,
   type DomainShiftDisplayMode,
@@ -24,6 +24,7 @@ type DomainOption = {
 
 export interface ConfidenceModelDomainBreakoutProps {
   domains: DomainOption[];
+  referenceModels: ModelsConfidenceModelResult[];
   signature: string;
   selectedModelIds: string[] | null;
   defaultModelIds: string[];
@@ -155,6 +156,7 @@ function buildModelRows(
   domains: DomainOption[],
   domainStates: Record<string, DomainQueryState>,
   effectiveModelIds: readonly string[],
+  overallConfidenceByModelId: ReadonlyMap<string, number | null>,
 ): ModelRowData[] {
   const modelLabels = new Map<string, string>();
 
@@ -170,8 +172,6 @@ function buildModelRows(
   }
 
   return effectiveModelIds.map((modelId) => {
-    let pooledStrong = 0;
-    let pooledLean = 0;
     const cells = new Map<string, ModelCellData>();
 
     for (const domain of domains) {
@@ -212,8 +212,6 @@ function buildModelRows(
 
       const total = model.overallStrongCount + model.overallLeanCount;
       const strongPct = total > 0 ? (model.overallStrongCount / total) * 100 : null;
-      pooledStrong += model.overallStrongCount;
-      pooledLean += model.overallLeanCount;
       cells.set(domain.id, {
         strongCount: model.overallStrongCount,
         leanCount: model.overallLeanCount,
@@ -223,8 +221,7 @@ function buildModelRows(
       });
     }
 
-    const total = pooledStrong + pooledLean;
-    const averageStrongPct = total > 0 ? (pooledStrong / total) * 100 : null;
+    const averageStrongPct = overallConfidenceByModelId.get(modelId) ?? null;
 
     for (const [domainId, cell] of cells.entries()) {
       if (cell.status !== 'ready' || cell.strongPct == null) continue;
@@ -246,7 +243,7 @@ function buildModelRows(
 function getCellValue(cell: ModelCellData, displayMode: DomainShiftDisplayMode): string {
   if (cell.status === 'loading') return '…';
   if (cell.status === 'error' || cell.strongPct == null) return '—';
-  if (displayMode === 'shift') return cell.shift == null ? '—' : formatReportPointShift(cell.shift);
+  if (displayMode === 'shift') return cell.shift == null ? '—' : formatPointShift(cell.shift);
   return formatPercent(cell.strongPct);
 }
 
@@ -308,6 +305,7 @@ function SortableHeader({
 
 export function ConfidenceModelDomainBreakout({
   domains,
+  referenceModels,
   signature,
   selectedModelIds,
   defaultModelIds,
@@ -325,6 +323,13 @@ export function ConfidenceModelDomainBreakout({
         ? domains.filter((domain) => domain.id === selectedDomainId)
         : domains,
     [domains, selectedDomainId],
+  );
+  const overallConfidenceByModelId = useMemo(
+    () =>
+      new Map<string, number | null>(
+        referenceModels.map((model) => [model.modelId, model.overallConfidence ?? null] as const),
+      ),
+    [referenceModels],
   );
   const noModelsSelected = effectiveModelIds.length === 0;
 
@@ -398,8 +403,8 @@ export function ConfidenceModelDomainBreakout({
   }, [client, signature, visibleDomains]);
 
   const rows = useMemo(
-    () => buildModelRows(visibleDomains, domainStates, effectiveModelIds),
-    [domainStates, effectiveModelIds, visibleDomains],
+    () => buildModelRows(visibleDomains, domainStates, effectiveModelIds, overallConfidenceByModelId),
+    [domainStates, effectiveModelIds, overallConfidenceByModelId, visibleDomains],
   );
 
   const sortedRows = useMemo(

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceHeatmap.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceHeatmap.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ModelGroupingSignificanceHeatmap } from './ModelGroupingSignificanceHeatmap';
+import type {
+  ModelGroupingSignificanceModel,
+  ModelGroupingSignificanceRow,
+} from '../../api/operations/modelGroupingSignificance';
+
+function createModel(modelId: string, label: string): ModelGroupingSignificanceModel {
+  return {
+    __typename: 'ModelGroupingSignificanceModel',
+    modelId,
+    label,
+  };
+}
+
+function createRow(overrides: Partial<ModelGroupingSignificanceRow>): ModelGroupingSignificanceRow {
+  return {
+    __typename: 'ModelGroupingSignificanceRow',
+    modelAId: 'alpha',
+    modelALabel: 'Alpha',
+    modelBId: 'beta',
+    modelBLabel: 'Beta',
+    n: 10,
+    meanDifference: 0.5,
+    rawPValue: 0.01,
+    holmCorrectedPValue: 0.03,
+    effectSize: 0.8,
+    effectLabel: 'Strong',
+    confidenceIntervalLow: 0.2,
+    confidenceIntervalHigh: 0.8,
+    verdict: 'Significant',
+    ...overrides,
+  };
+}
+
+describe('ModelGroupingSignificanceHeatmap', () => {
+  it('renders the diagonal placeholder and cell titles', () => {
+    render(
+      <ModelGroupingSignificanceHeatmap
+        models={[createModel('alpha', 'Alpha'), createModel('beta', 'Beta'), createModel('gamma', 'Gamma')]}
+        rows={[
+          createRow({ modelBId: 'beta', modelBLabel: 'Beta', meanDifference: 0.5, effectSize: 0.8, verdict: 'Significant' }),
+          createRow({ modelBId: 'gamma', modelBLabel: 'Gamma', meanDifference: -0.2, effectSize: 0.2, verdict: 'Weak' }),
+          createRow({
+            modelAId: 'beta',
+            modelALabel: 'Beta',
+            modelBId: 'gamma',
+            modelBLabel: 'Gamma',
+            meanDifference: 0,
+            effectSize: null,
+            rawPValue: 0.5,
+            holmCorrectedPValue: 0.5,
+            effectLabel: 'Weak',
+            verdict: 'Not significant',
+            confidenceIntervalLow: -0.1,
+            confidenceIntervalHigh: 0.1,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTitle('Alpha compared with itself')).toBeDefined();
+    expect(screen.getByTitle('Beta compared with itself')).toBeDefined();
+    expect(screen.getByTitle('Gamma compared with itself')).toBeDefined();
+    expect(
+      screen.getByTitle(
+        /Alpha vs Beta: mean difference \+0\.5 pp, effect size \+0\.80, verdict Significant/,
+      ),
+    ).toBeDefined();
+    expect(
+      screen.getByTitle(
+        /Alpha vs Gamma: mean difference -0\.2 pp, effect size \+0\.20, verdict Weak/,
+      ),
+    ).toBeDefined();
+    expect(screen.getAllByText('S')).toHaveLength(2);
+    expect(screen.getAllByText('W')).toHaveLength(2);
+  });
+
+  it('renders an empty message when there are no models', () => {
+    render(<ModelGroupingSignificanceHeatmap models={[]} rows={[]} />);
+
+    expect(screen.getByText('No pairwise significance data available.')).toBeDefined();
+  });
+});

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceHeatmap.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceHeatmap.tsx
@@ -1,0 +1,160 @@
+import type { ModelGroupingSignificanceModel, ModelGroupingSignificanceRow } from '../../api/operations/modelGroupingSignificance';
+import { cn } from '../../lib/utils';
+
+function formatEffectSize(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return '—';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}`;
+}
+
+function formatDifference(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return '—';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(1)} pp`;
+}
+
+function getTone(effectSize: number | null): string {
+  if (effectSize == null || !Number.isFinite(effectSize)) {
+    return 'bg-gray-50 text-gray-400';
+  }
+  const magnitude = Math.min(Math.abs(effectSize) / 1.5, 1);
+  if (Math.abs(effectSize) < 0.12) {
+    return 'bg-gray-50 text-gray-600';
+  }
+  return effectSize > 0
+    ? magnitude > 0.66
+      ? 'bg-teal-200 text-teal-950'
+      : magnitude > 0.33
+        ? 'bg-teal-100 text-teal-900'
+        : 'bg-teal-50 text-teal-800'
+    : magnitude > 0.66
+      ? 'bg-rose-200 text-rose-950'
+      : magnitude > 0.33
+        ? 'bg-rose-100 text-rose-900'
+        : 'bg-rose-50 text-rose-800';
+}
+
+function getVerdictRing(verdict: ModelGroupingSignificanceRow['verdict']): string {
+  switch (verdict) {
+    case 'Significant':
+      return 'ring-2 ring-gray-900/70';
+    case 'Weak':
+      return 'ring-1 ring-amber-400';
+    default:
+      return 'ring-0';
+  }
+}
+
+function getVerdictBadge(verdict: ModelGroupingSignificanceRow['verdict']): string {
+  switch (verdict) {
+    case 'Significant':
+      return 'S';
+    case 'Weak':
+      return 'W';
+    default:
+      return '';
+  }
+}
+
+export function ModelGroupingSignificanceHeatmap({
+  models,
+  rows,
+}: {
+  models: ModelGroupingSignificanceModel[];
+  rows: ModelGroupingSignificanceRow[];
+}) {
+  const rowByPair = new Map(rows.map((row) => [`${row.modelAId}::${row.modelBId}`, row] as const));
+
+  if (models.length === 0) {
+    return <div className="text-sm text-gray-500">No pairwise significance data available.</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white p-3">
+      <div className="mb-2 flex items-center justify-between gap-3 text-xs text-gray-500">
+        <span>Color shows effect size. Border shows Holm-Bonferroni significance.</span>
+        <span>S = Significant, W = Weak</span>
+      </div>
+      <table className="min-w-full border-collapse text-xs">
+        <caption className="sr-only">Pairwise significance heatmap</caption>
+        <thead>
+          <tr>
+            <th scope="col" className="px-2 py-2 text-left font-medium text-gray-500">Model</th>
+            {models.map((model) => (
+              <th key={model.modelId} scope="col" className="px-2 py-2 text-right font-medium text-gray-500">
+                <span className="whitespace-nowrap">{model.label}</span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {models.map((rowModel, rowIndex) => (
+            <tr key={rowModel.modelId} className="border-t border-gray-100">
+              <th scope="row" className="px-2 py-2 text-left font-medium text-gray-900">
+                {rowModel.label}
+              </th>
+              {models.map((colModel, colIndex) => {
+                const sameCell = rowIndex === colIndex;
+                const upper = rowIndex < colIndex;
+                const sourceRow = upper
+                  ? rowByPair.get(`${rowModel.modelId}::${colModel.modelId}`) ?? null
+                  : rowByPair.get(`${colModel.modelId}::${rowModel.modelId}`) ?? null;
+                const sourceEffectSize = sourceRow?.effectSize ?? null;
+                const sourceMeanDifference = sourceRow?.meanDifference ?? null;
+                const effectSize = sourceRow != null
+                  ? (upper ? sourceEffectSize : (sourceEffectSize == null ? null : -sourceEffectSize))
+                  : null;
+                const meanDifference = sourceRow != null
+                  ? (upper ? sourceMeanDifference : (sourceMeanDifference == null ? null : -sourceMeanDifference))
+                  : null;
+                const verdict = sourceRow?.verdict ?? 'Not significant';
+                const title = sameCell
+                  ? `${rowModel.label} compared with itself`
+                  : sourceRow == null
+                    ? `${rowModel.label} and ${colModel.label}: no data`
+                    : `${rowModel.label} vs ${colModel.label}: mean difference ${formatDifference(meanDifference)}, effect size ${formatEffectSize(effectSize)}, verdict ${verdict}`;
+
+                return (
+                  <td key={colModel.modelId} className="px-1 py-1 text-right" title={title}>
+                    {sameCell ? (
+                      <span className="inline-flex h-14 w-14 items-center justify-center rounded-md border border-dashed border-gray-200 bg-gray-50 text-gray-300">
+                        —
+                      </span>
+                    ) : sourceRow == null ? (
+                      <span className="inline-flex h-14 w-14 items-center justify-center rounded-md border border-gray-100 bg-gray-50 text-gray-300">
+                        —
+                      </span>
+                    ) : (
+                      <div
+                        className={cn(
+                          'relative inline-flex h-14 w-14 items-center justify-center rounded-md border px-2 py-2 text-xs font-semibold tabular-nums shadow-sm transition',
+                          getTone(effectSize),
+                          getVerdictRing(verdict),
+                        )}
+                      >
+                        {getVerdictBadge(verdict) !== '' && (
+                          <span
+                            className={cn(
+                              'absolute right-1 top-1 flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-bold',
+                              verdict === 'Significant'
+                                ? 'bg-gray-900 text-white'
+                                : 'bg-amber-400 text-amber-950',
+                            )}
+                            aria-hidden="true"
+                          >
+                            {getVerdictBadge(verdict)}
+                          </span>
+                        )}
+                        <span>{formatEffectSize(effectSize)}</span>
+                      </div>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceSection.tsx
@@ -1,0 +1,91 @@
+import { useRef } from 'react';
+import { CopyVisualButton } from '../ui/CopyVisualButton';
+import { ErrorMessage } from '../ui/ErrorMessage';
+import { Loading } from '../ui/Loading';
+import type { ModelGroupingSignificanceResult } from '../../api/operations/modelGroupingSignificance';
+import { ModelGroupingSignificanceHeatmap } from './ModelGroupingSignificanceHeatmap';
+import { ModelGroupingSignificanceTable } from './ModelGroupingSignificanceTable';
+
+type Props = {
+  report: ModelGroupingSignificanceResult | null;
+  selectedModelCount: number;
+  scopeLabel: string;
+  loading?: boolean;
+  errorMessage?: string | null;
+};
+
+export function ModelGroupingSignificanceSection({
+  report,
+  selectedModelCount,
+  scopeLabel,
+  loading = false,
+  errorMessage = null,
+}: Props) {
+  const reportRef = useRef<HTMLDivElement>(null);
+
+  if (errorMessage != null) {
+    return <ErrorMessage message={`Failed to load statistical differences report: ${errorMessage}`} />;
+  }
+
+  if (selectedModelCount < 2) {
+    return (
+      <section className="rounded-lg border border-gray-200 bg-white p-4 md:p-5">
+        <h2 className="text-lg font-semibold text-gray-900">Statistical Differences in Value Preferences</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Select at least two models in the header picker to compare value preferences.
+        </p>
+      </section>
+    );
+  }
+
+  if (loading && report == null) {
+    return <Loading size="lg" text="Loading statistical differences report..." />;
+  }
+
+  if (report == null) {
+    return (
+      <section className="rounded-lg border border-gray-200 bg-white p-4 md:p-5">
+        <h2 className="text-lg font-semibold text-gray-900">Statistical Differences in Value Preferences</h2>
+        <p className="mt-2 text-sm text-gray-600">No pairwise significance data is available for the current selection.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4 md:p-5">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">Statistical Differences in Value Preferences</h2>
+            <p className="mt-1 text-sm text-gray-600">
+              This report compares the selected models one pair at a time. Each vignette counts once.
+              Holm-Bonferroni correction is applied across every pair in view.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2 text-xs text-gray-600">
+            <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 font-medium">
+              Scope: {scopeLabel}
+            </span>
+            <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 font-medium">
+              Models: {selectedModelCount}
+            </span>
+            <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 font-medium">
+              Pairs: {report.rows.length}
+            </span>
+            <span className="rounded-full border border-gray-200 bg-gray-50 px-2.5 py-1 font-medium">
+              Table is source of truth
+            </span>
+          </div>
+        </div>
+
+        <CopyVisualButton targetRef={reportRef} label="statistical differences in value preferences" />
+      </div>
+
+      <div ref={reportRef} className="space-y-4">
+        <ModelGroupingSignificanceHeatmap models={report.models} rows={report.rows} />
+        <ModelGroupingSignificanceTable rows={report.rows} />
+      </div>
+    </section>
+  );
+}

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ModelGroupingSignificanceTable } from './ModelGroupingSignificanceTable';
+import type { ModelGroupingSignificanceRow } from '../../api/operations/modelGroupingSignificance';
+
+function createRow(overrides: Partial<ModelGroupingSignificanceRow>): ModelGroupingSignificanceRow {
+  return {
+    __typename: 'ModelGroupingSignificanceRow',
+    modelAId: 'model-a',
+    modelALabel: 'Model A',
+    modelBId: 'model-b',
+    modelBLabel: 'Model B',
+    n: 10,
+    meanDifference: 0,
+    rawPValue: 0.5,
+    holmCorrectedPValue: 0.5,
+    effectSize: 0,
+    effectLabel: 'Weak',
+    confidenceIntervalLow: -1,
+    confidenceIntervalHigh: 1,
+    verdict: 'Not significant',
+    ...overrides,
+  };
+}
+
+describe('ModelGroupingSignificanceTable', () => {
+  it('sorts by model pair by default and can sort by p-value', () => {
+    render(
+      <ModelGroupingSignificanceTable
+        rows={[
+          createRow({ modelAId: 'b', modelALabel: 'Model B', modelBId: 'c', modelBLabel: 'Model C', rawPValue: 0.5, holmCorrectedPValue: 0.5 }),
+          createRow({ modelAId: 'a', modelALabel: 'Model A', modelBId: 'c', modelBLabel: 'Model C', rawPValue: 0.01, holmCorrectedPValue: 0.03, effectSize: 0.9, effectLabel: 'Strong', verdict: 'Significant' }),
+          createRow({ modelAId: 'a', modelALabel: 'Model A', modelBId: 'b', modelBLabel: 'Model B', rawPValue: 0.2, holmCorrectedPValue: 0.4, effectSize: 0.2, effectLabel: 'Weak', verdict: 'Not significant' }),
+        ]}
+      />,
+    );
+
+    const rows = screen.getAllByRole('row');
+    expect(rows[1]?.textContent ?? '').toContain('Model A');
+    expect(rows[1]?.textContent ?? '').toContain('Model B');
+
+    fireEvent.click(screen.getByRole('button', { name: /sort by raw p-value/i }));
+
+    const resortedRows = screen.getAllByRole('row');
+    expect(resortedRows[1]?.textContent ?? '').toContain('Model B');
+    expect(resortedRows[1]?.textContent ?? '').toContain('Model C');
+    expect(resortedRows[1]?.textContent ?? '').toContain('0.500');
+
+    fireEvent.click(screen.getByRole('button', { name: /sort by raw p-value ascending/i }));
+
+    const ascendingRows = screen.getAllByRole('row');
+    expect(ascendingRows[1]?.textContent ?? '').toContain('Model A');
+    expect(ascendingRows[1]?.textContent ?? '').toContain('Model C');
+    expect(ascendingRows[1]?.textContent ?? '').toContain('0.010');
+
+    const rawPValueHeader = screen.getByRole('columnheader', { name: /raw p-value/i });
+    expect(rawPValueHeader.getAttribute('aria-sort')).toBe('ascending');
+  });
+
+  it('shows verdict badges in the table', () => {
+    render(
+      <ModelGroupingSignificanceTable
+        rows={[
+          createRow({ modelAId: 'a', modelALabel: 'Model A', modelBId: 'b', modelBLabel: 'Model B', verdict: 'Significant', effectLabel: 'Strong' }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Significant')).toBeDefined();
+    expect(screen.getByText('Strong')).toBeDefined();
+  });
+
+  it('does not use the double-headed sort icon', () => {
+    render(
+      <ModelGroupingSignificanceTable
+        rows={[createRow({ modelAId: 'a', modelALabel: 'Model A', modelBId: 'b', modelBLabel: 'Model B' })]}
+      />,
+    );
+
+    expect(screen.queryByText('↕')).toBeNull();
+  });
+});

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.tsx
@@ -1,0 +1,220 @@
+import { useMemo, useState } from 'react';
+import { Button } from '../ui/Button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/Table';
+import { cn } from '../../lib/utils';
+import type { ModelGroupingSignificanceRow } from '../../api/operations/modelGroupingSignificance';
+
+type SortKey =
+  | 'modelA'
+  | 'modelB'
+  | 'rawPValue'
+  | 'holmCorrectedPValue'
+  | 'effectSize'
+  | 'effectLabel'
+  | 'confidenceInterval';
+
+type SortDirection = 'asc' | 'desc';
+
+type SortState = {
+  key: SortKey;
+  direction: SortDirection;
+};
+
+const DEFAULT_SORT: SortState = {
+  key: 'modelA',
+  direction: 'asc',
+};
+
+function formatPValue(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return '—';
+  if (value < 0.001) return '<0.001';
+  return value.toFixed(3);
+}
+
+function formatDifference(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return '—';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(1)} pp`;
+}
+
+function formatEffectSize(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return '—';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}`;
+}
+
+function formatInterval(low: number | null, high: number | null): string {
+  if (low == null || high == null || !Number.isFinite(low) || !Number.isFinite(high)) return '—';
+  return `[${formatDifference(low)}, ${formatDifference(high)}]`;
+}
+
+function getVerdictClass(verdict: ModelGroupingSignificanceRow['verdict']): string {
+  switch (verdict) {
+    case 'Significant':
+      return 'border-teal-200 bg-teal-50 text-teal-800';
+    case 'Weak':
+      return 'border-amber-200 bg-amber-50 text-amber-800';
+    default:
+      return 'border-gray-200 bg-gray-50 text-gray-600';
+  }
+}
+
+function getSortDirectionLabel(direction: SortDirection): 'ascending' | 'descending' {
+  return direction === 'asc' ? 'ascending' : 'descending';
+}
+
+function getNextSort(sort: SortState, key: SortKey): SortState {
+  if (sort.key === key) {
+    return { key, direction: sort.direction === 'asc' ? 'desc' : 'asc' };
+  }
+  if (key === 'modelA' || key === 'modelB' || key === 'effectLabel') {
+    return { key, direction: 'asc' };
+  }
+  return { key, direction: 'desc' };
+}
+
+function sortRows(rows: ModelGroupingSignificanceRow[], sort: SortState): ModelGroupingSignificanceRow[] {
+  return [...rows].sort((left, right) => {
+    const direction = sort.direction === 'asc' ? 1 : -1;
+    const leftLabel = `${left.modelALabel}::${left.modelBLabel}`;
+    const rightLabel = `${right.modelALabel}::${right.modelBLabel}`;
+
+    const getValue = (row: ModelGroupingSignificanceRow): string | number | null => {
+      switch (sort.key) {
+        case 'modelA':
+          return row.modelALabel;
+        case 'modelB':
+          return row.modelBLabel;
+        case 'rawPValue':
+          return row.rawPValue ?? null;
+        case 'holmCorrectedPValue':
+          return row.holmCorrectedPValue ?? null;
+        case 'effectSize':
+          return row.effectSize ?? null;
+        case 'effectLabel':
+          return row.effectLabel;
+        case 'confidenceInterval':
+          return row.meanDifference ?? (row.confidenceIntervalLow != null && row.confidenceIntervalHigh != null
+            ? ((row.confidenceIntervalLow + row.confidenceIntervalHigh) / 2)
+            : null);
+      }
+    };
+
+    const leftValue = getValue(left);
+    const rightValue = getValue(right);
+
+    if (leftValue == null && rightValue == null) return leftLabel.localeCompare(rightLabel);
+    if (leftValue == null) return 1;
+    if (rightValue == null) return -1;
+
+    if (typeof leftValue === 'string' && typeof rightValue === 'string') {
+      const comparison = leftValue.localeCompare(rightValue);
+      return comparison === 0 ? leftLabel.localeCompare(rightLabel) : comparison * direction;
+    }
+
+    const comparison = Number(leftValue) - Number(rightValue);
+    return comparison === 0 ? leftLabel.localeCompare(rightLabel) : comparison * direction;
+  });
+}
+
+function SortableHeader({
+  label,
+  sortKey,
+  sortState,
+  onSort,
+  align = 'left',
+}: {
+  label: string;
+  sortKey: SortKey;
+  sortState: SortState;
+  onSort: (sortKey: SortKey) => void;
+  align?: 'left' | 'center' | 'right';
+}) {
+  const isActive = sortState.key === sortKey;
+  const nextDirection = getSortDirectionLabel(isActive ? (sortState.direction === 'asc' ? 'desc' : 'asc') : getNextSort(sortState, sortKey).direction);
+
+  return (
+    <TableHead
+      scope="col"
+      aria-sort={isActive ? getSortDirectionLabel(sortState.direction) : 'none'}
+      className="bg-gray-50 px-2 py-2 text-xs uppercase tracking-wide text-gray-500"
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => onSort(sortKey)}
+        className={cn(
+          'w-full gap-1 rounded-none bg-transparent px-0 py-0 min-h-0 text-xs font-semibold uppercase tracking-wide text-gray-500 shadow-none transition-colors hover:bg-transparent hover:text-gray-900 focus:ring-0 focus:ring-offset-0',
+          align === 'left' && 'justify-start text-left',
+          align === 'center' && 'justify-center text-center',
+          align === 'right' && 'justify-end text-right',
+          isActive && 'text-teal-700',
+        )}
+        aria-label={`Sort by ${label} ${nextDirection}`}
+      >
+        <span className="whitespace-nowrap">{label}</span>
+        {isActive && (
+          <span aria-hidden="true" className="text-[11px] leading-none text-gray-400">
+            {sortState.direction === 'desc' ? '↑' : '↓'}
+          </span>
+        )}
+      </Button>
+    </TableHead>
+  );
+}
+
+export function ModelGroupingSignificanceTable({ rows }: { rows: ModelGroupingSignificanceRow[] }) {
+  const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
+
+  const sortedRows = useMemo(() => sortRows(rows, sort), [rows, sort]);
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+      <Table variant="bordered" className="min-w-full">
+        <TableHeader variant="bordered">
+          <TableRow>
+            <SortableHeader label="Model A" sortKey="modelA" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} />
+            <SortableHeader label="Model B" sortKey="modelB" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} />
+            <SortableHeader label="raw p-value" sortKey="rawPValue" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+            <SortableHeader label="Holm-corrected p-value" sortKey="holmCorrectedPValue" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+            <SortableHeader label="effect size" sortKey="effectSize" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+            <SortableHeader label="effect label" sortKey="effectLabel" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} />
+            <SortableHeader label="confidence interval" sortKey="confidenceInterval" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sortedRows.map((row) => {
+            const effectSize = row.effectSize ?? null;
+            return (
+            <TableRow key={`${row.modelAId}::${row.modelBId}`} hoverable>
+              <TableCell className="font-medium text-gray-900">{row.modelALabel}</TableCell>
+              <TableCell className="font-medium text-gray-900">{row.modelBLabel}</TableCell>
+              <TableCell className="text-right font-mono tabular-nums text-gray-800">
+                {formatPValue(row.rawPValue ?? null)}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums text-gray-800">
+                {formatPValue(row.holmCorrectedPValue ?? null)}
+              </TableCell>
+              <TableCell className={cn('text-right font-mono tabular-nums', effectSize != null && effectSize < 0 ? 'text-rose-700' : 'text-gray-800')}>
+                {formatEffectSize(effectSize)}
+              </TableCell>
+              <TableCell>
+                <div className="space-y-1">
+                  <div className="font-medium text-gray-900">{row.effectLabel}</div>
+                  <div className={`inline-flex rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${getVerdictClass(row.verdict)}`}>
+                    {row.verdict}
+                  </div>
+                </div>
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums text-gray-800">
+                {formatInterval(row.confidenceIntervalLow ?? null, row.confidenceIntervalHigh ?? null)}
+              </TableCell>
+            </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1528,6 +1528,35 @@ export type ModelCostEstimate = {
   totalCost: Scalars['Float']['output'];
 };
 
+export type ModelGroupingSignificanceModel = {
+  __typename?: 'ModelGroupingSignificanceModel';
+  label: Scalars['String']['output'];
+  modelId: Scalars['String']['output'];
+};
+
+export type ModelGroupingSignificanceResult = {
+  __typename?: 'ModelGroupingSignificanceResult';
+  models: Array<ModelGroupingSignificanceModel>;
+  rows: Array<ModelGroupingSignificanceRow>;
+};
+
+export type ModelGroupingSignificanceRow = {
+  __typename?: 'ModelGroupingSignificanceRow';
+  confidenceIntervalHigh?: Maybe<Scalars['Float']['output']>;
+  confidenceIntervalLow?: Maybe<Scalars['Float']['output']>;
+  effectLabel: Scalars['String']['output'];
+  effectSize?: Maybe<Scalars['Float']['output']>;
+  holmCorrectedPValue?: Maybe<Scalars['Float']['output']>;
+  meanDifference?: Maybe<Scalars['Float']['output']>;
+  modelAId: Scalars['String']['output'];
+  modelALabel: Scalars['String']['output'];
+  modelBId: Scalars['String']['output'];
+  modelBLabel: Scalars['String']['output'];
+  n: Scalars['Int']['output'];
+  rawPValue?: Maybe<Scalars['Float']['output']>;
+  verdict: Scalars['String']['output'];
+};
+
 export type ModelPairwiseWinRates = {
   __typename?: 'ModelPairwiseWinRates';
   label: Scalars['String']['output'];
@@ -2522,11 +2551,19 @@ export type PressureSensitivityValueRate = {
   averageWinRate?: Maybe<Scalars['Float']['output']>;
   balancedWinRate?: Maybe<Scalars['Float']['output']>;
   highPressureOnOpposingValueWinRate?: Maybe<Scalars['Float']['output']>;
-  highPressureOnThisValueDomainRates: Array<HighPressureDomainRate>;
+  highPressureOnThisValueDomainRates: Array<PressureSensitivityValueRateByDomain>;
   highPressureOnThisValueWinRate?: Maybe<Scalars['Float']['output']>;
   pairsMeasured: Scalars['Int']['output'];
   valueLabel: Scalars['String']['output'];
   valueToken: Scalars['String']['output'];
+};
+
+export type PressureSensitivityValueRateByDomain = {
+  __typename?: 'PressureSensitivityValueRateByDomain';
+  domainId: Scalars['String']['output'];
+  domainName: Scalars['String']['output'];
+  pairsMeasured: Scalars['Int']['output'];
+  rate?: Maybe<Scalars['Float']['output']>;
 };
 
 /** Result of a probe job execution */
@@ -2760,6 +2797,7 @@ export type Query = {
    *
    */
   me?: Maybe<User>;
+  modelGroupingSignificance: ModelGroupingSignificanceResult;
   /** Get token statistics for specific models. Useful for understanding prediction quality. */
   modelTokenStats: Array<ModelTokenStats>;
   modelsAnalysis: ModelsAnalysisResult;
@@ -3188,6 +3226,14 @@ export type QueryLlmProviderArgs = {
 export type QueryLlmProvidersArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryModelGroupingSignificanceArgs = {
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  modelIds: Array<Scalars['String']['input']>;
+  scope: Scalars['String']['input'];
+  signature: Scalars['String']['input'];
 };
 
 
@@ -4745,6 +4791,16 @@ export type SetProviderBalanceMutationVariables = Exact<{
 
 export type SetProviderBalanceMutation = { __typename?: 'Mutation', setProviderBalance: { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: string, updatedAt: string } };
 
+export type ModelGroupingSignificanceQueryVariables = Exact<{
+  modelIds: Array<Scalars['String']['input']> | Scalars['String']['input'];
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  scope: Scalars['String']['input'];
+  signature: Scalars['String']['input'];
+}>;
+
+
+export type ModelGroupingSignificanceQuery = { __typename?: 'Query', modelGroupingSignificance: { __typename?: 'ModelGroupingSignificanceResult', models: Array<{ __typename?: 'ModelGroupingSignificanceModel', modelId: string, label: string }>, rows: Array<{ __typename?: 'ModelGroupingSignificanceRow', modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, n: number, meanDifference?: number | null, rawPValue?: number | null, holmCorrectedPValue?: number | null, effectSize?: number | null, effectLabel: string, confidenceIntervalLow?: number | null, confidenceIntervalHigh?: number | null, verdict: string }> } };
+
 export type AvailableModelsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -4815,7 +4871,7 @@ export type PressureSensitivityQueryVariables = Exact<{
 }>;
 
 
-export type PressureSensitivityQuery = { __typename?: 'Query', pressureSensitivity: { __typename?: 'PressureSensitivityResult', pressureConditionExcludedCount: number, transcriptCapHit: boolean, models: Array<{ __typename?: 'PressureSensitivityModel', modelId: string, label: string, providerName: string, unscoredCount: number, pushedForEffect?: number | null, pushedAgainstEffect?: number | null, pushedEffectPairsUsed: number, domainPressureEffects: Array<{ __typename?: 'DomainPressureEffect', domainId: string, domainName: string, pushedForEffect?: number | null }>, pressureResponseSummary: { __typename?: 'PressureResponseSummary', mean?: number | null, rangeMin?: number | null, rangeMax?: number | null, pairsMeasured: number }, valueRates: Array<{ __typename?: 'PressureSensitivityValueRate', valueToken: string, valueLabel: string, averageWinRate?: number | null, balancedWinRate?: number | null, highPressureOnThisValueWinRate?: number | null, highPressureOnOpposingValueWinRate?: number | null, pairsMeasured: number, highPressureOnThisValueDomainRates: Array<{ __typename?: 'HighPressureDomainRate', domainId: string, domainName: string, rate?: number | null, pairsMeasured: number }> }>, valuePairs: Array<{ __typename?: 'PressureSensitivityValuePair', pairKey: string, firstValueToken: string, firstValueLabel: string, secondValueToken: string, secondValueLabel: string, n: number, unscoredCount: number, definitionsMeasured: number, directionBalancedWinRate?: number | null, directionBalancedOpponentWinRate?: number | null, directionBalancedBalancedWinRate?: number | null, directionBalancedBalancedOpponentWinRate?: number | null, directionBalancedHighPressureOwnWinRate?: number | null, directionBalancedHighPressureOwnOpponentWinRate?: number | null, directionBalancedHighPressureOpponentWinRate?: number | null, directionBalancedHighPressureOpponentOpponentWinRate?: number | null, pressureResponse: { __typename?: 'PressureResponse', value?: number | null, baselineRate?: number | null, pushTowardFirstRate?: number | null, pushTowardSecondRate?: number | null, qualifyingTrials: number, ciLow?: number | null, ciHigh?: number | null, reason?: string | null }, grid: Array<{ __typename?: 'SensitivityCell', ownLevel: number, opponentLevel: number, n: number, unscoredCount: number, winRate?: number | null, opponentWinRate?: number | null, conviction?: number | null, netScore?: number | null, lowData: boolean }> }> }>, insufficient: Array<{ __typename?: 'InsufficientPressureSensitivityModel', modelId: string, label: string, providerName: string, reason: string }>, excludedDefinitions: Array<{ __typename?: 'ExcludedDefinition', definitionId: string, name: string, reason: string }>, pressureConditionExclusionBreakdown: { __typename?: 'PressureConditionExclusionBreakdown', sourceRunMapping: number, definitionMetadata: number, missingScenario: number, invalidMetadata: number, levelAssignment: number }, directionalSanityCheck: { __typename?: 'DirectionalSanityCheck', positivePct: number, flatPct: number, negativePct: number, measuredCount: number, unmeasurableCount: number, breakdown: Array<{ __typename?: 'DirectionalSanityCheckEntry', modelId: string, pairKey: string, pressureResponse: number, classification: string }> } } };
+export type PressureSensitivityQuery = { __typename?: 'Query', pressureSensitivity: { __typename?: 'PressureSensitivityResult', pressureConditionExcludedCount: number, transcriptCapHit: boolean, models: Array<{ __typename?: 'PressureSensitivityModel', modelId: string, label: string, providerName: string, unscoredCount: number, pushedForEffect?: number | null, pushedAgainstEffect?: number | null, pushedEffectPairsUsed: number, domainPressureEffects: Array<{ __typename?: 'DomainPressureEffect', domainId: string, domainName: string, pushedForEffect?: number | null }>, pressureResponseSummary: { __typename?: 'PressureResponseSummary', mean?: number | null, rangeMin?: number | null, rangeMax?: number | null, pairsMeasured: number }, valueRates: Array<{ __typename?: 'PressureSensitivityValueRate', valueToken: string, valueLabel: string, averageWinRate?: number | null, balancedWinRate?: number | null, highPressureOnThisValueWinRate?: number | null, highPressureOnOpposingValueWinRate?: number | null, pairsMeasured: number, highPressureOnThisValueDomainRates: Array<{ __typename?: 'PressureSensitivityValueRateByDomain', domainId: string, domainName: string, rate?: number | null, pairsMeasured: number }> }>, valuePairs: Array<{ __typename?: 'PressureSensitivityValuePair', pairKey: string, firstValueToken: string, firstValueLabel: string, secondValueToken: string, secondValueLabel: string, n: number, unscoredCount: number, definitionsMeasured: number, directionBalancedWinRate?: number | null, directionBalancedOpponentWinRate?: number | null, directionBalancedBalancedWinRate?: number | null, directionBalancedBalancedOpponentWinRate?: number | null, directionBalancedHighPressureOwnWinRate?: number | null, directionBalancedHighPressureOwnOpponentWinRate?: number | null, directionBalancedHighPressureOpponentWinRate?: number | null, directionBalancedHighPressureOpponentOpponentWinRate?: number | null, pressureResponse: { __typename?: 'PressureResponse', value?: number | null, baselineRate?: number | null, pushTowardFirstRate?: number | null, pushTowardSecondRate?: number | null, qualifyingTrials: number, ciLow?: number | null, ciHigh?: number | null, reason?: string | null }, grid: Array<{ __typename?: 'SensitivityCell', ownLevel: number, opponentLevel: number, n: number, unscoredCount: number, winRate?: number | null, opponentWinRate?: number | null, conviction?: number | null, netScore?: number | null, lowData: boolean }> }> }>, insufficient: Array<{ __typename?: 'InsufficientPressureSensitivityModel', modelId: string, label: string, providerName: string, reason: string }>, excludedDefinitions: Array<{ __typename?: 'ExcludedDefinition', definitionId: string, name: string, reason: string }>, pressureConditionExclusionBreakdown: { __typename?: 'PressureConditionExclusionBreakdown', sourceRunMapping: number, definitionMetadata: number, missingScenario: number, invalidMetadata: number, levelAssignment: number }, directionalSanityCheck: { __typename?: 'DirectionalSanityCheck', positivePct: number, flatPct: number, negativePct: number, measuredCount: number, unmeasurableCount: number, breakdown: Array<{ __typename?: 'DirectionalSanityCheckEntry', modelId: string, pairKey: string, pressureResponse: number, classification: string }> } } };
 
 export type OpenRunAnomaliesQueryVariables = Exact<{
   domainId?: InputMaybe<Scalars['ID']['input']>;
@@ -7207,6 +7263,40 @@ export const SetProviderBalanceDocument = gql`
 export function useSetProviderBalanceMutation() {
   return Urql.useMutation<SetProviderBalanceMutation, SetProviderBalanceMutationVariables>(SetProviderBalanceDocument);
 };
+export const ModelGroupingSignificanceDocument = gql`
+    query ModelGroupingSignificance($modelIds: [String!]!, $domainId: ID, $scope: String!, $signature: String!) {
+  modelGroupingSignificance(
+    modelIds: $modelIds
+    domainId: $domainId
+    scope: $scope
+    signature: $signature
+  ) {
+    models {
+      modelId
+      label
+    }
+    rows {
+      modelAId
+      modelALabel
+      modelBId
+      modelBLabel
+      n
+      meanDifference
+      rawPValue
+      holmCorrectedPValue
+      effectSize
+      effectLabel
+      confidenceIntervalLow
+      confidenceIntervalHigh
+      verdict
+    }
+  }
+}
+    `;
+
+export function useModelGroupingSignificanceQuery(options: Omit<Urql.UseQueryArgs<ModelGroupingSignificanceQueryVariables>, 'query'>) {
+  return Urql.useQuery<ModelGroupingSignificanceQuery, ModelGroupingSignificanceQueryVariables>({ query: ModelGroupingSignificanceDocument, ...options });
+};
 export const AvailableModelsDocument = gql`
     query AvailableModels {
   availableModels {
@@ -7469,13 +7559,13 @@ export const PressureSensitivityDocument = gql`
         averageWinRate
         balancedWinRate
         highPressureOnThisValueWinRate
+        highPressureOnOpposingValueWinRate
         highPressureOnThisValueDomainRates {
           domainId
           domainName
           rate
           pairsMeasured
         }
-        highPressureOnOpposingValueWinRate
         pairsMeasured
       }
       valuePairs {

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -261,6 +261,8 @@ export function DomainAnalysis() {
         values,
         winRates,
         stabilityScores,
+        // `totalComparisons` counts each transcript once per value in the pair.
+        // Divide by 2 to get the unique trial total for this model row.
         totalTrials: Math.round(totalComparisons / 2),
       };
     });

--- a/cloud/apps/web/src/pages/ModelsConfidence.tsx
+++ b/cloud/apps/web/src/pages/ModelsConfidence.tsx
@@ -205,7 +205,6 @@ export function ModelsConfidence() {
       {domains.length > 0 && (
         <ConfidenceModelDomainBreakout
           domains={domains}
-          referenceModels={models}
           signature={selectedSignature}
           selectedModelIds={selectedModelIds}
           defaultModelIds={defaultModelIds}

--- a/cloud/apps/web/src/pages/ModelsConfidence.tsx
+++ b/cloud/apps/web/src/pages/ModelsConfidence.tsx
@@ -205,6 +205,7 @@ export function ModelsConfidence() {
       {domains.length > 0 && (
         <ConfidenceModelDomainBreakout
           domains={domains}
+          referenceModels={models}
           signature={selectedSignature}
           selectedModelIds={selectedModelIds}
           defaultModelIds={defaultModelIds}

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -21,10 +21,16 @@ import {
   type ModelsAnalysisQueryResult,
   type ModelsAnalysisQueryVariables,
 } from '../api/operations/modelsAnalysis';
+import {
+  MODEL_GROUPING_SIGNIFICANCE_QUERY,
+  type ModelGroupingSignificanceQueryResult,
+  type ModelGroupingSignificanceQueryVariables,
+} from '../api/operations/modelGroupingSignificance';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
 import { ModelAnalysisSettingsBar } from '../components/models/ModelAnalysisSettingsBar';
 import { ModelSimilarityTableSection } from '../components/models/ModelSimilarityTableSection';
+import { ModelGroupingSignificanceSection } from '../components/models/ModelGroupingSignificanceSection';
 import { type CalculationMethod } from '../components/models/ModelSimilarityMetrics';
 import { useDomains } from '../hooks/useDomains';
 import { VALUES, type ModelEntry, type ValueKey } from '../data/domainAnalysisData';
@@ -230,7 +236,29 @@ export function ModelsGroups() {
     () => (visibleModelIds.length === 0 ? [] : models.filter((model) => visibleModelIds.includes(model.model))),
     [models, visibleModelIds],
   );
+  const [{ data: groupingSignificanceData, fetching: groupingSignificanceFetching, error: groupingSignificanceError }] = useQuery<
+    ModelGroupingSignificanceQueryResult,
+    ModelGroupingSignificanceQueryVariables
+  >({
+    query: MODEL_GROUPING_SIGNIFICANCE_QUERY,
+    variables: {
+      modelIds: visibleModelIds,
+      ...(selectedScope === 'DOMAIN' && selectedDomainId !== '' ? { domainId: selectedDomainId } : {}),
+      scope: selectedScope,
+      signature: selectedSignature,
+    },
+    pause:
+      selectedSignature === ''
+      || visibleModelIds.length < 2
+      || (selectedScope === 'DOMAIN' && selectedDomainId === '')
+      || llmModelsData == null,
+    requestPolicy: 'cache-and-network',
+  });
   const isAllDomains = selectedScope === 'ALL_DOMAINS';
+  const selectedDomainLabel = isAllDomains
+    ? 'All domains'
+    : (domains.find((domain) => domain.id === selectedDomainId)?.name ?? selectedDomainId);
+  const significanceScopeLabel = `${selectedDomainLabel} · ${selectedSignature || 'No signature selected'}`;
 
   if (domainsError != null || signaturesError != null || error != null || modelsAnalysisError != null || llmModelsError != null) {
     return (
@@ -313,6 +341,13 @@ export function ModelsGroups() {
           <ModelSimilarityTableSection
             models={filteredModels}
             method={similarityMethod}
+          />
+          <ModelGroupingSignificanceSection
+            report={groupingSignificanceData?.modelGroupingSignificance ?? null}
+            selectedModelCount={visibleModelIds.length}
+            scopeLabel={significanceScopeLabel}
+            loading={groupingSignificanceFetching}
+            errorMessage={groupingSignificanceError?.message ?? null}
           />
         </div>
       )}

--- a/docs/workflow/feature-runs/model-grouping-pairwise-significance/plan.md
+++ b/docs/workflow/feature-runs/model-grouping-pairwise-significance/plan.md
@@ -1,0 +1,239 @@
+# Implementation Plan: Model Grouping Pairwise Significance
+
+**Branch:** `codex/model-grouping-pairwise-significance` | **Date:** 2026-05-07  
+**Spec:** `docs/workflow/feature-runs/model-grouping-pairwise-significance/spec.md`
+
+## Summary
+
+Add a new report at the bottom of the existing `/models` page that answers one question:
+
+**Which selected models are statistically significantly different in their value preferences?**
+
+The report uses the page header picker scope, one average win-rate score per vignette, a paired permutation test, and Holm-Bonferroni correction across all selected model pairs. The backend owns the math. The client renders a heatmap plus a sortable table.
+
+## Review Reconciliation
+
+- Gemini finding 1 accepted in plan form: the metric is now explicit. `score` means the existing equal-vignette **win rate of the value**.
+- Gemini finding 2 accepted in plan form: the report follows the same header-picker scope as the page. That means selected models, domain/all-domains choice, signature, and any other header filters already on `/models`.
+- Gemini finding 3 accepted in plan form: missing vignette coverage means the selected slice does not have a complete vignette set for every selected model. The resolver must fail loudly instead of dropping missing data.
+- Gemini finding 4 accepted in plan form: the backend owns the pairwise permutation test, Holm-Bonferroni adjustment, effect size, and confidence interval. The client should not recompute the statistics.
+
+## Technical Context
+
+| Aspect | Detail |
+|---|---|
+| Language | TypeScript (strict) |
+| Web framework | React + urql + Vite |
+| API framework | Pothos + Prisma |
+| Existing page | `cloud/apps/web/src/pages/ModelsGroups.tsx` for `/models` |
+| Existing filters | `selectedScope`, `selectedDomainId`, `selectedSignature`, model multiselect, and the page `dataSource` toggle |
+| Existing page controls | `AnalysisContextBar`, `ModelAnalysisSettingsBar`, `ModelGroupsSection`, `ModelSimilarityTableSection` |
+| New math owner | API resolver |
+| Testing | Vitest (web and API) |
+| Data sensitivity | Medium-high, because the feature affects statistical interpretation |
+
+## Architecture Decisions
+
+### Decision 1: Keep the report inside `/models`
+
+**Chosen:** Add the report as a new section at the bottom of the existing Model Groups page.
+
+**Rationale:**
+- The user asked for the report at the bottom of the Model Grouping page.
+- The page already owns the relevant filters and selected models.
+- Keeping the feature in-place avoids a new navigation surface.
+
+### Decision 2: Use the page header picker scope exactly as-is
+
+**Chosen:** The report uses the same scope as the rest of the page:
+- selected models
+- domain vs all-domains choice
+- selected domain ID
+- selected signature
+- any other header picker state already wired into the page
+
+**Rationale:**
+- The user explicitly defined scope that way.
+- The report should never compare a different slice than the rest of the page.
+
+### Decision 3: The score is the existing equal-vignette win rate
+
+**Chosen:** For each selected model and vignette, use the existing equal-vignette win-rate definition exactly as-is.
+
+**Rationale:**
+- This keeps the new report aligned with current `/models` semantics.
+- It avoids inventing a new meaning for “score.”
+- It keeps the pairwise test focused on value preference, not a new metric.
+
+### Decision 4: Backend owns the stats
+
+**Chosen:** The API computes the paired permutation test, p-values, Holm-Bonferroni correction, Cohen’s d, and the confidence interval. The web app only renders the returned results.
+
+**Rationale:**
+- One source of truth for the math.
+- Lower risk of client/server drift.
+- Easier to test and easier to explain.
+
+### Decision 5: Missing coverage is a hard failure
+
+**Chosen:** If the selected scope does not produce the same vignette set for every selected model, the resolver returns a loud error state.
+
+**Rationale:**
+- This matches the spec’s fail-loud rule.
+- It prevents silent partial comparisons.
+
+### Decision 6: Existing sort control and table patterns should be reused
+
+**Chosen:** The report table uses the app’s standard sortable-table control and its current sort direction indicator pattern. Do not introduce a double-headed arrow icon.
+
+**Rationale:**
+- Keeps the UI consistent with the rest of the app.
+- Reduces new interaction patterns for a simple reporting table.
+
+## Implementation Slices
+
+### Slice A — API: pairwise stats resolver and types [CHECKPOINT]
+
+Estimated diff: ~250-350 lines
+
+**Files likely involved:**
+- `cloud/apps/api/src/graphql/types/models-analysis.ts`
+- `cloud/apps/api/src/graphql/queries/models-analysis.ts`
+- `cloud/apps/api/src/graphql/types/index.ts`
+- `cloud/apps/api/src/graphql/queries/index.ts`
+- `cloud/apps/web/schema.graphql`
+- new API test file(s) under `cloud/apps/api/tests/`
+
+**Work:**
+- Extend the models-analysis GraphQL shape, or add a sibling field on the same page query, to return pairwise significance rows.
+- Add a result type for pairwise rows, plus any required coverage metadata.
+- Make the resolver consume the header-picker scope values passed from the page.
+- Build the vignette-level win-rate inputs server-side.
+- Run the paired permutation test and Holm-Bonferroni correction in the resolver.
+- Return the corrected row results plus a hard error when coverage is incomplete.
+
+**Key implementation rule:**
+- The resolver should not return a partial “best effort” result when a selected model is missing vignettes in the current scope.
+
+**Verification:**
+- API unit/integration tests for:
+  - complete coverage happy path
+  - missing coverage error path
+  - all-zero / tie rows
+  - multiple pair correction
+
+### Slice B — Web: query layer, page wiring, and report shell [CHECKPOINT]
+
+Estimated diff: ~200-300 lines
+
+**Files likely involved:**
+- `cloud/apps/web/src/api/operations/modelsAnalysis.graphql`
+- `cloud/apps/web/src/api/operations/modelsAnalysis.ts`
+- `cloud/apps/web/src/pages/ModelsGroups.tsx`
+- new web component file(s) under `cloud/apps/web/src/components/models/`
+
+**Work:**
+- Extend the page query to fetch the pairwise significance payload.
+- Pass the current header-picker scope into the query.
+- Add a new section component at the bottom of the page.
+- Keep the existing page content above it unchanged.
+- Show a simple empty state when fewer than two models are selected.
+
+**Verification:**
+- Web tests for:
+  - section renders at page bottom
+  - fewer than two models shows empty state
+  - filters change the report scope
+
+### Slice C — Web: heatmap and sortable table [CHECKPOINT]
+
+Estimated diff: ~250-350 lines
+
+**Files likely involved:**
+- new component file(s) under `cloud/apps/web/src/components/models/`
+- maybe a small shared table helper if the standard sort pattern needs it
+
+**Work:**
+- Render the pairwise heatmap with:
+  - color = effect size
+  - significance marker or border = Holm-Bonferroni result
+  - signed direction visible in hover or cell copy
+- Render the table with columns:
+  - Model A
+  - Model B
+  - raw p-value
+  - Holm-corrected p-value
+  - effect size
+  - effect label
+  - confidence interval
+- Make every column sortable.
+- Keep the table as the source of truth.
+
+**Verification:**
+- Component tests for:
+  - sort behavior
+  - verdict labels
+  - heatmap color/significance mapping
+  - row hover details
+
+### Slice D — Docs, copy, and final polish [CHECKPOINT]
+
+Estimated diff: ~80-160 lines
+
+**Files likely involved:**
+- `docs/canonical-glossary.md` if the new methodology wording needs a small update
+- page-level copy strings in the new component
+- maybe `STATUS.md` if the feature is meaningfully complete at the end of this work
+
+**Work:**
+- Add the plain-language explanation for:
+  - selected-model scope
+  - one vignette = one unit
+  - why weak differences are still shown
+  - why missing coverage fails loudly
+- Make sure the report wording does not imply “better.”
+
+**Verification:**
+- Copy review by grep and targeted UI test snapshots if needed
+
+## Data Flow
+
+1. The page header picker defines the scope.
+2. The page passes that scope into the models-analysis query.
+3. The API resolver loads only the selected slice.
+4. For each model and vignette, the resolver computes the existing equal-vignette win-rate score.
+5. The resolver builds paired differences for every selected model pair.
+6. The resolver computes the paired permutation test, effect size, and CI.
+7. Holm-Bonferroni adjusts the p-values across the selected pairs.
+8. The client renders the heatmap and the sortable table.
+
+## Testing Strategy
+
+### API
+
+- Add fixtures that cover:
+  - 2-model happy path
+  - 8-model full pair matrix
+  - missing vignette coverage error
+  - ties / zero differences
+  - multiple-comparison correction
+- Verify the resolver refuses to return a partial comparison set.
+
+### Web
+
+- Add a page test for `/models` with the new section visible.
+- Add a component test for the sortable table.
+- Add a component test for the heatmap cell encoding.
+- Add a page test that changes the header picker and confirms the report scope changes with it.
+
+## Risks
+
+1. The page already has multiple control layers, so the new report could be confusing if the scope copy is not clear.
+   verification: add a short scope summary directly above the report.
+2. The table will grow quickly as models are selected.
+   verification: make the heatmap the fast scan layer and keep the table compact.
+3. The fail-loud rule could be too strict if the upstream slice is often incomplete.
+   verification: add a focused missing-data test so we can see exactly what fails before implementing the UI.
+4. The backend math will be more complex than the current `/models` payload.
+   verification: keep the resolver pure where possible and cover the math with unit tests.
+

--- a/docs/workflow/feature-runs/model-grouping-pairwise-significance/reviews/spec.gemini.requirements-adversarial.review.md
+++ b/docs/workflow/feature-runs/model-grouping-pairwise-significance/reviews/spec.gemini.requirements-adversarial.review.md
@@ -1,0 +1,76 @@
+---
+reviewer: "gemini"
+lens: "requirements-adversarial"
+stage: "spec"
+artifact_path: "docs/workflow/feature-runs/model-grouping-pairwise-significance/spec.md"
+artifact_sha256: "a9b56f8a04671644bc62e347c9e785e14aca1b738d2681d4f1f9fef9f188de44"
+repo_root: "."
+git_head_sha: "3a5af11db33c010c8b6f91c57141ca0042ad4560"
+git_base_ref: "origin/main"
+git_base_sha: "d7d5907a3652d38fb68d434385e2f7b4a273c36d"
+generation_method: "gemini-cli"
+resolution_status: "open"
+resolution_note: ""
+raw_output_path: "docs/workflow/feature-runs/model-grouping-pairwise-significance/reviews/spec.gemini.requirements-adversarial.review.md.json"
+narrowed_artifact_path: ""
+narrowed_artifact_sha256: ""
+coverage_status: "full"
+coverage_note: ""
+---
+
+# Review: spec requirements-adversarial
+
+## Findings
+
+### 1. Undefined Core Metric Leads to Inconsistency
+
+**Severity: HIGH**
+
+The spec’s unit of analysis is an "average score per vignette," but "score" is never defined. The surrounding application code and context reveal multiple distinct, competing metrics that this new feature ignores. Specifically, `ModelsGroups.tsx` includes a `dataSource` state that allows the user to toggle the existing cluster visualizations between `'log-odds'` and `'win-rate'`. The new significance report is not specified to react to this control. This will create a confusing and misleading user experience where the main cluster visualizations could be based on one metric (e.g., win-rate) while the statistical significance report at the bottom of the page is based on another (e.g., log-odds), without any indication to the user. The methodology is therefore not just undefined, it is disconnected from the interactive context it will inhabit.
+
+**Evidence: [CODE-CONFIRMED]**
+The code in `ModelsGroups.tsx` explicitly defines and manages the `dataSource` state (`const [dataSource, setDataSource] = useState<'log-odds' | 'win-rate'>('log-odds');`), which is then passed to `ModelGroupsSection` and `ModelAnalysisSettingsBar`. The spec for the new significance report makes no mention of this `dataSource` and does not specify how it should adapt its own "score" metric, creating a guaranteed inconsistency.
+
+### 2. Report Ignores Critical Page-Level Filters
+
+**Severity: HIGH**
+
+The spec states that the report "uses only the models currently selected in the page filter" but is silent on all other critical filters that govern the page's data. The `ModelsGroups.tsx` component is controlled by `selectedScope` ('ALL_DOMAINS' vs. a single domain), `selectedDomainId`, and `selectedSignature`. These states directly control the variables for the GraphQL queries that fetch the page's data. By ignoring these filters, the spec creates a major ambiguity: will the significance report operate on "all domains" data even when the user has filtered to a single domain? Will it ignore the signature filter? This omission guarantees that the new report will either not respond to the page's primary controls or will be implemented with implicit assumptions that contradict the user's view of the data, undermining the feature's reliability.
+
+**Evidence: [CODE-CONFIRMED]**
+`ModelsGroups.tsx` clearly shows state and effects for `selectedDomainId`, `selectedScope`, and `selectedSignature`, which are used to construct the variables for `DOMAIN_ANALYSIS_QUERY` and `MODELS_ANALYSIS_QUERY`. The `models-analysis.ts` API resolver also accepts `domainId` and `signature` arguments. The feature spec for the new report does not account for how it will integrate with this existing, fundamental filtering logic.
+
+### 3. Vague Failure Condition for Incomplete Data
+
+**Severity: MEDIUM**
+
+The requirement to "fail loudly" if "vignette coverage is incomplete" is a good principle, but "vignette coverage" is not defined with enough precision. Given the page's existing `selectedScope` and `selectedDomainId` filters, the definition of the required vignette set is ambiguous. Does "complete coverage" mean every selected model must have data for every vignette within the `selectedDomainId`? Or across all domains if the scope is `ALL_DOMAINS`? What if a `signature` is also applied? Without a precise definition of the expected vignette set based on the page's filters, this "hard failure" condition is unimplementable as specified. It risks being either too strict (failing constantly) or too loose (allowing comparisons on mismatched data sets), which defeats the purpose of the requirement.
+
+**Evidence: [CODE-CONFIRMED]**
+The code in `ModelsGroups.tsx` and the `models-analysis.ts` resolver demonstrates that data is fetched within a specific scope (`domainId`, `signature`). The spec's failure condition must be defined in terms of this same scope to be meaningful, but it currently is not.
+
+### 4. Contradictory and Inefficient Data Contract
+
+**Severity: MEDIUM**
+
+The spec's "Data Contract" section is contradictory. It states the backend must provide both the low-level `average score per vignette per selected model` and the final, high-level outputs like `pairwise test result` and `corrected p-value`. This is redundant. The backend should provide one or the other. If it provides vignette-level data, the client performs the tests. If it provides the final results, it should not also need to send the underlying data that was used to generate them. This suggests a lack of a clear architectural decision on the division of responsibilities, which will lead to wasted effort and a potentially inefficient implementation.
+
+**Evidence: [UNVERIFIED]**
+This is a logical flaw within the spec for a new feature. Existing code cannot directly confirm or refute the implementation of a future data contract, but the contradiction is inherent to the spec document itself.
+
+## Residual Risks
+
+-   **User Frustration:** The "fail loudly" requirement for incomplete data, while correct, may lead to a frustrating user experience if the underlying data sources are frequently incomplete. The feature may appear to be perpetually broken to end-users.
+-   **Information Overload:** As noted in the spec, the table can become very dense very quickly as more models are selected (e.g., 8 models yields 28 pairwise comparisons). This risks overwhelming the user and making the report difficult to interpret, despite its statistical validity.
+-   **Misinterpretation of "Weak" vs. "Not significant":** The distinction is statistically sound but may be subtle for users. There is a risk that users will misinterpret "Weak" (statistically significant, but small effect) as being functionally equivalent to "Not significant," leading them to draw incorrect conclusions. The UI design will need to be very clear to mitigate this.
+
+## Token Stats
+
+- total_input=30342
+- total_output=1268
+- total_tokens=34456
+- `gemini-2.5-pro`: input=30342, output=1268, total=34456
+
+## Resolution
+- status: open
+- note:

--- a/docs/workflow/feature-runs/model-grouping-pairwise-significance/reviews/spec.gemini.requirements-adversarial.review.md.json
+++ b/docs/workflow/feature-runs/model-grouping-pairwise-significance/reviews/spec.gemini.requirements-adversarial.review.md.json
@@ -1,0 +1,57 @@
+{
+  "session_id": "605f6d3b-a938-4ee0-853c-e089db8cd9c5",
+  "response": "## Findings\n\n### 1. Undefined Core Metric Leads to Inconsistency\n\n**Severity: HIGH**\n\nThe spec\u2019s unit of analysis is an \"average score per vignette,\" but \"score\" is never defined. The surrounding application code and context reveal multiple distinct, competing metrics that this new feature ignores. Specifically, `ModelsGroups.tsx` includes a `dataSource` state that allows the user to toggle the existing cluster visualizations between `'log-odds'` and `'win-rate'`. The new significance report is not specified to react to this control. This will create a confusing and misleading user experience where the main cluster visualizations could be based on one metric (e.g., win-rate) while the statistical significance report at the bottom of the page is based on another (e.g., log-odds), without any indication to the user. The methodology is therefore not just undefined, it is disconnected from the interactive context it will inhabit.\n\n**Evidence: [CODE-CONFIRMED]**\nThe code in `ModelsGroups.tsx` explicitly defines and manages the `dataSource` state (`const [dataSource, setDataSource] = useState<'log-odds' | 'win-rate'>('log-odds');`), which is then passed to `ModelGroupsSection` and `ModelAnalysisSettingsBar`. The spec for the new significance report makes no mention of this `dataSource` and does not specify how it should adapt its own \"score\" metric, creating a guaranteed inconsistency.\n\n### 2. Report Ignores Critical Page-Level Filters\n\n**Severity: HIGH**\n\nThe spec states that the report \"uses only the models currently selected in the page filter\" but is silent on all other critical filters that govern the page's data. The `ModelsGroups.tsx` component is controlled by `selectedScope` ('ALL_DOMAINS' vs. a single domain), `selectedDomainId`, and `selectedSignature`. These states directly control the variables for the GraphQL queries that fetch the page's data. By ignoring these filters, the spec creates a major ambiguity: will the significance report operate on \"all domains\" data even when the user has filtered to a single domain? Will it ignore the signature filter? This omission guarantees that the new report will either not respond to the page's primary controls or will be implemented with implicit assumptions that contradict the user's view of the data, undermining the feature's reliability.\n\n**Evidence: [CODE-CONFIRMED]**\n`ModelsGroups.tsx` clearly shows state and effects for `selectedDomainId`, `selectedScope`, and `selectedSignature`, which are used to construct the variables for `DOMAIN_ANALYSIS_QUERY` and `MODELS_ANALYSIS_QUERY`. The `models-analysis.ts` API resolver also accepts `domainId` and `signature` arguments. The feature spec for the new report does not account for how it will integrate with this existing, fundamental filtering logic.\n\n### 3. Vague Failure Condition for Incomplete Data\n\n**Severity: MEDIUM**\n\nThe requirement to \"fail loudly\" if \"vignette coverage is incomplete\" is a good principle, but \"vignette coverage\" is not defined with enough precision. Given the page's existing `selectedScope` and `selectedDomainId` filters, the definition of the required vignette set is ambiguous. Does \"complete coverage\" mean every selected model must have data for every vignette within the `selectedDomainId`? Or across all domains if the scope is `ALL_DOMAINS`? What if a `signature` is also applied? Without a precise definition of the expected vignette set based on the page's filters, this \"hard failure\" condition is unimplementable as specified. It risks being either too strict (failing constantly) or too loose (allowing comparisons on mismatched data sets), which defeats the purpose of the requirement.\n\n**Evidence: [CODE-CONFIRMED]**\nThe code in `ModelsGroups.tsx` and the `models-analysis.ts` resolver demonstrates that data is fetched within a specific scope (`domainId`, `signature`). The spec's failure condition must be defined in terms of this same scope to be meaningful, but it currently is not.\n\n### 4. Contradictory and Inefficient Data Contract\n\n**Severity: MEDIUM**\n\nThe spec's \"Data Contract\" section is contradictory. It states the backend must provide both the low-level `average score per vignette per selected model` and the final, high-level outputs like `pairwise test result` and `corrected p-value`. This is redundant. The backend should provide one or the other. If it provides vignette-level data, the client performs the tests. If it provides the final results, it should not also need to send the underlying data that was used to generate them. This suggests a lack of a clear architectural decision on the division of responsibilities, which will lead to wasted effort and a potentially inefficient implementation.\n\n**Evidence: [UNVERIFIED]**\nThis is a logical flaw within the spec for a new feature. Existing code cannot directly confirm or refute the implementation of a future data contract, but the contradiction is inherent to the spec document itself.\n\n## Residual Risks\n\n-   **User Frustration:** The \"fail loudly\" requirement for incomplete data, while correct, may lead to a frustrating user experience if the underlying data sources are frequently incomplete. The feature may appear to be perpetually broken to end-users.\n-   **Information Overload:** As noted in the spec, the table can become very dense very quickly as more models are selected (e.g., 8 models yields 28 pairwise comparisons). This risks overwhelming the user and making the report difficult to interpret, despite its statistical validity.\n-   **Misinterpretation of \"Weak\" vs. \"Not significant\":** The distinction is statistically sound but may be subtle for users. There is a risk that users will misinterpret \"Weak\" (statistically significant, but small effect) as being functionally equivalent to \"Not significant,\" leading them to draw incorrect conclusions. The UI design will need to be very clear to mitigate this.",
+  "stats": {
+    "models": {
+      "gemini-2.5-pro": {
+        "api": {
+          "totalRequests": 2,
+          "totalErrors": 1,
+          "totalLatencyMs": 87765
+        },
+        "tokens": {
+          "input": 30342,
+          "prompt": 30342,
+          "candidates": 1268,
+          "total": 34456,
+          "cached": 0,
+          "thoughts": 2846,
+          "tool": 0
+        },
+        "roles": {
+          "main": {
+            "totalRequests": 2,
+            "totalErrors": 1,
+            "totalLatencyMs": 87765,
+            "tokens": {
+              "input": 30342,
+              "prompt": 30342,
+              "candidates": 1268,
+              "total": 34456,
+              "cached": 0,
+              "thoughts": 2846,
+              "tool": 0
+            }
+          }
+        }
+      }
+    },
+    "tools": {
+      "totalCalls": 0,
+      "totalSuccess": 0,
+      "totalFail": 0,
+      "totalDurationMs": 0,
+      "totalDecisions": {
+        "accept": 0,
+        "reject": 0,
+        "modify": 0,
+        "auto_accept": 0
+      },
+      "byName": {}
+    },
+    "files": {
+      "totalLinesAdded": 0,
+      "totalLinesRemoved": 0
+    }
+  }
+}

--- a/docs/workflow/feature-runs/model-grouping-pairwise-significance/reviews/spec.gemini.requirements-adversarial.review.md.stderr.txt
+++ b/docs/workflow/feature-runs/model-grouping-pairwise-significance/reviews/spec.gemini.requirements-adversarial.review.md.stderr.txt
@@ -1,0 +1,119 @@
+Warning: Basic terminal detected (TERM=dumb). Visual rendering will be limited. For the best experience, use a terminal emulator with truecolor support.
+Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience.
+YOLO mode is enabled. All tool calls will be automatically approved.
+YOLO mode is enabled. All tool calls will be automatically approved.
+Attempt 1 failed with status 429. Retrying with backoff... _GaxiosError: [{
+  "error": {
+    "code": 429,
+    "message": "No capacity available for model gemini-2.5-pro on the server",
+    "errors": [
+      {
+        "message": "No capacity available for model gemini-2.5-pro on the server",
+        "domain": "global",
+        "reason": "rateLimitExceeded"
+      }
+    ],
+    "status": "RESOURCE_EXHAUSTED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "MODEL_CAPACITY_EXHAUSTED",
+        "domain": "cloudcode-pa.googleapis.com",
+        "metadata": {
+          "model": "gemini-2.5-pro"
+        }
+      }
+    ]
+  }
+}
+]
+    at Gaxios._request (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-UIBQS45C.js:8800:19)
+    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+    at async _OAuth2Client.requestAsync (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-UIBQS45C.js:10763:16)
+    at async CodeAssistServer.requestStreamingPost (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-UIBQS45C.js:277779:17)
+    at async CodeAssistServer.generateContentStream (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-UIBQS45C.js:277579:23)
+    at async file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-UIBQS45C.js:278424:19
+    at async file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-UIBQS45C.js:255329:23
+    at async retryWithBackoff (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-UIBQS45C.js:275301:23)
+    at async GeminiChat.makeApiCallAndProcessStream (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-UIBQS45C.js:312614:28)
+    at async GeminiChat.streamWithRetries (file:///opt/homebrew/lib/node_modules/@google/gemini-cli/bundle/chunk-UIBQS45C.js:312452:29) {
+  config: {
+    url: 'https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse',
+    method: 'POST',
+    params: { alt: 'sse' },
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': 'GeminiCLI/0.39.1/gemini-2.5-pro (darwin; arm64; terminal) google-api-nodejs-client/9.15.1',
+      Authorization: '<<REDACTED> - See `errorRedactor` option in `gaxios` for configuration>.',
+      'x-goog-api-client': 'gl-node/25.2.1'
+    },
+    responseType: 'stream',
+    body: '<<REDACTED> - See `errorRedactor` option in `gaxios` for configuration>.',
+    signal: AbortSignal { aborted: false },
+    retry: false,
+    paramsSerializer: [Function: paramsSerializer],
+    validateStatus: [Function: validateStatus],
+    errorRedactor: [Function: defaultErrorRedactor]
+  },
+  response: {
+    config: {
+      url: 'https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse',
+      method: 'POST',
+      params: [Object],
+      headers: [Object],
+      responseType: 'stream',
+      body: '<<REDACTED> - See `errorRedactor` option in `gaxios` for configuration>.',
+      signal: [AbortSignal],
+      retry: false,
+      paramsSerializer: [Function: paramsSerializer],
+      validateStatus: [Function: validateStatus],
+      errorRedactor: [Function: defaultErrorRedactor]
+    },
+    data: '[{\n' +
+      '  "error": {\n' +
+      '    "code": 429,\n' +
+      '    "message": "No capacity available for model gemini-2.5-pro on the server",\n' +
+      '    "errors": [\n' +
+      '      {\n' +
+      '        "message": "No capacity available for model gemini-2.5-pro on the server",\n' +
+      '        "domain": "global",\n' +
+      '        "reason": "rateLimitExceeded"\n' +
+      '      }\n' +
+      '    ],\n' +
+      '    "status": "RESOURCE_EXHAUSTED",\n' +
+      '    "details": [\n' +
+      '      {\n' +
+      '        "@type": "type.googleapis.com/google.rpc.ErrorInfo",\n' +
+      '        "reason": "MODEL_CAPACITY_EXHAUSTED",\n' +
+      '        "domain": "cloudcode-pa.googleapis.com",\n' +
+      '        "metadata": {\n' +
+      '          "model": "gemini-2.5-pro"\n' +
+      '        }\n' +
+      '      }\n' +
+      '    ]\n' +
+      '  }\n' +
+      '}\n' +
+      ']',
+    headers: {
+      'alt-svc': 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000',
+      'content-length': '606',
+      'content-type': 'application/json; charset=UTF-8',
+      date: 'Thu, 07 May 2026 18:01:27 GMT',
+      server: 'ESF',
+      'server-timing': 'gfet4t7; dur=526',
+      vary: 'Origin, X-Origin, Referer',
+      'x-cloudaicompanion-trace-id': '994d3a5280717e71',
+      'x-content-type-options': 'nosniff',
+      'x-frame-options': 'SAMEORIGIN',
+      'x-xss-protection': '0'
+    },
+    status: 429,
+    statusText: 'Too Many Requests',
+    request: {
+      responseURL: 'https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse'
+    }
+  },
+  error: undefined,
+  status: 429,
+  Symbol(gaxios-gaxios-error): '6.7.1'
+}

--- a/docs/workflow/feature-runs/model-grouping-pairwise-significance/reviews/spec.gemini.requirements-adversarial.review.md.stdout.txt
+++ b/docs/workflow/feature-runs/model-grouping-pairwise-significance/reviews/spec.gemini.requirements-adversarial.review.md.stdout.txt
@@ -1,0 +1,57 @@
+MCP issues detected. Run /mcp list for status.{
+  "session_id": "605f6d3b-a938-4ee0-853c-e089db8cd9c5",
+  "response": "## Findings\n\n### 1. Undefined Core Metric Leads to Inconsistency\n\n**Severity: HIGH**\n\nThe spec’s unit of analysis is an \"average score per vignette,\" but \"score\" is never defined. The surrounding application code and context reveal multiple distinct, competing metrics that this new feature ignores. Specifically, `ModelsGroups.tsx` includes a `dataSource` state that allows the user to toggle the existing cluster visualizations between `'log-odds'` and `'win-rate'`. The new significance report is not specified to react to this control. This will create a confusing and misleading user experience where the main cluster visualizations could be based on one metric (e.g., win-rate) while the statistical significance report at the bottom of the page is based on another (e.g., log-odds), without any indication to the user. The methodology is therefore not just undefined, it is disconnected from the interactive context it will inhabit.\n\n**Evidence: [CODE-CONFIRMED]**\nThe code in `ModelsGroups.tsx` explicitly defines and manages the `dataSource` state (`const [dataSource, setDataSource] = useState<'log-odds' | 'win-rate'>('log-odds');`), which is then passed to `ModelGroupsSection` and `ModelAnalysisSettingsBar`. The spec for the new significance report makes no mention of this `dataSource` and does not specify how it should adapt its own \"score\" metric, creating a guaranteed inconsistency.\n\n### 2. Report Ignores Critical Page-Level Filters\n\n**Severity: HIGH**\n\nThe spec states that the report \"uses only the models currently selected in the page filter\" but is silent on all other critical filters that govern the page's data. The `ModelsGroups.tsx` component is controlled by `selectedScope` ('ALL_DOMAINS' vs. a single domain), `selectedDomainId`, and `selectedSignature`. These states directly control the variables for the GraphQL queries that fetch the page's data. By ignoring these filters, the spec creates a major ambiguity: will the significance report operate on \"all domains\" data even when the user has filtered to a single domain? Will it ignore the signature filter? This omission guarantees that the new report will either not respond to the page's primary controls or will be implemented with implicit assumptions that contradict the user's view of the data, undermining the feature's reliability.\n\n**Evidence: [CODE-CONFIRMED]**\n`ModelsGroups.tsx` clearly shows state and effects for `selectedDomainId`, `selectedScope`, and `selectedSignature`, which are used to construct the variables for `DOMAIN_ANALYSIS_QUERY` and `MODELS_ANALYSIS_QUERY`. The `models-analysis.ts` API resolver also accepts `domainId` and `signature` arguments. The feature spec for the new report does not account for how it will integrate with this existing, fundamental filtering logic.\n\n### 3. Vague Failure Condition for Incomplete Data\n\n**Severity: MEDIUM**\n\nThe requirement to \"fail loudly\" if \"vignette coverage is incomplete\" is a good principle, but \"vignette coverage\" is not defined with enough precision. Given the page's existing `selectedScope` and `selectedDomainId` filters, the definition of the required vignette set is ambiguous. Does \"complete coverage\" mean every selected model must have data for every vignette within the `selectedDomainId`? Or across all domains if the scope is `ALL_DOMAINS`? What if a `signature` is also applied? Without a precise definition of the expected vignette set based on the page's filters, this \"hard failure\" condition is unimplementable as specified. It risks being either too strict (failing constantly) or too loose (allowing comparisons on mismatched data sets), which defeats the purpose of the requirement.\n\n**Evidence: [CODE-CONFIRMED]**\nThe code in `ModelsGroups.tsx` and the `models-analysis.ts` resolver demonstrates that data is fetched within a specific scope (`domainId`, `signature`). The spec's failure condition must be defined in terms of this same scope to be meaningful, but it currently is not.\n\n### 4. Contradictory and Inefficient Data Contract\n\n**Severity: MEDIUM**\n\nThe spec's \"Data Contract\" section is contradictory. It states the backend must provide both the low-level `average score per vignette per selected model` and the final, high-level outputs like `pairwise test result` and `corrected p-value`. This is redundant. The backend should provide one or the other. If it provides vignette-level data, the client performs the tests. If it provides the final results, it should not also need to send the underlying data that was used to generate them. This suggests a lack of a clear architectural decision on the division of responsibilities, which will lead to wasted effort and a potentially inefficient implementation.\n\n**Evidence: [UNVERIFIED]**\nThis is a logical flaw within the spec for a new feature. Existing code cannot directly confirm or refute the implementation of a future data contract, but the contradiction is inherent to the spec document itself.\n\n## Residual Risks\n\n-   **User Frustration:** The \"fail loudly\" requirement for incomplete data, while correct, may lead to a frustrating user experience if the underlying data sources are frequently incomplete. The feature may appear to be perpetually broken to end-users.\n-   **Information Overload:** As noted in the spec, the table can become very dense very quickly as more models are selected (e.g., 8 models yields 28 pairwise comparisons). This risks overwhelming the user and making the report difficult to interpret, despite its statistical validity.\n-   **Misinterpretation of \"Weak\" vs. \"Not significant\":** The distinction is statistically sound but may be subtle for users. There is a risk that users will misinterpret \"Weak\" (statistically significant, but small effect) as being functionally equivalent to \"Not significant,\" leading them to draw incorrect conclusions. The UI design will need to be very clear to mitigate this.",
+  "stats": {
+    "models": {
+      "gemini-2.5-pro": {
+        "api": {
+          "totalRequests": 2,
+          "totalErrors": 1,
+          "totalLatencyMs": 87765
+        },
+        "tokens": {
+          "input": 30342,
+          "prompt": 30342,
+          "candidates": 1268,
+          "total": 34456,
+          "cached": 0,
+          "thoughts": 2846,
+          "tool": 0
+        },
+        "roles": {
+          "main": {
+            "totalRequests": 2,
+            "totalErrors": 1,
+            "totalLatencyMs": 87765,
+            "tokens": {
+              "input": 30342,
+              "prompt": 30342,
+              "candidates": 1268,
+              "total": 34456,
+              "cached": 0,
+              "thoughts": 2846,
+              "tool": 0
+            }
+          }
+        }
+      }
+    },
+    "tools": {
+      "totalCalls": 0,
+      "totalSuccess": 0,
+      "totalFail": 0,
+      "totalDurationMs": 0,
+      "totalDecisions": {
+        "accept": 0,
+        "reject": 0,
+        "modify": 0,
+        "auto_accept": 0
+      },
+      "byName": {}
+    },
+    "files": {
+      "totalLinesAdded": 0,
+      "totalLinesRemoved": 0
+    }
+  }
+}

--- a/docs/workflow/feature-runs/model-grouping-pairwise-significance/spec.md
+++ b/docs/workflow/feature-runs/model-grouping-pairwise-significance/spec.md
@@ -1,0 +1,313 @@
+# Spec: Model Grouping Pairwise Significance
+
+**Feature slug:** `model-grouping-pairwise-significance`  
+**Created:** 2026-05-07  
+**Status:** draft  
+**Path:** Feature Factory (`docs/workflow/feature-runs/model-grouping-pairwise-significance/`)
+
+## Background
+
+The `/models` page already helps people scan model grouping, model similarity, and value-level summaries. What it does not yet answer is a different question:
+
+**Which models are statistically significantly different in their value preferences?**
+
+This report adds that answer to the bottom of the existing Model Groups page. It does **not** frame one model as better than another. It only asks whether two models behave differently enough that chance is a weak explanation.
+
+The current `/models` API returns pooled win rates and domain breakdowns, but it does not provide the vignette-level data needed for a paired test. This feature therefore needs a new pairwise significance data path, either by extending the existing models-analysis response or by adding a sibling field on the same page query.
+
+## Discovery: Assumptions Carried In
+
+The user already made the key choices. Those choices are carried into this spec as assumptions:
+
+1. The report lives at the bottom of the Model Groups page, not on a new page.
+2. The report uses only the models currently selected in the page filter.
+3. The unit of analysis is one average score per vignette per model.
+4. Vignettes must not be overweighted just because they have more trials.
+5. The statistical test is a paired permutation test.
+6. Multiple pairwise tests use Holm-Bonferroni correction.
+7. The report compares all selected model pairs.
+8. The report shows all differences, but small effects are labeled `Weak`.
+9. Missing vignette data is not allowed. The report must fail loudly.
+10. Ties and zero-difference rows are allowed.
+11. The significance cutoff is `alpha = 0.05`.
+12. The table uses the standard sortable-table control already used elsewhere in the app. Do not use a double-headed arrow icon.
+
+## Product Goal
+
+The report should let a researcher answer, quickly and honestly:
+
+1. Which selected models are different from each other?
+2. How strong is each difference?
+3. Which differences still hold after correcting for many comparisons?
+4. Which differences are small enough that the app should label them as weak?
+
+The report should be readable at a glance, but the table should stay the source of truth.
+
+## In Scope
+
+- A new significance report at the bottom of the `/models` page
+- Pairwise comparisons for the currently selected models
+- A heatmap overview plus a sortable results table
+- A loud error state when vignette coverage is missing
+- Table copy and labels for `Significant`, `Weak`, and `Not significant`
+- Tests that lock in the methodology and the fail-loud behavior
+
+## Non-Goals
+
+- No new top-level page or navigation item
+- No change to the Model Groups clustering math
+- No change to the existing similarity table
+- No change to the domain-analysis reports
+- No pooled-count shortcut that reweights vignettes by trial count
+- No silent gap filling when data is missing
+
+## Methodology
+
+### Unit of analysis
+
+For each selected model, compute **one average score per vignette**.
+
+Plain English:
+
+- if a vignette has 1 trial, that one trial sets the vignette average
+- if a vignette has 5 trials, those 5 trials are averaged together first
+- each vignette still counts once in the model comparison
+
+This is the rule that keeps the report from over-weighting vignettes with more trials.
+
+### Pairwise comparison
+
+For each model pair:
+
+1. Line up the same vignette set for both models.
+2. Subtract one model's vignette average from the other model's vignette average.
+3. Use those paired differences as the input to the test.
+4. Run a **two-sided paired permutation test**.
+
+The pair order should be alphabetical by model name by default. The sign of the mean difference must follow that order:
+
+- positive means `Model A` is higher than `Model B`
+- negative means `Model A` is lower than `Model B`
+
+### Multiple comparisons
+
+Because the report compares many model pairs, the raw p-values must be adjusted with **Holm-Bonferroni** across all selected pairs in the current view.
+
+### Effect size
+
+Report **Cohen's d** for the paired vignette differences.
+
+The table should show:
+
+- the numeric effect size
+- a short effect label
+
+For this report:
+
+- `Weak` means `|d| < 0.5`
+- `Strong` means `|d| >= 0.5`
+
+### Row verdict
+
+The verdict column should use only these labels:
+
+- `Significant`
+- `Weak`
+- `Not significant`
+
+The verdict should follow both the corrected p-value and the effect size:
+
+- `Significant` = corrected p-value is below `0.05` and `|d| >= 0.5`
+- `Weak` = corrected p-value is below `0.05` and `|d| < 0.5`
+- `Not significant` = corrected p-value is `>= 0.05`
+
+### Confidence interval
+
+Show a **95% confidence interval for the mean difference** between the two models.
+
+The CI should be based on the paired vignette differences, not on pooled raw transcripts.
+
+### Missing data
+
+Missing vignette data is a hard failure.
+
+The report must not:
+
+- silently drop missing vignettes
+- silently compare only the overlapping subset
+- silently pad missing values with zeros
+
+If the selected models do not all have the same vignette coverage for the current scope, the report must show an error state and stop.
+
+### Ties and zero differences
+
+Ties are allowed.
+
+If the paired differences are all zero for a pair, the row should still render, with:
+
+- p-value showing no significance
+- effect size showing zero or the chosen zero-equivalent format
+- confidence interval centered on zero
+
+## UI Requirements
+
+### Placement
+
+- Add the report as the last section on the existing `/models` page.
+- Keep the current Model Groups section and the similarity table above it.
+- Do not create a separate route.
+
+### Title
+
+The section title must be:
+
+- `Statistical Differences in Value Preferences`
+
+### Layout
+
+The section should have two main parts:
+
+1. A pairwise heatmap for a quick scan
+2. A sortable table as the source of truth
+
+### Heatmap
+
+The heatmap should be a square matrix of the selected models.
+
+Requirements:
+
+- color encodes effect size
+- border or icon encodes significance after Holm-Bonferroni
+- the diagonal can be blank or muted because a model compared with itself is not useful here
+- hovering a cell should show the same key stats as the table row
+
+### Table
+
+The table must include these columns:
+
+1. `Model A`
+2. `Model B`
+3. `raw p-value`
+4. `Holm-corrected p-value`
+5. `effect size`
+6. `effect label`
+7. `confidence interval`
+
+The table is the source of truth. The heatmap is only a scan layer.
+
+### Sorting
+
+- Every column must be sortable.
+- Default sort should be alphabetical by model pair.
+- Use the app's standard sort control for tables.
+- Do not use the double-headed arrow icon.
+
+### Scope copy
+
+The section should say, in plain language, that:
+
+- only the selected models are compared
+- each vignette counts once
+- the report is corrected for multiple comparisons
+
+### Error state
+
+If data is missing, the report must show a loud error that explains the problem in plain English.
+
+The error should say that pairwise significance could not be computed because vignette coverage is incomplete.
+
+## Data Contract
+
+The current `modelsAnalysis` payload is not enough by itself for this report. It only gives pooled win rates and domain breakdowns.
+
+The new data path must provide enough information to compute pairwise significance from vignette-level averages.
+
+At minimum, the backend must provide:
+
+- the selected model IDs and labels
+- the vignette IDs in the current scope
+- the average score per vignette per selected model
+- the pairwise test result for each model pair
+- the corrected p-value for each pair
+- the effect size and confidence interval for each pair
+- a hard error when vignette coverage is incomplete
+
+The client should not try to rebuild the statistics from partially shaped data.
+
+## User Stories
+
+### US-1 — See which selected models differ (P1)
+
+As a researcher, I want to see all pairwise model differences so I can tell which models behave differently in value preference.
+
+**Acceptance scenarios**
+
+1. **Given** I open `/models` with at least two models selected, **when** the page loads, **then** I see the new report at the bottom of the page.
+2. **Given** the report is visible, **when** I scan the heatmap, **then** I can quickly see which model pairs have larger or smaller differences.
+3. **Given** the report is visible, **when** I read the table, **then** I can see every selected model pair and its test result.
+
+### US-2 — Use the same vignette once, not many times (P1)
+
+As a researcher, I want each vignette to count once so that a busy vignette does not dominate the result just because it has more trials.
+
+**Acceptance scenarios**
+
+1. **Given** a vignette has multiple trials for one model, **when** the report computes the pairwise test, **then** those trials are averaged before the comparison.
+2. **Given** one vignette has more trials than another, **when** the report computes the comparison, **then** the larger trial count does not give that vignette extra weight.
+
+### US-3 — Fail loudly on missing data (P1)
+
+As a researcher, I want the report to stop if vignette coverage is incomplete so I do not trust a partial answer.
+
+**Acceptance scenarios**
+
+1. **Given** one selected model is missing a vignette that another selected model has, **when** the report tries to load, **then** I see a clear error instead of a partial table.
+2. **Given** the data are incomplete, **when** I inspect the page, **then** the report does not silently drop the missing vignette and continue.
+
+### US-4 — Read weak differences quickly (P2)
+
+As a researcher, I want small but significant differences to be labeled as weak so I do not overread them.
+
+**Acceptance scenarios**
+
+1. **Given** a pair has a corrected p-value below `0.05` and `|d| < 0.5`, **when** the table renders, **then** the verdict says `Weak`.
+2. **Given** a pair has a corrected p-value below `0.05` and `|d| >= 0.5`, **when** the table renders, **then** the verdict says `Significant`.
+3. **Given** a pair is not significant after correction, **when** the table renders, **then** the verdict says `Not significant`.
+
+## Acceptance Criteria
+
+1. The `/models` page shows a new `Statistical Differences in Value Preferences` section at the bottom.
+2. The section uses only the models selected in the page filter.
+3. Each vignette is averaged once per model before any comparison is run.
+4. The report compares all selected model pairs.
+5. The report uses a two-sided paired permutation test.
+6. Holm-Bonferroni correction is applied across the selected pairwise tests.
+7. The table shows `Model A`, `Model B`, raw p-value, Holm-corrected p-value, effect size, effect label, and confidence interval.
+8. The table is sortable by every column using the app's standard sort control.
+9. The heatmap uses effect size for color and significance for the visible marker or border.
+10. `Weak` is used for significant rows with `|d| < 0.5`.
+11. Missing vignette coverage produces a loud error state.
+12. Ties and zero-difference rows still render.
+13. The report never silently reweights a vignette because it has more trials.
+14. The report does not change the existing Model Groups clustering or similarity reports.
+
+## Risks
+
+- A table with 8 selected models produces 28 pairwise rows, so the page can get busy fast.
+- If the heatmap is too dense, readers may ignore the table and overread the scan layer.
+- A loud error on missing data is correct, but it may frustrate users if the upstream data are often incomplete.
+- The distinction between `Weak` and `Not significant` must stay very clear or readers may misread the verdict column.
+
+## Likely Files
+
+- `cloud/apps/web/src/pages/ModelsGroups.tsx`
+- `cloud/apps/web/src/components/models/ModelGroupsSignificanceSection.tsx`
+- `cloud/apps/web/src/components/models/PairwiseSignificanceHeatmap.tsx`
+- `cloud/apps/web/src/components/models/PairwiseSignificanceTable.tsx`
+- `cloud/apps/web/src/api/operations/modelsAnalysis.ts`
+- `cloud/apps/api/src/graphql/queries/models-analysis.ts`
+- `cloud/apps/api/src/graphql/types/models-analysis.ts`
+- `cloud/apps/web/tests/pages/ModelsGroups.test.tsx`
+- `cloud/apps/web/tests/components/PairwiseSignificanceTable.test.tsx`
+- `cloud/apps/api/tests/graphql/queries/models-analysis.test.ts`
+

--- a/docs/workflow/feature-runs/model-grouping-pairwise-significance/state.json
+++ b/docs/workflow/feature-runs/model-grouping-pairwise-significance/state.json
@@ -1,0 +1,62 @@
+{
+  "review_policy": {
+    "sensitive": false,
+    "large_structural": false,
+    "performance_sensitive": false,
+    "extra_gemini_lenses": []
+  },
+  "blocked": {
+    "active": false,
+    "reason": "",
+    "updated_at": 0
+  },
+  "discovery": {
+    "version": 2,
+    "required": false,
+    "complete": true,
+    "question_count": 0,
+    "asked_count": 0,
+    "questions": [],
+    "assumptions": [],
+    "summary": "",
+    "updated_at": 0,
+    "answers": {},
+    "non_goals": [],
+    "acceptance_criteria": [],
+    "unresolved": []
+  },
+  "delivery": {},
+  "dirty_overrides": {},
+  "checkpoint_fallback": {},
+  "parallel_analysis": {
+    "reviewed": false,
+    "found": false,
+    "note": "",
+    "updated_at": 0
+  },
+  "init_head_sha": "",
+  "token_usage": [
+    {
+      "stage": "spec",
+      "round": 0,
+      "activity_type": "adversarial_review",
+      "model": "gemini-2.5-pro",
+      "lens": "requirements-adversarial",
+      "prompt_chars": 75138,
+      "prompt_cap": 200000,
+      "input_tokens": 30342,
+      "output_tokens": 1268,
+      "cost_usd_estimate": 0.0442675,
+      "timestamp": "2026-05-07T18:02:59.387842Z",
+      "started_at": "2026-05-07T18:01:17.517606Z",
+      "ended_at": "2026-05-07T18:02:59.387842Z",
+      "duration_seconds": 101.869352,
+      "agent_id": null,
+      "artifact_sha_at_time": null
+    }
+  ],
+  "command_telemetry": [],
+  "stages": {},
+  "invariant_warnings": [],
+  "schema_version": 1
+}

--- a/docs/workflow/feature-runs/model-grouping-pairwise-significance/tasks.md
+++ b/docs/workflow/feature-runs/model-grouping-pairwise-significance/tasks.md
@@ -1,0 +1,231 @@
+# Tasks: Model Grouping Pairwise Significance
+
+Plan: `docs/workflow/feature-runs/model-grouping-pairwise-significance/plan.md`  
+Spec: `docs/workflow/feature-runs/model-grouping-pairwise-significance/spec.md`
+
+Constraints: keep each slice small and focused. `[CHECKPOINT]` marks a diff-review boundary.
+
+---
+
+## Slice A — API: pairwise stats resolver, types, and schema [CHECKPOINT]
+
+Estimated diff: ~300 lines. If the slice grows too large, split helper math into a separate service file before expanding the resolver.
+
+### A1. Add pairwise significance GraphQL types
+
+- [ ] Create `cloud/apps/api/src/graphql/types/model-grouping-significance.ts`.
+- [ ] Define Pothos object types for the response shape:
+  - `ModelGroupingSignificanceModel`
+  - `ModelGroupingSignificanceRow`
+  - `ModelGroupingSignificanceResult`
+  - `ModelGroupingSignificanceHeatmapCell` if the resolver needs a small nested cell type
+- [ ] Keep the type names aligned with the report name and avoid reusing the existing `modelsAnalysis` result names.
+- [ ] Export the Refs from the new types file.
+- [ ] Keep the file under 120 lines if possible.
+
+### A2. Add pairwise significance resolver
+
+- [ ] Create `cloud/apps/api/src/graphql/queries/model-grouping-significance.ts`.
+- [ ] Register a new query field, `modelGroupingSignificance`.
+- [ ] Query args should include:
+  - `modelIds: [ID!]!`
+  - `domainId: ID`
+  - `signature: String`
+- [ ] Read the selected scope from the same header-picker values the page already uses.
+- [ ] Use the backend as the owner of the math. The resolver should return final pairwise rows, not ask the client to recompute significance.
+- [ ] Use the existing equal-vignette win-rate definition exactly as-is for the model score used in the test.
+- [ ] Compute one paired observation per vignette within the selected scope.
+- [ ] Build the pairwise test internally:
+  - paired permutation test
+  - Holm-Bonferroni correction across all selected pairs
+  - Cohen's d effect size
+  - 95% confidence interval for the mean difference
+- [ ] Return one row per model pair, with the verdict labels:
+  - `Significant`
+  - `Weak`
+  - `Not significant`
+- [ ] Return a loud error when the selected scope does not have complete vignette coverage for every selected model.
+- [ ] Do not return a partial comparison set when coverage is incomplete.
+- [ ] Do not expose raw vignette averages to the client as the main contract. Keep the client-facing payload to final pairwise rows plus minimal model labels / scope metadata.
+- [ ] Keep the file under 300 lines by moving testable math into a service module if needed.
+
+### A3. Add pure math helpers
+
+- [ ] Create `cloud/apps/api/src/services/model-grouping-significance/math.ts`.
+- [ ] Add pure helpers for:
+  - building vignette-level model averages from the equal-vignette source data
+  - paired permutation p-values
+  - Holm-Bonferroni correction
+  - Cohen's d
+  - paired mean confidence intervals
+- [ ] Keep the helpers free of I/O and logger imports.
+- [ ] Reuse the project's strict typing rules; do not use `any`.
+
+### A4. Register the new query in API wiring
+
+- [ ] Add the new type import in `cloud/apps/api/src/graphql/types/index.ts`.
+- [ ] Add the new query import in `cloud/apps/api/src/graphql/queries/index.ts`.
+- [ ] Append the matching SDL to `cloud/apps/web/schema.graphql`.
+
+### A5. Add API tests
+
+- [ ] Add a happy-path API test for a complete selected slice.
+- [ ] Add a missing-coverage test that proves the resolver fails loudly.
+- [ ] Add a tie / zero-difference test.
+- [ ] Add a multiple-comparison test with 3+ pairs.
+- [ ] Add a test that proves the backend owns the math and the client does not need raw vignette values.
+
+### A6. Verify Slice A
+
+- [ ] `npm run lint --workspace @valuerank/api`
+- [ ] `npm run test --workspace @valuerank/api`
+- [ ] `npm run build --workspace @valuerank/api`
+- [ ] Confirm the new GraphQL field is exposed in the compiled schema output.
+
+**Slice A checkpoint.**
+
+---
+
+## Slice B — Web: query layer, page wiring, and section shell [CHECKPOINT]
+
+Estimated diff: ~220 lines.
+
+### B1. Add the web GraphQL operation
+
+- [ ] Create `cloud/apps/web/src/api/operations/modelGroupingSignificance.graphql`.
+- [ ] Query the new `modelGroupingSignificance` field with:
+  - `modelIds`
+  - `domainId`
+  - `signature`
+- [ ] Request only the fields needed for the heatmap, table, and scope copy.
+
+### B2. Add the web operation re-export
+
+- [ ] Create `cloud/apps/web/src/api/operations/modelGroupingSignificance.ts`.
+- [ ] Re-export the generated GraphQL document and types.
+
+### B3. Wire the page
+
+- [ ] Update `cloud/apps/web/src/pages/ModelsGroups.tsx`.
+- [ ] Pass the selected model IDs from the header picker into the new query.
+- [ ] Pass the current header-picker scope into the new query.
+- [ ] Keep the report scope aligned with the same page filters already used above it.
+- [ ] Do not use the page's `dataSource` toggle for this report. The report always uses the existing equal-vignette win-rate metric.
+- [ ] Add a bottom-of-page section mount point after the existing similarity table.
+- [ ] Show a simple empty state when fewer than two models are selected.
+- [ ] Surface the backend error as a loud report error rather than trying to recover locally.
+
+### B4. Add the section shell
+
+- [ ] Create `cloud/apps/web/src/components/models/ModelGroupingSignificanceSection.tsx`.
+- [ ] Add the section title `Statistical Differences in Value Preferences`.
+- [ ] Add the short scope summary copy:
+  - only the selected models are compared
+  - each vignette counts once
+  - Holm-Bonferroni is applied across all selected pairs
+- [ ] Keep the section layout as two parts:
+  - pairwise heatmap
+  - sortable table
+- [ ] Make the table the source of truth.
+- [ ] Keep the heatmap as a scan layer only.
+
+### B5. Verify Slice B
+
+- [ ] Run codegen for the web package.
+- [ ] `npm run lint --workspace @valuerank/web`
+- [ ] `npm run test --workspace @valuerank/web`
+- [ ] `npm run build --workspace @valuerank/web`
+- [ ] Confirm the new section appears at the bottom of `/models`.
+
+**Slice B checkpoint.**
+
+---
+
+## Slice C — Web: heatmap and sortable results table [CHECKPOINT]
+
+Estimated diff: ~280 lines.
+
+### C1. Build the heatmap
+
+- [ ] Create `cloud/apps/web/src/components/models/ModelGroupingSignificanceHeatmap.tsx`.
+- [ ] Render a square matrix for the selected models.
+- [ ] Use effect size for color.
+- [ ] Use a border or icon to show significance after Holm-Bonferroni.
+- [ ] Show signed direction in hover text or cell copy.
+- [ ] Keep the diagonal muted or blank.
+- [ ] Keep the heatmap compact enough to scan quickly.
+
+### C2. Build the sortable table
+
+- [ ] Create `cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.tsx`.
+- [ ] Include these columns:
+  - `Model A`
+  - `Model B`
+  - `raw p-value`
+  - `Holm-corrected p-value`
+  - `effect size`
+  - `effect label`
+  - `confidence interval`
+- [ ] Make every column sortable.
+- [ ] Use the app's standard table sort control.
+- [ ] Do not use the double-headed arrow icon.
+- [ ] Show the verdict labels exactly as agreed:
+  - `Significant`
+  - `Weak`
+  - `Not significant`
+- [ ] Label rows with `Weak` when the corrected p-value is below 0.05 and `|d| < 0.5`.
+- [ ] Keep the table as the source of truth if the heatmap and table ever feel redundant.
+
+### C3. Add helper copy
+
+- [ ] Add hover text or row copy that explains:
+  - the mean difference
+  - the confidence interval
+  - why a row is significant or weak
+- [ ] Keep the language short and plain.
+
+### C4. Verify Slice C
+
+- [ ] Add component tests for:
+  - heatmap color and significance mapping
+  - table sort behavior
+  - verdict labels
+  - confidence interval display
+- [ ] `npm run lint --workspace @valuerank/web`
+- [ ] `npm run test --workspace @valuerank/web`
+- [ ] `npm run build --workspace @valuerank/web`
+
+**Slice C checkpoint.**
+
+---
+
+## Slice D — Copy, docs, and regression coverage [CHECKPOINT]
+
+Estimated diff: ~120 lines.
+
+### D1. Add page copy that matches the methodology
+
+- [ ] Update the new section copy so it clearly says the report uses the existing equal-vignette win rate.
+- [ ] State that the selected header-picker scope controls the comparison.
+- [ ] State that the report fails loudly if the selected slice is incomplete.
+- [ ] Avoid any wording that implies the report is ranking models as better or worse.
+
+### D2. Update glossary or doc wording if needed
+
+- [ ] Update `docs/canonical-glossary.md` only if a short cross-reference is needed for the new report wording.
+- [ ] Keep the terminology aligned with the existing win-rate definition.
+
+### D3. Add regression coverage for the page scope
+
+- [ ] Add a page test that changes the header picker and confirms the report scope changes with it.
+- [ ] Add a test that proves a single selected model shows the empty state.
+- [ ] Add a test that proves missing coverage produces the loud error.
+
+### D4. Final verification
+
+- [ ] Re-run the API and web test suites that changed.
+- [ ] Re-run the relevant lint and build commands for touched workspaces.
+- [ ] Confirm the report still sits at the bottom of the page and the rest of `/models` is unchanged.
+
+**Slice D checkpoint.**
+


### PR DESCRIPTION
## What changed
- Added a new pairwise significance report to the bottom of the Model Grouping page.
- The report uses the existing equal-vignette win-rate metric and the current header-picker scope.
- The backend now owns the paired permutation test, effect size, confidence interval, and Holm-Bonferroni correction.
- The UI shows a heatmap plus a sortable table, with the table as the source of truth.
- The report fails loudly if any selected model is missing vignette coverage in the active scope.

## Why
We want to see which models are statistically different in their value preferences without framing the result as "better" or "worse".

## Validation
- `npm run test --workspace @valuerank/api -- tests/services/model-grouping-significance/math.test.ts`
- `npm run test --workspace @valuerank/web -- src/components/models/ModelGroupingSignificanceTable.test.tsx src/components/models/ModelGroupingSignificanceHeatmap.test.tsx`
- `npm run build --workspace @valuerank/api`
- `npm run build --workspace @valuerank/web`
- `npm run lint --workspace @valuerank/api`
- `npm run lint --workspace @valuerank/web`
- `npm run verify --workspace @valuerank/web` (fails on an unrelated preexisting expectation in `tests/components/analysis/PairedRunComparisonCard.test.tsx`)
