### PR TITLE
ff-checkpoint-findings-summary: surface review findings to stderr after checkpoint

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_checkpoint.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_checkpoint.py
@@ -74,6 +74,13 @@ from factory_review import (  # noqa: E402
     _extract_file_paths_from_artifact,
 )
 
+from factory_review_specs import (  # noqa: E402
+    _count_findings_by_severity,
+    _strip_non_finding_markdown,
+    _findings_scan_text,
+    _SEVERITY_ORDER,
+)
+
 from factory_emit import _emit_next_action  # noqa: E402
 from factory_heartbeat import HeartbeatEmitter, set_activity as heartbeat_set_activity  # noqa: E402
 from factory_next_action import recommended_next_action  # noqa: E402
@@ -136,6 +143,53 @@ def _rollback_adversarial_round(slug: str, stage: str) -> None:
         stage,
         {"adversarial_rounds": max(current_rounds - 1, 0)},
     )
+
+
+def _print_findings_summary(slug: str, stage: str, reviews_ran: list[dict] | None) -> None:
+    """Print a non-blocking findings summary to stderr after a successful checkpoint.
+
+    When no reviews were configured for the stage, prints a single informational
+    line. When reviews ran, scans each review file for actionable findings and
+    prints per-file severity counts. Files with zero findings across all
+    severities are omitted. The inspect section lists full repo-relative paths
+    so the operator can copy-paste directly into cat or an editor.
+    """
+    print(f"[ff] checkpoint completed for stage={stage}", file=sys.stderr)
+
+    if reviews_ran is None or len(reviews_ran) == 0:
+        print(f"[ff] no default reviews configured for this stage", file=sys.stderr)
+        return
+
+    rev_dir = reviews_dir(slug)
+    # Glob review files for this stage (not .raw.txt / .stderr.txt etc.)
+    review_files = sorted(rev_dir.glob(f"{stage}.*.review.md"))
+    if not review_files:
+        print("[ff] reviews ran, no actionable findings raised", file=sys.stderr)
+        return
+
+    files_with_findings: list[tuple[Path, dict[str, int]]] = []
+    for review_path in review_files:
+        try:
+            raw = _strip_non_finding_markdown(_findings_scan_text(review_path.read_text(encoding="utf-8"))).lower()
+        except OSError:
+            continue
+        counts = _count_findings_by_severity(raw)
+        if any(v > 0 for v in counts.values()):
+            files_with_findings.append((review_path, counts))
+
+    if not files_with_findings:
+        print("[ff] reviews ran, no actionable findings raised", file=sys.stderr)
+        return
+
+    print("[ff] findings raised:", file=sys.stderr)
+    for review_path, counts in files_with_findings:
+        parts = [f"{counts[sev]} {sev}" for sev in _SEVERITY_ORDER if counts.get(sev, 0) > 0]
+        print(f"[ff]   {review_path.name}: {' · '.join(parts)}", file=sys.stderr)
+
+    print("[ff] inspect:", file=sys.stderr)
+    for review_path, _ in files_with_findings:
+        repo_rel = f"docs/workflow/feature-runs/{slug}/reviews/{review_path.name}"
+        print(f"[ff]   {repo_rel}", file=sys.stderr)
 
 
 def _prior_stage_for_checkpoint(stage: str) -> str | None:
@@ -517,6 +571,7 @@ def command_checkpoint(args: argparse.Namespace) -> int:
                 payload = _checkpoint_next_action_payload(args.slug, post_state, args.stage)
                 _persist_last_action_result(args.slug, payload)
                 heartbeat_set_activity("all reviews complete")
+                _print_findings_summary(args.slug, args.stage, reviews_arg)
                 if args.json:
                     print(json.dumps(payload))
                 else:
@@ -549,6 +604,7 @@ def command_checkpoint(args: argparse.Namespace) -> int:
         payload = _checkpoint_next_action_payload(args.slug, post_state, args.stage)
         _persist_last_action_result(args.slug, payload)
         heartbeat_set_activity("all reviews complete")
+        _print_findings_summary(args.slug, args.stage, reviews_arg)
         if args.json:
             print(json.dumps(payload))
         else:

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review_specs.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review_specs.py
@@ -156,6 +156,30 @@ def detect_actionable_findings(review_path: Path) -> bool:
     return bool(_ACTIONABLE_FINDING_RE.search(text))
 
 
