### PR TITLE
[codex] wrap pressure effect header

### DIFF
--- a/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.test.tsx
+++ b/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.test.tsx
@@ -51,7 +51,8 @@ describe('PressureDirectionalBreakdown', () => {
     renderBreakdown([createModel('alpha', 'Alpha', 0.2, DOMAINS)]);
 
     expect(screen.getByText('Pressure sensitivity by domain')).toBeDefined();
-    expect(screen.getByText('High Pressure on Value Effect')).toBeDefined();
+    expect(screen.getByText('High pressure')).toBeDefined();
+    expect(screen.getByText('on value effect')).toBeDefined();
     expect(screen.getByText('Ethics')).toBeDefined();
     expect(screen.getByText('Politics')).toBeDefined();
   });

--- a/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.tsx
+++ b/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.tsx
@@ -23,6 +23,15 @@ const MAX_DELTA = 0.25;
 const OVERALL_TOOLTIP =
   "Win-rate lift above balanced when a value's pressure is high and the opposing value's pressure is low to moderate. Averaged symmetrically across both push directions, all domains, and all measured value pairs.";
 
+function WrappedHighPressureLabel({ suffix }: { suffix: string }) {
+  return (
+    <span className="inline-flex flex-col items-end leading-tight text-right">
+      <span className="whitespace-nowrap">High pressure</span>
+      <span>{suffix}</span>
+    </span>
+  );
+}
+
 function domainTooltip(domainName: string): string {
   return `How this model's pressure sensitivity in ${domainName} compares to its overall pressure sensitivity. Green means more responsive to pressure than its overall; red means less responsive.`;
 }
@@ -100,12 +109,16 @@ export function PressureDirectionalBreakdown({ models }: Props) {
       <Table variant="bordered">
         <TableHeader variant="bordered">
           <TableRow>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">Model</TableHead>
-            <TableHead className="text-xs uppercase tracking-wide text-gray-500">
-              <HeaderTooltip label="High Pressure on Value Effect" content={OVERALL_TOOLTIP} />
+            <TableHead className="text-left text-xs uppercase tracking-wide text-gray-700">Model</TableHead>
+            <TableHead className="text-right text-xs uppercase tracking-wide text-gray-700">
+              <HeaderTooltip
+                label={<WrappedHighPressureLabel suffix="on value effect" />}
+                ariaLabel="High pressure on value effect"
+                content={OVERALL_TOOLTIP}
+              />
             </TableHead>
             {domains.map((domain) => (
-              <TableHead key={domain.id} className="text-xs uppercase tracking-wide text-gray-500">
+              <TableHead key={domain.id} className="text-right text-xs uppercase tracking-wide text-gray-700">
                 <HeaderTooltip label={domain.name} content={domainTooltip(domain.name)} />
               </TableHead>
             ))}
@@ -115,8 +128,12 @@ export function PressureDirectionalBreakdown({ models }: Props) {
           {rows.map((row) => (
             <TableRow key={row.modelId}>
               <TableCell className="font-medium text-gray-900">{row.label}</TableCell>
-              <TableCell className={`font-mono ${row.overallEffect < 0 ? 'text-red-700' : 'text-gray-900'}`}>
-                {formatSignedPoints(row.overallEffect)}
+              <TableCell
+                className={`text-right text-sm ${row.overallEffect < 0 ? 'text-red-700' : 'text-gray-900'}`}
+              >
+                <span className="font-mono">
+                  {formatSignedPoints(row.overallEffect)}
+                </span>
               </TableCell>
               {domains.map((domain) => {
                 const effect = row.domainEffects.get(domain.id) ?? null;
@@ -124,13 +141,13 @@ export function PressureDirectionalBreakdown({ models }: Props) {
                 return (
                   <TableCell
                     key={domain.id}
-                    className={`text-center text-xs font-semibold transition-colors ${
+                    className={`text-right text-sm font-semibold transition-colors ${
                       delta != null
                         ? getCellDeltaClass(delta)
                         : 'border-gray-100 bg-gray-50 text-gray-400'
                     }`}
                   >
-                    {delta != null ? formatSignedPoints(delta) : '—'}
+                    <span className="font-mono">{delta != null ? formatSignedPoints(delta) : '—'}</span>
                   </TableCell>
                 );
               })}

--- a/cloud/apps/web/src/components/ui/HeaderTooltip.tsx
+++ b/cloud/apps/web/src/components/ui/HeaderTooltip.tsx
@@ -5,10 +5,11 @@ import { Tooltip } from './Tooltip';
 type Props = {
   label: ReactNode;
   content: string | ReactNode;
+  ariaLabel?: string;
 };
 
-export function HeaderTooltip({ label, content }: Props) {
-  const labelText = typeof label === 'string' || typeof label === 'number' ? String(label) : 'header';
+export function HeaderTooltip({ label, content, ariaLabel }: Props) {
+  const labelText = ariaLabel ?? (typeof label === 'string' || typeof label === 'number' ? String(label) : 'header');
 
   return (
     <span className="inline-flex items-center gap-1">


### PR DESCRIPTION
## What changed
- Wrapped the Pressure sensitivity by domain effect header into two lines so it matches the Win Rate by Pressure Conditions by Value header style.
- Right-aligned the numeric columns to match the Win Rate table.
- Kept the same tooltip and accessible label behavior.

## Why
- This makes the two model tables feel consistent and keeps the long header readable.

## Validation
- `npm run test --workspace=@valuerank/web -- --run src/components/models/PressureDirectionalBreakdown.test.tsx` - passed
- `npx turbo lint --filter=@valuerank/web` - passed with existing unrelated warnings, no errors
- `npx turbo build --filter=@valuerank/web` - passed
