### PR TITLE
Fix significance resolver: deduplicate to one run per definition

### DIFF
--- a/cloud/apps/api/src/graphql/queries/model-grouping-significance.ts
+++ b/cloud/apps/api/src/graphql/queries/model-grouping-significance.ts
@@ -117,6 +117,20 @@ builder.queryField('modelGroupingSignificance', (t) =>
         );
       }
 
+      // resolveSignatureRuns returns ALL matching runs per definition (sorted newest-first).
+      // For McNemar we only need one binary choice per definition, so cap at the most
+      // recent run per definition to keep the IN clause small.
+      const latestRunIdByDefinition = new Map<string, string>();
+      for (const [runId, definitionId] of resolvedSignatureRuns.filteredSourceRunDefinitionById) {
+        if (!latestRunIdByDefinition.has(definitionId)) {
+          latestRunIdByDefinition.set(definitionId, runId);
+        }
+      }
+      const dedupedRunIds = [...latestRunIdByDefinition.values()];
+      const dedupedDefinitionById = new Map(
+        [...latestRunIdByDefinition.entries()].map(([definitionId, runId]) => [runId, definitionId] as const),
+      );
+
       const selectedModelIdSet = new Set(sortedModels.map((model) => model.modelId));
       const countsByDefinitionModel = new Map<string, WinLossCounts>();
       let offset = 0;
@@ -125,7 +139,7 @@ builder.queryField('modelGroupingSignificance', (t) =>
       while (hasMoreTranscripts) {
         const transcripts: TranscriptRecord[] = await db.transcript.findMany({
           where: {
-            runId: { in: resolvedSignatureRuns.filteredSourceRunIds },
+            runId: { in: dedupedRunIds },
             modelId: { in: [...selectedModelIdSet] },
             deletedAt: null,
           },
@@ -159,7 +173,7 @@ builder.queryField('modelGroupingSignificance', (t) =>
           if (transcript.deletedAt != null) continue;
           if (transcript.scenario == null || transcript.scenario.deletedAt != null) continue;
 
-          const definitionId = resolvedSignatureRuns.filteredSourceRunDefinitionById.get(transcript.runId);
+          const definitionId = dedupedDefinitionById.get(transcript.runId);
           if (definitionId === undefined) continue;
 
           const valuePair = getSnapshotValuePair(transcript.definitionSnapshot);


### PR DESCRIPTION
## Summary
- `resolveSignatureRuns` returns ALL historical matching runs per definition, not just the latest
- For all-domains scope with many definitions × many historical runs, `filteredSourceRunIds` can be 1000+ entries, making the Prisma IN clause huge and causing query timeout
- Fix: before the transcript query loop, deduplicate to the most-recent run per definition (Map insertion order preserves newest-first from the query)
- Reduces the IN clause from N×K entries to N entries (one per definition)

## Root cause detail
`resolveSignatureRuns` fetches all completed runs ordered `createdAt DESC` per definition and pushes every matching one into `filteredSourceRunIds`. For McNemar's test we only need a binary choice per definition — the most recent run is sufficient.

## Validation
- `npx turbo build --filter=@valuerank/api` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)