### PR TITLE
fix(model-agreement): equal-weight value pairs in headline kappa

### DIFF
--- a/cloud/apps/api/src/services/model-agreement/aggregation.ts
+++ b/cloud/apps/api/src/services/model-agreement/aggregation.ts
@@ -1,10 +1,8 @@
 import {
   cohensKappa,
-  equalWeightAggregate,
   isTied,
   kappaInterpretation,
   MIN_TRIALS_FOR_CONSISTENCY,
-  percentAgreement,
 } from './math.js';
 import type {
   ModelAgreementBuildProgressShape,
@@ -75,14 +73,6 @@ export function sortModels(models: ReadonlyArray<ModelSummary>): ModelSummary[] 
     const labelDelta = left.label.localeCompare(right.label);
     return labelDelta !== 0 ? labelDelta : left.modelId.localeCompare(right.modelId);
   });
-}
-
-function mean(values: ReadonlyArray<number>): number | null {
-  if (values.length === 0) {
-    return null;
-  }
-
-  return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
 export function parseCellLevelOutcomeKey(key: string): {
@@ -227,14 +217,60 @@ export function collectComparableCells(params: {
   return { cells, tiedCells };
 }
 
+type NestedCellValues = Map<string /* valuePairKey */, Map<string /* definitionId */, number[]>>;
+
+function pushNested(
+  map: NestedCellValues,
+  valuePairKey: string,
+  definitionId: string,
+  value: number,
+): void {
+  let byVignette = map.get(valuePairKey);
+  if (byVignette == null) {
+    byVignette = new Map<string, number[]>();
+    map.set(valuePairKey, byVignette);
+  }
+  const bucket = byVignette.get(definitionId) ?? [];
+  bucket.push(value);
+  byVignette.set(definitionId, bucket);
+}
+
 /**
- * Three-category Cohen's kappa over A / TIED / B.
+ * Three-level equal-weight aggregation: cell → vignette → value-pair → headline.
  *
- * Per-vignette aggregation: for each vignette compute the fraction of cells
- * in each category for each model, then equal-weight average those fractions
- * across vignettes. P_chance = sum over categories of pX(k) * pY(k). Both
- * models tied counts as agreement; one tied + one decided counts as
- * disagreement.
+ * Each vignette is the equal-weighted mean of its cells. Each value pair is the
+ * equal-weighted mean of its vignettes. The headline is the equal-weighted mean
+ * of all value pairs. A value pair backed by 6 vignettes contributes the same
+ * to the headline as one backed by 1 vignette.
+ *
+ * Returns null if there is no data at any level.
+ */
+function aggregateNested(map: NestedCellValues): number | null {
+  const valuePairAverages: number[] = [];
+  for (const byVignette of map.values()) {
+    const vignetteAverages: number[] = [];
+    for (const cellValues of byVignette.values()) {
+      if (cellValues.length === 0) continue;
+      vignetteAverages.push(cellValues.reduce((sum, value) => sum + value, 0) / cellValues.length);
+    }
+    if (vignetteAverages.length === 0) continue;
+    valuePairAverages.push(vignetteAverages.reduce((sum, value) => sum + value, 0) / vignetteAverages.length);
+  }
+  if (valuePairAverages.length === 0) return null;
+  return valuePairAverages.reduce((sum, value) => sum + value, 0) / valuePairAverages.length;
+}
+
+/**
+ * Three-category Cohen's kappa over A / TIED / B with three-level equal-weight
+ * aggregation.
+ *
+ * Aggregation chain: cell → vignette → value-pair → headline. Each level is
+ * equal-weighted, so neither cells-per-vignette nor vignettes-per-value-pair
+ * bias the headline. A value pair tested by many vignettes contributes the
+ * same to the cross-pair number as one tested by few.
+ *
+ * Both models tied counts as agreement; one tied + one decided counts as
+ * disagreement. P_chance = sum over categories of pX(k) * pY(k).
  */
 export function summarizePairCells(cells: ReadonlyArray<ComparableCell>): PairMetrics {
   if (cells.length === 0) {
@@ -247,63 +283,35 @@ export function summarizePairCells(cells: ReadonlyArray<ComparableCell>): PairMe
     };
   }
 
-  const perVignetteAgreementRates = new Map<string, { matchedCells: number; totalCells: number }>();
-  const perVignetteDivergences = new Map<string, number[]>();
-  const perVignetteFractionsAByModel: Record<'A' | 'B', Map<string, number[]>> = {
-    A: new Map<string, number[]>(),
-    B: new Map<string, number[]>(),
-  };
-  const perVignetteFractionsTiedByModel: Record<'A' | 'B', Map<string, number[]>> = {
-    A: new Map<string, number[]>(),
-    B: new Map<string, number[]>(),
-  };
-  const perVignetteFractionsBByModel: Record<'A' | 'B', Map<string, number[]>> = {
-    A: new Map<string, number[]>(),
-    B: new Map<string, number[]>(),
-  };
-
-  function pushChoiceIndicator(
-    map: Map<string, number[]>,
-    definitionId: string,
-    indicator: number,
-  ): void {
-    const bucket = map.get(definitionId) ?? [];
-    bucket.push(indicator);
-    map.set(definitionId, bucket);
-  }
+  const agreement: NestedCellValues = new Map();
+  const divergence: NestedCellValues = new Map();
+  const indicatorAx: NestedCellValues = new Map();
+  const indicatorTx: NestedCellValues = new Map();
+  const indicatorBx: NestedCellValues = new Map();
+  const indicatorAy: NestedCellValues = new Map();
+  const indicatorTy: NestedCellValues = new Map();
+  const indicatorBy: NestedCellValues = new Map();
 
   for (const cell of cells) {
-    const agreementBucket = perVignetteAgreementRates.get(cell.definitionId) ?? { matchedCells: 0, totalCells: 0 };
-    agreementBucket.totalCells += 1;
-    if (cell.agrees) {
-      agreementBucket.matchedCells += 1;
-    }
-    perVignetteAgreementRates.set(cell.definitionId, agreementBucket);
-
-    const divergenceBucket = perVignetteDivergences.get(cell.definitionId) ?? [];
-    divergenceBucket.push(cell.divergence);
-    perVignetteDivergences.set(cell.definitionId, divergenceBucket);
-
-    pushChoiceIndicator(perVignetteFractionsAByModel.A, cell.definitionId, cell.modelAChoice === 'A' ? 1 : 0);
-    pushChoiceIndicator(perVignetteFractionsTiedByModel.A, cell.definitionId, cell.modelAChoice === 'TIED' ? 1 : 0);
-    pushChoiceIndicator(perVignetteFractionsBByModel.A, cell.definitionId, cell.modelAChoice === 'B' ? 1 : 0);
-    pushChoiceIndicator(perVignetteFractionsAByModel.B, cell.definitionId, cell.modelBChoice === 'A' ? 1 : 0);
-    pushChoiceIndicator(perVignetteFractionsTiedByModel.B, cell.definitionId, cell.modelBChoice === 'TIED' ? 1 : 0);
-    pushChoiceIndicator(perVignetteFractionsBByModel.B, cell.definitionId, cell.modelBChoice === 'B' ? 1 : 0);
+    pushNested(agreement, cell.valuePairKey, cell.definitionId, cell.agrees ? 1 : 0);
+    pushNested(divergence, cell.valuePairKey, cell.definitionId, cell.divergence);
+    pushNested(indicatorAx, cell.valuePairKey, cell.definitionId, cell.modelAChoice === 'A' ? 1 : 0);
+    pushNested(indicatorTx, cell.valuePairKey, cell.definitionId, cell.modelAChoice === 'TIED' ? 1 : 0);
+    pushNested(indicatorBx, cell.valuePairKey, cell.definitionId, cell.modelAChoice === 'B' ? 1 : 0);
+    pushNested(indicatorAy, cell.valuePairKey, cell.definitionId, cell.modelBChoice === 'A' ? 1 : 0);
+    pushNested(indicatorTy, cell.valuePairKey, cell.definitionId, cell.modelBChoice === 'TIED' ? 1 : 0);
+    pushNested(indicatorBy, cell.valuePairKey, cell.definitionId, cell.modelBChoice === 'B' ? 1 : 0);
   }
 
-  const agreementRates = Array.from(perVignetteAgreementRates.values())
-    .map((bucket) => percentAgreement(bucket.matchedCells, bucket.totalCells))
-    .filter((value): value is number => value != null);
-  const percentAgreementValue = mean(agreementRates);
-  const meanAbsoluteDivergence = equalWeightAggregate(Array.from(perVignetteDivergences.values()));
+  const percentAgreementValue = aggregateNested(agreement);
+  const meanAbsoluteDivergence = aggregateNested(divergence);
 
-  const pAx = equalWeightAggregate(Array.from(perVignetteFractionsAByModel.A.values()));
-  const pTx = equalWeightAggregate(Array.from(perVignetteFractionsTiedByModel.A.values()));
-  const pBx = equalWeightAggregate(Array.from(perVignetteFractionsBByModel.A.values()));
-  const pAy = equalWeightAggregate(Array.from(perVignetteFractionsAByModel.B.values()));
-  const pTy = equalWeightAggregate(Array.from(perVignetteFractionsTiedByModel.B.values()));
-  const pBy = equalWeightAggregate(Array.from(perVignetteFractionsBByModel.B.values()));
+  const pAx = aggregateNested(indicatorAx);
+  const pTx = aggregateNested(indicatorTx);
+  const pBx = aggregateNested(indicatorBx);
+  const pAy = aggregateNested(indicatorAy);
+  const pTy = aggregateNested(indicatorTy);
+  const pBy = aggregateNested(indicatorBy);
 
   const chanceAgreement = pAx != null && pTx != null && pBx != null
     && pAy != null && pTy != null && pBy != null
@@ -322,6 +330,12 @@ export function summarizePairCells(cells: ReadonlyArray<ComparableCell>): PairMe
   };
 }
 
+/**
+ * Trial consistency for a single model with three-level equal-weight
+ * aggregation (cell → vignette → value-pair → headline). Each value pair
+ * contributes equally to the headline regardless of how many vignettes
+ * back it.
+ */
 export function summarizeTrialConsistency(params: {
   positionCells: ReadonlyMap<string, PositionCell>;
   modelId: string;
@@ -329,7 +343,7 @@ export function summarizeTrialConsistency(params: {
   cellsObserved: number;
   meanTrialConsistency: number | null;
 } {
-  const perVignetteConsistencies = new Map<string, number[]>();
+  const consistency: NestedCellValues = new Map();
   let cellsObserved = 0;
 
   for (const position of params.positionCells.values()) {
@@ -348,16 +362,14 @@ export function summarizeTrialConsistency(params: {
       continue;
     }
 
-    const consistency = Math.max(proportionA, 1 - proportionA);
-    const bucket = perVignetteConsistencies.get(position.definitionId) ?? [];
-    bucket.push(consistency);
-    perVignetteConsistencies.set(position.definitionId, bucket);
+    const valuePairKey = `${position.canonicalA}::${position.canonicalB}`;
+    pushNested(consistency, valuePairKey, position.definitionId, Math.max(proportionA, 1 - proportionA));
     cellsObserved += 1;
   }
 
   return {
     cellsObserved,
-    meanTrialConsistency: equalWeightAggregate(Array.from(perVignetteConsistencies.values())),
+    meanTrialConsistency: aggregateNested(consistency),
   };
 }
 

--- a/cloud/apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts
@@ -557,4 +557,71 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
       noisy: false,
     });
   });
+
+  it('equal-weights value pairs in the headline kappa (no over-tested-pair bias)', async () => {
+    // Setup: two value pairs of very different sizes.
+    //
+    // Pair 1 (Achievement vs Tradition, 1 vignette, 2 cells): models PERFECTLY DISAGREE.
+    //   Both pick canonicalA at fractions that produce kappa near -1 within the pair.
+    //
+    // Pair 2 (Hedonism vs Stimulation, 1 vignette, 4 cells): models PERFECTLY AGREE.
+    //   Both pick canonicalA on every cell.
+    //
+    // Cell counts differ (2 vs 4). Under the OLD aggregation (vignette equal-weight,
+    // value-pair NOT equal-weight) the cells-per-vignette didn't bias things, but
+    // vignettes-per-pair did — and with 1 vignette each here the old and new
+    // approaches would coincide. To prove value-pair equal-weighting matters, we
+    // need different vignette counts per pair.
+    //
+    // So: pair 1 has 2 vignettes (disagreeing); pair 2 has 1 vignette (agreeing).
+    // Old aggregation: 3 vignette slots (2 disagree + 1 agree) → headline leans
+    //   toward disagree.
+    // New aggregation: 2 value-pair slots (1 disagree + 1 agree) → headline lands
+    //   in the middle.
+    mocks.readModelAgreementSnapshotStateFromSnapshot.mockResolvedValue({
+      cellLevelOutcomes: snapshot({
+        // Pair 1, vignette 1: A picks canonicalA, B picks canonicalB
+        'def-1::model-a::Achievement::Tradition::1::1': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        'def-1::model-b::Achievement::Tradition::1::1': { aChoices: 0, bChoices: 6, neutrals: 0 },
+        'def-1::model-a::Achievement::Tradition::2::2': { aChoices: 0, bChoices: 6, neutrals: 0 },
+        'def-1::model-b::Achievement::Tradition::2::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        // Pair 1, vignette 2: same disagreement pattern
+        'def-2::model-a::Achievement::Tradition::1::1': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        'def-2::model-b::Achievement::Tradition::1::1': { aChoices: 0, bChoices: 6, neutrals: 0 },
+        'def-2::model-a::Achievement::Tradition::2::2': { aChoices: 0, bChoices: 6, neutrals: 0 },
+        'def-2::model-b::Achievement::Tradition::2::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        // Pair 2, vignette 3: both pick canonicalA always (perfect agreement)
+        'def-3::model-a::Hedonism::Stimulation::1::1': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        'def-3::model-b::Hedonism::Stimulation::1::1': { aChoices: 6, bChoices: 0, neutrals: 0 },
+      }),
+      buildProgress: null,
+      inputHash: 'hash-equal-weight',
+    });
+
+    const response = await graphqlRequest(agreementQuery, {
+      modelIds: ['model-a', 'model-b'],
+      scope: 'ALL_DOMAINS',
+      signature: 'sig-1',
+    });
+
+    const agreement = response.body.data.modelAgreementOnTradeoffs as {
+      pairwiseAgreementMatrix: Array<{
+        percentAgreement: number | null;
+        meanAbsoluteDivergence: number | null;
+      }>;
+    };
+
+    // With value-pair equal-weighting:
+    //   Pair 1 percent-agreement = 0 (every cell disagrees)
+    //   Pair 2 percent-agreement = 1 (every cell agrees)
+    //   Headline percent-agreement = (0 + 1) / 2 = 0.5
+    expect(agreement.pairwiseAgreementMatrix).toHaveLength(1);
+    expect(agreement.pairwiseAgreementMatrix[0]?.percentAgreement).toBeCloseTo(0.5, 6);
+
+    // Same logic for divergence:
+    //   Pair 1 mean abs divergence = 1 (each cell |1 - 0| = 1)
+    //   Pair 2 mean abs divergence = 0 (each cell |1 - 1| = 0)
+    //   Headline = (1 + 0) / 2 = 0.5
+    expect(agreement.pairwiseAgreementMatrix[0]?.meanAbsoluteDivergence).toBeCloseTo(0.5, 6);
+  });
 });


