### PR TITLE
Keep Model Groups rendering on partial GraphQL errors

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -37,6 +37,7 @@
 
 | Feature | Branch | Status | Notes |
 |---------|--------|--------|-------|
+| **model-groups-resilient-error-handling** | `codex/model-groups-resilient-error-handling` | 🟢 Done locally | Model Groups now shows an inline warning when one GraphQL request fails, but keeps rendering the rest of the report instead of replacing the whole page with a fatal error. Added a regression test for partial query failure and verified the web build. |
 | **forest-plot-pairwise-drawer** | `—` | 🟢 Done locally | Pairwise Win Rate Matrix cells now open a right-side drawer for single-model, single-domain, signed selections. The drawer fetches pair detail data, renders a forest plot with split-by-direction toggle, summary band, I² label, inline expansion for averaged rows, and loading/error/empty states. Focused web test added; local web lint, full vitest, and build checks pass. |
 | **model-grouping-pairwise-significance-tasks** | `—` | 🟢 Done locally | Added the implementation task list for the bottom-of-page `/models` pairwise significance report, with backend-owned paired permutation tests, page-scope wiring, and heatmap/table UI slices. |
 | **model-grouping-pairwise-significance-plan** | `—` | 🟢 Done locally | Drafted the implementation plan for the new bottom-of-page `/models` pairwise significance report, with backend-owned paired permutation tests, Holm-Bonferroni correction, and a heatmap + sortable table UI. |

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -212,9 +212,10 @@ export function ModelsGroups() {
     [data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt, transcriptCount],
   );
   const showPageLoader = domainsLoading
-    || (selectedDomainId !== '' && data?.domainAnalysis == null && fetching)
-    || (selectedDomainId !== '' && modelsAnalysisData == null && modelsAnalysisFetching)
-    || llmModelsData == null;
+    || (selectedDomainId !== '' && data?.domainAnalysis == null && fetching && error == null)
+    || (selectedDomainId !== '' && modelsAnalysisData == null && modelsAnalysisFetching && modelsAnalysisError == null)
+    || (signatureData == null && signaturesLoading && signaturesError == null)
+    || (llmModelsData == null && llmModelsError == null);
   const models = useMemo(
     () => buildModelEntries(data?.domainAnalysis.models ?? [], modelsAnalysisData?.modelsAnalysis.models ?? []),
     [data?.domainAnalysis.models, modelsAnalysisData?.modelsAnalysis.models],
@@ -232,22 +233,21 @@ export function ModelsGroups() {
     [models, visibleModelIds],
   );
   const isAllDomains = selectedScope === 'ALL_DOMAINS';
+  const pageError = domainsError ?? signaturesError ?? error ?? modelsAnalysisError ?? llmModelsError;
   const showAgreementSection =
     selectedSignature !== ''
     && visibleModelIds.length >= 2
     && !(selectedScope === 'DOMAIN' && selectedDomainId === '')
     && llmModelsData != null;
 
-  if (domainsError != null || signaturesError != null || error != null || modelsAnalysisError != null || llmModelsError != null) {
-    return (
-      <div className="space-y-6">
-        <ErrorMessage message={`Failed to load model groups report: ${(domainsError ?? signaturesError ?? error ?? modelsAnalysisError ?? llmModelsError)?.message ?? 'Unknown error'}`} />
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-6">
+      {pageError != null && (
+        <ErrorMessage
+          message={`Some model groups data failed to load: ${pageError.message ?? 'Unknown error'}`}
+        />
+      )}
+
       <AnalysisContextBar
         domain={{
           label: 'Domain',

--- a/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
@@ -242,4 +242,49 @@ describe('ModelsGroups', () => {
     expect(await screen.findByText(/^Fresh$/)).toBeInTheDocument();
     expect(screen.getByText(/0 transcripts analyzed/i)).toBeInTheDocument();
   });
+
+  it('keeps rendering when one query fails with cached data', async () => {
+    useQueryMock.mockImplementation((args: { query: unknown }) => {
+      if (args.query === DOMAIN_AVAILABLE_SIGNATURES_QUERY) {
+        return [{
+          data: defaultSignatureData,
+          fetching: false,
+          error: undefined,
+        }];
+      }
+      if (args.query === DOMAIN_ANALYSIS_QUERY || args.query === DOMAIN_ANALYSIS_QUERY_LEGACY) {
+        return [{
+          data: defaultAnalysis,
+          fetching: false,
+          error: undefined,
+        }];
+      }
+      if (args.query === MODELS_ANALYSIS_QUERY) {
+        return [{
+          data: defaultModelsAnalysis,
+          fetching: false,
+          error: undefined,
+        }];
+      }
+      if (args.query === LLM_MODELS_QUERY) {
+        return [{
+          data: defaultLlmModels,
+          fetching: false,
+          error: new Error('GraphQL Unexpected error occurred'),
+        }];
+      }
+      return [{ data: undefined, fetching: false, error: undefined }];
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/models?domainId=domain-a&signature=vnewtd']}>
+        <ModelsGroups />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Some model groups data failed to load/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Model Clusters', level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Similarity by Model' })).toBeInTheDocument();
+    expect(screen.getByText('Model Agreement on Value Tradeoffs')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Stop the Model Groups page from hard-failing when one GraphQL request returns an error.
- Show an inline warning and keep rendering the rest of the report.
- Add a regression test for the partial-failure case and update project status.

## Test plan
- [x] Preflight passed (lint + tests + build)
- [ ] Manual smoke test done

🤖 Generated with [Claude Code](https://claude.com/claude-code)