### PR TITLE
Surface traceable GraphQL errors in Model Groups

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -37,7 +37,7 @@
 
 | Feature | Branch | Status | Notes |
 |---------|--------|--------|-------|
-| **model-groups-fast-fail-debug** | `codex/model-groups-fast-fail-debug` | 🟢 Done locally | Model Groups now fails fast on GraphQL errors again, using network-only requests and a full-page error state so debugging is immediate. Added a regression test for the fatal path and verified the web build. |
+| **model-groups-fast-fail-debug** | `codex/model-groups-fast-fail-debug` | 🟢 Done locally | Model Groups now fails fast on GraphQL errors again, using network-only requests and a full-page error state so debugging is immediate. The page now names the failing query and includes trace details like path, code, and error ID. Added a regression test for the fatal path and verified the web build. |
 | **forest-plot-pairwise-drawer** | `—` | 🟢 Done locally | Pairwise Win Rate Matrix cells now open a right-side drawer for single-model, single-domain, signed selections. The drawer fetches pair detail data, renders a forest plot with split-by-direction toggle, summary band, I² label, inline expansion for averaged rows, and loading/error/empty states. Focused web test added; local web lint, full vitest, and build checks pass. |
 | **model-grouping-pairwise-significance-tasks** | `—` | 🟢 Done locally | Added the implementation task list for the bottom-of-page `/models` pairwise significance report, with backend-owned paired permutation tests, page-scope wiring, and heatmap/table UI slices. |
 | **model-grouping-pairwise-significance-plan** | `—` | 🟢 Done locally | Drafted the implementation plan for the new bottom-of-page `/models` pairwise significance report, with backend-owned paired permutation tests, Holm-Bonferroni correction, and a heatmap + sortable table UI. |

--- a/cloud/apps/api/src/graphql/index.ts
+++ b/cloud/apps/api/src/graphql/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { createYoga, type Plugin, createGraphQLError } from 'graphql-yoga';
 import type { Request, Response } from 'express';
 import { graphql, type ExecutionResult, getOperationAST, type DocumentNode, Kind } from 'graphql';
@@ -127,6 +128,10 @@ function getOriginalError(value: unknown): unknown {
   return maybeOriginal ?? null;
 }
 
