### PR TITLE
Format pairwise win rates with one decimal

### DIFF
--- a/cloud/apps/web/src/components/domains/PairwiseWinRateMatrix.test.tsx
+++ b/cloud/apps/web/src/components/domains/PairwiseWinRateMatrix.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { PairwiseWinRateMatrix, type PairwiseMatrixModel } from './PairwiseWinRateMatrix';
+
+function buildModel(): PairwiseMatrixModel {
+  const valueOrder = [
+    'Universalism_Nature',
+    'Benevolence_Dependability',
+    'Tradition',
+    'Conformity_Interpersonal',
+    'Security_Personal',
+    'Power_Dominance',
+    'Achievement',
+    'Hedonism',
+    'Stimulation',
+    'Self_Direction_Action',
+  ];
+
+  const winRateMatrix = valueOrder.map((_rowKey, rowIndex) =>
+    valueOrder.map((_colKey, colIndex) => (rowIndex === colIndex ? null : 0.5))
+  );
+
+  const trialCountMatrix = valueOrder.map((_rowKey, rowIndex) =>
+    valueOrder.map((_colKey, colIndex) => (rowIndex === colIndex ? 0 : 12))
+  );
+
+  return {
+    model: 'model-a',
+    label: 'Model A',
+    pairwiseWinRateModel: {
+      valueOrder,
+      winRateMatrix,
+      trialCountMatrix,
+    },
+  };
+}
+
+describe('PairwiseWinRateMatrix', () => {
+  it('renders win rates with one decimal place', () => {
+    render(
+      <PairwiseWinRateMatrix
+        models={[buildModel()]}
+        selectedModelId={null}
+        domainId={null}
+        signature={null}
+        onCellClick={vi.fn()}
+      />,
+    );
+
+    const table = screen.getByRole('table');
+    expect(within(table).getAllByText('50.0%').length).toBeGreaterThan(0);
+    expect(within(table).queryByText('50%')).toBeNull();
+  });
+});

--- a/cloud/apps/web/src/components/domains/PairwiseWinRateMatrix.tsx
+++ b/cloud/apps/web/src/components/domains/PairwiseWinRateMatrix.tsx
@@ -52,6 +52,10 @@ function winRateCellColor(winRate: number): string {
   return getHeatmapColor((winRate - 0.5) * 2);
 }
 
+function formatWinRatePercent(winRate: number): string {
+  return `${(winRate * 100).toFixed(1)}%`;
+}
+
 type PairwiseWinRateMatrixProps = {
   models: PairwiseMatrixModel[];
   selectedModelId: string | null;
@@ -225,14 +229,14 @@ export function PairwiseWinRateMatrix({
                           isDiagonal
                             ? undefined
                             : winRate != null
-                              ? `${Math.round(winRate * 100)}% (${trials} trial${trials === 1 ? '' : 's'})`
+                              ? `${formatWinRatePercent(winRate)} (${trials} trial${trials === 1 ? '' : 's'})`
                               : 'No data'
                         }
                       >
                         {isDiagonal
                           ? '—'
                           : winRate != null
-                            ? `${Math.round(winRate * 100)}%`
+                            ? formatWinRatePercent(winRate)
                             : '—'}
                       </td>
                     );


### PR DESCRIPTION
## Summary
- Format pairwise win rate matrix values with one decimal place.
- Add a focused test that checks the matrix renders `50.0%` instead of `50%`.

## Test plan
- [x] Focused vitest: `npx vitest run src/components/domains/PairwiseWinRateMatrix.test.tsx`
- [x] Preflight passed (lint + build)
- [ ] Manual smoke test done

🤖 Generated with [Claude Code](https://claude.com/claude-code)