### PR TITLE
Fix significance resolver: add modelId filter to transcript query

### DIFF
--- a/cloud/apps/api/src/graphql/queries/model-grouping-significance.ts
+++ b/cloud/apps/api/src/graphql/queries/model-grouping-significance.ts
@@ -126,6 +126,7 @@ builder.queryField('modelGroupingSignificance', (t) =>
         const transcripts: TranscriptRecord[] = await db.transcript.findMany({
           where: {
             runId: { in: resolvedSignatureRuns.filteredSourceRunIds },
+            modelId: { in: [...selectedModelIdSet] },
             deletedAt: null,
           },
           select: {


### PR DESCRIPTION
## Summary
- The transcript batch query had no `modelId` filter — it fetched every transcript for all models in the scope, then discarded non-selected models in the loop
- For all-domains scope this means tens of thousands of rows per batch, causing the spinner to hang indefinitely
- Fix: add `modelId: { in: selectedModelIds }` to the Prisma WHERE clause, cutting the fetch by ~90% when a handful of models are selected

## Root cause
`filteredSourceRunIds` contains runs for all definitions in scope (can be 1000+ run IDs). The query then returned all transcripts across all models for those runs, with in-code filtering. Each batch of 500 was full of rows we threw away.

## Validation
- `npx turbo build --filter=@valuerank/api` — clean (TypeScript compiles)
- Logic unchanged: same results, just fetched efficiently from DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)