+function createErrorReferenceId(): string {
+  return `vr-${randomUUID().slice(0, 8)}`;
+}
+
 const [{ queriesReady }, { mutationsReady }] = await Promise.all([
   import('./queries/index.js'),
   import('./mutations/index.js'),
@@ -188,9 +193,12 @@ export const yoga = createYoga<{
       }
 
       if (appError !== null) {
+        const errorId = createErrorReferenceId();
+        log.error({ errorId, err: appError }, 'GraphQL app error');
         return createGraphQLError(appError.message, {
           extensions: {
             code: appError.code || 'APP_ERROR',
+            errorId,
             http: {
               status: appError.statusCode || 400,
             },
@@ -198,9 +206,12 @@ export const yoga = createYoga<{
         });
       }
       // Mask other errors with generic message
+      const errorId = createErrorReferenceId();
+      log.error({ errorId, err: error }, 'GraphQL unhandled error');
       return createGraphQLError('Unexpected error occurred.', {
         extensions: {
           code: 'INTERNAL_SERVER_ERROR',
+          errorId,
           http: {
             status: 500,
           },

--- a/cloud/apps/web/src/hooks/useDomains.ts
+++ b/cloud/apps/web/src/hooks/useDomains.ts
@@ -24,6 +24,7 @@ import {
   type RunTrialsForDomainMutationResult,
   type RunTrialsForDomainMutationVariables,
 } from '../api/operations/domains';
+import { formatQueryError } from '../utils/urqlError';
 
 type RunTrialsForDomainResult = RunTrialsForDomainMutationResult['runTrialsForDomain'];
 type CreatedDomainResult = CreateDomainMutationResult['createDomain'];
@@ -74,21 +75,21 @@ export function useDomains(): UseDomainsResult {
 
   const createDomain = async (name: string): Promise<CreatedDomainResult | null> => {
     const result = await createMutation({ name });
-    if (result.error) throw new Error(result.error.message);
+    if (result.error) throw new Error(formatQueryError('Create domain mutation', result.error, { name }));
     refetch();
     return result.data?.createDomain ?? null;
   };
 
   const renameDomain = async (id: string, name: string): Promise<RenamedDomainResult | null> => {
     const result = await renameMutation({ id, name });
-    if (result.error) throw new Error(result.error.message);
+    if (result.error) throw new Error(formatQueryError('Rename domain mutation', result.error, { id, name }));
     refetch();
     return result.data?.renameDomain ?? null;
   };
 
   const deleteDomain = async (id: string): Promise<DomainMutationResult | null> => {
     const result = await deleteMutation({ id });
-    if (result.error) throw new Error(result.error.message);
+    if (result.error) throw new Error(formatQueryError('Delete domain mutation', result.error, { id }));
     refetch();
     return result.data?.deleteDomain ?? null;
   };
@@ -98,7 +99,12 @@ export function useDomains(): UseDomainsResult {
     domainId: string | null
   ): Promise<DomainMutationResult | null> => {
     const result = await assignIdsMutation({ definitionIds, domainId });
-    if (result.error) throw new Error(result.error.message);
+    if (result.error) {
+      throw new Error(formatQueryError('Assign domain to definitions mutation', result.error, {
+        domainId: domainId ?? '(none)',
+        definitionCount: definitionIds.length,
+      }));
+    }
     return result.data?.assignDomainToDefinitions ?? null;
   };
 
@@ -116,7 +122,16 @@ export function useDomains(): UseDomainsResult {
       domainId: input.domainId,
       sourceDomainId: input.sourceDomainId ?? undefined,
     });
-    if (result.error) throw new Error(result.error.message);
+    if (result.error) {
+      throw new Error(formatQueryError('Assign domain by filter mutation', result.error, {
+        domainId: input.domainId ?? '(none)',
+        rootOnly: input.rootOnly ?? false,
+        search: input.search ?? '(none)',
+        hasRuns: input.hasRuns ?? '(any)',
+        sourceDomainId: input.sourceDomainId ?? '(none)',
+        withoutDomain: input.withoutDomain ?? false,
+      }));
+    }
     return result.data?.assignDomainToDefinitionsByFilter ?? null;
   };
 
@@ -125,7 +140,12 @@ export function useDomains(): UseDomainsResult {
     temperature?: number
   ): Promise<RunTrialsForDomainResult | null> => {
     const result = await runTrialsMutation({ domainId, temperature });
-    if (result.error) throw new Error(result.error.message);
+    if (result.error) {
+      throw new Error(formatQueryError('Run trials for domain mutation', result.error, {
+        domainId,
+        temperature: temperature ?? '(default)',
+      }));
+    }
     const payload = result.data?.runTrialsForDomain ?? null;
     if (payload && payload.failedDefinitions > 0) {
       throw new Error(
@@ -153,7 +173,7 @@ export function useDomains(): UseDomainsResult {
     assigningByIds: assignIdsResult.fetching,
     assigningByFilter: assignFilterResult.fetching,
     runningDomainTrials: runTrialsResult.fetching,
-    error: queryResult.error ? new Error(queryResult.error.message) : null,
+    error: queryResult.error ? new Error(formatQueryError('Domains query', queryResult.error, { limit: 500, offset: 0 })) : null,
     refetch,
     createDomain,
     renameDomain,

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -29,6 +29,7 @@ import { ModelAgreementSection } from '../components/models/ModelAgreementSectio
 import { type CalculationMethod } from '../components/models/ModelSimilarityMetrics';
 import { useDomains } from '../hooks/useDomains';
 import { VALUES, type ModelEntry, type ValueKey } from '../data/domainAnalysisData';
+import { formatQueryError } from '../utils/urqlError';
 import {
   countAnalyzedTranscripts,
   formatSignatureOptionLabel,
@@ -233,18 +234,44 @@ export function ModelsGroups() {
     [models, visibleModelIds],
   );
   const isAllDomains = selectedScope === 'ALL_DOMAINS';
-  const pageError = domainsError ?? signaturesError ?? error ?? modelsAnalysisError ?? llmModelsError;
+  const pageErrorMessage = domainsError != null
+    ? domainsError.message
+    : signaturesError != null
+      ? formatQueryError('Model Groups available signatures query', signaturesError, {
+        domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
+        scope: selectedScope,
+      })
+      : error != null
+        ? formatQueryError(
+          activeUseLegacyQuery ? 'Model Groups legacy domain analysis query' : 'Model Groups domain analysis query',
+          error,
+          {
+            domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
+            scope: selectedScope,
+            signature: selectedSignature === '' ? '(none)' : selectedSignature,
+          },
+        )
+        : modelsAnalysisError != null
+          ? formatQueryError('Model Groups models analysis query', modelsAnalysisError, {
+            domainId: selectedScope === 'DOMAIN' && selectedDomainId !== '' ? selectedDomainId : ALL_DOMAINS_SCOPE,
+            signature: selectedSignature === '' ? '(none)' : selectedSignature,
+          })
+          : llmModelsError != null
+            ? formatQueryError('Model Groups active LLM models query', llmModelsError, {
+              status: 'ACTIVE',
+            })
+            : null;
   const showAgreementSection =
     selectedSignature !== ''
     && visibleModelIds.length >= 2
     && !(selectedScope === 'DOMAIN' && selectedDomainId === '')
     && llmModelsData != null;
 
-  if (pageError != null) {
+  if (pageErrorMessage != null) {
     return (
       <div className="space-y-6">
         <ErrorMessage
-          message={`Failed to load model groups report: ${pageError.message ?? 'Unknown error'}`}
+          message={`Failed to load model groups report: ${pageErrorMessage}`}
         />
       </div>
     );

--- a/cloud/apps/web/src/utils/urqlError.ts
+++ b/cloud/apps/web/src/utils/urqlError.ts
@@ -1,0 +1,103 @@
+type GraphQLErrorLike = {
+  message?: string;
+  path?: Array<string | number> | null;
+  extensions?: Record<string, unknown> | null;
+};
+
+type CombinedErrorLike = {
+  message?: string;
+  graphQLErrors?: GraphQLErrorLike[];
+  networkError?: {
+    message?: string;
+    response?: {
+      status?: number;
+      statusText?: string;
+    };
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+}
+
+function formatContext(context?: Record<string, string | number | boolean | null | undefined>): string {
+  if (context == null) return '';
+
+  const parts = Object.entries(context)
+    .filter(([, value]) => value != null)
+    .map(([key, value]) => `${key}=${String(value)}`);
+
+  return parts.length > 0 ? ` (${parts.join(', ')})` : '';
+}
+
+function getGraphQLErrorDetails(error: CombinedErrorLike): string | null {
+  const firstGraphQLError = error.graphQLErrors?.[0];
+  if (firstGraphQLError == null) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  const path = firstGraphQLError.path != null && firstGraphQLError.path.length > 0
+    ? firstGraphQLError.path.map((part) => String(part)).join('.')
+    : null;
+  if (path != null) parts.push(`path=${path}`);
+
+  if (isRecord(firstGraphQLError.extensions)) {
+    const code = readString(firstGraphQLError.extensions.code);
+    if (code != null) parts.push(`code=${code}`);
+
+    const errorId = readString(firstGraphQLError.extensions.errorId);
+    if (errorId != null) parts.push(`errorId=${errorId}`);
+  }
+
+  return parts.length > 0 ? parts.join(', ') : null;
+}
+
+function getNetworkErrorDetails(error: CombinedErrorLike): string | null {
+  const response = error.networkError?.response;
+  const status = response?.status;
+  const statusText = readString(response?.statusText);
+  if (status == null && statusText == null) {
+    return null;
+  }
+  return [status != null ? `status=${status}` : null, statusText != null ? `statusText=${statusText}` : null]
+    .filter((part): part is string => part != null)
+    .join(', ');
+}
+
+export function formatUrqlError(error: unknown, fallback: string): string {
+  if (!isRecord(error)) {
+    if (error instanceof Error && readString(error.message) != null) {
+      return error.message;
+    }
+    return fallback;
+  }
+
+  const combinedError = error as CombinedErrorLike;
+  const graphQLErrorDetails = getGraphQLErrorDetails(combinedError);
+  const networkErrorDetails = getNetworkErrorDetails(combinedError);
+  const detailPrefix = graphQLErrorDetails != null
+    ? `${graphQLErrorDetails}`
+    : networkErrorDetails != null
+      ? `${networkErrorDetails}`
+      : null;
+
+  const message = readString(combinedError.message) ?? fallback;
+  if (detailPrefix == null) {
+    return message;
+  }
+
+  return `${message} (${detailPrefix})`;
+}
+
+export function formatQueryError(
+  queryLabel: string,
+  error: unknown,
+  context?: Record<string, string | number | boolean | null | undefined>,
+): string {
+  return `${queryLabel} failed${formatContext(context)}: ${formatUrqlError(error, 'Unknown error')}`;
+}

--- a/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
+++ b/cloud/apps/web/tests/pages/ModelsGroups.test.tsx
@@ -270,7 +270,19 @@ describe('ModelsGroups', () => {
         return [{
           data: defaultLlmModels,
           fetching: false,
-          error: new Error('GraphQL Unexpected error occurred'),
+          error: {
+            message: '[GraphQL] Unexpected error occurred.',
+            graphQLErrors: [
+              {
+                message: 'Active models resolver failed.',
+                path: ['llmModels'],
+                extensions: {
+                  code: 'INTERNAL_SERVER_ERROR',
+                  errorId: 'vr-1234abcd',
+                },
+              },
+            ],
+          },
         }];
       }
       return [{ data: undefined, fetching: false, error: undefined }];
@@ -282,7 +294,9 @@ describe('ModelsGroups', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText(/Failed to load model groups report/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Model Groups active LLM models query failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/errorId=vr-1234abcd/i)).toBeInTheDocument();
+    expect(screen.getByText(/path=llmModels/i)).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Model Clusters', level: 2 })).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Similarity by Model' })).not.toBeInTheDocument();
     expect(screen.queryByText('Model Agreement on Value Tradeoffs')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Preserve and display query-specific error details on the Model Groups page.
- Add a short server-generated error ID to masked GraphQL failures so logs and UI can be matched.
- Improve shared urql error formatting so the page reports which query and selection context failed.

## Validation
- [x] `npm run lint --workspace @valuerank/api`
- [x] `npm run build --workspace @valuerank/api`
- [x] `npm run lint --workspace @valuerank/web`
- [x] `npm run test --workspace=@valuerank/web -- tests/pages/ModelsGroups.test.tsx`
- [x] `npm run build --workspace @valuerank/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)