### PR TITLE
Replace McNemar with Wilcoxon signed-rank on averaged win rates

### DIFF
--- a/cloud/apps/api/src/graphql/queries/model-grouping-significance.ts
+++ b/cloud/apps/api/src/graphql/queries/model-grouping-significance.ts
@@ -1,14 +1,18 @@
 import { ValidationError } from '@valuerank/shared';
+import { db } from '@valuerank/db';
 import { builder } from '../builder.js';
 import { getModelsFromDatabase } from '../../config/models.js';
-import { ModelGroupingSignificanceResultRef } from '../types/model-grouping-significance.js';
+import {
+  ModelGroupingSignificanceResultRef,
+  type ModelGroupingSignificanceRowShape,
+} from '../types/model-grouping-significance.js';
 import {
   classifyEffectSize,
   classifyVerdict,
-  exactMcNemar,
   holmBonferroni,
-  matchedPairsOddsRatio,
-  oddsRatioCI,
+  bootstrapMeanDiffCI,
+  rankBiserialCorrelation,
+  wilcoxonSignedRank,
 } from '../../services/model-grouping-significance/math.js';
 import { resolveDomainAnalysisScopeDefinitions } from '../../services/analysis/domain-analysis-scope-loader.js';
 import { resolveSignatureRuns } from '../queries/domain/shared.js';
@@ -35,7 +39,12 @@ function sortModels(models: ReadonlyArray<ModelSummary>): ModelSummary[] {
 }
 
 function encodeDefinitionModelKey(definitionId: string, modelId: string): string { return `${definitionId}::${modelId}`; }
-function getChoice(counts: WinLossCounts | undefined): 0 | 1 { return counts != null && counts.wins > counts.losses ? 1 : 0; }
+
+function computeWinRate(wins: number, losses: number): number | undefined {
+  const total = wins + losses;
+  if (total === 0) return undefined;
+  return wins / total;
+}
 
 function intersectCoveredDefinitions(models: ReadonlyArray<ModelSummary>, coverageByModel: Map<string, Set<string>>): Set<string> {
   const firstCoverage = coverageByModel.get(models[0]!.modelId) ?? new Set<string>();
@@ -165,42 +174,115 @@ builder.queryField('modelGroupingSignificance', (t) =>
         );
       }
 
