### PR TITLE
Fail fast on Model Groups errors for easier debugging

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -37,7 +37,7 @@
 
 | Feature | Branch | Status | Notes |
 |---------|--------|--------|-------|
-| **model-groups-resilient-error-handling** | `codex/model-groups-resilient-error-handling` | 🟢 Done locally | Model Groups now shows an inline warning when one GraphQL request fails, but keeps rendering the rest of the report instead of replacing the whole page with a fatal error. Added a regression test for partial query failure and verified the web build. |
+| **model-groups-fast-fail-debug** | `codex/model-groups-fast-fail-debug` | 🟢 Done locally | Model Groups now fails fast on GraphQL errors again, using network-only requests and a full-page error state so debugging is immediate. Added a regression test for the fatal path and verified the web build. |
 | **forest-plot-pairwise-drawer** | `—` | 🟢 Done locally | Pairwise Win Rate Matrix cells now open a right-side drawer for single-model, single-domain, signed selections. The drawer fetches pair detail data, renders a forest plot with split-by-direction toggle, summary band, I² label, inline expansion for averaged rows, and loading/error/empty states. Focused web test added; local web lint, full vitest, and build checks pass. |
 | **model-grouping-pairwise-significance-tasks** | `—` | 🟢 Done locally | Added the implementation task list for the bottom-of-page `/models` pairwise significance report, with backend-owned paired permutation tests, page-scope wiring, and heatmap/table UI slices. |
 | **model-grouping-pairwise-significance-plan** | `—` | 🟢 Done locally | Drafted the implementation plan for the new bottom-of-page `/models` pairwise significance report, with backend-owned paired permutation tests, Holm-Bonferroni correction, and a heatmap + sortable table UI. |

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -95,7 +95,7 @@ export function ModelsGroups() {
       scope: selectedScope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined,
     },
     pause: selectedDomainId === '',
-    requestPolicy: 'cache-and-network',
+    requestPolicy: 'network-only',
   });
 
   const signatureOptions = useMemo<DomainAvailableSignature[]>(() => {
@@ -152,7 +152,7 @@ export function ModelsGroups() {
       signature: selectedSignature === '' ? undefined : selectedSignature,
     },
     pause: selectedDomainId === '' || activeUseLegacyQuery,
-    requestPolicy: 'cache-and-network',
+    requestPolicy: 'network-only',
   });
   const [{ data: modelsAnalysisData, fetching: modelsAnalysisFetching, error: modelsAnalysisError }] = useQuery<
     ModelsAnalysisQueryResult,
@@ -164,18 +164,18 @@ export function ModelsGroups() {
       ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
     },
     pause: selectedScope === 'DOMAIN' && selectedDomainId === '',
-    requestPolicy: 'cache-and-network',
+    requestPolicy: 'network-only',
   });
   const [{ data: llmModelsData, error: llmModelsError }] = useQuery<LlmModelsQueryResult>({
     query: LLM_MODELS_QUERY,
     variables: { status: 'ACTIVE' },
-    requestPolicy: 'cache-and-network',
+    requestPolicy: 'network-only',
   });
   const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<DomainAnalysisQueryResult, { domainId: string }>({
     query: DOMAIN_ANALYSIS_QUERY_LEGACY,
     variables: { domainId: selectedDomainId },
     pause: selectedDomainId === '' || !activeUseLegacyQuery,
-    requestPolicy: 'cache-and-network',
+    requestPolicy: 'network-only',
   });
 
   useEffect(() => {
@@ -240,14 +240,18 @@ export function ModelsGroups() {
     && !(selectedScope === 'DOMAIN' && selectedDomainId === '')
     && llmModelsData != null;
 
+  if (pageError != null) {
+    return (
+      <div className="space-y-6">
+        <ErrorMessage
+          message={`Failed to load model groups report: ${pageError.message ?? 'Unknown error'}`}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
-      {pageError != null && (
-        <ErrorMessage
-          message={`Some model groups data failed to load: ${pageError.message ?? 'Unknown error'}`}
-        />
-      )}
-
       <AnalysisContextBar
         domain={{
           label: 'Domain',

--- a/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
@@ -243,7 +243,7 @@ describe('ModelsGroups', () => {
     expect(screen.getByText(/0 transcripts analyzed/i)).toBeInTheDocument();
   });
 
-  it('keeps rendering when one query fails with cached data', async () => {
+  it('shows a full-page error when one query fails', async () => {
     useQueryMock.mockImplementation((args: { query: unknown }) => {
       if (args.query === DOMAIN_AVAILABLE_SIGNATURES_QUERY) {
         return [{
@@ -282,9 +282,9 @@ describe('ModelsGroups', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText(/Some model groups data failed to load/i)).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Model Clusters', level: 2 })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Similarity by Model' })).toBeInTheDocument();
-    expect(screen.getByText('Model Agreement on Value Tradeoffs')).toBeInTheDocument();
+    expect(await screen.findByText(/Failed to load model groups report/i)).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Model Clusters', level: 2 })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Similarity by Model' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Model Agreement on Value Tradeoffs')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Restore a full-page error state for Model Groups when a critical GraphQL request fails.
- Switch the page queries to `network-only` so we see failures immediately instead of waiting on cached data.
- Add a regression test that verifies the report does not render after a query failure.

## Test plan
- [x] Preflight passed (lint + tests + build)
- [ ] Manual smoke test done

🤖 Generated with [Claude Code](https://claude.com/claude-code)