### PR TITLE
feat(model-clusters): add kappa-agreement option to data source toggle

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-clustering.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-clustering.ts
@@ -62,7 +62,7 @@ export type ClusterModelInput = {
 
 export type ClusteringMethod = 'upgma' | 'ward';
 export type ClusterDistanceMethod = 'cosine' | 'euclidean' | 'absolute-value' | 'spearman' | 'kendall';
-export type ClusterDataSource = 'log-odds' | 'win-rate';
+export type ClusterDataSource = 'log-odds' | 'win-rate' | 'kappa-agreement';
 
 // --- Calibration constants ---
 const OUTLIER_SILHOUETTE_THRESHOLD = 0.2;
@@ -567,4 +567,51 @@ export function computeClusterAnalysis(models: ClusterModelInput[], method: Clus
     return v.map((x) => x - mean);
   });
   return runClusteringFromDistMatrix(models, cosineDistanceMatrix(vectors), valueKeys, method);
+}
+
+/**
+ * Build a hierarchical-clustering distance matrix from a kappa matrix.
+ *
+ * Maps Cohen's kappa from [-1, 1] to a distance in [0, 1]:
+ *   kappa =  1   →  distance = 0    (perfect agreement, identical players)
+ *   kappa =  0   →  distance = 0.5  (chance agreement, no signal)
+ *   kappa = -1   →  distance = 1    (worse than chance, opposite players)
+ *
+ * Null kappa entries (no overlap or degenerate marginals) are mapped to
+ * 0.5 — the same as "no signal" — which avoids breaking the distance
+ * matrix while not pretending we know more than we do.
+ */
+export function kappaDistanceMatrix(kappaMatrix: ReadonlyArray<ReadonlyArray<number | null>>): number[][] {
+  const n = kappaMatrix.length;
+  const matrix: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0));
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const k = kappaMatrix[i]?.[j];
+      const dist = k == null ? 0.5 : Math.max(0, Math.min(1, (1 - k) / 2));
+      matrix[i]![j] = dist;
+      matrix[j]![i] = dist;
+    }
+  }
+  return matrix;
+}
+
+/**
+ * Cluster models by behavioral agreement (Cohen's kappa) rather than by
+ * value-score similarity. The grouping is driven by which models make the
+ * same choices on the same scenarios; the per-cluster centroids are still
+ * computed from the models' log-odds scores so the resulting centroids and
+ * fault lines describe what each behaviorally-similar group tends to value.
+ */
+export function computeKappaClusterAnalysis(
+  models: ClusterModelInput[],
+  kappaMatrix: ReadonlyArray<ReadonlyArray<number | null>>,
+  method: ClusteringMethod = 'upgma',
+): ClusterAnalysis {
+  if (models.length === 0) {
+    return { clusters: [], faultLinesByPair: {}, defaultPair: null, skipped: true,
+      skipReason: 'No models provided.' };
+  }
+  const valueKeys = Object.keys(models[0]!.scores);
+  const distMatrix = kappaDistanceMatrix(kappaMatrix);
+  return runClusteringFromDistMatrix(models, distMatrix, valueKeys, method, 'log-odds');
 }

