### PR TITLE
Remove pp suffix from pressure response column

### DIFF
--- a/cloud/apps/web/src/components/analysis/PairedRunComparisonCard.tsx
+++ b/cloud/apps/web/src/components/analysis/PairedRunComparisonCard.tsx
@@ -119,7 +119,7 @@ function formatSignedPoints(value: number | null | undefined): string {
   const pp = value * 100;
   const rounded = Math.round(pp * 10) / 10;
   const sign = rounded > 0 ? '+' : '';
-  return `${sign}${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)} pp`;
+  return `${sign}${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}`;
 }
 
 function buildAnalysisHref(

--- a/cloud/apps/web/tests/components/analysis/PairedRunComparisonCard.test.tsx
+++ b/cloud/apps/web/tests/components/analysis/PairedRunComparisonCard.test.tsx
@@ -144,7 +144,7 @@ describe('PairedRunComparisonCard', () => {
     expect(screen.getByText('GPT-4')).toBeInTheDocument();
     expect(screen.getByText('65%')).toBeInTheDocument();
     expect(screen.getByText('35%')).toBeInTheDocument();
-    expect(screen.getByText('+20 pp')).toBeInTheDocument();
+    expect(screen.getByText('+20')).toBeInTheDocument();
     expect(screen.getByText('2 / 2')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- Drops the "pp" (percentage points) suffix from `formatSignedPoints` in `PairedRunComparisonCard`
- Updates the corresponding test assertion

## Validation
- Test updated: `PairedRunComparisonCard > renders blended per-model rows from the server-aggregated query`

🤖 Generated with [Claude Code](https://claude.com/claude-code)