### PR TITLE
feat(model-agreement): add help-icon tooltip explaining the methodology

### DIFF
--- a/cloud/apps/web/src/components/models/ModelAgreementSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelAgreementSection.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
+import { HelpCircle, X } from 'lucide-react';
+import { Button } from '../ui/Button';
 import { ErrorMessage } from '../ui/ErrorMessage';
 import { useModelAgreementOnTradeoffsQuery } from '../../generated/graphql';
 import { PairwiseAgreementMatrixReport } from './PairwiseAgreementMatrixReport';
@@ -168,6 +170,7 @@ export function ModelAgreementSection({ modelIds, scope, domainId, signature }: 
   const agreement = data?.modelAgreementOnTradeoffs ?? null;
   const rows = agreement?.pairwiseAgreementMatrix ?? EMPTY_PAIRWISE_ROWS;
   const [selectedPair, setSelectedPair] = useState<SelectedPair | null>(null);
+  const [showHelp, setShowHelp] = useState(false);
   const selectedPairKey = formatSelectedPair(selectedPair);
   const isFetchingRef = useRef(fetching);
 
@@ -262,7 +265,95 @@ export function ModelAgreementSection({ modelIds, scope, domainId, signature }: 
   return (
     <section className="space-y-8">
       <div className="space-y-2">
-        <h2 className="text-lg font-semibold text-gray-900">Model Agreement on Value Tradeoffs</h2>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <h2 className="text-lg font-semibold text-gray-900">Model Agreement on Value Tradeoffs</h2>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setShowHelp((value) => !value)}
+            className="h-8 w-8 text-gray-500 hover:text-gray-700"
+            aria-label={showHelp ? 'Hide model agreement explanation' : 'Show model agreement explanation'}
+          >
+            {showHelp ? <X className="h-8 w-8" /> : <HelpCircle className="h-8 w-8" />}
+          </Button>
+        </div>
+        {showHelp ? (
+          <div className="space-y-3 rounded-lg border border-blue-100 bg-blue-50 p-3 text-xs leading-5 text-gray-700">
+            <p>
+              This number, <strong>Cohen&apos;s kappa</strong>, tells you how often two models reach the same conclusion
+              on the same vignette cells — adjusted for how often they&apos;d agree by chance alone. It runs from −1 to
+              +1. Positive means the two models tend to make the same choices; zero means their agreement is no better
+              than coincidence; negative means they actively pick opposite values.
+            </p>
+            <div>
+              <p className="mb-1 font-semibold text-gray-800">What a &quot;cell&quot; is</p>
+              <p>
+                Every vignette tests a specific value pair — for example, Conformity vs Universalism. Within that
+                vignette, the same tradeoff is presented at multiple intensity combinations (one value at a higher
+                pressure, the other at a lower pressure, and so on). Each unique intensity combination is a{' '}
+                <strong>cell</strong>. Each cell gets sent to the model multiple times across runs, producing a series
+                of <strong>trials</strong>. So one cell has multiple trials, one vignette has multiple cells, and one
+                value pair has multiple vignettes.
+              </p>
+            </div>
+            <div>
+              <p className="mb-1 font-semibold text-gray-800">How a model&apos;s lean on a cell is computed</p>
+              <p>
+                For each cell, we look at the model&apos;s trials and ask: across those attempts, which side did the
+                model lean toward? A neutral trial is treated as halfway between the two values — it counts as half
+                a vote for each side. So a model that picked value A on 4 trials, value B on 0 trials, and was
+                neutral on 2 trials has a lean score of (4 + 1) / 6 ≈ 83% toward A.
+              </p>
+              <p className="mt-2">That lean score sorts the cell into one of three categories:</p>
+              <ul className="ml-4 mt-1 list-disc space-y-0.5">
+                <li><strong>A</strong> — leaned more than halfway toward the alphabetically-first value</li>
+                <li><strong>TIED</strong> — landed at exactly 50/50, no preference (covers both all-neutral cells and cells where decisive picks split evenly)</li>
+                <li><strong>B</strong> — leaned more than halfway toward the alphabetically-second value</li>
+              </ul>
+            </div>
+            <div>
+              <p className="mb-1 font-semibold text-gray-800">How agreement gets scored across cells</p>
+              <p>
+                Agreement on each cell is rated on a soft scale rather than a binary match/mismatch:
+              </p>
+              <ul className="ml-4 mt-1 list-disc space-y-0.5">
+                <li>Both on the same category → <strong>1.0</strong> (full agreement)</li>
+                <li>One A and one TIED, or one TIED and one B → <strong>0.5</strong> (soft disagreement — one leaned, the other was uncommitted)</li>
+                <li>One A and one B → <strong>0.0</strong> (hard disagreement — they picked opposite sides)</li>
+              </ul>
+              <p className="mt-2">
+                The reason for the soft middle case: TIED genuinely sits between A and B on a 1-2-3 scale. When one
+                model says &quot;lean A&quot; and the other says &quot;no opinion,&quot; that&apos;s a smaller gap than
+                when one says &quot;lean A&quot; and the other says &quot;lean B.&quot;
+              </p>
+            </div>
+            <div>
+              <p className="mb-1 font-semibold text-gray-800">Chance correction</p>
+              <p>
+                A naive percent-agreement would inflate scores when models happen to share a preference (if both lean
+                A on most cells, they&apos;d &quot;agree&quot; a lot just by luck). Cohen&apos;s kappa subtracts the
+                agreement that would be expected from each model&apos;s overall mix of A / TIED / B across all cells.
+                The remaining agreement is the part that comes from genuinely making the same choices on the same
+                cells.
+              </p>
+            </div>
+            <div>
+              <p className="mb-1 font-semibold text-gray-800">How to read the result</p>
+              <ul className="ml-4 list-disc space-y-0.5">
+                <li><strong>&lt; 0 — Poor</strong>: worse than chance, the models systematically disagree</li>
+                <li><strong>0 to 0.2 — Slight</strong>: barely above chance</li>
+                <li><strong>0.2 to 0.4 — Fair</strong>: some real signal of agreement</li>
+                <li><strong>0.4 to 0.6 — Moderate</strong>: reliable agreement</li>
+                <li><strong>0.6 to 0.8 — Substantial</strong>: strong agreement on the same choices</li>
+                <li><strong>0.8 to 1.0 — Near-perfect</strong>: the two models almost always make the same call</li>
+              </ul>
+            </div>
+            <p>
+              Aggregation is equal-weighted at every level: each cell counts the same regardless of trial count, each
+              vignette the same regardless of cell count, and each value pair the same regardless of vignette count.
+            </p>
+          </div>
+        ) : null}
         {unavailableModelsNotice != null ? (
           <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
             {unavailableModelsNotice}


### PR DESCRIPTION
## Summary

Adds a `?` icon next to the \"Model Agreement on Value Tradeoffs\" section title that toggles open a help box explaining how the agreement metric works. Same pattern as the existing help button on the Model Clusters section.

## Tooltip content

The expanded help box covers, in plain language:

- What Cohen's kappa is and how to read its range
- What a \"cell\" is (a vignette × intensity-combination at the data level, sent through multiple trials per model)
- How a model's lean on a cell is computed, including how neutral trials count as half-votes between A and B
- The three-category coding (A / TIED / B)
- Soft vs hard disagreement weighting (1.0 / 0.5 / 0.0) — why TIED-vs-A is treated as a softer disagreement than A-vs-B
- Why chance correction matters
- Landis-Koch interpretation buckets (Poor → Near-perfect)
- Equal-weight aggregation at every level (cell → vignette → value pair)

The text describes the current methodology — no \"this used to be different\" framing. It reads as documentation of how the report works.

## Implementation

Pure UI change in `ModelAgreementSection.tsx`:
- Imports `HelpCircle`, `X` from lucide-react and `Button` from `../ui/Button`
- Adds a `showHelp` state hook
- Wraps the title in a flex row alongside a toggle button (HelpCircle when collapsed, X when expanded)
- Renders a blue-bg help panel below the title when expanded

No backend changes. No new dependencies. No data-shape impact. Existing tests pass.

## Validation

- `npm run lint --workspace @valuerank/web` ✅ 0 errors
- `npm run build --workspace @valuerank/web` ✅ clean
- `npm run test --workspace @valuerank/web -- ModelAgreementSection` ✅ 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)