### PR TITLE
Show model agreement build progress

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -113,6 +113,7 @@ Once the above are resolved:
 - [x] Pressure Directional Breakdown now labels the overall column as **High Pressure on Value Effect** for consistency with the pressure value tables.
 - [x] Pressure Sensitivity now uses the standard default-model multi-select, keeps the tooltip anchored while scrolling, and moves the cross-model response table to the bottom of the report.
 - [x] Pressure Response by Value now weights each vignette once and uses pooled directional coverage, so sparse cells no longer trip the "below coverage thresholds" error when the report has enough total vignette coverage.
+- [x] Model Agreement on Value Tradeoffs now shows live source-run progress counts and a progress bar while the report is building, so users can see how close it is to finishing.
 - [ ] Review the new pairwise forest drawer copy and capture screenshots for the AAPOR deck now that the drilldown is available.
 
 ---

--- a/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
@@ -32,7 +32,7 @@ import { resolveDomainAnalysisScopeDefinitions } from '../../services/analysis/d
 import { resolveSignatureRuns } from '../queries/domain/shared.js';
 import {
   queueDomainAnalysisRefresh,
-  readCellLevelOutcomesFromSnapshot,
+  readModelAgreementSnapshotStateFromSnapshot,
 } from '../../services/analysis/domain-analysis-cache.js';
 import type { DomainAnalysisScope } from '../../services/analysis/domain-analysis-scope.js';
 import type { Context } from '../context.js';
