### PR TITLE
Significance resolver: use domain-analysis snapshot as fast path

### DIFF
--- a/cloud/apps/api/src/graphql/queries/model-grouping-significance.ts
+++ b/cloud/apps/api/src/graphql/queries/model-grouping-significance.ts
@@ -16,6 +16,7 @@ import { resolveSignatureRuns } from '../queries/domain/shared.js';
 import { getSnapshotValuePair } from '../../services/analysis/transcript-cell-accumulator.js';
 import { resolveTranscriptDecisionModel } from '../queries/domain/decision-model.js';
 import { assignOwnOpponent } from '../../services/pressure-sensitivity/value-pair.js';
+import { readDefinitionModelVotesFromSnapshot } from '../../services/analysis/domain-analysis-cache.js';
 import type { DomainAnalysisScope } from '../../services/analysis/domain-analysis-scope.js';
 
 const ALL_DOMAINS_SCOPE_ID = 'all-domains';
@@ -107,68 +108,90 @@ builder.queryField('modelGroupingSignificance', (t) =>
       }
 
       const selectedModelIdSet = new Set(sortedModels.map((model) => model.modelId));
-      const allRunIds = resolvedSignatureRuns.filteredSourceRunIds;
 
-      // Query 1: one row per run to extract the value pair from the definition snapshot.
-      // Using distinct avoids fetching the large snapshot field for every transcript.
-      const runSnapshotRows = await db.transcript.findMany({
-        where: { runId: { in: allRunIds }, deletedAt: null },
-        select: { runId: true, definitionSnapshot: true },
-        distinct: ['runId'],
-      });
-      const valuePairByRunId = new Map<string, NonNullable<ReturnType<typeof getSnapshotValuePair>>>();
-      for (const row of runSnapshotRows) {
-        const pair = getSnapshotValuePair(row.definitionSnapshot);
-        if (pair != null) valuePairByRunId.set(row.runId, pair);
-      }
-
-      // Query 2: all transcripts for the selected models across all matching runs.
-      // Excludes definitionSnapshot (already extracted above) to keep the payload small.
-      const allTranscripts = await db.transcript.findMany({
-        where: {
-          runId: { in: allRunIds },
-          modelId: { in: [...selectedModelIdSet] },
-          deletedAt: null,
-        },
-        select: {
-          runId: true,
-          modelId: true,
-          decisionMetadata: true,
-          scenario: {
-            select: { orientationFlipped: true, deletedAt: true },
-          },
-        },
-      });
+      // Fast path: read pre-computed per-(definitionId::modelId) vote counts from the
+      // domain-analysis snapshot (built by v1.10.0+). Falls back to the two-query DB
+      // scan when the snapshot is absent or pre-dates v1.10.0.
+      const snapshotVotes = await readDefinitionModelVotesFromSnapshot(
+        scope,
+        domainId ?? ALL_DOMAINS_SCOPE_ID,
+        signature,
+      );
 
       const countsByDefinitionModel = new Map<string, WinLossCounts>();