-      const rows = [];
+      // Fetch definition names for pairing
+      const coveredIdsArray = [...coveredDefinitionIds];
+      const definitionRows = await db.definition.findMany({
+        where: { id: { in: coveredIdsArray }, deletedAt: null },
+        select: { id: true, name: true },
+      });
+      const nameById = new Map(definitionRows.map((def) => [def.id, def.name]));
+
+      // Pair definitions: "A -> B" pairs with "B -> A"
+      type ValuePair = { ids: [string] | [string, string] };
+      const valuePairs: ValuePair[] = [];
+      const paired = new Set<string>();
+
+      for (const idA of coveredIdsArray) {
+        if (paired.has(idA)) continue;
+        const nameA = nameById.get(idA);
+        if (nameA == null) {
+          valuePairs.push({ ids: [idA] });
+          paired.add(idA);
+          continue;
+        }
+        const parts = nameA.split(' -> ');
+        const reversedName =
+          parts.length === 2 ? `${parts[1]!.trim()} -> ${parts[0]!.trim()}` : null;
+
+        let partnerId: string | undefined;
+        if (reversedName != null) {
+          partnerId = coveredIdsArray.find(
+            (idB) => !paired.has(idB) && idB !== idA && nameById.get(idB) === reversedName,
+          );
+        }
+
+        if (partnerId != null) {
+          valuePairs.push({ ids: [idA, partnerId] });
+          paired.add(idA);
+          paired.add(partnerId);
+        } else {
+          valuePairs.push({ ids: [idA] });
+          paired.add(idA);
+        }
+      }
+
+      // Compute avgWinRate per (valuePair, model) and track maxOrderEffect
+      let maxOrderEffect = 0;
+      const avgWinRateByPair: Array<Map<string, number | undefined>> = valuePairs.map((pair) => {
+        const byModel = new Map<string, number | undefined>();
+        for (const model of sortedModels) {
+          if (pair.ids.length === 1) {
+            const counts = countsByDefinitionModel.get(encodeDefinitionModelKey(pair.ids[0], model.modelId));
+            byModel.set(model.modelId, counts != null ? computeWinRate(counts.wins, counts.losses) : undefined);
+          } else {
+            const [idA, idB] = pair.ids as [string, string];
+            const countsA = countsByDefinitionModel.get(encodeDefinitionModelKey(idA, model.modelId));
+            const countsB = countsByDefinitionModel.get(encodeDefinitionModelKey(idB, model.modelId));
+            const wrA = countsA != null ? computeWinRate(countsA.wins, countsA.losses) : undefined;
+            const wrB = countsB != null ? computeWinRate(countsB.wins, countsB.losses) : undefined;
+            if (wrA !== undefined && wrB !== undefined) {
+              byModel.set(model.modelId, (wrA + wrB) / 2);
+              const orderEffect = Math.abs(wrA - wrB);
+              if (orderEffect > maxOrderEffect) maxOrderEffect = orderEffect;
+            } else {
+              byModel.set(model.modelId, undefined);
+            }
+          }
+        }
+        return byModel;
+      });
+
+      const rows: ModelGroupingSignificanceRowShape[] = [];
       for (let leftIndex = 0; leftIndex < sortedModels.length; leftIndex += 1) {
         for (let rightIndex = leftIndex + 1; rightIndex < sortedModels.length; rightIndex += 1) {
           const modelA = sortedModels[leftIndex]!;
           const modelB = sortedModels[rightIndex]!;
-          let discordantAtoB = 0;
-          let discordantBtoA = 0;
 
-          for (const definitionId of coveredDefinitionIds) {
-            const choiceA = getChoice(countsByDefinitionModel.get(encodeDefinitionModelKey(definitionId, modelA.modelId)));
-            const choiceB = getChoice(countsByDefinitionModel.get(encodeDefinitionModelKey(definitionId, modelB.modelId)));
-            if (choiceA === 1 && choiceB === 0) {
-              discordantAtoB += 1;
-            } else if (choiceA === 0 && choiceB === 1) {
-              discordantBtoA += 1;
+          const differences: number[] = [];
+          const winRatesA: number[] = [];
+          const winRatesB: number[] = [];
+          for (const pairMap of avgWinRateByPair) {
+            const wrA = pairMap.get(modelA.modelId);
+            const wrB = pairMap.get(modelB.modelId);
+            if (wrA !== undefined && wrB !== undefined) {
+              differences.push(wrA - wrB);
+              winRatesA.push(wrA);
+              winRatesB.push(wrB);
             }
           }
 
-          const n = coveredDefinitionIds.size;
-          const concordant = n - discordantAtoB - discordantBtoA;
-          const rawPValue = exactMcNemar(discordantAtoB, discordantBtoA);
-          const oddsRatio = matchedPairsOddsRatio(discordantAtoB, discordantBtoA);
-          const { low, high } = oddsRatioCI(discordantAtoB, discordantBtoA, 0.05);
+          const n = differences.length;
+          const { statistic, pValue: rawPValue, nEff } = wilcoxonSignedRank(differences);
+          const effectSize = nEff > 0 ? rankBiserialCorrelation(statistic, nEff) : 0;
+          const { low, high } = bootstrapMeanDiffCI(differences);
+          const meanDifference = n > 0 ? differences.reduce((sum, d) => sum + d, 0) / n : 0;
+          const winRateA = winRatesA.length > 0 ? winRatesA.reduce((sum, v) => sum + v, 0) / winRatesA.length : 0;
+          const winRateB = winRatesB.length > 0 ? winRatesB.reduce((sum, v) => sum + v, 0) / winRatesB.length : 0;
+
           rows.push({
             modelAId: modelA.modelId,
             modelALabel: modelA.label,
             modelBId: modelB.modelId,
             modelBLabel: modelB.label,
             n,
-            agreementRate: n > 0 ? concordant / n : 0,
-            discordantAtoB,
-            discordantBtoA,
             rawPValue,
             holmCorrectedPValue: null,
-            oddsRatio,
-            effectLabel: classifyEffectSize(oddsRatio),
+            meanDifference,
+            effectSize,
+            effectLabel: classifyEffectSize(effectSize),
+            winRateA,
+            winRateB,
+            maxOrderEffect,
             confidenceIntervalLow: low,
             confidenceIntervalHigh: high,
             verdict: 'Not significant' as const,
@@ -217,7 +299,7 @@ builder.queryField('modelGroupingSignificance', (t) =>
             holmCorrectedPValue,
             verdict: classifyVerdict({
               correctedPValue: holmCorrectedPValue,
-              oddsRatio: row.oddsRatio,
+              effectSize: row.effectSize,
               alpha: 0.05,
             }),
           };
@@ -236,6 +318,8 @@ builder.queryField('modelGroupingSignificance', (t) =>
           modelCount: sortedModels.length,
           pairCount: sortedRows.length,
           coveredDefinitionCount: coveredDefinitionIds.size,
+          valuePairCount: valuePairs.length,
+          maxOrderEffect,
         },
         'Computed model grouping significance report',
       );

--- a/cloud/apps/api/src/graphql/types/model-grouping-significance.ts
+++ b/cloud/apps/api/src/graphql/types/model-grouping-significance.ts
@@ -11,12 +11,13 @@ export type ModelGroupingSignificanceRowShape = {
   modelBId: string;
   modelBLabel: string;
   n: number;
-  agreementRate: number;
-  discordantAtoB: number;
-  discordantBtoA: number;
   rawPValue: number | null;
   holmCorrectedPValue: number | null;
-  oddsRatio: number | null;
+  meanDifference: number;
+  effectSize: number;
+  winRateA: number;
+  winRateB: number;
+  maxOrderEffect: number;
   effectLabel: 'Weak' | 'Strong';
   confidenceIntervalLow: number | null;
   confidenceIntervalHigh: number | null;
@@ -57,12 +58,13 @@ builder.objectType(ModelGroupingSignificanceRowRef, {
     modelBId: t.exposeString('modelBId'),
     modelBLabel: t.exposeString('modelBLabel'),
     n: t.exposeInt('n'),
-    agreementRate: t.exposeFloat('agreementRate'),
-    discordantAtoB: t.exposeInt('discordantAtoB'),
-    discordantBtoA: t.exposeInt('discordantBtoA'),
     rawPValue: t.exposeFloat('rawPValue', { nullable: true }),
     holmCorrectedPValue: t.exposeFloat('holmCorrectedPValue', { nullable: true }),
-    oddsRatio: t.exposeFloat('oddsRatio', { nullable: true }),
+    meanDifference: t.exposeFloat('meanDifference'),
+    effectSize: t.exposeFloat('effectSize'),
+    winRateA: t.exposeFloat('winRateA'),
+    winRateB: t.exposeFloat('winRateB'),
+    maxOrderEffect: t.exposeFloat('maxOrderEffect'),
     effectLabel: t.exposeString('effectLabel'),
     confidenceIntervalLow: t.exposeFloat('confidenceIntervalLow', { nullable: true }),
     confidenceIntervalHigh: t.exposeFloat('confidenceIntervalHigh', { nullable: true }),

--- a/cloud/apps/api/src/services/model-grouping-significance/math.ts
+++ b/cloud/apps/api/src/services/model-grouping-significance/math.ts
@@ -1,57 +1,134 @@
-function logCoeff(n: number, k: number): number {
-  if (k < 0 || k > n) return Number.NEGATIVE_INFINITY;
-  const limitedK = Math.min(k, n - k);
-  let total = 0;
-  for (let index = 1; index <= limitedK; index += 1) {
-    total += Math.log(n - limitedK + index) - Math.log(index);
-  }
-  return total;
+function erfc(x: number): number {
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+  const sign = x >= 0 ? 1 : -1;
+  const absX = Math.abs(x);
+  const t = 1 / (1 + p * absX);
+  const poly = (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t;
+  const y = 1 - poly * Math.exp(-absX * absX);
+  return 1 - sign * y;
 }
 
-function logSumExp(values: ReadonlyArray<number>): number {
-  if (values.length === 0) return Number.NEGATIVE_INFINITY;
-  const maxValue = Math.max(...values);
-  if (!Number.isFinite(maxValue)) return maxValue;
-
-  let sum = 0;
-  for (const value of values) {
-    sum += Math.exp(value - maxValue);
-  }
-  return maxValue + Math.log(sum);
+function normalCdf(x: number): number {
+  return 0.5 * erfc(-x / Math.SQRT2);
 }
 
-export function exactMcNemar(b: number, c: number): number {
-  const n = b + c;
-  if (n === 0) return 1;
-
-  const minVal = Math.min(b, c);
-  const logTerms: number[] = [];
-  for (let k = 0; k <= minVal; k += 1) {
-    logTerms.push(logCoeff(n, k) + n * Math.log(0.5));
-  }
-
-  const tailProbability = Math.exp(logSumExp(logTerms));
-  return Math.min(1, 2 * tailProbability);
+function meanOfSample(values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
-export function matchedPairsOddsRatio(b: number, c: number): number | null {
-  if (b === 0 && c === 0) return 1;
-  if (b === 0 || c === 0) return null;
-  return c / b;
-}
-
-export function oddsRatioCI(b: number, c: number, _alpha: number): { low: number | null; high: number | null } {
-  if (b === 0 || c === 0) {
-    return { low: null, high: null };
+export function wilcoxonSignedRank(differences: number[]): { statistic: number; pValue: number; nEff: number } {
+  const nonZero = differences.filter((difference) => difference !== 0);
+  const nEff = nonZero.length;
+  if (nEff === 0) {
+    return { statistic: 0, pValue: 1, nEff: 0 };
   }
 
-  const standardError = Math.sqrt((1 / b) + (1 / c));
-  const z = 1.96;
-  const logOddsRatio = Math.log(c / b);
-  return {
-    low: Math.exp(logOddsRatio - z * standardError),
-    high: Math.exp(logOddsRatio + z * standardError),
-  };
+  const ranked = nonZero
+    .map((difference, index) => ({ abs: Math.abs(difference), index, difference }))
+    .sort((left, right) => left.abs - right.abs);
+
+  const ranks = new Array<number>(nEff);
+  let hasTies = false;
+  let position = 0;
+  while (position < ranked.length) {
+    let end = position + 1;
+    while (end < ranked.length && ranked[end]!.abs === ranked[position]!.abs) {
+      end += 1;
+    }
+    const startRank = position + 1;
+    const endRank = end;
+    const averageRank = (startRank + endRank) / 2;
+    if (end - position > 1) {
+      hasTies = true;
+    }
+    for (let cursor = position; cursor < end; cursor += 1) {
+      const entry = ranked[cursor]!;
+      ranks[entry.index] = averageRank;
+    }
+    position = end;
+  }
+
+  let wPlus = 0;
+  let wMinus = 0;
+  for (let index = 0; index < nEff; index += 1) {
+    const rank = ranks[index] ?? 0;
+    if ((nonZero[index] ?? 0) > 0) {
+      wPlus += rank;
+    } else {
+      wMinus += rank;
+    }
+  }
+
+  const statistic = Math.min(wPlus, wMinus);
+  let pValue = 1;
+
+  if (!hasTies && nEff <= 25) {
+    const dp = new Map<number, number>();
+    dp.set(0, 1);
+    for (let rank = 1; rank <= nEff; rank += 1) {
+      const snapshot = Array.from(dp.entries());
+      for (const [sum, count] of snapshot) {
+        const nextSum = sum + rank;
+        dp.set(nextSum, (dp.get(nextSum) ?? 0) + count);
+      }
+    }
+
+    const totalAssignments = 2 ** nEff;
+    let extreme = 0;
+    for (const [sum, count] of dp.entries()) {
+      if (sum <= statistic) {
+        extreme += count;
+      }
+    }
+    pValue = Math.min(1, (2 * extreme) / totalAssignments);
+  } else {
+    const mu = (nEff * (nEff + 1)) / 4;
+    const sigma = Math.sqrt((nEff * (nEff + 1) * (2 * nEff + 1)) / 24);
+    if (sigma === 0) {
+      pValue = 1;
+    } else {
+      const z = (statistic + 0.5 - mu) / sigma;
+      pValue = Math.min(1, 2 * normalCdf(-Math.abs(z)));
+    }
+  }
+
+  return { statistic, pValue, nEff };
+}
+
+export function rankBiserialCorrelation(w: number, nEff: number): number {
+  return 1 - (2 * w) / (nEff * (nEff + 1));
+}
+
+export function bootstrapMeanDiffCI(
+  differences: number[],
+  alpha = 0.05,
+  nResamples = 1000,
+): { low: number; high: number } {
+  if (differences.length === 0) {
+    return { low: 0, high: 0 };
+  }
+
+  const means: number[] = [];
+  for (let iteration = 0; iteration < nResamples; iteration += 1) {
+    const sample: number[] = [];
+    for (let index = 0; index < differences.length; index += 1) {
+      const selected = differences[Math.floor(Math.random() * differences.length)] ?? 0;
+      sample.push(selected);
+    }
+    means.push(meanOfSample(sample));
+  }
+
+  means.sort((left, right) => left - right);
+  const lowIndex = Math.max(0, Math.floor((alpha / 2) * nResamples));
+  const highIndex = Math.max(0, Math.floor((1 - alpha / 2) * nResamples));
+  const low = means[Math.min(lowIndex, means.length - 1)] ?? 0;
+  const high = means[Math.min(highIndex, means.length - 1)] ?? 0;
+  return { low, high };
 }
 
 export function holmBonferroni(values: ReadonlyArray<number | null>): Array<number | null> {
@@ -74,20 +151,19 @@ export function holmBonferroni(values: ReadonlyArray<number | null>): Array<numb
   return adjusted;
 }
 
-export function classifyEffectSize(oddsRatio: number | null): 'Weak' | 'Strong' {
-  if (oddsRatio == null || !Number.isFinite(oddsRatio)) return 'Weak';
-  return oddsRatio >= 0.5 && oddsRatio <= 2 ? 'Weak' : 'Strong';
+export function classifyEffectSize(r: number | null): 'Weak' | 'Strong' {
+  if (r == null || !Number.isFinite(r)) return 'Weak';
+  return Math.abs(r) >= 0.3 ? 'Strong' : 'Weak';
 }
 
 export function classifyVerdict(params: {
   correctedPValue: number | null;
-  oddsRatio: number | null;
+  effectSize: number | null;
   alpha?: number;
 }): 'Significant' | 'Weak' | 'Not significant' {
   const alpha = params.alpha ?? 0.05;
   if (params.correctedPValue == null || !Number.isFinite(params.correctedPValue) || params.correctedPValue >= alpha) {
     return 'Not significant';
   }
-
-  return classifyEffectSize(params.oddsRatio) === 'Weak' ? 'Weak' : 'Significant';
+  return classifyEffectSize(params.effectSize) === 'Weak' ? 'Weak' : 'Significant';
 }

--- a/cloud/apps/api/tests/services/model-grouping-significance/math.test.ts
+++ b/cloud/apps/api/tests/services/model-grouping-significance/math.test.ts
@@ -1,59 +1,96 @@
 import { describe, expect, it } from 'vitest';
 import {
+  bootstrapMeanDiffCI,
   classifyEffectSize,
   classifyVerdict,
-  exactMcNemar,
   holmBonferroni,
-  matchedPairsOddsRatio,
-  oddsRatioCI,
+  rankBiserialCorrelation,
+  wilcoxonSignedRank,
 } from '../../../src/services/model-grouping-significance/math.js';
 
 describe('model-grouping-significance math', () => {
-  it('computes exact McNemar p-values for key edge cases', () => {
-    expect(exactMcNemar(0, 0)).toBe(1);
-    expect(exactMcNemar(0, 5)).toBeCloseTo(0.0625, 10);
-    expect(exactMcNemar(5, 5)).toBe(1);
-    expect(exactMcNemar(1, 10)).toBeLessThan(0.05);
-    expect(exactMcNemar(3, 3)).toBe(1);
+  // ---- wilcoxonSignedRank ----
+
+  it('returns trivial result for empty input', () => {
+    expect(wilcoxonSignedRank([])).toEqual({ statistic: 0, pValue: 1, nEff: 0 });
   });
 
-  it('computes matched-pairs odds ratios', () => {
-    expect(matchedPairsOddsRatio(0, 0)).toBe(1);
-    expect(matchedPairsOddsRatio(0, 5)).toBeNull();
-    expect(matchedPairsOddsRatio(5, 0)).toBeNull();
-    expect(matchedPairsOddsRatio(4, 1)).toBe(0.25);
-    expect(matchedPairsOddsRatio(1, 4)).toBe(4);
+  it('returns trivial result when all differences are zero', () => {
+    expect(wilcoxonSignedRank([0, 0, 0])).toEqual({ statistic: 0, pValue: 1, nEff: 0 });
   });
 
-  it('computes odds-ratio confidence intervals when both discordant cells are non-zero', () => {
-    const interval = oddsRatioCI(4, 1, 0.05);
-    expect(interval.low).not.toBeNull();
-    expect(interval.high).not.toBeNull();
-    expect(interval.low!).toBeLessThan(0.25);
-    expect(interval.high!).toBeGreaterThan(0.25);
+  it('uses exact distribution for small nEff with no ties', () => {
+    // All 10 differences negative → W+ = 0, exactly 1 of 2^10 sign assignments has W+ = 0
+    const result = wilcoxonSignedRank([-1, -2, -3, -4, -5, -6, -7, -8, -9, -10]);
+    expect(result.nEff).toBe(10);
+    expect(result.statistic).toBe(0);
+    expect(result.pValue).toBeCloseTo(2 / 1024, 5);
   });
 
-  it('returns undefined odds-ratio intervals when a discordant cell is zero', () => {
-    expect(oddsRatioCI(0, 5, 0.05)).toEqual({ low: null, high: null });
-    expect(oddsRatioCI(5, 0, 0.05)).toEqual({ low: null, high: null });
-    expect(oddsRatioCI(0, 0, 0.05)).toEqual({ low: null, high: null });
+  it('returns high p-value for symmetric differences', () => {
+    // Equal positive and negative magnitudes → statistic at midpoint, p should be high
+    const result = wilcoxonSignedRank([1, -1, 2, -2, 3, -3]);
+    expect(result.pValue).toBeGreaterThan(0.5);
   });
+
+  it('uses normal approximation for nEff > 25', () => {
+    // 26 differences all negative → falls through to normal approx
+    const diffs = Array.from({ length: 26 }, (_, i) => -(i + 1));
+    const result = wilcoxonSignedRank(diffs);
+    expect(result.nEff).toBe(26);
+    expect(result.pValue).toBeLessThan(0.001);
+  });
+
+  // ---- rankBiserialCorrelation ----
+
+  it('computes rank-biserial correlation correctly', () => {
+    // W = 0 → r = 1 (all ranks on positive side)
+    expect(rankBiserialCorrelation(0, 10)).toBe(1);
+    // W = n*(n+1)/4 → r = 0.5
+    expect(rankBiserialCorrelation(27.5, 10)).toBe(0.5);
+    // W = n*(n+1)/2 → r = 0 (all ranks on negative side)
+    expect(rankBiserialCorrelation(55, 10)).toBe(0);
+  });
+
+  // ---- bootstrapMeanDiffCI ----
+
+  it('returns zeros for empty input', () => {
+    expect(bootstrapMeanDiffCI([])).toEqual({ low: 0, high: 0 });
+  });
+
+  it('returns a valid interval for a non-trivial input', () => {
+    const { low, high } = bootstrapMeanDiffCI([-2, -1, 0, 1, 2], 0.05, 500);
+    expect(low).toBeLessThanOrEqual(high);
+  });
+
+  it('returns zero interval for all-zero differences', () => {
+    const { low, high } = bootstrapMeanDiffCI([0, 0, 0]);
+    expect(low).toBe(0);
+    expect(high).toBe(0);
+  });
+
+  // ---- holmBonferroni ----
 
   it('applies Holm-Bonferroni correction in ascending order', () => {
     expect(holmBonferroni([0.01, 0.03, 0.04])).toEqual([0.03, 0.06, 0.06]);
   });
 
-  it('classifies odds-ratio effect sizes and final verdicts', () => {
-    expect(classifyEffectSize(null)).toBe('Weak');
-    expect(classifyEffectSize(1.5)).toBe('Weak');
-    expect(classifyEffectSize(3)).toBe('Strong');
-    expect(classifyEffectSize(0.3)).toBe('Strong');
-    expect(classifyEffectSize(0.5)).toBe('Weak');
-    expect(classifyEffectSize(2)).toBe('Weak');
+  // ---- classifyEffectSize ----
 
-    expect(classifyVerdict({ correctedPValue: 0.01, oddsRatio: 1.5 })).toBe('Weak');
-    expect(classifyVerdict({ correctedPValue: 0.01, oddsRatio: 3 })).toBe('Significant');
-    expect(classifyVerdict({ correctedPValue: 0.2, oddsRatio: 3 })).toBe('Not significant');
-    expect(classifyVerdict({ correctedPValue: null, oddsRatio: 3 })).toBe('Not significant');
+  it('classifies effect sizes using |r| >= 0.3 threshold', () => {
+    expect(classifyEffectSize(null)).toBe('Weak');
+    expect(classifyEffectSize(0)).toBe('Weak');
+    expect(classifyEffectSize(0.1)).toBe('Weak');
+    expect(classifyEffectSize(0.3)).toBe('Strong');
+    expect(classifyEffectSize(0.5)).toBe('Strong');
+    expect(classifyEffectSize(-0.4)).toBe('Strong');
+    expect(classifyEffectSize(-0.1)).toBe('Weak');
+  });
+
+  it('classifies final verdicts correctly', () => {
+    expect(classifyVerdict({ correctedPValue: 0.01, effectSize: 0.1 })).toBe('Weak');
+    expect(classifyVerdict({ correctedPValue: 0.01, effectSize: 0.5 })).toBe('Significant');
+    expect(classifyVerdict({ correctedPValue: 0.2, effectSize: 0.5 })).toBe('Not significant');
+    expect(classifyVerdict({ correctedPValue: null, effectSize: 0.5 })).toBe('Not significant');
   });
 });

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1629,20 +1629,21 @@ type ModelGroupingSignificanceResult {
 }
 
 type ModelGroupingSignificanceRow {
-  agreementRate: Float!
   confidenceIntervalHigh: Float
   confidenceIntervalLow: Float
-  discordantAtoB: Int!
-  discordantBtoA: Int!
   effectLabel: String!
+  effectSize: Float!
   holmCorrectedPValue: Float
+  maxOrderEffect: Float!
+  meanDifference: Float!
   modelAId: String!
   modelALabel: String!
   modelBId: String!
   modelBLabel: String!
   n: Int!
-  oddsRatio: Float
   rawPValue: Float
+  winRateA: Float!
+  winRateB: Float!
   verdict: String!
 }
 

--- a/cloud/apps/web/src/api/operations/modelGroupingSignificance.graphql
+++ b/cloud/apps/web/src/api/operations/modelGroupingSignificance.graphql
@@ -13,10 +13,11 @@ query ModelGroupingSignificance($modelIds: [String!]!, $domainId: ID, $scope: St
       n
       rawPValue
       holmCorrectedPValue
-      agreementRate
-      discordantAtoB
-      discordantBtoA
-      oddsRatio
+      effectSize
+      maxOrderEffect
+      meanDifference
+      winRateA
+      winRateB
       effectLabel
       confidenceIntervalLow
       confidenceIntervalHigh

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceHeatmap.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceHeatmap.test.tsx
@@ -22,10 +22,11 @@ function createRow(overrides: Partial<ModelGroupingSignificanceRow> = {}): Model
     modelBId: 'beta',
     modelBLabel: 'Beta',
     n: 10,
-    agreementRate: 0.8,
-    discordantAtoB: 1,
-    discordantBtoA: 1,
-    oddsRatio: 1,
+    winRateA: 0.8,
+    winRateB: 0.7,
+    meanDifference: 0.1,
+    effectSize: 1,
+    maxOrderEffect: 0.05,
     rawPValue: 0.5,
     holmCorrectedPValue: 0.5,
     effectLabel: 'Weak',
@@ -49,27 +50,21 @@ describe('ModelGroupingSignificanceHeatmap', () => {
     expect(screen.getByTitle('Beta compared with itself')).toBeDefined();
   });
 
-  it('renders hover title with agreement rate and discordant counts', () => {
+  it('renders hover title with mean diff', () => {
     render(
       <ModelGroupingSignificanceHeatmap
         models={[createModel('alpha', 'Alpha'), createModel('beta', 'Beta')]}
         rows={[
           createRow({
-            agreementRate: 0.8,
-            discordantAtoB: 1,
-            discordantBtoA: 3,
+            meanDifference: 0.08,
             verdict: 'Weak',
           }),
         ]}
       />,
     );
 
-    expect(
-      screen.getByTitle('Alpha vs Beta: agreement 80%, discordant A→B 1, B→A 3, verdict Weak'),
-    ).toBeDefined();
-    expect(
-      screen.getByTitle('Beta vs Alpha: agreement 80%, discordant A→B 3, B→A 1, verdict Weak'),
-    ).toBeDefined();
+    expect(screen.getByTitle('Alpha vs Beta: mean diff +8.0%, verdict Weak')).toBeDefined();
+    expect(screen.getByTitle('Beta vs Alpha: mean diff +8.0%, verdict Weak')).toBeDefined();
   });
 
   it('shows S badge for Significant rows and W badge for Weak rows', () => {

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceHeatmap.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceHeatmap.tsx
@@ -1,22 +1,23 @@
 import type { ModelGroupingSignificanceModel, ModelGroupingSignificanceRow } from '../../api/operations/modelGroupingSignificance';
 import { cn } from '../../lib/utils';
 
-function formatAgreementRate(value: number | null): string {
+function formatMeanDiff(value: number | null): string {
   if (value == null || !Number.isFinite(value)) return '—';
-  return `${Math.round(value * 100)}%`;
+  const sign = value >= 0 ? '+' : '';
+  return `${sign}${(value * 100).toFixed(1)}%`;
 }
 
-function getAgreementTone(agreementRate: number | null): string {
-  if (agreementRate == null || !Number.isFinite(agreementRate)) {
+function getMeanDiffTone(absDiff: number | null): string {
+  if (absDiff == null || !Number.isFinite(absDiff)) {
     return 'bg-gray-50 text-gray-400';
   }
-  if (agreementRate >= 0.9) {
-    return 'bg-teal-100 text-teal-900';
+  if (absDiff >= 0.2) {
+    return 'bg-rose-100 text-rose-900';
   }
-  if (agreementRate >= 0.7) {
-    return 'bg-gray-50 text-gray-700';
+  if (absDiff >= 0.1) {
+    return 'bg-amber-50 text-amber-900';
   }
-  return 'bg-rose-50 text-rose-800';
+  return 'bg-gray-50 text-gray-700';
 }
 
 function getVerdictRing(verdict: ModelGroupingSignificanceRow['verdict']): string {
@@ -57,7 +58,7 @@ export function ModelGroupingSignificanceHeatmap({
   return (
     <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white p-3">
       <div className="mb-2 flex items-center justify-between gap-3 text-xs text-gray-500">
-        <span>Color shows agreement rate. Border shows Holm-Bonferroni significance.</span>
+        <span>Color shows |mean win-rate difference|. Border shows Holm-Bonferroni significance.</span>
         <span>S = Significant, W = Weak</span>
       </div>
       <table className="min-w-full border-collapse text-xs">
@@ -84,23 +85,13 @@ export function ModelGroupingSignificanceHeatmap({
                 const sourceRow = upper
                   ? rowByPair.get(`${rowModel.modelId}::${colModel.modelId}`) ?? null
                   : rowByPair.get(`${colModel.modelId}::${rowModel.modelId}`) ?? null;
-                const agreementRate = sourceRow?.agreementRate ?? null;
-                const discordantAtoB = sourceRow == null
-                  ? null
-                  : upper
-                    ? sourceRow.discordantAtoB
-                    : sourceRow.discordantBtoA;
-                const discordantBtoA = sourceRow == null
-                  ? null
-                  : upper
-                    ? sourceRow.discordantBtoA
-                    : sourceRow.discordantAtoB;
+                const meanDifference = sourceRow?.meanDifference ?? null;
                 const verdict = sourceRow?.verdict ?? 'Not significant';
                 const title = sameCell
                   ? `${rowModel.label} compared with itself`
                   : sourceRow == null
                     ? `${rowModel.label} and ${colModel.label}: no data`
-                    : `${rowModel.label} vs ${colModel.label}: agreement ${formatAgreementRate(agreementRate)}, discordant A→B ${discordantAtoB}, B→A ${discordantBtoA}, verdict ${verdict}`;
+                    : `${rowModel.label} vs ${colModel.label}: mean diff ${formatMeanDiff(meanDifference)}, verdict ${verdict}`;
 
                 return (
                   <td key={colModel.modelId} className="px-1 py-1 text-right" title={title}>
@@ -116,7 +107,7 @@ export function ModelGroupingSignificanceHeatmap({
                       <div
                         className={cn(
                           'relative inline-flex h-14 w-14 items-center justify-center rounded-md border px-2 py-2 text-xs font-semibold tabular-nums shadow-sm transition',
-                          getAgreementTone(agreementRate),
+                          getMeanDiffTone(meanDifference != null ? Math.abs(meanDifference) : null),
                           getVerdictRing(verdict),
                         )}
                       >
@@ -133,7 +124,7 @@ export function ModelGroupingSignificanceHeatmap({
                             {getVerdictBadge(verdict)}
                           </span>
                         )}
-                        <span>{formatAgreementRate(agreementRate)}</span>
+                        <span>{formatMeanDiff(meanDifference)}</span>
                       </div>
                     )}
                   </td>

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceSection.tsx
@@ -94,8 +94,7 @@ export function ModelGroupingSignificanceSection({
           <div>
             <h2 className="text-lg font-semibold text-gray-900">Statistical Differences in Value Preferences</h2>
             <p className="mt-1 text-sm text-gray-600">
-              For each vignette, each model&apos;s binary side choice is derived from its transcripts (majority wins).
-              McNemar&apos;s test compares each pair of models on these binary choices, corrected for multiple comparisons using Holm-Bonferroni.
+              For each value pair, each model&apos;s win rate is averaged across both presentation orders. The Wilcoxon signed-rank test compares these win rates for each model pair, corrected for multiple comparisons using Holm-Bonferroni.
             </p>
           </div>
 

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.test.tsx
@@ -88,7 +88,7 @@ describe('ModelGroupingSignificanceTable', () => {
   it('shows the mean diff, effect size, and max order effect columns', () => {
     render(
       <ModelGroupingSignificanceTable
-        rows={[createRow({ meanDifference: -0.125, effectSize: 1.2345, maxOrderEffect: -0.05 })]}
+        rows={[createRow({ meanDifference: -0.125, effectSize: 0.456, maxOrderEffect: -0.05 })]}
       />,
     );
 
@@ -96,7 +96,7 @@ describe('ModelGroupingSignificanceTable', () => {
     expect(screen.getByRole('columnheader', { name: /effect size/i })).toBeDefined();
     expect(screen.getByRole('columnheader', { name: /max order effect/i })).toBeDefined();
     expect(screen.getByText('-12.5%')).toBeDefined();
-    expect(screen.getByText('+1.235')).toBeDefined();
+    expect(screen.getByText('+0.456')).toBeDefined();
     expect(screen.getByText('-5.0%')).toBeDefined();
   });
 

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.test.tsx
@@ -11,10 +11,11 @@ function createRow(overrides: Partial<ModelGroupingSignificanceRow> = {}): Model
     modelBId: 'model-b',
     modelBLabel: 'Model B',
     n: 10,
-    agreementRate: 0.7,
-    discordantAtoB: 2,
-    discordantBtoA: 1,
-    oddsRatio: 0.5,
+    winRateA: 0.7,
+    winRateB: 0.6,
+    meanDifference: 0.1,
+    effectSize: 0.5,
+    maxOrderEffect: 0.2,
     rawPValue: 0.5,
     holmCorrectedPValue: 0.5,
     effectLabel: 'Weak',
@@ -31,7 +32,7 @@ describe('ModelGroupingSignificanceTable', () => {
       <ModelGroupingSignificanceTable
         rows={[
           createRow({ modelAId: 'b', modelALabel: 'Model B', modelBId: 'c', modelBLabel: 'Model C', rawPValue: 0.5, holmCorrectedPValue: 0.5 }),
-          createRow({ modelAId: 'a', modelALabel: 'Model A', modelBId: 'c', modelBLabel: 'Model C', rawPValue: 0.01, holmCorrectedPValue: 0.03, oddsRatio: 2, effectLabel: 'Strong', verdict: 'Significant' }),
+          createRow({ modelAId: 'a', modelALabel: 'Model A', modelBId: 'c', modelBLabel: 'Model C', rawPValue: 0.01, holmCorrectedPValue: 0.03, effectSize: 2, effectLabel: 'Strong', verdict: 'Significant' }),
           createRow({ modelAId: 'a', modelALabel: 'Model A', modelBId: 'b', modelBLabel: 'Model B', rawPValue: 0.2, holmCorrectedPValue: 0.4 }),
         ]}
       />,
@@ -71,28 +72,32 @@ describe('ModelGroupingSignificanceTable', () => {
     expect(rawPValueHeader.getAttribute('aria-sort')).toBe('ascending');
   });
 
-  it('shows the agreement rate column with percent format', () => {
+  it('shows the win rate columns with percent format', () => {
     render(
       <ModelGroupingSignificanceTable
-        rows={[createRow({ agreementRate: 0.73 })]}
+        rows={[createRow({ winRateA: 0.73, winRateB: 0.54 })]}
       />,
     );
 
-    expect(screen.getByRole('columnheader', { name: /agreement rate/i })).toBeDefined();
-    expect(screen.getByText('73%')).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: /win rate a/i })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: /win rate b/i })).toBeDefined();
+    expect(screen.getByText('+73.0%')).toBeDefined();
+    expect(screen.getByText('+54.0%')).toBeDefined();
   });
 
-  it('shows the discordant A→B and B→A columns as integers', () => {
+  it('shows the mean diff, effect size, and max order effect columns', () => {
     render(
       <ModelGroupingSignificanceTable
-        rows={[createRow({ discordantAtoB: 4, discordantBtoA: 7 })]}
+        rows={[createRow({ meanDifference: -0.125, effectSize: 1.2345, maxOrderEffect: -0.05 })]}
       />,
     );
 
-    expect(screen.getByRole('columnheader', { name: /discordant A→B/i })).toBeDefined();
-    expect(screen.getByRole('columnheader', { name: /discordant B→A/i })).toBeDefined();
-    expect(screen.getByText('4')).toBeDefined();
-    expect(screen.getByText('7')).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: /mean diff/i })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: /effect size/i })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: /max order effect/i })).toBeDefined();
+    expect(screen.getByText('-12.5%')).toBeDefined();
+    expect(screen.getByText('+1.235')).toBeDefined();
+    expect(screen.getByText('-5.0%')).toBeDefined();
   });
 
   it('shows verdict badges', () => {
@@ -122,14 +127,14 @@ describe('ModelGroupingSignificanceTable', () => {
     expect(screen.queryByText('↕')).toBeNull();
   });
 
-  it('shows the odds ratio column header', () => {
+  it('shows the confidence interval column header', () => {
     render(
       <ModelGroupingSignificanceTable
-        rows={[createRow({ oddsRatio: 1.25 })]}
+        rows={[createRow({ confidenceIntervalLow: -0.1, confidenceIntervalHigh: 0.2 })]}
       />,
     );
 
-    expect(screen.getByRole('columnheader', { name: /odds ratio/i })).toBeDefined();
-    expect(screen.queryByRole('columnheader', { name: /effect size/i })).toBeNull();
+    expect(screen.getByRole('columnheader', { name: /confidence interval/i })).toBeDefined();
+    expect(screen.getByText('[-10.0%, +20.0%]')).toBeDefined();
   });
 });

--- a/cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.tsx
+++ b/cloud/apps/web/src/components/models/ModelGroupingSignificanceTable.tsx
@@ -7,12 +7,13 @@ import type { ModelGroupingSignificanceRow } from '../../api/operations/modelGro
 type SortKey =
   | 'modelA'
   | 'modelB'
-  | 'agreementRate'
-  | 'discordantAtoB'
-  | 'discordantBtoA'
+  | 'winRateA'
+  | 'winRateB'
+  | 'meanDifference'
+  | 'effectSize'
+  | 'maxOrderEffect'
   | 'rawPValue'
   | 'holmCorrectedPValue'
-  | 'oddsRatio'
   | 'effectLabel'
   | 'confidenceInterval';
 
@@ -34,18 +35,17 @@ function formatPValue(value: number | null): string {
   return value.toFixed(3);
 }
 
-function formatAgreementRate(value: number): string {
-  return `${Math.round(value * 100)}%`;
-}
-
-function formatOddsRatio(value: number | null): string {
+function formatRate(value: number | null | undefined): string {
   if (value == null || !Number.isFinite(value)) return '—';
-  return `×${value.toFixed(2)}`;
+  const sign = value >= 0 ? '+' : '';
+  return `${sign}${(value * 100).toFixed(1)}%`;
 }
 
-function formatOddsRatioInterval(low: number | null, high: number | null): string {
+function formatDiffCI(low: number | null | undefined, high: number | null | undefined): string {
   if (low == null || high == null || !Number.isFinite(low) || !Number.isFinite(high)) return '—';
-  return `[×${low.toFixed(2)}, ×${high.toFixed(2)}]`;
+  const lowSign = low >= 0 ? '+' : '';
+  const highSign = high >= 0 ? '+' : '';
+  return `[${lowSign}${(low * 100).toFixed(1)}%, ${highSign}${(high * 100).toFixed(1)}%]`;
 }
 
 function getVerdictClass(verdict: ModelGroupingSignificanceRow['verdict']): string {
@@ -85,24 +85,26 @@ function sortRows(rows: ModelGroupingSignificanceRow[], sort: SortState): ModelG
           return row.modelALabel;
         case 'modelB':
           return row.modelBLabel;
-        case 'agreementRate':
-          return row.agreementRate;
-        case 'discordantAtoB':
-          return row.discordantAtoB;
-        case 'discordantBtoA':
-          return row.discordantBtoA;
+        case 'winRateA':
+          return row.winRateA;
+        case 'winRateB':
+          return row.winRateB;
+        case 'meanDifference':
+          return row.meanDifference;
+        case 'effectSize':
+          return row.effectSize;
+        case 'maxOrderEffect':
+          return row.maxOrderEffect;
         case 'rawPValue':
           return row.rawPValue ?? null;
         case 'holmCorrectedPValue':
           return row.holmCorrectedPValue ?? null;
-        case 'oddsRatio':
-          return row.oddsRatio ?? null;
         case 'effectLabel':
           return row.effectLabel;
         case 'confidenceInterval':
-          return row.oddsRatio ?? ((row.confidenceIntervalLow != null && row.confidenceIntervalHigh != null)
-            ? ((row.confidenceIntervalLow + row.confidenceIntervalHigh) / 2)
-            : null);
+          return row.confidenceIntervalLow != null && row.confidenceIntervalHigh != null
+            ? (row.confidenceIntervalLow + row.confidenceIntervalHigh) / 2
+            : null;
       }
     };
 
@@ -182,14 +184,15 @@ export function ModelGroupingSignificanceTable({ rows }: { rows: ModelGroupingSi
           <TableRow>
             <SortableHeader label="Model A" sortKey="modelA" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} />
             <SortableHeader label="Model B" sortKey="modelB" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} />
-            <SortableHeader label="agreement rate" sortKey="agreementRate" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
-            <SortableHeader label="discordant A→B" sortKey="discordantAtoB" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
-            <SortableHeader label="discordant B→A" sortKey="discordantBtoA" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+            <SortableHeader label="Win rate A" sortKey="winRateA" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+            <SortableHeader label="Win rate B" sortKey="winRateB" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+            <SortableHeader label="Mean diff" sortKey="meanDifference" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+            <SortableHeader label="Effect size" sortKey="effectSize" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+            <SortableHeader label="Max order effect" sortKey="maxOrderEffect" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
             <SortableHeader label="raw p-value" sortKey="rawPValue" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
             <SortableHeader label="Holm-corrected p-value" sortKey="holmCorrectedPValue" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
-            <SortableHeader label="odds ratio" sortKey="oddsRatio" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
-            <SortableHeader label="effect label" sortKey="effectLabel" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} />
-            <SortableHeader label="confidence interval" sortKey="confidenceInterval" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+            <SortableHeader label="Effect label" sortKey="effectLabel" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} />
+            <SortableHeader label="Confidence interval" sortKey="confidenceInterval" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -198,22 +201,25 @@ export function ModelGroupingSignificanceTable({ rows }: { rows: ModelGroupingSi
               <TableCell className="font-medium text-gray-900">{row.modelALabel}</TableCell>
               <TableCell className="font-medium text-gray-900">{row.modelBLabel}</TableCell>
               <TableCell className="text-right font-mono tabular-nums text-gray-800">
-                {formatAgreementRate(row.agreementRate)}
+                {formatRate(row.winRateA)}
               </TableCell>
               <TableCell className="text-right font-mono tabular-nums text-gray-800">
-                {row.discordantAtoB.toString()}
+                {formatRate(row.winRateB)}
               </TableCell>
               <TableCell className="text-right font-mono tabular-nums text-gray-800">
-                {row.discordantBtoA.toString()}
+                {formatRate(row.meanDifference)}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums text-gray-800">
+                {row.effectSize != null && Number.isFinite(row.effectSize) ? `${row.effectSize >= 0 ? '+' : ''}${row.effectSize.toFixed(3)}` : '—'}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums text-gray-800">
+                {formatRate(row.maxOrderEffect)}
               </TableCell>
               <TableCell className="text-right font-mono tabular-nums text-gray-800">
                 {formatPValue(row.rawPValue ?? null)}
               </TableCell>
               <TableCell className="text-right font-mono tabular-nums text-gray-800">
                 {formatPValue(row.holmCorrectedPValue ?? null)}
-              </TableCell>
-              <TableCell className="text-right font-mono tabular-nums text-gray-800">
-                {formatOddsRatio(row.oddsRatio ?? null)}
               </TableCell>
               <TableCell>
                 <div className="space-y-1">
@@ -224,7 +230,7 @@ export function ModelGroupingSignificanceTable({ rows }: { rows: ModelGroupingSi
                 </div>
               </TableCell>
               <TableCell className="text-right font-mono tabular-nums text-gray-800">
-                {formatOddsRatioInterval(row.confidenceIntervalLow ?? null, row.confidenceIntervalHigh ?? null)}
+                {formatDiffCI(row.confidenceIntervalLow ?? null, row.confidenceIntervalHigh ?? null)}
               </TableCell>
             </TableRow>
           ))}

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1543,21 +1543,22 @@ export type ModelGroupingSignificanceResult = {
 
 export type ModelGroupingSignificanceRow = {
   __typename?: 'ModelGroupingSignificanceRow';
-  agreementRate: Scalars['Float']['output'];
   confidenceIntervalHigh?: Maybe<Scalars['Float']['output']>;
   confidenceIntervalLow?: Maybe<Scalars['Float']['output']>;
-  discordantAtoB: Scalars['Int']['output'];
-  discordantBtoA: Scalars['Int']['output'];
   effectLabel: Scalars['String']['output'];
+  effectSize: Scalars['Float']['output'];
   holmCorrectedPValue?: Maybe<Scalars['Float']['output']>;
+  maxOrderEffect: Scalars['Float']['output'];
+  meanDifference: Scalars['Float']['output'];
   modelAId: Scalars['String']['output'];
   modelALabel: Scalars['String']['output'];
   modelBId: Scalars['String']['output'];
   modelBLabel: Scalars['String']['output'];
   n: Scalars['Int']['output'];
-  oddsRatio?: Maybe<Scalars['Float']['output']>;
   rawPValue?: Maybe<Scalars['Float']['output']>;
   verdict: Scalars['String']['output'];
+  winRateA: Scalars['Float']['output'];
+  winRateB: Scalars['Float']['output'];
 };
 
 export type ModelPairwiseWinRates = {
@@ -4802,7 +4803,7 @@ export type ModelGroupingSignificanceQueryVariables = Exact<{
 }>;
 
 
-export type ModelGroupingSignificanceQuery = { __typename?: 'Query', modelGroupingSignificance: { __typename?: 'ModelGroupingSignificanceResult', pending: boolean, models: Array<{ __typename?: 'ModelGroupingSignificanceModel', modelId: string, label: string }>, rows: Array<{ __typename?: 'ModelGroupingSignificanceRow', modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, n: number, rawPValue?: number | null, holmCorrectedPValue?: number | null, agreementRate: number, discordantAtoB: number, discordantBtoA: number, oddsRatio?: number | null, effectLabel: string, confidenceIntervalLow?: number | null, confidenceIntervalHigh?: number | null, verdict: string }> } };
+export type ModelGroupingSignificanceQuery = { __typename?: 'Query', modelGroupingSignificance: { __typename?: 'ModelGroupingSignificanceResult', pending: boolean, models: Array<{ __typename?: 'ModelGroupingSignificanceModel', modelId: string, label: string }>, rows: Array<{ __typename?: 'ModelGroupingSignificanceRow', modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, n: number, rawPValue?: number | null, holmCorrectedPValue?: number | null, effectSize: number, maxOrderEffect: number, meanDifference: number, winRateA: number, winRateB: number, effectLabel: string, confidenceIntervalLow?: number | null, confidenceIntervalHigh?: number | null, verdict: string }> } };
 
 export type AvailableModelsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -7287,10 +7288,11 @@ export const ModelGroupingSignificanceDocument = gql`
       n
       rawPValue
       holmCorrectedPValue
-      agreementRate
-      discordantAtoB
-      discordantBtoA
-      oddsRatio
+      effectSize
+      maxOrderEffect
+      meanDifference
+      winRateA
+      winRateB
       effectLabel
       confidenceIntervalLow
       confidenceIntervalHigh


### PR DESCRIPTION
## Summary

- Replaces McNemar's test (binary majority votes, two directions counted as independent) with the Wilcoxon signed-rank test on **averaged win rates** per value pair
- Each value pair's two directions (e.g. "Tradition → Universalism" and "Universalism → Tradition") are averaged into one observation before the test runs — fixing the non-independence problem
- Effect size is now rank-biserial correlation r (threshold: |r| ≥ 0.3 = Strong) instead of matched-pairs odds ratio
- CI is now a 95% bootstrap CI on mean win-rate difference instead of an odds ratio CI
- Adds `winRateA`, `winRateB`, `maxOrderEffect` fields to the output; removes `agreementRate`, `discordantAtoB`, `discordantBtoA`, `oddsRatio`
- Table, heatmap (uses |meanDifference| for color), and section description text all updated
- All snapshot fast-path and pending/polling behavior unchanged

## Test plan

- [ ] Preflight passed: lint + build for both api and web (0 errors, pre-existing warnings only)
- [ ] Production smoke test: query modelGroupingSignificance for a known scope/signature with data; verify rows have non-null effectSize, winRateA, winRateB, meanDifference
- [ ] Table shows new columns and hides the removed ones
- [ ] Heatmap cells display mean difference (not agreement rate)
- [ ] Section description reads "Wilcoxon signed-rank test" not "McNemar"
- [ ] Pending state still works (first load queues snapshot rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)