### PR TITLE
agents-md-ship-as-merge-default: tell agents to /ship for merges instead of passively watching CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Canonical source: `docs/canonical-glossary.md`
 - Open PRs against `chrislawcodes/valuerank`.
 - Follow the Preflight Gate in `cloud/CLAUDE.md` before any `git push` or PR creation.
 - Invoked delivery actions (Feature Factory `deliver`, `/ship`, explicit "push and open the PR" instructions) do not need re-confirmation. The invocation is the consent. See `cloud/CLAUDE.md` for the full rule.
+- To merge a PR, invoke the `/ship` skill — not direct `gh pr merge` or passive "watch CI." `/ship` rebases onto main first, runs preflight, watches CI to completion, and squash-merges. Skipping the rebase step is the most common cause of stuck "CI failing on stale base" loops.
 - One feature per branch. Do not stack new work on top of an open feature PR unless the human asks.
 - Fix the root cause when CI fails. Do not retry blindly.
 


### PR DESCRIPTION
## Summary

One-line addition to `AGENTS.md` under Repo Rules: when an AI session needs to merge a PR, it should invoke the `/ship` skill instead of running `gh pr merge` directly or just watching CI passively.

## Why

The most common cause of stuck PRs in recent sessions: the branch is behind `main`, CI fails because of conflicts, the AI keeps watching, CI keeps failing — but the failure is structural (stale base) not a real test failure. The AI doesn't pivot to "rebase first."

`/ship` already handles this correctly. Step 2 fetches main, checks `merge-base --is-ancestor`, rebases if behind, force-pushes, then watches CI from a clean base. The skill exists; AI sessions just default to "watch CI" when "rebase first" is what's needed.

This rule names the failure mode explicitly ("stuck CI failing on stale base loops") so future sessions recognize the pattern and pivot.

## Test plan
- [x] Pure docs change
- [ ] Next AI session that hits a stale-base CI failure invokes `/ship` instead of looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)