--- a/cloud/apps/api/src/graphql/queries/model-agreement-cluster-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-cluster-analysis.ts
@@ -1,0 +1,220 @@
+import { ValidationError } from '@valuerank/shared';
+import { builder } from '../builder.js';
+import { getModelsFromDatabase } from '../../config/models.js';
+import { ClusterAnalysisRef } from './domain/types.js';
+import {
+  computeKappaClusterAnalysis,
+  type ClusterAnalysis,
+  type ClusteringMethod,
+  type ClusterModelInput,
+} from './domain-clustering.js';
+import {
+  buildPositionCells,
+  buildSelectedModels,
+  collectComparableCells,
+  normalizeModelIds,
+  summarizePairCells,
+} from '../../services/model-agreement/aggregation.js';
+import { resolveDomainAnalysisScopeDefinitions } from '../../services/analysis/domain-analysis-scope-loader.js';
+import { resolveSignatureRuns } from './domain/shared.js';
+import {
+  getDomainAnalysisResult,
+  queueDomainAnalysisRefresh,
+  readModelAgreementSnapshotStateFromSnapshot,
+} from '../../services/analysis/domain-analysis-cache.js';
+import type { DomainAnalysisScope } from '../../services/analysis/domain-analysis-scope.js';
+import type { Context } from '../context.js';
+
+const ALL_DOMAINS_SCOPE_ID = 'all-domains';
+const REFRESH_REASON = 'model-agreement-cluster-analysis-page-load-missing';
+
+function emptyClusterAnalysis(reason: string): ClusterAnalysis {
+  return {
+    clusters: [],
+    faultLinesByPair: {},
+    defaultPair: null,
+    skipped: true,
+    skipReason: reason,
+  };
+}
+
+async function resolveScope(params: {
+  scope: DomainAnalysisScope;
+  domainId: string | null;
+  signature: string;
+}): Promise<void> {
+  const scopeData = await resolveDomainAnalysisScopeDefinitions({
+    scope: params.scope,
+    domainId: params.domainId ?? ALL_DOMAINS_SCOPE_ID,
+  });
+  const resolvedSignatureRuns = await resolveSignatureRuns(
+    scopeData.latestDefinitionIds,
+    params.signature,
+    scopeData.domain.defaultModelIds,
+  );
+  if (resolvedSignatureRuns.filteredSourceRunIds.length === 0) {
+    throw new ValidationError('Kappa clustering could not be computed because no completed runs were found for the selected scope.');
+  }
+}
+
+async function readAgreementSnapshot(params: {
+  scope: DomainAnalysisScope;
+  domainId: string | null;
+  signature: string;
+  ctx: Context;
+}): Promise<Awaited<ReturnType<typeof readModelAgreementSnapshotStateFromSnapshot>>> {
+  const snapshotState = await readModelAgreementSnapshotStateFromSnapshot(
+    params.scope,
+    params.domainId ?? ALL_DOMAINS_SCOPE_ID,
+    params.signature,
+  );
+  if (snapshotState != null) {
+    return snapshotState;
+  }
+
+  await queueDomainAnalysisRefresh({
+    scope: params.scope,
+    domainId: params.domainId ?? ALL_DOMAINS_SCOPE_ID,
+    signature: params.signature,
+    reason: REFRESH_REASON,
+  });
+  params.ctx.log.info(
+    { scope: params.scope, domainId: params.domainId, signature: params.signature },
+    'Kappa cluster analysis snapshot not ready — rebuild queued, returning pending',
+  );
+  return null;
+}
+
+async function buildKappaMatrix(params: {
+  positionCells: ReturnType<typeof buildPositionCells>['positionCells'];
+  modelIds: ReadonlyArray<string>;
+}): Promise<Array<Array<number | null>>> {
+  const n = params.modelIds.length;
+  const matrix: Array<Array<number | null>> = Array.from({ length: n }, () => new Array<number | null>(n).fill(null));
+  for (let i = 0; i < n; i += 1) {
+    matrix[i]![i] = 1;
+  }
+  for (let i = 0; i < n; i += 1) {
+    for (let j = i + 1; j < n; j += 1) {
+      const modelAId = params.modelIds[i]!;
+      const modelBId = params.modelIds[j]!;
+      const { cells } = collectComparableCells({
+        positionCells: params.positionCells,
+        modelAId,
+        modelBId,
+      });
+      const kappa = summarizePairCells(cells).cohensKappa;
+      matrix[i]![j] = kappa;
+      matrix[j]![i] = kappa;
+    }
+  }
+  return matrix;
+}
+
+export async function resolveModelAgreementClusterAnalysis(
+  _root: unknown,
+  args: {
+    modelIds: ReadonlyArray<string | number>;
+    domainId?: string | number | null | undefined;
+    scope: string;
+    signature: string;
+    method: string;
+  },
+  ctx: Context,
+): Promise<ClusterAnalysis> {
+  const scopeValue = String(args.scope);
+  if (scopeValue !== 'DOMAIN' && scopeValue !== 'ALL_DOMAINS') {
+    throw new ValidationError(`Unsupported scope: ${scopeValue}`);
+  }
+  const scope: DomainAnalysisScope = scopeValue;
+
+  const domainId = args.domainId != null ? String(args.domainId).trim() : null;
+  if (scope === 'DOMAIN' && (domainId == null || domainId.length === 0)) {
+    throw new ValidationError('domainId is required when scope is DOMAIN');
+  }
+
+  const signature = String(args.signature).trim();
+  if (signature.length === 0) {
+    throw new ValidationError('signature is required');
+  }
+
+  const methodValue = String(args.method);
+  if (methodValue !== 'upgma' && methodValue !== 'ward') {
+    throw new ValidationError(`Unsupported clustering method: ${methodValue}`);
+  }
+  const method: ClusteringMethod = methodValue;
+
+  const selectedModelIds = normalizeModelIds(args.modelIds.map(String));
+  if (selectedModelIds.length < 3) {
+    return emptyClusterAnalysis('Kappa clustering requires at least 3 distinct modelIds.');
+  }
+
+  const activeModels = await getModelsFromDatabase({ activeOnly: true, availableOnly: false });
+  const labelByModelId = new Map(activeModels.map((model) => [model.modelId, model.displayName] as const));
+  const selectedModels = buildSelectedModels(selectedModelIds, labelByModelId);
+  const selectedModelIdSet = new Set(selectedModels.map((model) => model.modelId));
+
+  await resolveScope({ scope, domainId, signature });
+
+  const snapshotState = await readAgreementSnapshot({ scope, domainId, signature, ctx });
+  if (snapshotState == null) {
+    return emptyClusterAnalysis('Kappa cluster analysis is rebuilding — try again in a moment.');
+  }
+
+  const cellLevelOutcomes = snapshotState.cellLevelOutcomes;
+  if (cellLevelOutcomes == null) {
+    return emptyClusterAnalysis('Kappa cluster analysis is rebuilding — try again in a moment.');
+  }
+  const { positionCells, cellsObservedByModelId } = buildPositionCells(cellLevelOutcomes, selectedModelIdSet);
+  const availableModels = selectedModels.filter((model) => (cellsObservedByModelId.get(model.modelId) ?? 0) > 0);
+  if (availableModels.length < 3) {
+    return emptyClusterAnalysis('Kappa clustering requires at least 3 models with cell-level data in the selected scope.');
+  }
+
+  // Pull log-odds scores from the domain-analysis result so the cluster centroids
+  // and fault-lines are still labeled by what each behaviorally-similar group
+  // tends to value. Falls back to zeros if a model is missing from the result.
+  const domainAnalysis = await getDomainAnalysisResult({
+    scope,
+    domainId: domainId ?? ALL_DOMAINS_SCOPE_ID,
+    requestedSignature: signature,
+  });
+  const scoresByModelId = new Map<string, Record<string, number>>();
+  for (const model of domainAnalysis.models) {
+    const scoreEntries = model.values.map((entry) => [entry.valueKey, entry.score] as const);
+    scoresByModelId.set(model.model, Object.fromEntries(scoreEntries));
+  }
+  // Discover the value-key set deterministically — every domain-analysis model
+  // has the same set of values, so pull from the first model that has data.
+  const sampleValueScores = scoresByModelId.values().next().value;
+  if (sampleValueScores == null) {
+    return emptyClusterAnalysis('Kappa cluster analysis could not be computed because the domain-analysis snapshot has no model scores.');
+  }
+  const valueKeys = Object.keys(sampleValueScores);
+  const zeroScores: Record<string, number> = Object.fromEntries(valueKeys.map((vk) => [vk, 0]));
+
+  const clusterInputs: ClusterModelInput[] = availableModels.map((model) => ({
+    model: model.modelId,
+    label: model.label,
+    scores: scoresByModelId.get(model.modelId) ?? zeroScores,
+  }));
+
+  const orderedModelIds = clusterInputs.map((entry) => entry.model);
+  const kappaMatrix = await buildKappaMatrix({ positionCells, modelIds: orderedModelIds });
+
+  return computeKappaClusterAnalysis(clusterInputs, kappaMatrix, method);
+}
+
+builder.queryField('modelAgreementClusterAnalysis', (t) =>
+  t.field({
+    type: ClusterAnalysisRef,
+    args: {
+      modelIds: t.arg.idList({ required: true }),
+      domainId: t.arg.id({ required: false }),
+      scope: t.arg.string({ required: true }),
+      signature: t.arg.string({ required: true }),
+      method: t.arg.string({ required: true }),
+    },
+    resolve: resolveModelAgreementClusterAnalysis,
+  }),
+);

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -2721,6 +2721,7 @@ type Query {
 
   "\n      Get the currently authenticated user.\n      Returns null if not authenticated.\n    "
   me: User
+  modelAgreementClusterAnalysis(domainId: ID, method: String!, modelIds: [ID!]!, scope: String!, signature: String!): ClusterAnalysis!
   modelAgreementOnTradeoffs(domainId: ID, modelIds: [ID!]!, scope: String!, signature: String!): ModelAgreementResult!
   modelPairDivergenceBreakdown(domainId: ID, modelAId: ID!, modelBId: ID!, scope: String!, signature: String!): PairDivergenceBreakdown!
 

--- a/cloud/apps/web/src/api/operations/modelAgreementClusterAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/modelAgreementClusterAnalysis.graphql
@@ -1,0 +1,34 @@
+query ModelAgreementClusterAnalysis(
+  $modelIds: [ID!]!
+  $domainId: ID
+  $scope: String!
+  $signature: String!
+  $method: String!
+) {
+  modelAgreementClusterAnalysis(
+    modelIds: $modelIds
+    domainId: $domainId
+    scope: $scope
+    signature: $signature
+    method: $method
+  ) {
+    skipped
+    skipReason
+    defaultPair
+    clusters {
+      id
+      name
+      definingValues
+      centroid
+      members {
+        model
+        label
+        silhouetteScore
+        isOutlier
+        nearestClusterIds
+        distancesToNearestClusters
+      }
+    }
+    faultLinesByPair
+  }
+}

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -26,7 +26,7 @@ const LEGEND_COLORS = [
 ] as const;
 
 type ClusteringLinkage = 'upgma' | 'ward';
-type ClusterDataSource = 'log-odds' | 'win-rate';
+type ClusterDataSource = 'log-odds' | 'win-rate' | 'kappa-agreement';
 
 const LINKAGE_OPTIONS: Array<{ value: ClusteringLinkage; label: string }> = [
   { value: 'upgma', label: 'UPGMA' },
@@ -35,6 +35,14 @@ const LINKAGE_OPTIONS: Array<{ value: ClusteringLinkage; label: string }> = [
 
 type ModelGroupsSectionProps = {
   clusterAnalysisByMethod?: Record<string, ClusterAnalysis>;
+  /**
+   * When dataSource === 'kappa-agreement', this prop supplies the cluster
+   * analysis derived from pairwise Cohen's kappa instead of the precomputed
+   * `clusterAnalysisByMethod` map (which only covers score-based variants).
+   */
+  kappaClusterAnalysis?: ClusterAnalysis | null;
+  kappaClusterLoading?: boolean;
+  kappaClusterError?: string | null;
   dataSource?: ClusterDataSource;
   distanceMethod?: CalculationMethod;
   models: ModelEntry[];
@@ -73,6 +81,9 @@ function getGroupLabel(cluster: DomainCluster): string {
 
 export function ModelGroupsSection({
   clusterAnalysisByMethod,
+  kappaClusterAnalysis = null,
+  kappaClusterLoading = false,
+  kappaClusterError = null,
   dataSource = 'log-odds',
   distanceMethod,
   models,
@@ -87,7 +98,9 @@ export function ModelGroupsSection({
   const [activeGroupIds, setActiveGroupIds] = useState<string[]>([]);
 
   const backendKey = `${dataSource}-${toBackendDistanceMethod(distanceMethod)}-${clusteringMethod}`;
-  const activeClusterAnalysis = clusterAnalysisByMethod?.[backendKey] ?? null;
+  const activeClusterAnalysis = dataSource === 'kappa-agreement'
+    ? kappaClusterAnalysis
+    : (clusterAnalysisByMethod?.[backendKey] ?? null);
 
   const hasGroupedClusters = activeClusterAnalysis != null && !activeClusterAnalysis.skipped;
   const groupedClusters = useMemo(() => activeClusterAnalysis?.clusters ?? [], [activeClusterAnalysis]);
@@ -132,8 +145,27 @@ export function ModelGroupsSection({
     viewMode === 'dot' ? 'dot map' : viewMode === 'bar' ? 'bar chart' : 'radar chart'
   }`;
 
+  const showKappaLoader = dataSource === 'kappa-agreement' && kappaClusterAnalysis == null && kappaClusterLoading && kappaClusterError == null;
+  const showKappaError = dataSource === 'kappa-agreement' && kappaClusterError != null;
+
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-4">
+      {dataSource === 'kappa-agreement' ? (
+        <p className="mb-3 rounded-md border border-teal-200 bg-teal-50 px-3 py-2 text-xs text-teal-900">
+          Models are grouped by behavioral agreement (Cohen&apos;s kappa on shared scenarios). Per-cluster centroids and
+          fault lines are still labeled with each group&apos;s average log-odds value scores.
+        </p>
+      ) : null}
+      {showKappaError ? (
+        <p className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-900">
+          Could not load kappa-based clustering: {kappaClusterError}
+        </p>
+      ) : null}
+      {showKappaLoader ? (
+        <p className="mb-3 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-700">
+          Loading kappa-based clustering…
+        </p>
+      ) : null}
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <div className="flex flex-wrap items-center gap-1.5">
           <h2 className="text-base font-medium text-gray-900">Model Clusters</h2>
@@ -287,9 +319,20 @@ export function ModelGroupsSection({
           </div>
         ) : (
           <>
-            {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} activeGroupIds={activeGroupIds} dataSource={groupDisplayMode === 'groups' ? dataSource : 'log-odds'} />}
-            {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} activeGroupIds={activeGroupIds} dataSource={groupDisplayMode === 'groups' ? dataSource : 'log-odds'} />}
-            {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} activeGroupIds={activeGroupIds} dataSource={groupDisplayMode === 'groups' ? dataSource : 'log-odds'} />}
+            {(() => {
+              // Plot dataSource only controls how centroids are scaled. Under
+              // 'kappa-agreement' the grouping is by kappa but centroids are
+              // still log-odds, so the plots use 'log-odds' for scaling.
+              const plotDataSource: 'log-odds' | 'win-rate' =
+                dataSource === 'win-rate' && groupDisplayMode === 'groups' ? 'win-rate' : 'log-odds';
+              return (
+                <>
+                  {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} activeGroupIds={activeGroupIds} dataSource={plotDataSource} />}
+                  {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} activeGroupIds={activeGroupIds} dataSource={plotDataSource} />}
+                  {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} activeGroupIds={activeGroupIds} dataSource={plotDataSource} />}
+                </>
+              );
+            })()}
 
             <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
               {clusters.map((cluster, index) => {

--- a/cloud/apps/web/src/components/models/ModelAnalysisSettingsBar.tsx
+++ b/cloud/apps/web/src/components/models/ModelAnalysisSettingsBar.tsx
@@ -1,7 +1,7 @@
 import { Button } from '../ui/Button';
 import { CALCULATION_METHODS, type CalculationMethod } from './ModelSimilarityMetrics';
 
-type DataSource = 'log-odds' | 'win-rate';
+type DataSource = 'log-odds' | 'win-rate' | 'kappa-agreement';
 
 type ModelAnalysisSettingsBarProps = {
   dataSource: DataSource;
@@ -13,6 +13,7 @@ type ModelAnalysisSettingsBarProps = {
 const DATA_SOURCE_OPTIONS: Array<{ value: DataSource; label: string }> = [
   { value: 'log-odds', label: 'Log Odds' },
   { value: 'win-rate', label: 'Win Rate' },
+  { value: 'kappa-agreement', label: 'Kappa Agreement' },
 ];
 
 export function ModelAnalysisSettingsBar({

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -2820,6 +2820,7 @@ export type Query = {
    *
    */
   me?: Maybe<User>;
+  modelAgreementClusterAnalysis: ClusterAnalysis;
   modelAgreementOnTradeoffs: ModelAgreementResult;
   modelPairDivergenceBreakdown: PairDivergenceBreakdown;
   /** Get token statistics for specific models. Useful for understanding prediction quality. */
@@ -3249,6 +3250,15 @@ export type QueryLlmProviderArgs = {
 export type QueryLlmProvidersArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryModelAgreementClusterAnalysisArgs = {
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  method: Scalars['String']['input'];
+  modelIds: Array<Scalars['ID']['input']>;
+  scope: Scalars['String']['input'];
+  signature: Scalars['String']['input'];
 };
 
 
@@ -4839,6 +4849,17 @@ export type SetProviderBalanceMutationVariables = Exact<{
 
 
 export type SetProviderBalanceMutation = { __typename?: 'Mutation', setProviderBalance: { __typename?: 'LlmProvider', id: string, name: string, displayName: string, maxParallelRequests: number, requestsPerMinute: number, isEnabled: boolean, balance?: number | null, createdAt: string, updatedAt: string } };
+
+export type ModelAgreementClusterAnalysisQueryVariables = Exact<{
+  modelIds: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  scope: Scalars['String']['input'];
+  signature: Scalars['String']['input'];
+  method: Scalars['String']['input'];
+}>;
+
+
+export type ModelAgreementClusterAnalysisQuery = { __typename?: 'Query', modelAgreementClusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } };
 
 export type ModelAgreementOnTradeoffsQueryVariables = Exact<{
   modelIds: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
@@ -7322,6 +7343,40 @@ export const SetProviderBalanceDocument = gql`
 
 export function useSetProviderBalanceMutation() {
   return Urql.useMutation<SetProviderBalanceMutation, SetProviderBalanceMutationVariables>(SetProviderBalanceDocument);
+};
+export const ModelAgreementClusterAnalysisDocument = gql`
+    query ModelAgreementClusterAnalysis($modelIds: [ID!]!, $domainId: ID, $scope: String!, $signature: String!, $method: String!) {
+  modelAgreementClusterAnalysis(
+    modelIds: $modelIds
+    domainId: $domainId
+    scope: $scope
+    signature: $signature
+    method: $method
+  ) {
+    skipped
+    skipReason
+    defaultPair
+    clusters {
+      id
+      name
+      definingValues
+      centroid
+      members {
+        model
+        label
+        silhouetteScore
+        isOutlier
+        nearestClusterIds
+        distancesToNearestClusters
+      }
+    }
+    faultLinesByPair
+  }
+}
+    `;
+
+export function useModelAgreementClusterAnalysisQuery(options: Omit<Urql.UseQueryArgs<ModelAgreementClusterAnalysisQueryVariables>, 'query'>) {
+  return Urql.useQuery<ModelAgreementClusterAnalysisQuery, ModelAgreementClusterAnalysisQueryVariables>({ query: ModelAgreementClusterAnalysisDocument, ...options });
 };
 export const ModelAgreementOnTradeoffsDocument = gql`
     query ModelAgreementOnTradeoffs($modelIds: [ID!]!, $domainId: ID, $scope: String!, $signature: String!) {

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -22,6 +22,12 @@ import {
   type ModelsAnalysisQueryVariables,
 } from '../api/operations/modelsAnalysis';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
+import { type ClusterAnalysis } from '../api/operations/domainAnalysis';
+import {
+  ModelAgreementClusterAnalysisDocument,
+  type ModelAgreementClusterAnalysisQuery,
+  type ModelAgreementClusterAnalysisQueryVariables,
+} from '../generated/graphql';
 import { ModelGroupsSection } from '../components/domains/ModelGroupsSection';
 import { ModelAnalysisSettingsBar } from '../components/models/ModelAnalysisSettingsBar';
 import { ModelSimilarityTableSection } from '../components/models/ModelSimilarityTableSection';
@@ -83,7 +89,7 @@ export function ModelsGroups() {
   const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
   const [clusteringMethod, setClusteringMethod] = useState<'upgma' | 'ward'>('ward');
-  const [dataSource, setDataSource] = useState<'log-odds' | 'win-rate'>('log-odds');
+  const [dataSource, setDataSource] = useState<'log-odds' | 'win-rate' | 'kappa-agreement'>('log-odds');
   const [similarityMethod, setSimilarityMethod] = useState<CalculationMethod>('weighted-euclidean');
 
   const [{ data: signatureData, fetching: signaturesLoading, error: signaturesError }] = useQuery<
@@ -204,6 +210,41 @@ export function ModelsGroups() {
     }
   }, [defaultModelIds, selectedModelIds]);
   const visibleModelIds = selectedModelIds ?? defaultModelIds;
+
+  const isKappaClusterMode = dataSource === 'kappa-agreement';
+  const [{ data: kappaClusterData, fetching: kappaClusterFetching, error: kappaClusterError }] = useQuery<
+    ModelAgreementClusterAnalysisQuery,
+    ModelAgreementClusterAnalysisQueryVariables
+  >({
+    query: ModelAgreementClusterAnalysisDocument,
+    variables: {
+      modelIds: visibleModelIds,
+      ...(selectedScope === 'DOMAIN' && selectedDomainId !== '' ? { domainId: selectedDomainId } : {}),
+      scope: selectedScope,
+      signature: selectedSignature,
+      method: clusteringMethod,
+    },
+    pause:
+      !isKappaClusterMode
+      || selectedSignature === ''
+      || visibleModelIds.length < 3
+      || (selectedScope === 'DOMAIN' && selectedDomainId === '')
+      || llmModelsData == null,
+    requestPolicy: 'cache-and-network',
+  });
+
+  // Bridge codegen's optional-nullable fields to ClusterAnalysis's strict-nullable fields.
+  const kappaClusterAnalysis = useMemo<ClusterAnalysis | null>(() => {
+    const raw = kappaClusterData?.modelAgreementClusterAnalysis;
+    if (raw == null) return null;
+    return {
+      skipped: raw.skipped,
+      skipReason: raw.skipReason ?? null,
+      defaultPair: raw.defaultPair ?? null,
+      clusters: raw.clusters as ClusterAnalysis['clusters'],
+      faultLinesByPair: (raw.faultLinesByPair ?? {}) as ClusterAnalysis['faultLinesByPair'],
+    };
+  }, [kappaClusterData]);
   const transcriptCount = useMemo(
     () => countAnalyzedTranscripts(data?.domainAnalysis.models ?? [], visibleModelIds),
     [data?.domainAnalysis.models, visibleModelIds],
@@ -344,6 +385,9 @@ export function ModelsGroups() {
         <div className="space-y-6">
           <ModelGroupsSection
             clusterAnalysisByMethod={data?.domainAnalysis.clusterAnalysisByMethod}
+            kappaClusterAnalysis={kappaClusterAnalysis}
+            kappaClusterLoading={kappaClusterFetching}
+            kappaClusterError={kappaClusterError?.message ?? null}
             dataSource={dataSource}
             distanceMethod={similarityMethod}
             models={filteredModels}


### PR DESCRIPTION
## Summary

Adds a third option on the Model Clusters chart's existing 'data source' toggle: **Kappa Agreement**. When selected, models are grouped by Cohen's kappa (behavioral agreement on shared scenarios) instead of by log-odds or win-rate value-score similarity.

The two answer different questions:
- **Score-based** (existing): which models have similar value profiles? — *what they value*
- **Kappa-based** (new): which models make the same choices on the same scenarios? — *what they decide*

These can give different answers. Two models with identical averaged value profiles can disagree case-by-case (high score similarity, low kappa). Two models that consistently make the same choices can be labeled differently in score-space (low score similarity, high kappa).

## Backend

- `domain-clustering.ts`: adds `'kappa-agreement'` to `ClusterDataSource`; new helpers `kappaDistanceMatrix` and `computeKappaClusterAnalysis` (distance = `(1 − kappa) / 2`, mapped to `[0, 1]`).
- New resolver `model-agreement-cluster-analysis.ts`:
  - Reads `cellLevelOutcomes` from the agreement snapshot
  - Computes pairwise kappa between selected models (same code path as the agreement matrix)
  - Pulls log-odds scores from the domain-analysis result for centroids and fault-lines
  - Runs Ward/UPGMA hierarchical clustering with the kappa-derived distance matrix
- New GraphQL query: `modelAgreementClusterAnalysis(modelIds, scope, signature, method, domainId?)`

## Frontend

- `ModelAnalysisSettingsBar`: third radio option \"Kappa Agreement\" on the existing data-source row
- `ModelGroupsSection`:
  - Accepts a new `kappaClusterAnalysis` prop; when `dataSource === 'kappa-agreement'` it uses this instead of the precomputed `clusterAnalysisByMethod` map
  - Adds an inline note explaining the methodology when in kappa mode
  - Shows a loader and error state for the dedicated kappa query
- `ModelsGroups` page: fires `ModelAgreementClusterAnalysisQuery` when the toggle is on (paused otherwise)

## What stays the same

- The cluster centroids and per-cluster fault-line plots are still log-odds-based. Kappa is pairwise, not per-value, so it can't drive value-axis visualizations directly. Result: models get grouped by who-makes-the-same-choices-as-whom, but each group is still labeled by what its members tend to value on average.
- The existing log-odds / win-rate options are unchanged.
- No snapshot version bump.

## Validation

- 30/30 API model-agreement tests pass
- 1439/1439 web tests pass
- Full preflight: lint+build green for shared, db, api, web — 0 errors

## Production smoke test plan

After Railway deploy: load `/models`, select 3+ models, toggle the Data Source to \"Kappa Agreement\". Confirm dendrogram redraws; clusters reflect agreement-based grouping; explanatory note renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)