### PR TITLE
Restore bounded transcript batching

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
@@ -131,19 +131,24 @@ export async function buildSnapshotOutput(
 ): Promise<DomainAnalysisSnapshotOutput> {
   const valuePairByDefinition = await resolveValuePairsInChunks(state.latestDefinitionIds);
 
+  const TRANSCRIPT_BATCH_SIZE = 500;
   const cellMap = new Map<string, CellCounts>();
   const totalRuns = state.resolvedSignatureRuns.filteredSourceRunIds.length;
   let completedRuns = 0;
 
   if (state.resolvedSignatureRuns.filteredSourceRunIds.length > 0) {
-    // Fetch all transcripts for every run in parallel. Each run has a bounded
-    // transcript count (definitions × models × scenarios), so no per-run
-    // pagination is needed. This replaces the old sequential offset-pagination
-    // loop, cutting build time from O(total_batches) to O(1 round-trip).
-    const perRunTranscripts = await Promise.all(
-      state.resolvedSignatureRuns.filteredSourceRunIds.map((runId) =>
-        db.transcript.findMany({
-          where: { runId, deletedAt: null },
+    // Keep each transcript read bounded so large domains do not exhaust memory
+    // or the Prisma bridge. Aggregate each batch into the shared cell map.
+    for (const runId of state.resolvedSignatureRuns.filteredSourceRunIds) {
+      let offset = 0;
+      let fetchedCount = TRANSCRIPT_BATCH_SIZE;
+
+      while (fetchedCount >= TRANSCRIPT_BATCH_SIZE) {
+        const batch = await db.transcript.findMany({
+          where: {
+            runId,
+            deletedAt: null,
+          },
           select: {
             id: true,
             runId: true,
@@ -161,23 +166,27 @@ export async function buildSnapshotOutput(
             },
           },
           orderBy: { id: 'asc' },
-        }),
-      ),
-    );
+          take: TRANSCRIPT_BATCH_SIZE,
+          skip: offset,
+        });
 
-    for (const runTranscripts of perRunTranscripts) {
-      const runId = state.resolvedSignatureRuns.filteredSourceRunIds[completedRuns] ?? null;
-      const batchCellMap = accumulateTranscriptCells({
-        transcripts: runTranscripts,
-        filteredSourceRunDefinitionById: state.resolvedSignatureRuns.filteredSourceRunDefinitionById,
-      });
+        fetchedCount = batch.length;
+        if (fetchedCount === 0) break;
 
-      for (const [key, counts] of batchCellMap.entries()) {
-        const existing = cellMap.get(key) ?? { wins: 0, losses: 0, neutrals: 0 };
-        existing.wins += counts.wins;
-        existing.losses += counts.losses;
-        existing.neutrals += counts.neutrals;
-        cellMap.set(key, existing);
+        const batchCellMap = accumulateTranscriptCells({
+          transcripts: batch,
+          filteredSourceRunDefinitionById: state.resolvedSignatureRuns.filteredSourceRunDefinitionById,
+        });
+
+        for (const [key, counts] of batchCellMap.entries()) {
+          const existing = cellMap.get(key) ?? { wins: 0, losses: 0, neutrals: 0 };
+          existing.wins += counts.wins;
+          existing.losses += counts.losses;
+          existing.neutrals += counts.neutrals;
+          cellMap.set(key, existing);
+        }
+
+        offset += fetchedCount;
       }
 
       completedRuns += 1;

--- a/cloud/apps/api/src/services/analysis/transcript-cell-accumulator.ts
+++ b/cloud/apps/api/src/services/analysis/transcript-cell-accumulator.ts
@@ -152,70 +152,79 @@ export function accumulateTranscriptCells(params: {
   const cellMap = new Map<string, CellCounts>();
 
   for (const transcript of params.transcripts) {
-    if (transcript.deletedAt != null) continue;
-    if (transcript.scenario == null || transcript.scenario.deletedAt != null) continue;
+    try {
+      if (transcript.deletedAt != null) continue;
+      if (transcript.scenario == null || transcript.scenario.deletedAt != null) continue;
 
-    const definitionId = params.filteredSourceRunDefinitionById.get(transcript.runId);
-    if (definitionId === undefined) continue;
+      const definitionId = params.filteredSourceRunDefinitionById.get(transcript.runId);
+      if (definitionId === undefined) continue;
 
-    const valuePair = getSnapshotValuePair(transcript.definitionSnapshot);
-    if (valuePair == null) continue;
-    const [firstValueToken, secondValueToken] = valuePair;
-    if (!isDomainAnalysisValueKey(firstValueToken) || !isDomainAnalysisValueKey(secondValueToken)) continue;
+      const valuePair = getSnapshotValuePair(transcript.definitionSnapshot);
+      if (valuePair == null) continue;
+      const [firstValueToken, secondValueToken] = valuePair;
+      if (!isDomainAnalysisValueKey(firstValueToken) || !isDomainAnalysisValueKey(secondValueToken)) continue;
 
-    const dimensions = getDefinitionDimensions(transcript.definitionSnapshot, firstValueToken, secondValueToken);
-    if (dimensions == null || dimensions.ownDimension == null || dimensions.opponentDimension == null) continue;
+      const dimensions = getDefinitionDimensions(transcript.definitionSnapshot, firstValueToken, secondValueToken);
+      if (dimensions == null || dimensions.ownDimension == null || dimensions.opponentDimension == null) continue;
 
-    const ownLookup = buildSafeLevelLookup(dimensions.ownDimension);
-    const opponentLookup = buildSafeLevelLookup(dimensions.opponentDimension);
-    if (ownLookup.exclusionReason != null || opponentLookup.exclusionReason != null) continue;
+      const ownLookup = buildSafeLevelLookup(dimensions.ownDimension);
+      const opponentLookup = buildSafeLevelLookup(dimensions.opponentDimension);
+      if (ownLookup.exclusionReason != null || opponentLookup.exclusionReason != null) continue;
 
-    const scenarioContent = transcript.scenario.content;
-    if (!isRecord(scenarioContent)) continue;
-    // Production scenarios use snake_case `dimension_values`; test/newer data uses camelCase `dimensionValues`.
-    const dimensionValues = scenarioContent.dimensionValues ?? scenarioContent.dimension_values;
-    if (!isRecord(dimensionValues)) continue;
+      const scenarioContent = transcript.scenario.content;
+      if (!isRecord(scenarioContent)) continue;
+      // Production scenarios use snake_case `dimension_values`; test/newer data uses camelCase `dimensionValues`.
+      const dimensionValues = scenarioContent.dimensionValues ?? scenarioContent.dimension_values;
+      if (!isRecord(dimensionValues)) continue;
 
-    const levels = assignOwnOpponentLevels(
-      dimensions.dimensions,
-      dimensionValues,
-      ownLookup.lookup,
-      opponentLookup.lookup,
-      firstValueToken,
-      secondValueToken,
-    );
-    if (levels == null) continue;
+      const levels = assignOwnOpponentLevels(
+        dimensions.dimensions,
+        dimensionValues,
+        ownLookup.lookup,
+        opponentLookup.lookup,
+        firstValueToken,
+        secondValueToken,
+      );
+      if (levels == null) continue;
 
-    const resolved = resolveTranscriptDecisionModel({
-      decisionMetadata: transcript.decisionMetadata,
-      definitionSnapshot: transcript.definitionSnapshot,
-      orientationFlipped: transcript.scenario.orientationFlipped,
-      pairOverride: { valueA: firstValueToken, valueB: secondValueToken },
-    });
-    if (resolved.canonical.direction === 'unknown') continue;
+      const resolved = resolveTranscriptDecisionModel({
+        decisionMetadata: transcript.decisionMetadata,
+        definitionSnapshot: transcript.definitionSnapshot,
+        orientationFlipped: transcript.scenario.orientationFlipped,
+        pairOverride: { valueA: firstValueToken, valueB: secondValueToken },
+      });
+      if (resolved.canonical.direction === 'unknown') continue;
 
-    const outcome = assignOwnOpponent(firstValueToken, secondValueToken, resolved.canonical.direction);
-    if (outcome === 'unscored') continue;
+      const outcome = assignOwnOpponent(firstValueToken, secondValueToken, resolved.canonical.direction);
+      if (outcome === 'unscored') continue;
 
-    const firstKey = encodeCellKey({
-      definitionId,
-      modelId: transcript.modelId,
-      valueKey: firstValueToken,
-      ownLevel: levels.ownLevel,
-      opponentLevel: levels.opponentLevel,
-    });
-    const secondKey = encodeCellKey({
-      definitionId,
-      modelId: transcript.modelId,
-      valueKey: secondValueToken,
-      ownLevel: levels.opponentLevel,
-      opponentLevel: levels.ownLevel,
-    });
+      const firstKey = encodeCellKey({
+        definitionId,
+        modelId: transcript.modelId,
+        valueKey: firstValueToken,
+        ownLevel: levels.ownLevel,
+        opponentLevel: levels.opponentLevel,
+      });
+      const secondKey = encodeCellKey({
+        definitionId,
+        modelId: transcript.modelId,
+        valueKey: secondValueToken,
+        ownLevel: levels.opponentLevel,
+        opponentLevel: levels.ownLevel,
+      });
 
-    addCellCounts(cellMap, firstKey, outcome);
-    const mirroredOutcome: AssignedOutcome =
-      outcome === 'own_picked' ? 'opponent_picked' : outcome === 'opponent_picked' ? 'own_picked' : outcome;
-    addCellCounts(cellMap, secondKey, mirroredOutcome);
+      addCellCounts(cellMap, firstKey, outcome);
+      const mirroredOutcome: AssignedOutcome =
+        outcome === 'own_picked' ? 'opponent_picked' : outcome === 'opponent_picked' ? 'own_picked' : outcome;
+      addCellCounts(cellMap, secondKey, mirroredOutcome);
+    } catch (error) {
+      throw new ValidationError('Failed to accumulate transcript for domain analysis', {
+        transcriptId: transcript.id,
+        runId: transcript.runId,
+        modelId: transcript.modelId,
+        cause: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   return cellMap;

--- a/cloud/apps/api/tests/services/analysis/domain-analysis-snapshot-builder-batching.test.ts
+++ b/cloud/apps/api/tests/services/analysis/domain-analysis-snapshot-builder-batching.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  transcriptFindMany,
+  accumulateTranscriptCellsMock,
+  resolveValuePairsInChunksMock,
+  computeCellWeightedDomainRatesMock,
+} = vi.hoisted(() => ({
+  transcriptFindMany: vi.fn(),
+  accumulateTranscriptCellsMock: vi.fn(() => new Map()),
+  resolveValuePairsInChunksMock: vi.fn(async () => new Map()),
+  computeCellWeightedDomainRatesMock: vi.fn(() => ({
+    models: [],
+    analyzedDefinitionIds: new Set<string>(),
+  })),
+}));
+
+vi.mock('@valuerank/db', () => ({
+  db: {
+    transcript: {
+      findMany: transcriptFindMany,
+    },
+  },
+}));
+
+vi.mock('../../../src/graphql/queries/domain/shared.js', () => ({
+  resolveValuePairsInChunks: resolveValuePairsInChunksMock,
+}));
+
+vi.mock('../../../src/services/analysis/transcript-cell-accumulator.js', () => ({
+  accumulateTranscriptCells: accumulateTranscriptCellsMock,
+}));
+
+vi.mock('../../../src/services/analysis/domain-analysis-cell-win-rates.js', () => ({
+  computeCellWeightedDomainRates: computeCellWeightedDomainRatesMock,
+}));
+
+import { buildSnapshotOutput } from '../../../src/services/analysis/domain-analysis-snapshot-builder.js';
+
+function makeTranscript(runId: string, index: number) {
+  return {
+    id: `${runId}-transcript-${index}`,
+    runId,
+    modelId: 'model-1',
+    decisionMetadata: {},
+    definitionSnapshot: {},
+    deletedAt: null,
+    scenario: {
+      id: `${runId}-scenario-${index}`,
+      content: {},
+      orientationFlipped: false,
+      deletedAt: null,
+    },
+  };
+}
+
+describe('buildSnapshotOutput batching', () => {
+  beforeEach(() => {
+    transcriptFindMany.mockReset();
+    accumulateTranscriptCellsMock.mockReset();
+    resolveValuePairsInChunksMock.mockReset();
+    computeCellWeightedDomainRatesMock.mockReset();
+
+    resolveValuePairsInChunksMock.mockResolvedValue(new Map());
+    accumulateTranscriptCellsMock.mockReturnValue(new Map());
+    computeCellWeightedDomainRatesMock.mockReturnValue({
+      models: [],
+      analyzedDefinitionIds: new Set<string>(),
+    });
+  });
+
+  it('pages transcripts in bounded batches per run', async () => {
+    transcriptFindMany.mockImplementation(async (args: { where?: { runId?: string }; skip?: number }) => {
+      const runId = args.where?.runId;
+      const skip = args.skip ?? 0;
+
+      if (runId === 'run-1' && skip === 0) {
+        return Array.from({ length: 500 }, (_, index) => makeTranscript(runId, index));
+      }
+      if (runId === 'run-1' && skip === 500) {
+        return [makeTranscript(runId, 500)];
+      }
+      if (runId === 'run-2' && skip === 0) {
+        return [makeTranscript(runId, 0)];
+      }
+      return [];
+    });
+
+    const onProgress = vi.fn();
+    await buildSnapshotOutput({
+      scope: 'ALL_DOMAINS',
+      domain: { id: 'all-domains', name: 'All domains', defaultModelIds: [] },
+      domains: [],
+      definitions: [],
+      latestDefinitions: [],
+      latestDefinitionIds: [],
+      definitionNameById: new Map(),
+      definitionDomainIdById: new Map(),
+      resolvedSignatureRuns: {
+        selectedSignature: 'vnewtd',
+        filteredSourceRunIds: ['run-1', 'run-2'],
+        filteredSourceRunDefinitionById: new Map([
+          ['run-1', 'definition-1'],
+          ['run-2', 'definition-2'],
+        ]),
+        coveredDefinitionIds: new Set(['definition-1', 'definition-2']),
+        missingReasonByDefinitionId: new Map(),
+      },
+      selectedSignature: 'vnewtd',
+      configSignature: 'vnewtd',
+      fingerprintRows: [],
+      inputHash: 'hash-1',
+    }, {
+      onProgress,
+    });
+
+    expect(transcriptFindMany).toHaveBeenCalledTimes(3);
+    expect(transcriptFindMany).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      where: { runId: 'run-1', deletedAt: null },
+      take: 500,
+      skip: 0,
+    }));
+    expect(transcriptFindMany).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      where: { runId: 'run-1', deletedAt: null },
+      take: 500,
+      skip: 500,
+    }));
+    expect(transcriptFindMany).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      where: { runId: 'run-2', deletedAt: null },
+      take: 500,
+      skip: 0,
+    }));
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      completedRuns: 1,
+      totalRuns: 2,
+      currentRunId: 'run-1',
+    }));
+    expect(onProgress).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      completedRuns: 2,
+      totalRuns: 2,
+      currentRunId: 'run-2',
+    }));
+  });
+});