+_SEVERITY_EXTRACT_RE = re.compile(r"\b(critical|high|medium|low)\b")
+
+_SEVERITY_ORDER = ("CRITICAL", "HIGH", "MEDIUM", "LOW")
+
+
+def _count_findings_by_severity(text: str) -> dict[str, int]:
+    """Count actionable findings by severity in review text.
+
+    Uses _ACTIONABLE_FINDING_RE to find genuine finding lines, then extracts
+    the severity word from each match. Returns a dict with counts for CRITICAL,
+    HIGH, MEDIUM, LOW (uppercase keys). Lines that match the finding shape but
+    contain no severity word are ignored.
+
+    Callers should pass pre-processed text (lowercased, non-finding markdown
+    stripped) to match the contract used by detect_actionable_findings.
+    """
+    counts: dict[str, int] = {sev: 0 for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW")}
+    for match in _ACTIONABLE_FINDING_RE.finditer(text):
+        sev_match = _SEVERITY_EXTRACT_RE.search(match.group(0))
+        if sev_match:
+            counts[sev_match.group(0).upper()] += 1
+    return counts
+
+
 def trim_detail(text: str, limit: int = 240) -> str:
     stripped = " ".join(text.split())
     if len(stripped) <= limit:

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_checkpoint.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_cmd_checkpoint.py
@@ -246,5 +246,190 @@ class FactoryCheckpointTests(unittest.TestCase):
         self.assertEqual(persisted["stages"]["spec"]["adversarial_sha_history"], [first_sha, second_sha])
 
 
+class FindingsSummaryTests(unittest.TestCase):
+    """Tests for _print_findings_summary and its integration via command_checkpoint."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self._patches: list = []
+        for mod in list(gc.get_objects()):
+            if not isinstance(mod, types.ModuleType):
+                continue
+            if getattr(mod, "__name__", "") != "factory_state":
+                continue
+            if not hasattr(mod, "FACTORY_RUNS_ROOT"):
+                continue
+            p = patch.object(mod, "FACTORY_RUNS_ROOT", Path(self._tmpdir.name))
+            p.start()
+            self._patches.append(p)
+        self.addCleanup(lambda: [p.stop() for p in self._patches])
+
+    def _prepare_state(self, adversarial_rounds: int = 0) -> Path:
+        return _write_workflow_state(self._tmpdir.name, _spec_stage_state(adversarial_rounds))
+
+    def _reviews_dir(self, slug: str = "ff-checkpoint-test") -> Path:
+        with patch.object(FACTORY_STATE, "FACTORY_RUNS_ROOT", Path(self._tmpdir.name)):
+            return FACTORY_STATE.reviews_dir(slug)
+
+    def _capture_checkpoint_stderr(self, reviews_arg: list | None = None) -> str:
+        """Run command_checkpoint with patched reviews and return stderr text."""
+        self._prepare_state(0)
+        args = _args()
+        fake_result = subprocess.CompletedProcess(args=["repair"], returncode=0, stdout="", stderr="")
+        stderr_buf = io.StringIO()
+        with patch.object(CHECKPOINT, "ensure_sync", return_value=None), \
+            patch.object(CHECKPOINT, "revert_protected_files", return_value=[]), \
+            patch.object(CHECKPOINT, "stage_manifest_state", side_effect=_fake_stage_manifest_state), \
+            patch.object(CHECKPOINT, "reconciliation_state", return_value=(True, "")), \
+            patch.object(CHECKPOINT, "_emit_next_action", return_value=None), \
+            patch.object(CHECKPOINT, "required_reviews", return_value=reviews_arg or []), \
+            patch.object(CHECKPOINT.subprocess, "run", return_value=fake_result):
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr_buf):
+                CHECKPOINT.command_checkpoint(args)
+        return stderr_buf.getvalue()
+
+    # ------------------------------------------------------------------
+    # Unit tests for _print_findings_summary directly
+    # ------------------------------------------------------------------
+
+    def test_no_reviews_configured_prints_no_default_reviews_message(self) -> None:
+        self._prepare_state(0)
+        reviews_dir = self._reviews_dir()
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        stderr_buf = io.StringIO()
+        with contextlib.redirect_stderr(stderr_buf):
+            CHECKPOINT._print_findings_summary("ff-checkpoint-test", "tasks", [])
+        output = stderr_buf.getvalue()
+        self.assertIn("[ff] checkpoint completed for stage=tasks", output)
+        self.assertIn("no default reviews configured", output)
+
+    def test_reviews_ran_but_no_findings_prints_clean_message(self) -> None:
+        self._prepare_state(0)
+        reviews_dir = self._reviews_dir()
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        # Write a clean review with no findings
+        (reviews_dir / "spec.codex.feasibility-adversarial.review.md").write_text(
+            "## Findings\n\nNo issues found. Everything looks good.\n",
+            encoding="utf-8",
+        )
+        fake_reviews = [{"reviewer": "codex", "lens": "feasibility-adversarial"}]
+        stderr_buf = io.StringIO()
+        with contextlib.redirect_stderr(stderr_buf):
+            CHECKPOINT._print_findings_summary("ff-checkpoint-test", "spec", fake_reviews)
+        output = stderr_buf.getvalue()
+        self.assertIn("reviews ran, no actionable findings raised", output)
+        self.assertNotIn("findings raised:", output)
+
+    def test_reviews_with_findings_prints_per_file_severity_counts(self) -> None:
+        self._prepare_state(0)
+        reviews_dir = self._reviews_dir()
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        (reviews_dir / "plan.codex.implementation-adversarial.review.md").write_text(
+            "## Findings\n\n- medium: bootstrap CI missing seed\n",
+            encoding="utf-8",
+        )
+        (reviews_dir / "plan.gemini.testability-adversarial.review.md").write_text(
+            "## Findings\n\n- high: maxOrderEffect placed at row level\n",
+            encoding="utf-8",
+        )
+        fake_reviews = [
+            {"reviewer": "codex", "lens": "implementation-adversarial"},
+            {"reviewer": "gemini", "lens": "testability-adversarial"},
+        ]
+        stderr_buf = io.StringIO()
+        with contextlib.redirect_stderr(stderr_buf):
+            CHECKPOINT._print_findings_summary("ff-checkpoint-test", "plan", fake_reviews)
+        output = stderr_buf.getvalue()
+        self.assertIn("[ff] findings raised:", output)
+        self.assertIn("plan.codex.implementation-adversarial.review.md: 1 MEDIUM", output)
+        self.assertIn("plan.gemini.testability-adversarial.review.md: 1 HIGH", output)
+        self.assertIn("[ff] inspect:", output)
+        self.assertIn("docs/workflow/feature-runs/ff-checkpoint-test/reviews/plan.codex.implementation-adversarial.review.md", output)
+        self.assertIn("docs/workflow/feature-runs/ff-checkpoint-test/reviews/plan.gemini.testability-adversarial.review.md", output)
+
+    def test_only_files_with_findings_appear_in_summary(self) -> None:
+        self._prepare_state(0)
+        reviews_dir = self._reviews_dir()
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        (reviews_dir / "spec.codex.feasibility-adversarial.review.md").write_text(
+            "## Findings\n\n- high: serious problem\n",
+            encoding="utf-8",
+        )
+        (reviews_dir / "spec.gemini.requirements-adversarial.review.md").write_text(
+            "## Findings\n\nAll good. No issues.\n",
+            encoding="utf-8",
+        )
+        fake_reviews = [
+            {"reviewer": "codex", "lens": "feasibility-adversarial"},
+            {"reviewer": "gemini", "lens": "requirements-adversarial"},
+        ]
+        stderr_buf = io.StringIO()
+        with contextlib.redirect_stderr(stderr_buf):
+            CHECKPOINT._print_findings_summary("ff-checkpoint-test", "spec", fake_reviews)
+        output = stderr_buf.getvalue()
+        self.assertIn("spec.codex.feasibility-adversarial.review.md", output)
+        self.assertNotIn("spec.gemini.requirements-adversarial.review.md", output)
+
+    def test_stage_with_no_default_reviews_prints_no_default_message(self) -> None:
+        # tasks/diff/closeout get empty reviews_arg by default
+        self._prepare_state(0)
+        reviews_dir = self._reviews_dir()
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        stderr_buf = io.StringIO()
+        with contextlib.redirect_stderr(stderr_buf):
+            CHECKPOINT._print_findings_summary("ff-checkpoint-test", "tasks", [])
+        output = stderr_buf.getvalue()
+        self.assertIn("[ff] checkpoint completed for stage=tasks", output)
+        self.assertIn("no default reviews configured for this stage", output)
+
+    def test_idempotent_rerun_produces_same_summary(self) -> None:
+        self._prepare_state(0)
+        reviews_dir = self._reviews_dir()
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        (reviews_dir / "plan.codex.implementation-adversarial.review.md").write_text(
+            "## Findings\n\n- high: found an issue\n",
+            encoding="utf-8",
+        )
+        fake_reviews = [{"reviewer": "codex", "lens": "implementation-adversarial"}]
+        buf1 = io.StringIO()
+        buf2 = io.StringIO()
+        with contextlib.redirect_stderr(buf1):
+            CHECKPOINT._print_findings_summary("ff-checkpoint-test", "plan", fake_reviews)
+        with contextlib.redirect_stderr(buf2):
+            CHECKPOINT._print_findings_summary("ff-checkpoint-test", "plan", fake_reviews)
+        self.assertEqual(buf1.getvalue(), buf2.getvalue())
+
+    # ------------------------------------------------------------------
+    # Integration test: findings summary appears in command_checkpoint output
+    # ------------------------------------------------------------------
+
+    def test_checkpoint_success_emits_findings_summary_to_stderr(self) -> None:
+        self._prepare_state(0)
+        reviews_dir = self._reviews_dir()
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        (reviews_dir / "spec.codex.feasibility-adversarial.review.md").write_text(
+            "## Findings\n\n- high: missing validation\n",
+            encoding="utf-8",
+        )
+        args = _args()
+        fake_result = subprocess.CompletedProcess(args=["repair"], returncode=0, stdout="", stderr="")
+        fake_reviews = [{"reviewer": "codex", "lens": "feasibility-adversarial", "model": "gpt-5.4-mini"}]
+        stderr_buf = io.StringIO()
+        with patch.object(CHECKPOINT, "ensure_sync", return_value=None), \
+            patch.object(CHECKPOINT, "revert_protected_files", return_value=[]), \
+            patch.object(CHECKPOINT, "stage_manifest_state", side_effect=_fake_stage_manifest_state), \
+            patch.object(CHECKPOINT, "reconciliation_state", return_value=(True, "")), \
+            patch.object(CHECKPOINT, "_emit_next_action", return_value=None), \
+            patch.object(CHECKPOINT, "required_reviews", return_value=fake_reviews), \
+            patch.object(CHECKPOINT.subprocess, "run", return_value=fake_result):
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr_buf):
+                rc = CHECKPOINT.command_checkpoint(args)
+        self.assertEqual(rc, 0)
+        output = stderr_buf.getvalue()
+        self.assertIn("[ff] checkpoint completed for stage=spec", output)
+        self.assertIn("1 HIGH", output)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_review_specs.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_review_specs.py
@@ -298,5 +298,69 @@ class ActionableFindingShapesManifestTests(unittest.TestCase):
         self.assertGreaterEqual(len(FRS.ACTIONABLE_FINDING_SHAPES), 10)
 
 
+class CountFindingsBySeverityTests(unittest.TestCase):
+    """Tests for the _count_findings_by_severity helper."""
+
+    def _scan(self, text: str) -> dict[str, int]:
+        """Run the same pre-processing pipeline as _print_findings_summary."""
+        processed = FRS._strip_non_finding_markdown(FRS._findings_scan_text(text)).lower()
+        return FRS._count_findings_by_severity(processed)
+
+    def test_counts_each_severity_correctly(self) -> None:
+        body = (
+            "- critical: data loss risk\n"
+            "- high: missing index\n"
+            "- medium: stale cache\n"
+            "- low: minor typo\n"
+        )
+        counts = self._scan(body)
+        self.assertEqual(counts["CRITICAL"], 1)
+        self.assertEqual(counts["HIGH"], 1)
+        self.assertEqual(counts["MEDIUM"], 1)
+        self.assertEqual(counts["LOW"], 1)
+
+    def test_returns_zero_for_absent_severities(self) -> None:
+        body = "- high: only one finding\n"
+        counts = self._scan(body)
+        self.assertEqual(counts["CRITICAL"], 0)
+        self.assertEqual(counts["MEDIUM"], 0)
+        self.assertEqual(counts["LOW"], 0)
+
+    def test_empty_file_returns_all_zeros(self) -> None:
+        counts = self._scan("")
+        self.assertEqual(counts, {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0})
+
+    def test_prose_mention_of_high_without_finding_shape_not_counted(self) -> None:
+        body = "This would be a HIGH severity issue in production.\n"
+        counts = self._scan(body)
+        self.assertEqual(counts["HIGH"], 0)
+
+    def test_multiple_high_findings_are_counted_correctly(self) -> None:
+        body = (
+            "- high: first issue\n"
+            "- high: second issue\n"
+            "- medium: one medium\n"
+        )
+        counts = self._scan(body)
+        self.assertEqual(counts["HIGH"], 2)
+        self.assertEqual(counts["MEDIUM"], 1)
+
+    def test_fenced_code_block_not_counted(self) -> None:
+        body = (
+            "Example:\n"
+            "```\n"
+            "- HIGH: example finding\n"
+            "```\n"
+            "No real findings here.\n"
+        )
+        counts = self._scan(body)
+        self.assertEqual(counts["HIGH"], 0)
+
+    def test_inline_severity_field_form_counted(self) -> None:
+        body = "**Severity**: HIGH\nsome detail\n"
+        counts = self._scan(body)
+        self.assertEqual(counts["HIGH"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a non-blocking summary printed to stderr after each successful `checkpoint` invocation. Lists each review file that produced actionable findings with severity counts (`CRITICAL`/`HIGH`/`MEDIUM`/`LOW`), then prints inspection paths. Files with zero findings are omitted — operator only sees what's actionable.

**This is purely visibility. Exit codes unchanged. Operator decides whether to dig in.**

## Motivation

PR #989 (`significance-wilcoxon-winrate`) raised real findings during plan-stage reviews:

- 1 MEDIUM (codex implementation): `bootstrapMeanDiffCI` reproducibility — bootstrap with no fixed seed produces flapping CIs
- 1 HIGH (gemini testability): `maxOrderEffect` placed at row level instead of global — duplicate value in every row

The operator only saw these by manually reading review files. The data was already extractable via `factory_review_specs._ACTIONABLE_FINDING_RE` (12 finding shapes supported); this change surfaces it inline at checkpoint time.

This wouldn't have caught the actual production bug that shipped on #989 (web client querying removed schema fields — that's an implementation-completeness bug, structurally outside what spec/plan reviews evaluate). But it does close the gap between "review raised a finding" and "operator saw the finding."

## Sample output

```
[ff] checkpoint completed for stage=plan
[ff] findings raised:
[ff]   plan.gemini.testability-adversarial.review.md: 2 MEDIUM · 2 LOW
[ff] inspect:
[ff]   docs/workflow/feature-runs/ff-runner-fixes/reviews/plan.gemini.testability-adversarial.review.md
```

Three output modes:
- **Findings raised**: lists files with severity counts + inspection paths
- **Reviews ran but no findings**: `[ff] reviews ran, no actionable findings raised`
- **No default reviews for this stage** (post-Bundle 2 tasks/diff/closeout): `[ff] no default reviews configured for this stage`

## Implementation note

`detect_actionable_findings()` returned a bool only — no severity breakdown. Added a new helper `_count_findings_by_severity()` in `factory_review_specs.py` that reuses the existing `_ACTIONABLE_FINDING_RE` regex with a secondary `_SEVERITY_EXTRACT_RE` to pull the severity word per match. Existing `detect_actionable_findings()` untouched.

## Test plan
- [x] 307 FF tests pass (was 293; +14 new — 7 for the helper, 7 for checkpoint output modes)
- [x] Smoke test against real slug produced expected format
- [x] Zero state.json pollution after suite run

🤖 Generated with [Claude Code](https://claude.com/claude-code)