-      for (const transcript of allTranscripts) {
-        if (transcript.scenario == null || transcript.scenario.deletedAt != null) continue;
-        const definitionId = resolvedSignatureRuns.filteredSourceRunDefinitionById.get(transcript.runId);
-        if (definitionId === undefined) continue;
-        const valuePair = valuePairByRunId.get(transcript.runId);
-        if (valuePair == null) continue;
-        const firstValueToken = valuePair[0];
-        const secondValueToken = valuePair[1];
 
-        const resolved = resolveTranscriptDecisionModel({
-          decisionMetadata: transcript.decisionMetadata,
-          definitionSnapshot: null,
-          orientationFlipped: transcript.scenario.orientationFlipped,
-          pairOverride: { valueA: firstValueToken, valueB: secondValueToken },
-        });
-        if (resolved.canonical.direction === 'unknown') continue;
-
-        const outcome = assignOwnOpponent(firstValueToken, secondValueToken, resolved.canonical.direction);
-        if (outcome === 'unscored' || outcome === 'neutral') continue;
-
-        const key = encodeDefinitionModelKey(definitionId, transcript.modelId);
-        const counts = countsByDefinitionModel.get(key) ?? { wins: 0, losses: 0 };
-        if (outcome === 'own_picked') {
-          counts.wins += 1;
-        } else {
-          counts.losses += 1;
+      if (snapshotVotes != null) {
+        // Snapshot fast path: populate counts directly, no transcript queries needed.
+        for (const [key, votes] of Object.entries(snapshotVotes)) {
+          const parts = key.split('::');
+          const modelId = parts[1];
+          if (modelId !== undefined && selectedModelIdSet.has(modelId)) {
+            countsByDefinitionModel.set(key, { wins: votes.wins, losses: votes.losses });
+          }
         }
-        countsByDefinitionModel.set(key, counts);
+        ctx.log.debug({ scope, domainId, signature }, 'Significance: used domain-analysis snapshot (fast path)');
+      } else {
+        // Slow fallback: fetch transcripts directly. Used until the domain-analysis
+        // snapshot is rebuilt with v1.10.0.
+        const allRunIds = resolvedSignatureRuns.filteredSourceRunIds;
+
+        const runSnapshotRows = await db.transcript.findMany({
+          where: { runId: { in: allRunIds }, deletedAt: null },
+          select: { runId: true, definitionSnapshot: true },
+          distinct: ['runId'],
+        });
+        const valuePairByRunId = new Map<string, NonNullable<ReturnType<typeof getSnapshotValuePair>>>();
+        for (const row of runSnapshotRows) {
+          const pair = getSnapshotValuePair(row.definitionSnapshot);
+          if (pair != null) valuePairByRunId.set(row.runId, pair);
+        }
+
+        const allTranscripts = await db.transcript.findMany({
+          where: {
+            runId: { in: allRunIds },
+            modelId: { in: [...selectedModelIdSet] },
+            deletedAt: null,
+          },
+          select: {
+            runId: true,
+            modelId: true,
+            decisionMetadata: true,
+            scenario: {
+              select: { orientationFlipped: true, deletedAt: true },
+            },
+          },
+        });
+
+        for (const transcript of allTranscripts) {
+          if (transcript.scenario == null || transcript.scenario.deletedAt != null) continue;
+          const definitionId = resolvedSignatureRuns.filteredSourceRunDefinitionById.get(transcript.runId);
+          if (definitionId === undefined) continue;
+          const valuePair = valuePairByRunId.get(transcript.runId);
+          if (valuePair == null) continue;
+          const firstValueToken = valuePair[0];
+          const secondValueToken = valuePair[1];
+
+          const resolved = resolveTranscriptDecisionModel({
+            decisionMetadata: transcript.decisionMetadata,
+            definitionSnapshot: null,
+            orientationFlipped: transcript.scenario.orientationFlipped,
+            pairOverride: { valueA: firstValueToken, valueB: secondValueToken },
+          });
+          if (resolved.canonical.direction === 'unknown') continue;
+
+          const outcome = assignOwnOpponent(firstValueToken, secondValueToken, resolved.canonical.direction);
+          if (outcome === 'unscored' || outcome === 'neutral') continue;
+
+          const key = encodeDefinitionModelKey(definitionId, transcript.modelId);
+          const counts = countsByDefinitionModel.get(key) ?? { wins: 0, losses: 0 };
+          if (outcome === 'own_picked') {
+            counts.wins += 1;
+          } else {
+            counts.losses += 1;
+          }
+          countsByDefinitionModel.set(key, counts);
+        }
+        ctx.log.debug({ scope, domainId, signature }, 'Significance: used transcript scan (slow path — snapshot not yet available)');
       }
 
       const coverageByModel = new Map(sortedModels.map((model) => [model.modelId, new Set<string>()] as const));

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
@@ -17,7 +17,7 @@ export type DomainAnalysisCacheStatus =
   (typeof DOMAIN_ANALYSIS_CACHE_STATUS)[keyof typeof DOMAIN_ANALYSIS_CACHE_STATUS];
 
 export const DOMAIN_ANALYSIS_SNAPSHOT_TYPE = 'domain_overview';
-export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.9.0';
+export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.10.0';
 export const DOMAIN_ANALYSIS_ASSUMPTION_PREFIX = 'domain-analysis';
 export const DOMAIN_ANALYSIS_NONE_SIGNATURE = '__none__';
 
@@ -62,6 +62,10 @@ export type DomainAnalysisSnapshotOutput = {
   models: DomainAnalysisSnapshotModel[];
   contributionSummary: DomainAnalysisContributionSummary[];
   excludedDataSummary: DomainAnalysisExcludedDataSummary[];
+  // Per-(definitionId::modelId) win/loss vote counts, derived from the cellMap before
+  // domain-level aggregation. Used by the significance resolver to avoid a separate
+  // transcript scan. Optional for backward compatibility with pre-v1.10.0 snapshots.
+  definitionModelVotes?: Record<string, { wins: number; losses: number }>;
 };
 
 export type AnalysisFingerprintRow = {

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -344,3 +344,21 @@ export async function getDomainAnalysisResult(params: {
     cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.FRESH,
   });
 }
+
+/**
+ * Read the pre-computed per-(definitionId::modelId) vote counts from the current
+ * domain-analysis snapshot. Returns null if no CURRENT snapshot exists or if the
+ * snapshot pre-dates v1.10.0 (i.e. does not include `definitionModelVotes`).
+ *
+ * Used by the significance resolver to avoid a separate transcript scan.
+ */
+export async function readDefinitionModelVotesFromSnapshot(
+  scope: DomainAnalysisScope,
+  domainId: string,
+  configSignature: string,
+): Promise<Record<string, { wins: number; losses: number }> | null> {
+  const snapshot = await getCurrentSnapshot(db, scope, domainId, configSignature);
+  if (snapshot == null) return null;
+  const parsed = parseSnapshotOutput(snapshot.output);
+  return parsed?.definitionModelVotes ?? null;
+}

--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
@@ -180,6 +180,19 @@ export async function buildSnapshotOutput(
       offset += fetchedCount;
     }
   }
+  // Derive per-(definitionId::modelId) vote counts from the cellMap before it is
+  // aggregated into domain-level rates. These are stored in the snapshot so the
+  // significance resolver can run McNemar without a separate transcript scan.
+  const definitionModelVotes: Record<string, { wins: number; losses: number }> = {};
+  for (const [key, counts] of cellMap.entries()) {
+    const parts = key.split('::');
+    const combinedKey = `${parts[0]}::${parts[1]}`; // definitionId::modelId
+    const entry = definitionModelVotes[combinedKey] ?? { wins: 0, losses: 0 };
+    entry.wins += counts.wins;
+    entry.losses += counts.losses;
+    definitionModelVotes[combinedKey] = entry;
+  }
+
   const { models, analyzedDefinitionIds } = computeCellWeightedDomainRates({
     cellMap,
     filteredSourceRunDefinitionById: state.resolvedSignatureRuns.filteredSourceRunDefinitionById,
@@ -219,6 +232,7 @@ export async function buildSnapshotOutput(
     models,
     contributionSummary: [],
     excludedDataSummary: [],
+    definitionModelVotes,
   };
 }
 


### PR DESCRIPTION
## Summary
- The significance report was timing out (~30s) because it scanned hundreds of transcript rows on every request.
- The domain-analysis snapshot already computes per-(definitionId, model) win/loss counts during its transcript scan — they just weren't being stored.
- This PR preserves those counts as `definitionModelVotes` in the snapshot output (v1.10.0), and makes the significance resolver read from the snapshot instead of hitting the DB.
- Once the domain-analysis snapshot rebuilds (automatically triggered by the version bump), significance becomes a snapshot read + in-memory McNemar math — well under 100ms.
- The two-query transcript scan is kept as a fallback for the brief window before snapshots rebuild.

## No new infrastructure
This reuses the existing `assumptionAnalysisSnapshot` table, the existing domain-analysis cache lifecycle (freshness checks, background rebuilds), and the existing `cellMap` computation. No new snapshot type, no new queue job.

## Validation
- `npx turbo build --filter=@valuerank/api` — passed (0 errors)

## Test plan
- [ ] CI passes
- [ ] After deploy: confirm domain-analysis snapshot rebuilds (background job fires automatically)
- [ ] Confirm significance report loads in <1s once snapshot is fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)