### PR TITLE
fix(model-agreement): include tied cells via 3-category kappa

### DIFF
--- a/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
@@ -23,6 +23,7 @@ import {
   summarizeTrialConsistency,
   type CellOutcome,
   type ComparableCell,
+  type CellChoice,
 } from '../../services/model-agreement/aggregation.js';
 import {
   equalWeightAggregate,
@@ -177,18 +178,18 @@ export async function resolveModelAgreementOnTradeoffs(
   const availableModels = selectedModels.filter((model) => (cellsObservedByModelId.get(model.modelId) ?? 0) > 0);
 
   const pairwiseAgreementMatrix: PairwiseAgreementRowShape[] = [];
-  let excludedTiedCells = 0;
+  let tiedCells = 0;
 
   for (let leftIndex = 0; leftIndex < availableModels.length; leftIndex += 1) {
     for (let rightIndex = leftIndex + 1; rightIndex < availableModels.length; rightIndex += 1) {
       const modelA = availableModels[leftIndex]!;
       const modelB = availableModels[rightIndex]!;
-      const { cells, excludedTiedCells: pairExcludedTiedCells } = collectComparableCells({
+      const { cells, tiedCells: pairTiedCells } = collectComparableCells({
         positionCells,
         modelAId: modelA.modelId,
         modelBId: modelB.modelId,
       });
-      excludedTiedCells += pairExcludedTiedCells;
+      tiedCells += pairTiedCells;
       const metrics = summarizePairCells(cells);
 
       pairwiseAgreementMatrix.push({
@@ -252,7 +253,7 @@ export async function resolveModelAgreementOnTradeoffs(
     models: availableModels,
     unavailableModels,
     excludedNonBinaryCells: NON_BINARY_CELL_FALLBACK_COUNT,
-    excludedTiedCells,
+    tiedCells,
     pairwiseAgreementMatrix,
     trialConsistency,
   };
@@ -332,19 +333,22 @@ export async function resolveModelPairDivergenceBreakdown(
 
     const proportionA = computeProportionA(outcomeA);
     const proportionB = computeProportionA(outcomeB);
-    if (proportionA == null || proportionB == null || isTied(proportionA) || isTied(proportionB)) {
+    if (proportionA == null || proportionB == null) {
       continue;
     }
+
+    const modelAChoice: CellChoice = isTied(proportionA) ? 'TIED' : (proportionA > 0.5 ? 'A' : 'B');
+    const modelBChoice: CellChoice = isTied(proportionB) ? 'TIED' : (proportionB > 0.5 ? 'A' : 'B');
 
     const cell: ComparableCell = {
       definitionId: position.definitionId,
       valuePairKey: `${position.canonicalA}::${position.canonicalB}`,
       modelAProportionA: proportionA,
       modelBProportionA: proportionB,
+      modelAChoice,
+      modelBChoice,
       divergence: Math.abs(proportionA - proportionB),
-      agreesBinary:
-        (proportionA > 0.5 && proportionB > 0.5)
-        || (proportionA < 0.5 && proportionB < 0.5),
+      agrees: modelAChoice === modelBChoice,
     };
 
     const byDefinition = cellsByValuePair.get(cell.valuePairKey) ?? new Map<string, ComparableCell[]>();

--- a/cloud/apps/api/src/graphql/types/model-agreement-on-tradeoffs.ts
+++ b/cloud/apps/api/src/graphql/types/model-agreement-on-tradeoffs.ts
@@ -44,7 +44,7 @@ export type ModelAgreementResultShape = {
   models: ModelInfoShape[];
   unavailableModels: UnavailableModelInfoShape[];
   excludedNonBinaryCells: number;
-  excludedTiedCells: number;
+  tiedCells: number;
   pairwiseAgreementMatrix: PairwiseAgreementRowShape[];
   trialConsistency: ModelTrialConsistencyShape[];
 };
@@ -132,7 +132,7 @@ builder.objectType(ModelAgreementResultRef, {
     models: t.expose('models', { type: [ModelInfoRef] }),
     unavailableModels: t.expose('unavailableModels', { type: [UnavailableModelInfoRef] }),
     excludedNonBinaryCells: t.exposeInt('excludedNonBinaryCells'),
-    excludedTiedCells: t.exposeInt('excludedTiedCells'),
+    tiedCells: t.exposeInt('tiedCells'),
     pairwiseAgreementMatrix: t.expose('pairwiseAgreementMatrix', { type: [PairwiseAgreementRowRef] }),
     trialConsistency: t.expose('trialConsistency', { type: [ModelTrialConsistencyRef] }),
   }),

--- a/cloud/apps/api/src/services/model-agreement/aggregation.ts
+++ b/cloud/apps/api/src/services/model-agreement/aggregation.ts
@@ -33,13 +33,28 @@ export type PositionCell = {
   byModelId: Map<string, CellOutcome>;
 };
 
+/**
+ * Three-category coding for a model's choice on a cell:
+ * - 'A' = the model picked canonical-A more than canonical-B
+ * - 'B' = the model picked canonical-B more
+ * - 'TIED' = the model split 50/50 (within KAPPA_TIE_EPSILON)
+ *
+ * Tied cells are real data (the model is genuinely undecided) and are kept in
+ * every metric. For Cohen's kappa we use a 3-category coding where "both tied"
+ * counts as agreement. This is the standard variant used in content-coding
+ * reliability work when raters are allowed a "neutral" / "unclear" label.
+ */
+export type CellChoice = 'A' | 'TIED' | 'B';
+
 export type ComparableCell = {
   definitionId: string;
   valuePairKey: string;
   modelAProportionA: number;
   modelBProportionA: number;
+  modelAChoice: CellChoice;
+  modelBChoice: CellChoice;
   divergence: number;
-  agreesBinary: boolean;
+  agrees: boolean;
 };
 
 export type PairMetrics = {
@@ -161,16 +176,21 @@ export function buildPositionCells(
   return { positionCells, cellsObservedByModelId };
 }
 
+function classifyChoice(proportionA: number): CellChoice {
+  if (isTied(proportionA)) return 'TIED';
+  return proportionA > 0.5 ? 'A' : 'B';
+}
+
 export function collectComparableCells(params: {
   positionCells: ReadonlyMap<string, PositionCell>;
   modelAId: string;
   modelBId: string;
 }): {
   cells: ComparableCell[];
-  excludedTiedCells: number;
+  tiedCells: number;
 } {
   const cells: ComparableCell[] = [];
-  let excludedTiedCells = 0;
+  let tiedCells = 0;
 
   for (const position of params.positionCells.values()) {
     const outcomeA = position.byModelId.get(params.modelAId);
@@ -185,9 +205,11 @@ export function collectComparableCells(params: {
       continue;
     }
 
-    if (isTied(proportionA) || isTied(proportionB)) {
-      excludedTiedCells += 1;
-      continue;
+    const modelAChoice = classifyChoice(proportionA);
+    const modelBChoice = classifyChoice(proportionB);
+
+    if (modelAChoice === 'TIED' || modelBChoice === 'TIED') {
+      tiedCells += 1;
     }
 
     cells.push({
@@ -195,16 +217,25 @@ export function collectComparableCells(params: {
       valuePairKey: `${position.canonicalA}::${position.canonicalB}`,
       modelAProportionA: proportionA,
       modelBProportionA: proportionB,
+      modelAChoice,
+      modelBChoice,
       divergence: Math.abs(proportionA - proportionB),
-      agreesBinary:
-        (proportionA > 0.5 && proportionB > 0.5)
-        || (proportionA < 0.5 && proportionB < 0.5),
+      agrees: modelAChoice === modelBChoice,
     });
   }
 
-  return { cells, excludedTiedCells };
+  return { cells, tiedCells };
 }
 
+/**
+ * Three-category Cohen's kappa over A / TIED / B.
+ *
+ * Per-vignette aggregation: for each vignette compute the fraction of cells
+ * in each category for each model, then equal-weight average those fractions
+ * across vignettes. P_chance = sum over categories of pX(k) * pY(k). Both
+ * models tied counts as agreement; one tied + one decided counts as
+ * disagreement.
+ */
 export function summarizePairCells(cells: ReadonlyArray<ComparableCell>): PairMetrics {
   if (cells.length === 0) {
     return {
@@ -218,13 +249,33 @@ export function summarizePairCells(cells: ReadonlyArray<ComparableCell>): PairMe
 
   const perVignetteAgreementRates = new Map<string, { matchedCells: number; totalCells: number }>();
   const perVignetteDivergences = new Map<string, number[]>();
-  const perVignetteModelAProportions = new Map<string, number[]>();
-  const perVignetteModelBProportions = new Map<string, number[]>();
+  const perVignetteFractionsAByModel: Record<'A' | 'B', Map<string, number[]>> = {
+    A: new Map<string, number[]>(),
+    B: new Map<string, number[]>(),
+  };
+  const perVignetteFractionsTiedByModel: Record<'A' | 'B', Map<string, number[]>> = {
+    A: new Map<string, number[]>(),
+    B: new Map<string, number[]>(),
+  };
+  const perVignetteFractionsBByModel: Record<'A' | 'B', Map<string, number[]>> = {
+    A: new Map<string, number[]>(),
+    B: new Map<string, number[]>(),
+  };
+
+  function pushChoiceIndicator(
+    map: Map<string, number[]>,
+    definitionId: string,
+    indicator: number,
+  ): void {
+    const bucket = map.get(definitionId) ?? [];
+    bucket.push(indicator);
+    map.set(definitionId, bucket);
+  }
 
   for (const cell of cells) {
     const agreementBucket = perVignetteAgreementRates.get(cell.definitionId) ?? { matchedCells: 0, totalCells: 0 };
     agreementBucket.totalCells += 1;
-    if (cell.agreesBinary) {
+    if (cell.agrees) {
       agreementBucket.matchedCells += 1;
     }
     perVignetteAgreementRates.set(cell.definitionId, agreementBucket);
@@ -233,24 +284,30 @@ export function summarizePairCells(cells: ReadonlyArray<ComparableCell>): PairMe
     divergenceBucket.push(cell.divergence);
     perVignetteDivergences.set(cell.definitionId, divergenceBucket);
 
-    const modelABucket = perVignetteModelAProportions.get(cell.definitionId) ?? [];
-    modelABucket.push(cell.modelAProportionA);
-    perVignetteModelAProportions.set(cell.definitionId, modelABucket);
-
-    const modelBBucket = perVignetteModelBProportions.get(cell.definitionId) ?? [];
-    modelBBucket.push(cell.modelBProportionA);
-    perVignetteModelBProportions.set(cell.definitionId, modelBBucket);
+    pushChoiceIndicator(perVignetteFractionsAByModel.A, cell.definitionId, cell.modelAChoice === 'A' ? 1 : 0);
+    pushChoiceIndicator(perVignetteFractionsTiedByModel.A, cell.definitionId, cell.modelAChoice === 'TIED' ? 1 : 0);
+    pushChoiceIndicator(perVignetteFractionsBByModel.A, cell.definitionId, cell.modelAChoice === 'B' ? 1 : 0);
+    pushChoiceIndicator(perVignetteFractionsAByModel.B, cell.definitionId, cell.modelBChoice === 'A' ? 1 : 0);
+    pushChoiceIndicator(perVignetteFractionsTiedByModel.B, cell.definitionId, cell.modelBChoice === 'TIED' ? 1 : 0);
+    pushChoiceIndicator(perVignetteFractionsBByModel.B, cell.definitionId, cell.modelBChoice === 'B' ? 1 : 0);
   }
 
   const agreementRates = Array.from(perVignetteAgreementRates.values())
     .map((bucket) => percentAgreement(bucket.matchedCells, bucket.totalCells))
     .filter((value): value is number => value != null);
   const percentAgreementValue = mean(agreementRates);
-  const modelAProportionA = equalWeightAggregate(Array.from(perVignetteModelAProportions.values()));
-  const modelBProportionA = equalWeightAggregate(Array.from(perVignetteModelBProportions.values()));
   const meanAbsoluteDivergence = equalWeightAggregate(Array.from(perVignetteDivergences.values()));
-  const chanceAgreement = modelAProportionA != null && modelBProportionA != null
-    ? (modelAProportionA * modelBProportionA) + ((1 - modelAProportionA) * (1 - modelBProportionA))
+
+  const pAx = equalWeightAggregate(Array.from(perVignetteFractionsAByModel.A.values()));
+  const pTx = equalWeightAggregate(Array.from(perVignetteFractionsTiedByModel.A.values()));
+  const pBx = equalWeightAggregate(Array.from(perVignetteFractionsBByModel.A.values()));
+  const pAy = equalWeightAggregate(Array.from(perVignetteFractionsAByModel.B.values()));
+  const pTy = equalWeightAggregate(Array.from(perVignetteFractionsTiedByModel.B.values()));
+  const pBy = equalWeightAggregate(Array.from(perVignetteFractionsBByModel.B.values()));
+
+  const chanceAgreement = pAx != null && pTx != null && pBx != null
+    && pAy != null && pTy != null && pBy != null
+    ? (pAx * pAy) + (pTx * pTy) + (pBx * pBy)
     : null;
   const kappa = percentAgreementValue != null && chanceAgreement != null
     ? cohensKappa(percentAgreementValue, chanceAgreement)
@@ -322,7 +379,7 @@ export function buildEmptyAgreementResult(
     models: [],
     unavailableModels: [],
     excludedNonBinaryCells: 0,
-    excludedTiedCells: 0,
+    tiedCells: 0,
     pairwiseAgreementMatrix: [],
     trialConsistency: [],
   };

--- a/cloud/apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts
@@ -173,7 +173,7 @@ const agreementQuery = `
       models { modelId label }
       unavailableModels { modelId label reason }
       excludedNonBinaryCells
-      excludedTiedCells
+      tiedCells
       pairwiseAgreementMatrix {
         modelAId
         modelALabel
@@ -348,7 +348,7 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
       models: [],
       unavailableModels: [],
       excludedNonBinaryCells: 0,
-      excludedTiedCells: 0,
+      tiedCells: 0,
       pairwiseAgreementMatrix: [],
       trialConsistency: [],
     });
@@ -372,7 +372,7 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
       models: [],
       unavailableModels: [],
       excludedNonBinaryCells: 0,
-      excludedTiedCells: 0,
+      tiedCells: 0,
       pairwiseAgreementMatrix: [],
       trialConsistency: [],
     });
@@ -451,7 +451,7 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
       models: [],
       unavailableModels: [],
       excludedNonBinaryCells: 0,
-      excludedTiedCells: 0,
+      tiedCells: 0,
       pairwiseAgreementMatrix: [],
       trialConsistency: [],
     });
@@ -495,7 +495,10 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
     });
   });
 
-  it('excludes tied cells from both kappa and divergence, while keeping trial consistency', async () => {
+  it('includes tied cells as their own category in kappa and divergence', async () => {
+    // Model A is exactly 50/50 (TIED). Model B picks canonicalA always.
+    // With 3-category coding the cell counts as a disagreement (one TIED, one A).
+    // Mean abs divergence = |0.5 - 1.0| = 0.5.
     mocks.readModelAgreementSnapshotStateFromSnapshot.mockResolvedValue({
       cellLevelOutcomes: snapshot({
         'def-1::model-a::Achievement::Tradition::1::2': { aChoices: 3, bChoices: 3, neutrals: 0 },
@@ -512,7 +515,7 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
     });
 
     const agreement = response.body.data.modelAgreementOnTradeoffs as {
-      excludedTiedCells: number;
+      tiedCells: number;
       pairwiseAgreementMatrix: Array<{
         totalCells: number;
         percentAgreement: number | null;
@@ -527,15 +530,18 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
       }>;
     };
 
-    expect(agreement.excludedTiedCells).toBe(1);
+    // tiedCells = 1 (cell where at least one model was tied — informational, no longer "excluded")
+    expect(agreement.tiedCells).toBe(1);
     expect(agreement.pairwiseAgreementMatrix).toHaveLength(1);
     expect(agreement.pairwiseAgreementMatrix[0]).toMatchObject({
       modelAId: 'model-a',
       modelBId: 'model-b',
-      totalCells: 0,
-      percentAgreement: null,
-      cohensKappa: null,
-      meanAbsoluteDivergence: null,
+      // totalCells INCLUDES the tied cell now
+      totalCells: 1,
+      // Disagreement (TIED vs A) → percentAgreement = 0
+      percentAgreement: 0,
+      // Mean abs divergence INCLUDES the tied cell: |0.5 - 1.0| = 0.5
+      meanAbsoluteDivergence: 0.5,
     });
     expect(agreement.trialConsistency).toHaveLength(2);
     expect(agreement.trialConsistency[0]).toMatchObject({

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1566,22 +1566,22 @@ type LlmProvider {
   updatedAt: DateTime!
 }
 
-type ModelAgreementResult {
-  buildProgress: ModelAgreementBuildProgress
-  excludedNonBinaryCells: Int!
-  excludedTiedCells: Int!
-  models: [ModelInfo!]!
-  pairwiseAgreementMatrix: [PairwiseAgreementRow!]!
-  pending: Boolean!
-  trialConsistency: [ModelTrialConsistency!]!
-  unavailableModels: [UnavailableModelInfo!]!
-}
-
 type ModelAgreementBuildProgress {
   completedRuns: Int!
   currentRunId: String
   totalRuns: Int!
   updatedAt: String!
+}
+
+type ModelAgreementResult {
+  buildProgress: ModelAgreementBuildProgress
+  excludedNonBinaryCells: Int!
+  models: [ModelInfo!]!
+  pairwiseAgreementMatrix: [PairwiseAgreementRow!]!
+  pending: Boolean!
+  tiedCells: Int!
+  trialConsistency: [ModelTrialConsistency!]!
+  unavailableModels: [UnavailableModelInfo!]!
 }
 
 type ModelConsistency {

--- a/cloud/apps/web/src/api/operations/modelAgreementOnTradeoffs.graphql
+++ b/cloud/apps/web/src/api/operations/modelAgreementOnTradeoffs.graphql
@@ -18,7 +18,7 @@ query ModelAgreementOnTradeoffs(
       updatedAt
     }
     excludedNonBinaryCells
-    excludedTiedCells
+    tiedCells
     models {
       modelId
       label

--- a/cloud/apps/web/src/components/models/ModelAgreementSection.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelAgreementSection.test.tsx
@@ -44,7 +44,7 @@ describe('ModelAgreementSection', () => {
               updatedAt: '2026-05-08T15:00:00.000Z',
             },
             excludedNonBinaryCells: 0,
-            excludedTiedCells: 0,
+            tiedCells: 0,
             models: [],
             unavailableModels: [],
             pairwiseAgreementMatrix: [],

--- a/cloud/apps/web/src/components/models/ModelAgreementSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelAgreementSection.tsx
@@ -66,18 +66,19 @@ function pickDefaultPair(rows: readonly PairwiseAgreementRow[]): SelectedPair | 
   return next == null ? null : { modelAId: next.modelAId, modelBId: next.modelBId };
 }
 
-function buildExclusionNote(excludedNonBinaryCells: number, excludedTiedCells: number): string | null {
+function buildExclusionNote(excludedNonBinaryCells: number, tiedCells: number): string | null {
   const parts: string[] = [];
   if (excludedNonBinaryCells > 0) {
-    parts.push(`${excludedNonBinaryCells} non-binary cell${excludedNonBinaryCells === 1 ? '' : 's'}`);
+    parts.push(
+      `Excluded ${excludedNonBinaryCells} non-binary cell${excludedNonBinaryCells === 1 ? '' : 's'} from the agreement matrix.`,
+    );
   }
-  if (excludedTiedCells > 0) {
-    parts.push(`${excludedTiedCells} tied cell${excludedTiedCells === 1 ? '' : 's'}`);
+  if (tiedCells > 0) {
+    parts.push(
+      `${tiedCells} cell${tiedCells === 1 ? '' : 's'} had at least one model split 50/50 (counted as a third category in kappa, not excluded).`,
+    );
   }
-  if (parts.length === 0) {
-    return null;
-  }
-  return `Excluded ${parts.join(' and ')} from the agreement matrix.`;
+  return parts.length === 0 ? null : parts.join(' ');
 }
 
 function buildUnavailableModelsNotice(
@@ -255,7 +256,7 @@ export function ModelAgreementSection({ modelIds, scope, domainId, signature }: 
     );
   }
 
-  const exclusionNote = buildExclusionNote(agreement.excludedNonBinaryCells, agreement.excludedTiedCells);
+  const exclusionNote = buildExclusionNote(agreement.excludedNonBinaryCells, agreement.tiedCells);
   const unavailableModelsNotice = buildUnavailableModelsNotice(agreement.unavailableModels);
 
   return (

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1494,10 +1494,10 @@ export type ModelAgreementResult = {
   __typename?: 'ModelAgreementResult';
   buildProgress?: Maybe<ModelAgreementBuildProgress>;
   excludedNonBinaryCells: Scalars['Int']['output'];
-  excludedTiedCells: Scalars['Int']['output'];
   models: Array<ModelInfo>;
   pairwiseAgreementMatrix: Array<PairwiseAgreementRow>;
   pending: Scalars['Boolean']['output'];
+  tiedCells: Scalars['Int']['output'];
   trialConsistency: Array<ModelTrialConsistency>;
   unavailableModels: Array<UnavailableModelInfo>;
 };
@@ -4848,7 +4848,7 @@ export type ModelAgreementOnTradeoffsQueryVariables = Exact<{
 }>;
 
 
-export type ModelAgreementOnTradeoffsQuery = { __typename?: 'Query', modelAgreementOnTradeoffs: { __typename?: 'ModelAgreementResult', pending: boolean, excludedNonBinaryCells: number, excludedTiedCells: number, buildProgress?: { __typename?: 'ModelAgreementBuildProgress', completedRuns: number, totalRuns: number, currentRunId?: string | null, updatedAt: string } | null, models: Array<{ __typename?: 'ModelInfo', modelId: string, label: string }>, unavailableModels: Array<{ __typename?: 'UnavailableModelInfo', modelId: string, label: string, reason: string }>, pairwiseAgreementMatrix: Array<{ __typename?: 'PairwiseAgreementRow', modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, totalCells: number, percentAgreement?: number | null, cohensKappa?: number | null, kappaInterpretation?: string | null, meanAbsoluteDivergence?: number | null }>, trialConsistency: Array<{ __typename?: 'ModelTrialConsistency', modelId: string, modelLabel: string, cellsObserved: number, meanTrialConsistency?: number | null, noisy: boolean }> } };
+export type ModelAgreementOnTradeoffsQuery = { __typename?: 'Query', modelAgreementOnTradeoffs: { __typename?: 'ModelAgreementResult', pending: boolean, excludedNonBinaryCells: number, tiedCells: number, buildProgress?: { __typename?: 'ModelAgreementBuildProgress', completedRuns: number, totalRuns: number, currentRunId?: string | null, updatedAt: string } | null, models: Array<{ __typename?: 'ModelInfo', modelId: string, label: string }>, unavailableModels: Array<{ __typename?: 'UnavailableModelInfo', modelId: string, label: string, reason: string }>, pairwiseAgreementMatrix: Array<{ __typename?: 'PairwiseAgreementRow', modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, totalCells: number, percentAgreement?: number | null, cohensKappa?: number | null, kappaInterpretation?: string | null, meanAbsoluteDivergence?: number | null }>, trialConsistency: Array<{ __typename?: 'ModelTrialConsistency', modelId: string, modelLabel: string, cellsObserved: number, meanTrialConsistency?: number | null, noisy: boolean }> } };
 
 export type ModelPairDivergenceBreakdownQueryVariables = Exact<{
   modelAId: Scalars['ID']['input'];
@@ -7339,7 +7339,7 @@ export const ModelAgreementOnTradeoffsDocument = gql`
       updatedAt
     }
     excludedNonBinaryCells
-    excludedTiedCells
+    tiedCells
     models {
       modelId
       label


### PR DESCRIPTION
## Summary

Stops excluding tied cells (where either model split exactly 50/50) from kappa and mean absolute divergence. Switches Cohen's kappa to a 3-category coding (A / TIED / B) — the standard variant used in content-coding reliability work when raters can say \"neutral / unclear.\"

## Why

A 50/50 cell is real data — it's the model telling you \"this tradeoff is genuinely close for me.\" Excluding it could systematically drop the most informative scenarios. With ties dropped, two models that confidently agree on easy cases plus split 50/50 on hard ones look identical to two models that only ever take strong positions.

## What changed

| Before | After |
|--------|-------|
| 2-category kappa, ties excluded from numerator and denominator | 3-category kappa: \"both tied\" = agreement, mixed = disagreement, P_chance includes a TIED marginal |
| Mean absolute divergence excluded ties | Mean absolute divergence includes every decisive cell |
| Schema field `excludedTiedCells` (count of dropped data) | Schema field `tiedCells` (informational count, data is kept) |
| UI note: \"Excluded N tied cells from the agreement matrix\" | UI note: \"N cells had at least one model split 50/50 (counted as a third category in kappa, not excluded)\" |

## Validation

- API: 29/29 tests pass (math + integration)
- Web: ModelAgreement* component tests pass
- Full preflight: lint+build green for shared, db, api, web — 0 errors
- No snapshot version bump needed: this changes how we *compute* over existing snapshot data, not the snapshot shape

## Methodology note

3-category kappa numerically tends to be slightly higher than 2-category for the same data (lower max chance agreement → higher kappa for same observed agreement). The Landis-Koch interpretation labels still apply. This is the same scale that content-analysis researchers use; not novel methodology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)