--- a/cloud/apps/api/tests/services/analysis/transcript-cell-accumulator.test.ts
+++ b/cloud/apps/api/tests/services/analysis/transcript-cell-accumulator.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { accumulateTranscriptCells, encodeCellKey, type TranscriptForAccumulation } from '../../../src/services/analysis/transcript-cell-accumulator.js';
+import { ValidationError } from '@valuerank/shared';
+import { describe, expect, it, vi } from 'vitest';
+import * as decisionModelModule from '../../../src/graphql/queries/domain/decision-model.js';
+import {
+  accumulateTranscriptCells,
+  encodeCellKey,
+  type TranscriptForAccumulation,
+} from '../../../src/services/analysis/transcript-cell-accumulator.js';
 
 const FIRST_VALUE = 'Achievement';
 const SECOND_VALUE = 'Security_Personal';
@@ -266,5 +272,58 @@ describe('accumulateTranscriptCells', () => {
       ownLevel: 2,
       opponentLevel: 1,
     }))).toEqual({ wins: 0, losses: 1, neutrals: 0 });
+  });
+
+  it('throws a validation error with transcript context when accumulation fails', () => {
+    const spy = vi.spyOn(decisionModelModule, 'resolveTranscriptDecisionModel').mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    expect(() =>
+      accumulateTranscriptCells({
+        transcripts: [
+          buildTranscript({
+            id: 'transcript-bad',
+            runId: 'run-bad',
+            modelId: 'model-a',
+            decisionMetadata: { throw: true },
+          }),
+        ],
+        filteredSourceRunDefinitionById: new Map([
+          ['run-bad', 'definition-a'],
+        ]),
+      }),
+    ).toThrowError(ValidationError);
+
+    try {
+      accumulateTranscriptCells({
+        transcripts: [
+          buildTranscript({
+            id: 'transcript-bad',
+            runId: 'run-bad',
+            modelId: 'model-a',
+            decisionMetadata: { throw: true },
+          }),
+        ],
+        filteredSourceRunDefinitionById: new Map([
+          ['run-bad', 'definition-a'],
+        ]),
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect(error).toMatchObject({
+        message: 'Failed to accumulate transcript for domain analysis',
+        context: {
+          details: {
+            transcriptId: 'transcript-bad',
+            runId: 'run-bad',
+            modelId: 'model-a',
+            cause: 'boom',
+          },
+        },
+      });
+    } finally {
+      spy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Restore bounded paging for domain-analysis transcript reads so large domains stay memory-safe.
- Keep transcript accumulation fail-fast with a loud ValidationError that carries transcript context.
- Add regression coverage for both the batching path and the loud failure path.

## Validation
- `cd cloud/apps/api && npx vitest run tests/services/analysis/domain-analysis-snapshot-builder-batching.test.ts tests/services/analysis/transcript-cell-accumulator.test.ts`
- `cd cloud && npm run lint --workspace @valuerank/api`
- `cd cloud && npm run build --workspace @valuerank/api`
- `cd cloud && npm run lint --workspace @valuerank/shared && npm run lint --workspace @valuerank/db && npm run lint --workspace @valuerank/api && npm run build --workspace @valuerank/api && npm run lint --workspace @valuerank/web && npm run build --workspace @valuerank/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