@@ -74,27 +74,47 @@ async function readAgreementSnapshot(params: {
   signature: string;
   refreshReason: string;
   ctx: Context;
-}): Promise<Record<string, CellOutcome> | null> {
-  const snapshot = await readCellLevelOutcomesFromSnapshot(
+}): Promise<{
+  snapshot: Record<string, CellOutcome> | null;
+  buildProgress: {
+    completedRuns: number;
+    totalRuns: number;
+    currentRunId: string | null;
+    updatedAt: string;
+  } | null;
+  queued: boolean;
+}> {
+  const snapshotState = await readModelAgreementSnapshotStateFromSnapshot(
     params.scope,
     params.domainId ?? ALL_DOMAINS_SCOPE_ID,
     params.signature,
   );
-  if (snapshot != null) {
-    return snapshot;
+  if (snapshotState != null) {
+    return {
+      snapshot: snapshotState.cellLevelOutcomes,
+      buildProgress: snapshotState.buildProgress,
+      queued: true,
+    };
   }
 
-  await queueDomainAnalysisRefresh({
+  const queued = await queueDomainAnalysisRefresh({
     scope: params.scope,
     domainId: params.domainId ?? ALL_DOMAINS_SCOPE_ID,
     signature: params.signature,
     reason: params.refreshReason,
   });
-  params.ctx.log.info(
-    { scope: params.scope, domainId: params.domainId, signature: params.signature },
-    'Model agreement snapshot not ready - rebuild queued, returning pending',
-  );
-  return null;
+  if (queued) {
+    params.ctx.log.info(
+      { scope: params.scope, domainId: params.domainId, signature: params.signature },
+      'Model agreement snapshot not ready - rebuild queued, returning pending',
+    );
+  } else {
+    params.ctx.log.warn(
+      { scope: params.scope, domainId: params.domainId, signature: params.signature },
+      'Model agreement snapshot not ready and rebuild could not be queued',
+    );
+  }
+  return { snapshot: null, buildProgress: null, queued };
 }
 
 export async function resolveModelAgreementOnTradeoffs(
@@ -139,18 +159,18 @@ export async function resolveModelAgreementOnTradeoffs(
     signature,
   });
 
-  const snapshot = await readAgreementSnapshot({
+  const snapshotResult = await readAgreementSnapshot({
     scope,
     domainId,
     signature,
     refreshReason: AGREEMENT_REFRESH_REASON,
     ctx,
   });
-  if (snapshot == null) {
-    return buildEmptyAgreementResult();
+  if (snapshotResult.snapshot == null) {
+    return buildEmptyAgreementResult(snapshotResult.queued, snapshotResult.buildProgress);
   }
 
-  const { positionCells, cellsObservedByModelId } = buildPositionCells(snapshot, selectedModelIdSet);
+  const { positionCells, cellsObservedByModelId } = buildPositionCells(snapshotResult.snapshot, selectedModelIdSet);
   const unavailableModels = selectedModels
     .filter((model) => (cellsObservedByModelId.get(model.modelId) ?? 0) === 0)
     .map(buildUnavailableModelInfo);
@@ -228,6 +248,7 @@ export async function resolveModelAgreementOnTradeoffs(
 
   return {
     pending: false,
+    buildProgress: null,
     models: availableModels,
     unavailableModels,
     excludedNonBinaryCells: NON_BINARY_CELL_FALLBACK_COUNT,
@@ -284,19 +305,19 @@ export async function resolveModelPairDivergenceBreakdown(
     signature,
   });
 
-  const snapshot = await readAgreementSnapshot({
+  const snapshotResult = await readAgreementSnapshot({
     scope,
     domainId,
     signature,
     refreshReason: DRILLDOWN_REFRESH_REASON,
     ctx,
   });
-  if (snapshot == null) {
-    return buildEmptyPairBreakdown(modelAId, modelALabel, modelBId, modelBLabel);
+  if (snapshotResult.snapshot == null) {
+    return buildEmptyPairBreakdown(modelAId, modelALabel, modelBId, modelBLabel, snapshotResult.buildProgress);
   }
 
   const selectedModelIdSet = new Set([modelAId, modelBId]);
-  const { positionCells, cellsObservedByModelId } = buildPositionCells(snapshot, selectedModelIdSet);
+  const { positionCells, cellsObservedByModelId } = buildPositionCells(snapshotResult.snapshot, selectedModelIdSet);
   if ((cellsObservedByModelId.get(modelAId) ?? 0) === 0 || (cellsObservedByModelId.get(modelBId) ?? 0) === 0) {
     return buildEmptyPairBreakdown(modelAId, modelALabel, modelBId, modelBLabel);
   }
@@ -383,6 +404,7 @@ export async function resolveModelPairDivergenceBreakdown(
 
   return {
     pending: false,
+    buildProgress: null,
     modelAId,
     modelALabel,
     modelBId,

--- a/cloud/apps/api/src/graphql/types/model-agreement-on-tradeoffs.ts
+++ b/cloud/apps/api/src/graphql/types/model-agreement-on-tradeoffs.ts
@@ -31,8 +31,16 @@ export type ModelTrialConsistencyShape = {
   noisy: boolean;
 };
 
+export type ModelAgreementBuildProgressShape = {
+  completedRuns: number;
+  totalRuns: number;
+  currentRunId: string | null;
+  updatedAt: string;
+};
+
 export type ModelAgreementResultShape = {
   pending: boolean;
+  buildProgress: ModelAgreementBuildProgressShape | null;
   models: ModelInfoShape[];
   unavailableModels: UnavailableModelInfoShape[];
   excludedNonBinaryCells: number;
@@ -52,6 +60,7 @@ export type ValuePairDivergenceShape = {
 
 export type PairDivergenceBreakdownShape = {
   pending: boolean;
+  buildProgress: ModelAgreementBuildProgressShape | null;
   modelAId: string;
   modelALabel: string;
   modelBId: string;
@@ -63,6 +72,7 @@ const ModelInfoRef = builder.objectRef<ModelInfoShape>('ModelInfo');
 const UnavailableModelInfoRef = builder.objectRef<UnavailableModelInfoShape>('UnavailableModelInfo');
 const PairwiseAgreementRowRef = builder.objectRef<PairwiseAgreementRowShape>('PairwiseAgreementRow');
 const ModelTrialConsistencyRef = builder.objectRef<ModelTrialConsistencyShape>('ModelTrialConsistency');
+const ModelAgreementBuildProgressRef = builder.objectRef<ModelAgreementBuildProgressShape>('ModelAgreementBuildProgress');
 export const ModelAgreementResultRef = builder.objectRef<ModelAgreementResultShape>('ModelAgreementResult');
 const ValuePairDivergenceRef = builder.objectRef<ValuePairDivergenceShape>('ValuePairDivergence');
 export const PairDivergenceBreakdownRef = builder.objectRef<PairDivergenceBreakdownShape>('PairDivergenceBreakdown');
@@ -106,9 +116,19 @@ builder.objectType(ModelTrialConsistencyRef, {
   }),
 });
 
+builder.objectType(ModelAgreementBuildProgressRef, {
+  fields: (t) => ({
+    completedRuns: t.exposeInt('completedRuns'),
+    totalRuns: t.exposeInt('totalRuns'),
+    currentRunId: t.exposeString('currentRunId', { nullable: true }),
+    updatedAt: t.exposeString('updatedAt'),
+  }),
+});
+
 builder.objectType(ModelAgreementResultRef, {
   fields: (t) => ({
     pending: t.exposeBoolean('pending'),
+    buildProgress: t.expose('buildProgress', { type: ModelAgreementBuildProgressRef, nullable: true }),
     models: t.expose('models', { type: [ModelInfoRef] }),
     unavailableModels: t.expose('unavailableModels', { type: [UnavailableModelInfoRef] }),
     excludedNonBinaryCells: t.exposeInt('excludedNonBinaryCells'),
@@ -132,6 +152,7 @@ builder.objectType(ValuePairDivergenceRef, {
 builder.objectType(PairDivergenceBreakdownRef, {
   fields: (t) => ({
     pending: t.exposeBoolean('pending'),
+    buildProgress: t.expose('buildProgress', { type: ModelAgreementBuildProgressRef, nullable: true }),
     modelAId: t.exposeID('modelAId'),
     modelALabel: t.exposeString('modelALabel'),
     modelBId: t.exposeID('modelBId'),

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
@@ -23,6 +23,13 @@ export const DOMAIN_ANALYSIS_NONE_SIGNATURE = '__none__';
 
 export type SnapshotClient = Prisma.TransactionClient;
 
+export type DomainAnalysisBuildProgress = {
+  completedRuns: number;
+  totalRuns: number;
+  currentRunId: string | null;
+  updatedAt: string;
+};
+
 export type DomainAnalysisSnapshotModel = {
   model: string;
   counts: Record<string, DomainAnalysisValueCounts>;
@@ -79,6 +86,7 @@ export type DomainAnalysisSnapshotOutput = {
   // `neutrals` = trials with no decisive choice.
   // Used by the modelAgreementOnTradeoffs resolver (v1.12.0+).
   cellLevelOutcomes?: Record<string, { aChoices: number; bChoices: number; neutrals: number }>;
+  buildProgress?: DomainAnalysisBuildProgress;
 };
 
 export type AnalysisFingerprintRow = {

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -18,8 +18,10 @@ import type {
 import { SCHWARTZ_CIRCULAR_ORDER } from '@valuerank/shared/schwartz';
 import {
   DOMAIN_ANALYSIS_CACHE_STATUS,
+  DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION,
   DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
   type DomainAnalysisCacheStatus,
+  type DomainAnalysisBuildProgress,
   type DomainAnalysisSnapshotOutput,
   type DomainAnalysisSnapshotModel,
   type SnapshotClient,
@@ -30,7 +32,6 @@ import {
   parseSnapshotOutput,
   prepareDomainAnalysisState,
   buildSnapshotOutput,
-  writeSnapshot,
 } from './domain-analysis-snapshot-builder.js';
 import type { DomainAnalysisScope } from './domain-analysis-scope.js';
 import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE } from './domain-analysis-scope.js';
@@ -101,6 +102,34 @@ function buildPairwiseWinRateModel(
     trialCountMatrix.push(trialRow);
   }
   return { valueOrder: order, winRateMatrix, trialCountMatrix };
+}
+
+function parseBuildProgress(raw: unknown): DomainAnalysisBuildProgress | null {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+
+  const candidate = raw as { buildProgress?: unknown };
+  const progress = candidate.buildProgress;
+  if (progress == null || typeof progress !== 'object' || Array.isArray(progress)) {
+    return null;
+  }
+
+  const progressCandidate = progress as Partial<DomainAnalysisBuildProgress>;
+  if (
+    typeof progressCandidate.completedRuns !== 'number'
+    || typeof progressCandidate.totalRuns !== 'number'
+    || typeof progressCandidate.updatedAt !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    completedRuns: progressCandidate.completedRuns,
+    totalRuns: progressCandidate.totalRuns,
+    currentRunId: typeof progressCandidate.currentRunId === 'string' ? progressCandidate.currentRunId : null,
+    updatedAt: progressCandidate.updatedAt,
+  };
 }
 
 function buildDomainAnalysisResultFromSnapshot(params: {
@@ -244,20 +273,82 @@ export async function refreshDomainAnalysisSnapshot(params: {
     domainId: params.domainId,
     requestedSignature: params.requestedSignature,
   });
-  const output = await buildSnapshotOutput(state);
-  const snapshot = await db.$transaction((tx) => writeSnapshot({
-    client: tx,
-    scope: state.scope,
-    domainId: state.domain.id,
-    configSignature: state.configSignature,
-    inputHash: state.inputHash,
-    output,
-  }));
-  return {
-    snapshot,
-    selectedSignature: state.selectedSignature,
-    configSignature: state.configSignature,
-  };
+  const totalRuns = state.resolvedSignatureRuns.filteredSourceRunIds.length;
+  await db.assumptionAnalysisSnapshot.updateMany({
+    where: {
+      assumptionKey: buildAssumptionKey(state.scope, state.domain.id),
+      analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
+      status: 'CURRENT',
+      deletedAt: null,
+      OR: [
+        { configSignature: state.configSignature },
+        { inputHash: state.inputHash },
+      ],
+    },
+    data: {
+      status: 'SUPERSEDED',
+    },
+  });
+
+  const progressSnapshot = await db.assumptionAnalysisSnapshot.create({
+    data: {
+      assumptionKey: buildAssumptionKey(state.scope, state.domain.id),
+      analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
+      inputHash: state.inputHash,
+      codeVersion: DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION,
+      configSignature: state.configSignature,
+      config: {
+        scope: state.scope,
+        domainId: state.domain.id,
+        signature: state.configSignature,
+      },
+      output: {
+        buildProgress: {
+          completedRuns: 0,
+          totalRuns,
+          currentRunId: null,
+          updatedAt: new Date().toISOString(),
+        } satisfies DomainAnalysisBuildProgress,
+      },
+      status: 'CURRENT',
+    },
+  });
+
+  try {
+    const output = await buildSnapshotOutput(state, {
+      onProgress: async (buildProgress) => {
+        await db.assumptionAnalysisSnapshot.update({
+          where: { id: progressSnapshot.id },
+          data: {
+            output: {
+              buildProgress,
+            },
+          },
+        });
+      },
+    });
+
+    const snapshot = await db.assumptionAnalysisSnapshot.update({
+      where: { id: progressSnapshot.id },
+      data: {
+        output,
+      },
+    });
+
+    return {
+      snapshot,
+      selectedSignature: state.selectedSignature,
+      configSignature: state.configSignature,
+    };
+  } catch (error) {
+    await db.assumptionAnalysisSnapshot.update({
+      where: { id: progressSnapshot.id },
+      data: {
+        status: 'SUPERSEDED',
+      },
+    });
+    throw error;
+  }
 }
 
 export async function getDomainAnalysisResult(params: {
@@ -383,4 +474,34 @@ export async function readCellLevelOutcomesFromSnapshot(
   if (snapshot == null) return null;
   const parsed = parseSnapshotOutput(snapshot.output);
   return parsed?.cellLevelOutcomes ?? null;
+}
+
+export async function readModelAgreementSnapshotStateFromSnapshot(
+  scope: DomainAnalysisScope,
+  domainId: string,
+  configSignature: string,
+): Promise<{
+  cellLevelOutcomes: Record<string, { aChoices: number; bChoices: number; neutrals: number }> | null;
+  buildProgress: DomainAnalysisBuildProgress | null;
+  inputHash: string | null;
+} | null> {
+  const snapshot = await getCurrentSnapshot(db, scope, domainId, configSignature);
+  if (snapshot == null) {
+    return null;
+  }
+
+  const parsed = parseSnapshotOutput(snapshot.output);
+  if (parsed?.cellLevelOutcomes != null) {
+    return {
+      cellLevelOutcomes: parsed.cellLevelOutcomes,
+      buildProgress: null,
+      inputHash: snapshot.inputHash,
+    };
+  }
+
+  return {
+    cellLevelOutcomes: null,
+    buildProgress: parseBuildProgress(snapshot.output),
+    inputHash: snapshot.inputHash,
+  };
 }

--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
@@ -6,6 +6,7 @@ import {
   DOMAIN_ANALYSIS_NONE_SIGNATURE,
   DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION,
   DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
+  type DomainAnalysisBuildProgress,
   type AnalysisFingerprintRow,
   type DomainAnalysisPreparedState,
   type DomainAnalysisSnapshotOutput,
@@ -124,10 +125,15 @@ export async function prepareDomainAnalysisState(params: {
 
 export async function buildSnapshotOutput(
   state: DomainAnalysisPreparedState,
+  options?: {
+    onProgress?: (progress: DomainAnalysisBuildProgress) => Promise<void> | void;
+  },
 ): Promise<DomainAnalysisSnapshotOutput> {
   const valuePairByDefinition = await resolveValuePairsInChunks(state.latestDefinitionIds);
 
   const cellMap = new Map<string, CellCounts>();
+  const totalRuns = state.resolvedSignatureRuns.filteredSourceRunIds.length;
+  let completedRuns = 0;
 
   if (state.resolvedSignatureRuns.filteredSourceRunIds.length > 0) {
     // Fetch all transcripts for every run in parallel. Each run has a bounded
@@ -160,6 +166,7 @@ export async function buildSnapshotOutput(
     );
 
     for (const runTranscripts of perRunTranscripts) {
+      const runId = state.resolvedSignatureRuns.filteredSourceRunIds[completedRuns] ?? null;
       const batchCellMap = accumulateTranscriptCells({
         transcripts: runTranscripts,
         filteredSourceRunDefinitionById: state.resolvedSignatureRuns.filteredSourceRunDefinitionById,
@@ -171,6 +178,16 @@ export async function buildSnapshotOutput(
         existing.losses += counts.losses;
         existing.neutrals += counts.neutrals;
         cellMap.set(key, existing);
+      }
+
+      completedRuns += 1;
+      if (options?.onProgress != null) {
+        await options.onProgress({
+          completedRuns,
+          totalRuns,
+          currentRunId: runId,
+          updatedAt: new Date().toISOString(),
+        });
       }
     }
   }

--- a/cloud/apps/api/src/services/model-agreement/aggregation.ts
+++ b/cloud/apps/api/src/services/model-agreement/aggregation.ts
@@ -7,6 +7,7 @@ import {
   percentAgreement,
 } from './math.js';
 import type {
+  ModelAgreementBuildProgressShape,
   ModelAgreementResultShape,
   PairDivergenceBreakdownShape,
   UnavailableModelInfoShape,
@@ -311,9 +312,13 @@ export function buildUnavailableModelInfo(model: ModelSummary): UnavailableModel
   };
 }
 
-export function buildEmptyAgreementResult(): ModelAgreementResultShape {
+export function buildEmptyAgreementResult(
+  pending = true,
+  buildProgress: ModelAgreementBuildProgressShape | null = null,
+): ModelAgreementResultShape {
   return {
-    pending: true,
+    pending,
+    buildProgress,
     models: [],
     unavailableModels: [],
     excludedNonBinaryCells: 0,
@@ -328,9 +333,11 @@ export function buildEmptyPairBreakdown(
   modelALabel: string,
   modelBId: string,
   modelBLabel: string,
+  buildProgress: ModelAgreementBuildProgressShape | null = null,
 ): PairDivergenceBreakdownShape {
   return {
-    pending: false,
+    pending: buildProgress != null,
+    buildProgress,
     modelAId,
     modelALabel,
     modelBId,

--- a/cloud/apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => ({
   getModelsFromDatabase: vi.fn(),
   resolveDomainAnalysisScopeDefinitions: vi.fn(),
   resolveSignatureRuns: vi.fn(),
-  readCellLevelOutcomesFromSnapshot: vi.fn(),
+  readModelAgreementSnapshotStateFromSnapshot: vi.fn(),
   queueDomainAnalysisRefresh: vi.fn(),
 }));
 
@@ -36,7 +36,7 @@ vi.mock('../../../src/graphql/queries/domain/shared.js', () => ({
 }));
 
 vi.mock('../../../src/services/analysis/domain-analysis-cache.js', () => ({
-  readCellLevelOutcomesFromSnapshot: mocks.readCellLevelOutcomesFromSnapshot,
+  readModelAgreementSnapshotStateFromSnapshot: mocks.readModelAgreementSnapshotStateFromSnapshot,
   queueDomainAnalysisRefresh: mocks.queueDomainAnalysisRefresh,
 }));
 
@@ -164,6 +164,12 @@ const agreementQuery = `
   query ModelAgreement($modelIds: [ID!]!, $scope: String!, $signature: String!, $domainId: ID) {
     modelAgreementOnTradeoffs(modelIds: $modelIds, scope: $scope, signature: $signature, domainId: $domainId) {
       pending
+      buildProgress {
+        completedRuns
+        totalRuns
+        currentRunId
+        updatedAt
+      }
       models { modelId label }
       unavailableModels { modelId label reason }
       excludedNonBinaryCells
@@ -194,6 +200,12 @@ const drilldownQuery = `
   query PairDivergence($modelAId: ID!, $modelBId: ID!, $scope: String!, $signature: String!, $domainId: ID) {
     modelPairDivergenceBreakdown(modelAId: $modelAId, modelBId: $modelBId, scope: $scope, signature: $signature, domainId: $domainId) {
       pending
+      buildProgress {
+        completedRuns
+        totalRuns
+        currentRunId
+        updatedAt
+      }
       modelAId
       modelALabel
       modelBId
@@ -224,10 +236,14 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
   });
 
   it('returns perfect disagreement metrics and drilldown divergence', async () => {
-    mocks.readCellLevelOutcomesFromSnapshot.mockResolvedValue(snapshot({
-      'def-1::model-a::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
-      'def-1::model-b::Achievement::Tradition::1::2': { aChoices: 0, bChoices: 6, neutrals: 0 },
-    }));
+    mocks.readModelAgreementSnapshotStateFromSnapshot.mockResolvedValue({
+      cellLevelOutcomes: snapshot({
+        'def-1::model-a::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        'def-1::model-b::Achievement::Tradition::1::2': { aChoices: 0, bChoices: 6, neutrals: 0 },
+      }),
+      buildProgress: null,
+      inputHash: 'hash-1',
+    });
 
     const agreementResponse = await graphqlRequest(agreementQuery, {
       modelIds: ['model-a', 'model-b'],
@@ -238,6 +254,7 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
     expect(agreementResponse.body.errors).toBeUndefined();
     const agreement = agreementResponse.body.data.modelAgreementOnTradeoffs as {
       pending: boolean;
+      buildProgress: null;
       pairwiseAgreementMatrix: Array<{
         totalCells: number;
         percentAgreement: number | null;
@@ -316,7 +333,7 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
   });
 
   it('returns pending while a missing snapshot queues a refresh', async () => {
-    mocks.readCellLevelOutcomesFromSnapshot.mockResolvedValue(null);
+    mocks.readModelAgreementSnapshotStateFromSnapshot.mockResolvedValue(null);
 
     const response = await graphqlRequest(agreementQuery, {
       modelIds: ['model-a', 'model-b'],
@@ -327,6 +344,31 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
     expect(response.body.errors).toBeUndefined();
     expect(response.body.data.modelAgreementOnTradeoffs).toEqual({
       pending: true,
+      buildProgress: null,
+      models: [],
+      unavailableModels: [],
+      excludedNonBinaryCells: 0,
+      excludedTiedCells: 0,
+      pairwiseAgreementMatrix: [],
+      trialConsistency: [],
+    });
+    expect(mocks.queueDomainAnalysisRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a non-pending empty result when the refresh queue is unavailable', async () => {
+    mocks.readModelAgreementSnapshotStateFromSnapshot.mockResolvedValue(null);
+    mocks.queueDomainAnalysisRefresh.mockResolvedValue(false);
+
+    const response = await graphqlRequest(agreementQuery, {
+      modelIds: ['model-a', 'model-b'],
+      scope: 'ALL_DOMAINS',
+      signature: 'sig-1',
+    });
+
+    expect(response.body.errors).toBeUndefined();
+    expect(response.body.data.modelAgreementOnTradeoffs).toEqual({
+      pending: false,
+      buildProgress: null,
       models: [],
       unavailableModels: [],
       excludedNonBinaryCells: 0,
@@ -338,10 +380,14 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
   });
 
   it('lists a model with no cell-level outcomes as unavailable and keeps it out of the matrix', async () => {
-    mocks.readCellLevelOutcomesFromSnapshot.mockResolvedValue(snapshot({
-      'def-1::model-a::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
-      'def-1::model-b::Achievement::Tradition::1::2': { aChoices: 0, bChoices: 6, neutrals: 0 },
-    }));
+    mocks.readModelAgreementSnapshotStateFromSnapshot.mockResolvedValue({
+      cellLevelOutcomes: snapshot({
+        'def-1::model-a::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        'def-1::model-b::Achievement::Tradition::1::2': { aChoices: 0, bChoices: 6, neutrals: 0 },
+      }),
+      buildProgress: null,
+      inputHash: 'hash-2',
+    });
 
     const response = await graphqlRequest(agreementQuery, {
       modelIds: ['model-a', 'model-b', 'model-c'],
@@ -375,11 +421,51 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
     expect(drilldownResponse.body.data.modelPairDivergenceBreakdown.perValuePair).toEqual([]);
   });
 
+  it('surfaces build progress while the report is still rebuilding', async () => {
+    mocks.readModelAgreementSnapshotStateFromSnapshot.mockResolvedValue({
+      cellLevelOutcomes: null,
+      buildProgress: {
+        completedRuns: 4,
+        totalRuns: 10,
+        currentRunId: 'run-4',
+        updatedAt: '2026-05-08T15:00:00.000Z',
+      },
+      inputHash: 'hash-3',
+    });
+
+    const response = await graphqlRequest(agreementQuery, {
+      modelIds: ['model-a', 'model-b'],
+      scope: 'ALL_DOMAINS',
+      signature: 'sig-1',
+    });
+
+    expect(response.body.errors).toBeUndefined();
+    expect(response.body.data.modelAgreementOnTradeoffs).toEqual({
+      pending: true,
+      buildProgress: {
+        completedRuns: 4,
+        totalRuns: 10,
+        currentRunId: 'run-4',
+        updatedAt: '2026-05-08T15:00:00.000Z',
+      },
+      models: [],
+      unavailableModels: [],
+      excludedNonBinaryCells: 0,
+      excludedTiedCells: 0,
+      pairwiseAgreementMatrix: [],
+      trialConsistency: [],
+    });
+  });
+
   it('returns a zero-overlap row with null metrics when two models never share a cell', async () => {
-    mocks.readCellLevelOutcomesFromSnapshot.mockResolvedValue(snapshot({
-      'def-1::model-a::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
-      'def-2::model-b::Achievement::Tradition::1::2': { aChoices: 0, bChoices: 6, neutrals: 0 },
-    }));
+    mocks.readModelAgreementSnapshotStateFromSnapshot.mockResolvedValue({
+      cellLevelOutcomes: snapshot({
+        'def-1::model-a::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        'def-2::model-b::Achievement::Tradition::1::2': { aChoices: 0, bChoices: 6, neutrals: 0 },
+      }),
+      buildProgress: null,
+      inputHash: 'hash-4',
+    });
 
     const response = await graphqlRequest(agreementQuery, {
       modelIds: ['model-a', 'model-b'],
@@ -410,10 +496,14 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
   });
 
   it('excludes tied cells from both kappa and divergence, while keeping trial consistency', async () => {
-    mocks.readCellLevelOutcomesFromSnapshot.mockResolvedValue(snapshot({
-      'def-1::model-a::Achievement::Tradition::1::2': { aChoices: 3, bChoices: 3, neutrals: 0 },
-      'def-1::model-b::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
-    }));
+    mocks.readModelAgreementSnapshotStateFromSnapshot.mockResolvedValue({
+      cellLevelOutcomes: snapshot({
+        'def-1::model-a::Achievement::Tradition::1::2': { aChoices: 3, bChoices: 3, neutrals: 0 },
+        'def-1::model-b::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
+      }),
+      buildProgress: null,
+      inputHash: 'hash-5',
+    });
 
     const response = await graphqlRequest(agreementQuery, {
       modelIds: ['model-a', 'model-b'],

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1567,6 +1567,7 @@ type LlmProvider {
 }
 
 type ModelAgreementResult {
+  buildProgress: ModelAgreementBuildProgress
   excludedNonBinaryCells: Int!
   excludedTiedCells: Int!
   models: [ModelInfo!]!
@@ -1574,6 +1575,13 @@ type ModelAgreementResult {
   pending: Boolean!
   trialConsistency: [ModelTrialConsistency!]!
   unavailableModels: [UnavailableModelInfo!]!
+}
+
+type ModelAgreementBuildProgress {
+  completedRuns: Int!
+  currentRunId: String
+  totalRuns: Int!
+  updatedAt: String!
 }
 
 type ModelConsistency {
@@ -2107,6 +2115,7 @@ type OrderEffect {
 }
 
 type PairDivergenceBreakdown {
+  buildProgress: ModelAgreementBuildProgress
   modelAId: ID!
   modelALabel: String!
   modelBId: ID!

--- a/cloud/apps/web/src/api/operations/modelAgreementOnTradeoffs.graphql
+++ b/cloud/apps/web/src/api/operations/modelAgreementOnTradeoffs.graphql
@@ -11,6 +11,12 @@ query ModelAgreementOnTradeoffs(
     signature: $signature
   ) {
     pending
+    buildProgress {
+      completedRuns
+      totalRuns
+      currentRunId
+      updatedAt
+    }
     excludedNonBinaryCells
     excludedTiedCells
     models {
@@ -58,6 +64,12 @@ query ModelPairDivergenceBreakdown(
     signature: $signature
   ) {
     pending
+    buildProgress {
+      completedRuns
+      totalRuns
+      currentRunId
+      updatedAt
+    }
     modelAId
     modelALabel
     modelBId

--- a/cloud/apps/web/src/components/models/ModelAgreementSection.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelAgreementSection.test.tsx
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { ModelAgreementSection } from './ModelAgreementSection';
+import { useModelAgreementOnTradeoffsQuery } from '../../generated/graphql';
+
+vi.mock('../../generated/graphql', () => ({
+  useModelAgreementOnTradeoffsQuery: vi.fn(),
+}));
+
+const mockedUseModelAgreementOnTradeoffsQuery = vi.mocked(useModelAgreementOnTradeoffsQuery);
+
+describe('ModelAgreementSection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedUseModelAgreementOnTradeoffsQuery.mockReturnValue([
+      {
+        data: undefined,
+        fetching: false,
+        error: undefined,
+      },
+      vi.fn(),
+    ] as unknown as ReturnType<typeof useModelAgreementOnTradeoffsQuery>);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('polls again while the agreement report is pending', () => {
+    const reexecuteQuery = vi.fn();
+    mockedUseModelAgreementOnTradeoffsQuery.mockReturnValue([
+      {
+        data: {
+          modelAgreementOnTradeoffs: {
+            __typename: 'ModelAgreementResult',
+            pending: true,
+            buildProgress: {
+              __typename: 'ModelAgreementBuildProgress',
+              completedRuns: 4,
+              totalRuns: 10,
+              currentRunId: 'run-4',
+              updatedAt: '2026-05-08T15:00:00.000Z',
+            },
+            excludedNonBinaryCells: 0,
+            excludedTiedCells: 0,
+            models: [],
+            unavailableModels: [],
+            pairwiseAgreementMatrix: [],
+            trialConsistency: [],
+          },
+        },
+        fetching: false,
+        error: undefined,
+      },
+      reexecuteQuery,
+    ] as unknown as ReturnType<typeof useModelAgreementOnTradeoffsQuery>);
+
+    render(
+      <ModelAgreementSection
+        modelIds={['model-a', 'model-b']}
+        scope="ALL_DOMAINS"
+        domainId={null}
+        signature="vnewtd"
+      />,
+    );
+
+    expect(screen.getByText('4 of 10 source runs processed. Currently on run-4.')).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(reexecuteQuery).toHaveBeenCalledWith({ requestPolicy: 'network-only' });
+  });
+});

--- a/cloud/apps/web/src/components/models/ModelAgreementSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelAgreementSection.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ErrorMessage } from '../ui/ErrorMessage';
-import { Loading } from '../ui/Loading';
 import { useModelAgreementOnTradeoffsQuery } from '../../generated/graphql';
 import { PairwiseAgreementMatrixReport } from './PairwiseAgreementMatrixReport';
 import { ModelTrialConsistencyReport } from './ModelTrialConsistencyReport';
@@ -22,6 +21,7 @@ type SelectedPair = {
 };
 
 const MIN_DRILLDOWN_DEFAULT_CELLS = 10;
+const AGREEMENT_POLL_INTERVAL_MS = 5000;
 const EMPTY_PAIRWISE_ROWS: PairwiseAgreementRow[] = [];
 
 function formatSelectedPair(pair: SelectedPair | null): string | null {
@@ -89,8 +89,70 @@ function buildUnavailableModelsNotice(
   return `Unavailable models: ${unavailableModels.map((model) => `${model.label} (${model.reason})`).join(', ')}.`;
 }
 
+function formatProgressLabel(progress: {
+  completedRuns: number;
+  totalRuns: number;
+  currentRunId?: string | null;
+  updatedAt: string;
+}): string {
+  const totalRuns = progress.totalRuns;
+  const completedRuns = Math.min(progress.completedRuns, totalRuns);
+  const currentRunNote = progress.currentRunId != null ? ` Currently on ${progress.currentRunId.slice(-8)}.` : '';
+  return `${completedRuns.toLocaleString()} of ${totalRuns.toLocaleString()} source runs processed.${currentRunNote}`;
+}
+
+function getProgressPercent(progress: {
+  completedRuns: number;
+  totalRuns: number;
+}): number {
+  if (progress.totalRuns <= 0) {
+    return 0;
+  }
+  return Math.min(100, Math.round((Math.min(progress.completedRuns, progress.totalRuns) / progress.totalRuns) * 100));
+}
+
+function BuildStatusCard({
+  title,
+  message,
+  progress,
+}: {
+  title: string;
+  message: string;
+  progress: {
+    completedRuns: number;
+    totalRuns: number;
+    currentRunId?: string | null;
+    updatedAt: string;
+  } | null;
+}): JSX.Element {
+  const percent = progress != null ? getProgressPercent(progress) : null;
+
+  return (
+    <section className="space-y-4 rounded-lg border border-gray-200 bg-white p-4 md:p-5">
+      <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+      <div className="space-y-2">
+        <p className="text-sm text-gray-700">{message}</p>
+        {progress != null ? (
+          <>
+            <p className="text-sm font-medium text-gray-900">{formatProgressLabel(progress)}</p>
+            <div className="h-2 overflow-hidden rounded-full bg-gray-100">
+              <div
+                className="h-full rounded-full bg-teal-500 transition-[width] duration-300"
+                style={{ width: `${percent ?? 0}%` }}
+              />
+            </div>
+            <p className="text-xs text-gray-500">
+              Last updated {new Date(progress.updatedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}.
+            </p>
+          </>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
 export function ModelAgreementSection({ modelIds, scope, domainId, signature }: Props): JSX.Element {
-  const [{ data, fetching, error }] = useModelAgreementOnTradeoffsQuery({
+  const [{ data, fetching, error }, reexecuteQuery] = useModelAgreementOnTradeoffsQuery({
     variables: {
       modelIds,
       domainId: domainId ?? undefined,
@@ -105,6 +167,27 @@ export function ModelAgreementSection({ modelIds, scope, domainId, signature }: 
   const rows = agreement?.pairwiseAgreementMatrix ?? EMPTY_PAIRWISE_ROWS;
   const [selectedPair, setSelectedPair] = useState<SelectedPair | null>(null);
   const selectedPairKey = formatSelectedPair(selectedPair);
+  const isFetchingRef = useRef(fetching);
+
+  useEffect(() => {
+    isFetchingRef.current = fetching;
+  }, [fetching]);
+
+  useEffect(() => {
+    if (agreement == null || !agreement.pending) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      if (!isFetchingRef.current) {
+        reexecuteQuery({ requestPolicy: 'network-only' });
+      }
+    }, AGREEMENT_POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [agreement, reexecuteQuery]);
 
   useEffect(() => {
     if (rows.length === 0) {
@@ -134,7 +217,13 @@ export function ModelAgreementSection({ modelIds, scope, domainId, signature }: 
   }
 
   if (fetching && agreement == null) {
-    return <Loading size="lg" text="Loading model agreement report..." />;
+    return (
+      <BuildStatusCard
+        title="Model Agreement on Value Tradeoffs"
+        message="Preparing the model agreement report."
+        progress={null}
+      />
+    );
   }
 
   if (agreement == null) {
@@ -147,7 +236,13 @@ export function ModelAgreementSection({ modelIds, scope, domainId, signature }: 
   }
 
   if (agreement.pending) {
-    return <Loading size="lg" text="Model agreement report is building..." />;
+    return (
+      <BuildStatusCard
+        title="Model Agreement on Value Tradeoffs"
+        message="The model agreement report is building."
+        progress={agreement.buildProgress ?? null}
+      />
+    );
   }
 
   const exclusionNote = buildExclusionNote(agreement.excludedNonBinaryCells, agreement.excludedTiedCells);

--- a/cloud/apps/web/src/components/models/PairwiseDivergenceDrilldownReport.test.tsx
+++ b/cloud/apps/web/src/components/models/PairwiseDivergenceDrilldownReport.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
 import { PairwiseDivergenceDrilldownReport } from './PairwiseDivergenceDrilldownReport';
 import { useModelPairDivergenceBreakdownQuery } from '../../generated/graphql';
 
@@ -10,76 +10,50 @@ vi.mock('../../generated/graphql', () => ({
 const mockedUseModelPairDivergenceBreakdownQuery = vi.mocked(useModelPairDivergenceBreakdownQuery);
 
 describe('PairwiseDivergenceDrilldownReport', () => {
-  mockedUseModelPairDivergenceBreakdownQuery.mockReturnValue([
-    {
-      data: undefined,
-      fetching: false,
-      error: undefined,
-    },
-    vi.fn(),
-  ] as unknown as ReturnType<typeof useModelPairDivergenceBreakdownQuery>);
-
-  it('renders a placeholder when no pair is selected', () => {
-    render(
-      <PairwiseDivergenceDrilldownReport
-        selectedPair={null}
-        scope="ALL_DOMAINS"
-        domainId={null}
-        signature="sig"
-      />,
-    );
-
-    expect(
-      screen.getByText('Select a model pair from the matrix above to see per-value-pair divergence.'),
-    ).toBeDefined();
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedUseModelPairDivergenceBreakdownQuery.mockReturnValue([
+      {
+        data: undefined,
+        fetching: false,
+        error: undefined,
+      },
+      vi.fn(),
+    ] as unknown as ReturnType<typeof useModelPairDivergenceBreakdownQuery>);
   });
 
-  it('renders the divergence table sorted by mean absolute divergence descending', () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('polls again while the divergence breakdown is pending', () => {
+    const reexecuteQuery = vi.fn();
     mockedUseModelPairDivergenceBreakdownQuery.mockReturnValue([
       {
         data: {
           modelPairDivergenceBreakdown: {
             __typename: 'PairDivergenceBreakdown',
-            pending: false,
+            pending: true,
+            buildProgress: {
+              __typename: 'ModelAgreementBuildProgress',
+              completedRuns: 3,
+              totalRuns: 8,
+              currentRunId: 'run-3',
+              updatedAt: '2026-05-08T15:00:00.000Z',
+            },
             modelAId: 'alpha',
             modelALabel: 'Alpha',
             modelBId: 'beta',
             modelBLabel: 'Beta',
-            perValuePair: [
-              {
-                __typename: 'ValuePairDivergence',
-                valueA: 'Tradition',
-                valueB: 'Security',
-                cellsCompared: 12,
-                meanAbsoluteDivergence: 0.2,
-                modelAProportionA: 0.6,
-                modelBProportionA: 0.4,
-              },
-              {
-                __typename: 'ValuePairDivergence',
-                valueA: 'Achievement',
-                valueB: 'Tradition',
-                cellsCompared: 8,
-                meanAbsoluteDivergence: 0.9,
-                modelAProportionA: 0.1,
-                modelBProportionA: 1,
-              },
-              {
-                __typename: 'ValuePairDivergence',
-                valueA: 'Security',
-                valueB: 'Universalism',
-                cellsCompared: 4,
-                meanAbsoluteDivergence: 0.3,
-                modelAProportionA: 0.7,
-                modelBProportionA: 0.4,
-              },
-            ],
+            perValuePair: [],
           },
         },
         fetching: false,
         error: undefined,
       },
-      vi.fn(),
+      reexecuteQuery,
     ] as unknown as ReturnType<typeof useModelPairDivergenceBreakdownQuery>);
 
     render(
@@ -87,14 +61,16 @@ describe('PairwiseDivergenceDrilldownReport', () => {
         selectedPair={{ modelAId: 'alpha', modelBId: 'beta' }}
         scope="ALL_DOMAINS"
         domainId={null}
-        signature="sig"
+        signature="vnewtd"
       />,
     );
 
-    expect(screen.getByRole('heading', { name: 'Alpha vs Beta' })).toBeDefined();
+    expect(screen.getByText('3 of 8 source runs processed. Currently on run-3.')).toBeTruthy();
 
-    const rows = screen.getAllByRole('row');
-    expect(rows[1]?.textContent ?? '').toContain('Achievement vs Tradition');
-    expect(rows[1]?.textContent ?? '').toContain('90.0%');
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(reexecuteQuery).toHaveBeenCalledWith({ requestPolicy: 'network-only' });
   });
 });

--- a/cloud/apps/web/src/components/models/PairwiseDivergenceDrilldownReport.tsx
+++ b/cloud/apps/web/src/components/models/PairwiseDivergenceDrilldownReport.tsx
@@ -1,6 +1,5 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { ErrorMessage } from '../ui/ErrorMessage';
-import { Loading } from '../ui/Loading';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/Table';
 import type { ModelPairDivergenceBreakdownQuery } from '../../generated/graphql';
 import { useModelPairDivergenceBreakdownQuery } from '../../generated/graphql';
@@ -11,6 +10,7 @@ type SelectedPair = {
 };
 
 type ValuePairDivergence = ModelPairDivergenceBreakdownQuery['modelPairDivergenceBreakdown']['perValuePair'][number];
+const DRILLDOWN_POLL_INTERVAL_MS = 5000;
 
 type Props = {
   selectedPair: SelectedPair | null;
@@ -43,8 +43,29 @@ function sortRows(rows: ValuePairDivergence[]): ValuePairDivergence[] {
   });
 }
 
+function formatProgressLabel(progress: {
+  completedRuns: number;
+  totalRuns: number;
+  currentRunId?: string | null;
+  updatedAt: string;
+}): string {
+  const completedRuns = Math.min(progress.completedRuns, progress.totalRuns);
+  const currentRunNote = progress.currentRunId != null ? ` Currently on ${progress.currentRunId.slice(-8)}.` : '';
+  return `${completedRuns.toLocaleString()} of ${progress.totalRuns.toLocaleString()} source runs processed.${currentRunNote}`;
+}
+
+function getProgressPercent(progress: {
+  completedRuns: number;
+  totalRuns: number;
+}): number {
+  if (progress.totalRuns <= 0) {
+    return 0;
+  }
+  return Math.min(100, Math.round((Math.min(progress.completedRuns, progress.totalRuns) / progress.totalRuns) * 100));
+}
+
 export function PairwiseDivergenceDrilldownReport({ selectedPair, scope, domainId, signature }: Props) {
-  const [{ data, fetching, error }] = useModelPairDivergenceBreakdownQuery({
+  const [{ data, fetching, error }, reexecuteQuery] = useModelPairDivergenceBreakdownQuery({
     variables: {
       modelAId: selectedPair?.modelAId ?? '',
       modelBId: selectedPair?.modelBId ?? '',
@@ -58,6 +79,27 @@ export function PairwiseDivergenceDrilldownReport({ selectedPair, scope, domainI
 
   const drilldown = data?.modelPairDivergenceBreakdown ?? null;
   const rows = useMemo(() => sortRows(drilldown?.perValuePair ?? []), [drilldown?.perValuePair]);
+  const isFetchingRef = useRef(fetching);
+
+  useEffect(() => {
+    isFetchingRef.current = fetching;
+  }, [fetching]);
+
+  useEffect(() => {
+    if (drilldown == null || !drilldown.pending) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      if (!isFetchingRef.current) {
+        reexecuteQuery({ requestPolicy: 'network-only' });
+      }
+    }, DRILLDOWN_POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [drilldown, reexecuteQuery]);
 
   if (selectedPair == null) {
     return (
@@ -72,11 +114,40 @@ export function PairwiseDivergenceDrilldownReport({ selectedPair, scope, domainI
   }
 
   if (fetching && drilldown == null) {
-    return <Loading size="md" text="Loading pairwise divergence breakdown..." />;
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-600">
+        Preparing the pairwise divergence breakdown.
+      </div>
+    );
   }
 
   if (drilldown == null || drilldown.pending) {
-    return <Loading size="md" text="Loading pairwise divergence breakdown..." />;
+    const progress = drilldown?.buildProgress ?? null;
+    const percent = progress != null ? getProgressPercent(progress) : null;
+
+    return (
+      <div className="space-y-3 rounded-lg border border-gray-200 bg-white p-4">
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold text-gray-900">Pairwise divergence breakdown</h3>
+          <p className="text-sm text-gray-700">
+            {progress != null ? formatProgressLabel(progress) : 'The pairwise divergence breakdown is building.'}
+          </p>
+        </div>
+        {progress != null ? (
+          <>
+            <div className="h-2 overflow-hidden rounded-full bg-gray-100">
+              <div
+                className="h-full rounded-full bg-teal-500 transition-[width] duration-300"
+                style={{ width: `${percent ?? 0}%` }}
+              />
+            </div>
+            <p className="text-xs text-gray-500">
+              Last updated {new Date(progress.updatedAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}.
+            </p>
+          </>
+        ) : null}
+      </div>
+    );
   }
 
   if (rows.length === 0) {

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1482,8 +1482,17 @@ export type LlmProvider = {
   updatedAt: Scalars['DateTime']['output'];
 };
 
+export type ModelAgreementBuildProgress = {
+  __typename?: 'ModelAgreementBuildProgress';
+  completedRuns: Scalars['Int']['output'];
+  currentRunId?: Maybe<Scalars['String']['output']>;
+  totalRuns: Scalars['Int']['output'];
+  updatedAt: Scalars['String']['output'];
+};
+
 export type ModelAgreementResult = {
   __typename?: 'ModelAgreementResult';
+  buildProgress?: Maybe<ModelAgreementBuildProgress>;
   excludedNonBinaryCells: Scalars['Int']['output'];
   excludedTiedCells: Scalars['Int']['output'];
   models: Array<ModelInfo>;
@@ -2417,6 +2426,7 @@ export type OrderEffect = {
 
 export type PairDivergenceBreakdown = {
   __typename?: 'PairDivergenceBreakdown';
+  buildProgress?: Maybe<ModelAgreementBuildProgress>;
   modelAId: Scalars['ID']['output'];
   modelALabel: Scalars['String']['output'];
   modelBId: Scalars['ID']['output'];
@@ -4838,7 +4848,7 @@ export type ModelAgreementOnTradeoffsQueryVariables = Exact<{
 }>;
 
 
-export type ModelAgreementOnTradeoffsQuery = { __typename?: 'Query', modelAgreementOnTradeoffs: { __typename?: 'ModelAgreementResult', pending: boolean, excludedNonBinaryCells: number, excludedTiedCells: number, models: Array<{ __typename?: 'ModelInfo', modelId: string, label: string }>, unavailableModels: Array<{ __typename?: 'UnavailableModelInfo', modelId: string, label: string, reason: string }>, pairwiseAgreementMatrix: Array<{ __typename?: 'PairwiseAgreementRow', modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, totalCells: number, percentAgreement?: number | null, cohensKappa?: number | null, kappaInterpretation?: string | null, meanAbsoluteDivergence?: number | null }>, trialConsistency: Array<{ __typename?: 'ModelTrialConsistency', modelId: string, modelLabel: string, cellsObserved: number, meanTrialConsistency?: number | null, noisy: boolean }> } };
+export type ModelAgreementOnTradeoffsQuery = { __typename?: 'Query', modelAgreementOnTradeoffs: { __typename?: 'ModelAgreementResult', pending: boolean, excludedNonBinaryCells: number, excludedTiedCells: number, buildProgress?: { __typename?: 'ModelAgreementBuildProgress', completedRuns: number, totalRuns: number, currentRunId?: string | null, updatedAt: string } | null, models: Array<{ __typename?: 'ModelInfo', modelId: string, label: string }>, unavailableModels: Array<{ __typename?: 'UnavailableModelInfo', modelId: string, label: string, reason: string }>, pairwiseAgreementMatrix: Array<{ __typename?: 'PairwiseAgreementRow', modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, totalCells: number, percentAgreement?: number | null, cohensKappa?: number | null, kappaInterpretation?: string | null, meanAbsoluteDivergence?: number | null }>, trialConsistency: Array<{ __typename?: 'ModelTrialConsistency', modelId: string, modelLabel: string, cellsObserved: number, meanTrialConsistency?: number | null, noisy: boolean }> } };
 
 export type ModelPairDivergenceBreakdownQueryVariables = Exact<{
   modelAId: Scalars['ID']['input'];
@@ -4849,7 +4859,7 @@ export type ModelPairDivergenceBreakdownQueryVariables = Exact<{
 }>;
 
 
-export type ModelPairDivergenceBreakdownQuery = { __typename?: 'Query', modelPairDivergenceBreakdown: { __typename?: 'PairDivergenceBreakdown', pending: boolean, modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, perValuePair: Array<{ __typename?: 'ValuePairDivergence', valueA: string, valueB: string, cellsCompared: number, meanAbsoluteDivergence?: number | null, modelAProportionA?: number | null, modelBProportionA?: number | null }> } };
+export type ModelPairDivergenceBreakdownQuery = { __typename?: 'Query', modelPairDivergenceBreakdown: { __typename?: 'PairDivergenceBreakdown', pending: boolean, modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, buildProgress?: { __typename?: 'ModelAgreementBuildProgress', completedRuns: number, totalRuns: number, currentRunId?: string | null, updatedAt: string } | null, perValuePair: Array<{ __typename?: 'ValuePairDivergence', valueA: string, valueB: string, cellsCompared: number, meanAbsoluteDivergence?: number | null, modelAProportionA?: number | null, modelBProportionA?: number | null }> } };
 
 export type AvailableModelsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -7322,6 +7332,12 @@ export const ModelAgreementOnTradeoffsDocument = gql`
     signature: $signature
   ) {
     pending
+    buildProgress {
+      completedRuns
+      totalRuns
+      currentRunId
+      updatedAt
+    }
     excludedNonBinaryCells
     excludedTiedCells
     models {
@@ -7368,6 +7384,12 @@ export const ModelPairDivergenceBreakdownDocument = gql`
     signature: $signature
   ) {
     pending
+    buildProgress {
+      completedRuns
+      totalRuns
+      currentRunId
+      updatedAt
+    }
     modelAId
     modelALabel
     modelBId


### PR DESCRIPTION
## Summary
- Replace the indefinite spinner with real build progress for Model Agreement on Value Tradeoffs.
- Stream progress counts from the snapshot builder so users can see how many source runs are done.
- Keep the pairwise divergence drilldown in sync with the same progress state.

## Test plan
- [x] Preflight passed (lint + build for shared, db, api, and web)
- [x] API GraphQL query test passed
- [x] Web component tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)