### PR DESCRIPTION
## Summary

Closes a methodological inconsistency in the aggregation chain. Cells were equal-weighted within a vignette and vignettes were equal-weighted within the headline — but value pairs were NOT equal-weighted. A value pair backed by 6 vignettes was contributing 6 slots to the cross-pair mean while a pair backed by 1 vignette contributed 1.

That meant the headline kappa leaned toward whichever value tradeoffs we happened to test more, even though that's an artifact of testing decisions, not intrinsic importance.

## Aggregation chain (now consistent at every level)

| Level | Aggregation |
|-------|-------------|
| Within a cell | Trials → proportion (one number per cell) |
| Within a vignette | Cells → vignette mean (equal weight per cell) |
| Within a value pair | Vignettes → value-pair mean (equal weight per vignette) |
| Across the model pair | Value pairs → headline mean (equal weight per value pair) |

Applied to: `cohensKappa`, `percentAgreement`, `meanAbsoluteDivergence` in the headline matrix; and `meanTrialConsistency` per model.

The drilldown is unchanged (each row IS a value pair, so within-row aggregation is two-level by design — that was already correct).

## What this changes in real numbers

A model pair where the two models perfectly disagree on Achievement/Tradition (2 vignettes) and perfectly agree on Hedonism/Stimulation (1 vignette):

- **Before:** headline percent-agreement ≈ 0.33 (3 vignette slots: 2 disagree + 1 agree)
- **After:** headline percent-agreement = 0.50 (2 value-pair slots: 1 disagree + 1 agree)

Same models, same data — only the aggregation method changed.

## Validation

- 30/30 API model-agreement tests pass (added 1 new integration test asserting the equal-weight-by-value-pair invariant)
- 1439/1439 web tests pass
- Full preflight: lint+build green for shared, db, api, web — 0 errors
- No snapshot version bump: this changes how we compute over existing snapshot data, not the snapshot shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)