### PR TITLE
feat(model-clusters): show dendrogram + kappa heatmap in kappa mode

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-clustering.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-clustering.ts
@@ -45,12 +45,21 @@ export type DomainCluster = {
   definingValues: string[];        // top 3 centroid valueKeys
 };
 
+export type DendrogramMerge = {
+  leftMemberIds: string[];   // model IDs in the left subtree (flat list)
+  rightMemberIds: string[];  // model IDs in the right subtree (flat list)
+  height: number;             // distance at which they merged
+};
+
 export type ClusterAnalysis = {
   clusters: DomainCluster[];
   faultLinesByPair: Record<string, ClusterPairFaultLines>;
   defaultPair: [string, string] | null;
   skipped: boolean;
   skipReason: string | null;
+  dendrogram?: DendrogramMerge[];
+  leafOrder?: string[];
+  clusterIdByModelId?: Record<string, string>;
 };
 
 export type ClusterModelInput = {
@@ -569,6 +578,82 @@ export function computeClusterAnalysis(models: ClusterModelInput[], method: Clus
   return runClusteringFromDistMatrix(models, cosineDistanceMatrix(vectors), valueKeys, method);
 }
 
+// ---------------------------------------------------------------------------
+// Dendrogram helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the merge tree from UPGMA/Ward snapshots and merge heights.
+ *
+ * At step k, snapshot[k] → snapshot[k+1] identifies which two clusters
+ * merged. The merged cluster is the one in snapshot[k+1] that is a
+ * superset of two distinct clusters from snapshot[k].
+ */
+export function deriveDendrogram(
+  snapshots: number[][][],
+  mergeHeights: number[],
+  models: ClusterModelInput[],
+): DendrogramMerge[] {
+  const merges: DendrogramMerge[] = [];
+  for (let step = 0; step < mergeHeights.length; step++) {
+    const before = snapshots[step]!;
+    const after = snapshots[step + 1]!;
+    const height = mergeHeights[step]!;
+
+    // Find the cluster in `after` that grew (its size > any single cluster in `before`)
+    for (const newCluster of after) {
+      // How many clusters from `before` are subsets of newCluster?
+      const parentClusters = before.filter((oldCluster) =>
+        oldCluster.every((idx) => newCluster.includes(idx)),
+      );
+      if (parentClusters.length < 2) continue;
+
+      // The two largest parent clusters that combined to form newCluster
+      // In practice there will be exactly 2 at each step
+      const sorted = [...parentClusters].sort((a, b) => b.length - a.length);
+      const left = sorted[0]!;
+      const right = sorted[1]!;
+
+      merges.push({
+        leftMemberIds: left.map((idx) => models[idx]!.model),
+        rightMemberIds: right.map((idx) => models[idx]!.model),
+        height,
+      });
+      break;
+    }
+  }
+  return merges;
+}
+
+/**
+ * Derive leaf order from the merge tree by doing a depth-first left-to-right
+ * traversal of the binary merge tree.
+ */
+export function deriveLeafOrder(merges: DendrogramMerge[], allModelIds: string[]): string[] {
+  if (merges.length === 0) return [...allModelIds];
+
+  // Build a lookup: set of model IDs → the merge that produced them
+  // We represent sets as sorted joined strings for lookup
+  const mergeByKey = new Map<string, DendrogramMerge>();
+  for (const merge of merges) {
+    const combined = [...merge.leftMemberIds, ...merge.rightMemberIds].sort().join('|');
+    mergeByKey.set(combined, merge);
+  }
+
+  function walkSubtree(memberIds: string[]): string[] {
+    if (memberIds.length === 1) return [memberIds[0]!];
+    const key = [...memberIds].sort().join('|');
+    const merge = mergeByKey.get(key);
+    if (merge == null) return memberIds; // fallback
+    return [...walkSubtree(merge.leftMemberIds), ...walkSubtree(merge.rightMemberIds)];
+  }
+
+  // The root merge is the last merge (merges are in ascending height order)
+  const root = merges[merges.length - 1]!;
+  const rootMembers = [...root.leftMemberIds, ...root.rightMemberIds];
+  return walkSubtree(rootMembers);
+}
+
 /**
  * Build a hierarchical-clustering distance matrix from a kappa matrix.
  *
@@ -601,6 +686,9 @@ export function kappaDistanceMatrix(kappaMatrix: ReadonlyArray<ReadonlyArray<num
  * same choices on the same scenarios; the per-cluster centroids are still
  * computed from the models' log-odds scores so the resulting centroids and
  * fault lines describe what each behaviorally-similar group tends to value.
+ *
+ * Also exposes dendrogram, leafOrder, and clusterIdByModelId for the
+ * dual-chart frontend visualization.
  */
 export function computeKappaClusterAnalysis(
   models: ClusterModelInput[],
@@ -613,5 +701,27 @@ export function computeKappaClusterAnalysis(
   }
   const valueKeys = Object.keys(models[0]!.scores);
   const distMatrix = kappaDistanceMatrix(kappaMatrix);
-  return runClusteringFromDistMatrix(models, distMatrix, valueKeys, method, 'log-odds');
+  const n = models.length;
+  const { mergeHeights, snapshots } = method === 'ward' ? ward(distMatrix, n) : upgma(distMatrix, n);
+
+  const analysis = runClusteringFromDistMatrix(models, distMatrix, valueKeys, method, 'log-odds');
+
+  // Derive dendrogram, leaf order, and per-model cluster ID mapping
+  const dendrogram = deriveDendrogram(snapshots, mergeHeights, models);
+  const allModelIds = models.map((m) => m.model);
+  const leafOrder = deriveLeafOrder(dendrogram, allModelIds);
+
+  const clusterIdByModelId: Record<string, string> = {};
+  for (const cluster of analysis.clusters) {
+    for (const member of cluster.members) {
+      clusterIdByModelId[member.model] = cluster.id;
+    }
+  }
+
+  return {
+    ...analysis,
+    dendrogram,
+    leafOrder,
+    clusterIdByModelId,
+  };
 }

--- a/cloud/apps/api/src/graphql/queries/domain/types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/types.ts
@@ -9,6 +9,7 @@ import {
   type ClusterMember,
   type ValueFaultLine,
   type ClusterPairFaultLines,
+  type DendrogramMerge,
 } from '../domain-clustering.js';
 import type {
   DomainAnalysisMissingDefinition,
@@ -36,6 +37,17 @@ export {
   DomainAnalysisConditionTranscriptRef,
   DomainAnalysisValueDetailResultRef,
 } from './types-detail.js';
+
+export type KappaPair = {
+  modelAId: string;
+  modelBId: string;
+  kappa: number | null;
+};
+
+export type KappaClusterPayload = {
+  clusterAnalysis: ClusterAnalysis;
+  kappaPairs: KappaPair[];
+};
 
 export type PairwiseWinRateModel = {
   valueOrder: string[];
@@ -80,6 +92,9 @@ export const DomainClusterRef = builder.objectRef<DomainCluster>('DomainCluster'
 export const ValueFaultLineRef = builder.objectRef<ValueFaultLine>('ValueFaultLine');
 export const ClusterPairFaultLinesRef = builder.objectRef<ClusterPairFaultLines>('ClusterPairFaultLines');
 export const ClusterAnalysisRef = builder.objectRef<ClusterAnalysis>('ClusterAnalysis');
+export const DendrogramMergeRef = builder.objectRef<DendrogramMerge>('DendrogramMerge');
+export const KappaPairRef = builder.objectRef<KappaPair>('KappaPair');
+export const KappaClusterPayloadRef = builder.objectRef<KappaClusterPayload>('KappaClusterPayload');
 export const DomainAnalysisValueScoreRef = builder.objectRef<DomainAnalysisValueScore>('DomainAnalysisValueScore');
 export const PairwiseWinRateModelRef = builder.objectRef<PairwiseWinRateModel>('PairwiseWinRateModel');
 export const DomainAnalysisModelRef = builder.objectRef<DomainAnalysisModel>('DomainAnalysisModel');
@@ -179,6 +194,42 @@ builder.objectType(ClusterAnalysisRef, {
     defaultPair: t.exposeStringList('defaultPair', { nullable: true }),
     skipped: t.exposeBoolean('skipped'),
     skipReason: t.exposeString('skipReason', { nullable: true }),
+    dendrogram: t.field({
+      type: [DendrogramMergeRef],
+      nullable: true,
+      resolve: (parent) => parent.dendrogram ?? null,
+    }),
+    leafOrder: t.exposeStringList('leafOrder', { nullable: true }),
+    clusterIdByModelId: t.expose('clusterIdByModelId', { type: 'JSON', nullable: true }),
+  }),
+});
+
+builder.objectType(DendrogramMergeRef, {
+  fields: (t) => ({
+    leftMemberIds: t.exposeStringList('leftMemberIds'),
+    rightMemberIds: t.exposeStringList('rightMemberIds'),
+    height: t.exposeFloat('height'),
+  }),
+});
+
+builder.objectType(KappaPairRef, {
+  fields: (t) => ({
+    modelAId: t.exposeString('modelAId'),
+    modelBId: t.exposeString('modelBId'),
+    kappa: t.exposeFloat('kappa', { nullable: true }),
+  }),
+});
+
+builder.objectType(KappaClusterPayloadRef, {
+  fields: (t) => ({
+    clusterAnalysis: t.field({
+      type: ClusterAnalysisRef,
+      resolve: (parent) => parent.clusterAnalysis,
+    }),
+    kappaPairs: t.field({
+      type: [KappaPairRef],
+      resolve: (parent) => parent.kappaPairs,
+    }),
   }),
 });
 

--- a/cloud/apps/api/src/graphql/queries/model-agreement-cluster-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-cluster-analysis.ts
@@ -1,13 +1,13 @@
 import { ValidationError } from '@valuerank/shared';
 import { builder } from '../builder.js';
 import { getModelsFromDatabase } from '../../config/models.js';
-import { ClusterAnalysisRef } from './domain/types.js';
+import { KappaClusterPayloadRef } from './domain/types.js';
 import {
   computeKappaClusterAnalysis,
-  type ClusterAnalysis,
   type ClusteringMethod,
   type ClusterModelInput,
 } from './domain-clustering.js';
+import type { KappaClusterPayload, KappaPair } from './domain/types.js';
 import {
   buildPositionCells,
   buildSelectedModels,
@@ -28,13 +28,16 @@ import type { Context } from '../context.js';
 const ALL_DOMAINS_SCOPE_ID = 'all-domains';
 const REFRESH_REASON = 'model-agreement-cluster-analysis-page-load-missing';
 
-function emptyClusterAnalysis(reason: string): ClusterAnalysis {
+function emptyPayload(reason: string): KappaClusterPayload {
   return {
-    clusters: [],
-    faultLinesByPair: {},
-    defaultPair: null,
-    skipped: true,
-    skipReason: reason,
+    clusterAnalysis: {
+      clusters: [],
+      faultLinesByPair: {},
+      defaultPair: null,
+      skipped: true,
+      skipReason: reason,
+    },
+    kappaPairs: [],
   };
 }
 
@@ -121,7 +124,7 @@ export async function resolveModelAgreementClusterAnalysis(
     method: string;
   },
   ctx: Context,
-): Promise<ClusterAnalysis> {
+): Promise<KappaClusterPayload> {
   const scopeValue = String(args.scope);
   if (scopeValue !== 'DOMAIN' && scopeValue !== 'ALL_DOMAINS') {
     throw new ValidationError(`Unsupported scope: ${scopeValue}`);
@@ -146,7 +149,7 @@ export async function resolveModelAgreementClusterAnalysis(
 
   const selectedModelIds = normalizeModelIds(args.modelIds.map(String));
   if (selectedModelIds.length < 3) {
-    return emptyClusterAnalysis('Kappa clustering requires at least 3 distinct modelIds.');
+    return emptyPayload('Kappa clustering requires at least 3 distinct modelIds.');
   }
 
   const activeModels = await getModelsFromDatabase({ activeOnly: true, availableOnly: false });
@@ -158,17 +161,17 @@ export async function resolveModelAgreementClusterAnalysis(
 
   const snapshotState = await readAgreementSnapshot({ scope, domainId, signature, ctx });
   if (snapshotState == null) {
-    return emptyClusterAnalysis('Kappa cluster analysis is rebuilding — try again in a moment.');
+    return emptyPayload('Kappa cluster analysis is rebuilding — try again in a moment.');
   }
 
   const cellLevelOutcomes = snapshotState.cellLevelOutcomes;
   if (cellLevelOutcomes == null) {
-    return emptyClusterAnalysis('Kappa cluster analysis is rebuilding — try again in a moment.');
+    return emptyPayload('Kappa cluster analysis is rebuilding — try again in a moment.');
   }
   const { positionCells, cellsObservedByModelId } = buildPositionCells(cellLevelOutcomes, selectedModelIdSet);
   const availableModels = selectedModels.filter((model) => (cellsObservedByModelId.get(model.modelId) ?? 0) > 0);
   if (availableModels.length < 3) {
-    return emptyClusterAnalysis('Kappa clustering requires at least 3 models with cell-level data in the selected scope.');
+    return emptyPayload('Kappa clustering requires at least 3 models with cell-level data in the selected scope.');
   }
 
   // Pull log-odds scores from the domain-analysis result so the cluster centroids
@@ -188,7 +191,7 @@ export async function resolveModelAgreementClusterAnalysis(
   // has the same set of values, so pull from the first model that has data.
   const sampleValueScores = scoresByModelId.values().next().value;
   if (sampleValueScores == null) {
-    return emptyClusterAnalysis('Kappa cluster analysis could not be computed because the domain-analysis snapshot has no model scores.');
+    return emptyPayload('Kappa cluster analysis could not be computed because the domain-analysis snapshot has no model scores.');
   }
   const valueKeys = Object.keys(sampleValueScores);
   const zeroScores: Record<string, number> = Object.fromEntries(valueKeys.map((vk) => [vk, 0]));
@@ -202,12 +205,27 @@ export async function resolveModelAgreementClusterAnalysis(
   const orderedModelIds = clusterInputs.map((entry) => entry.model);
   const kappaMatrix = await buildKappaMatrix({ positionCells, modelIds: orderedModelIds });
 
-  return computeKappaClusterAnalysis(clusterInputs, kappaMatrix, method);
+  const clusterAnalysis = computeKappaClusterAnalysis(clusterInputs, kappaMatrix, method);
+
+  // Build flat kappa pairs list for the frontend heatmap
+  const n = orderedModelIds.length;
+  const kappaPairs: KappaPair[] = [];
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      kappaPairs.push({
+        modelAId: orderedModelIds[i]!,
+        modelBId: orderedModelIds[j]!,
+        kappa: kappaMatrix[i]![j] ?? null,
+      });
+    }
+  }
+
+  return { clusterAnalysis, kappaPairs };
 }
 
 builder.queryField('modelAgreementClusterAnalysis', (t) =>
   t.field({
-    type: ClusterAnalysisRef,
+    type: KappaClusterPayloadRef,
     args: {
       modelIds: t.arg.idList({ required: true }),
       domainId: t.arg.id({ required: false }),

--- a/cloud/apps/api/tests/graphql/queries/domain-clustering.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/domain-clustering.test.ts
@@ -12,6 +12,10 @@ import {
   computeSilhouettes,
   nameCluster,
   computeClusterAnalysis,
+  computeKappaClusterAnalysis,
+  deriveDendrogram,
+  deriveLeafOrder,
+  kappaDistanceMatrix,
   type ClusterModelInput,
 } from '../../../src/graphql/queries/domain-clustering.js';
 
@@ -474,5 +478,137 @@ describe('computeClusterAnalysis', () => {
         expect(member.silhouetteScore).toBeLessThanOrEqual(1 + 1e-10);
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveDendrogram and deriveLeafOrder
+// ---------------------------------------------------------------------------
+
+describe('deriveDendrogram', () => {
+  const models: ClusterModelInput[] = [
+    { model: 'm1', label: 'M1', scores: { A: 1.0, B: 0.0, C: 0.0 } },
+    { model: 'm2', label: 'M2', scores: { A: 0.9, B: 0.1, C: 0.0 } },
+    { model: 'm3', label: 'M3', scores: { A: 0.0, B: 0.0, C: 1.0 } },
+    { model: 'm4', label: 'M4', scores: { A: 0.0, B: 0.1, C: 0.9 } },
+  ];
+
+  it('produces N-1 merges for N models', () => {
+    const dist = cosineDistanceMatrix([[1, 0, 0], [0.9, 0.1, 0], [0, 0, 1], [0, 0.1, 0.9]]);
+    const { mergeHeights, snapshots } = upgma(dist, 4);
+    const merges = deriveDendrogram(snapshots, mergeHeights, models);
+    expect(merges).toHaveLength(models.length - 1);
+  });
+
+  it('each merge has valid leftMemberIds and rightMemberIds', () => {
+    const dist = cosineDistanceMatrix([[1, 0, 0], [0.9, 0.1, 0], [0, 0, 1], [0, 0.1, 0.9]]);
+    const { mergeHeights, snapshots } = upgma(dist, 4);
+    const merges = deriveDendrogram(snapshots, mergeHeights, models);
+    const modelIds = new Set(models.map((m) => m.model));
+    for (const merge of merges) {
+      expect(merge.leftMemberIds.length).toBeGreaterThanOrEqual(1);
+      expect(merge.rightMemberIds.length).toBeGreaterThanOrEqual(1);
+      for (const id of [...merge.leftMemberIds, ...merge.rightMemberIds]) {
+        expect(modelIds.has(id)).toBe(true);
+      }
+    }
+  });
+
+  it('merge heights are non-decreasing', () => {
+    const dist = cosineDistanceMatrix([[1, 0, 0], [0.9, 0.1, 0], [0, 0, 1], [0, 0.1, 0.9]]);
+    const { mergeHeights, snapshots } = upgma(dist, 4);
+    const merges = deriveDendrogram(snapshots, mergeHeights, models);
+    for (let i = 1; i < merges.length; i++) {
+      expect(merges[i]!.height).toBeGreaterThanOrEqual(merges[i - 1]!.height - 1e-10);
+    }
+  });
+});
+
+describe('deriveLeafOrder', () => {
+  const models: ClusterModelInput[] = [
+    { model: 'm1', label: 'M1', scores: { A: 1.0, B: 0.0, C: 0.0 } },
+    { model: 'm2', label: 'M2', scores: { A: 0.9, B: 0.1, C: 0.0 } },
+    { model: 'm3', label: 'M3', scores: { A: 0.0, B: 0.0, C: 1.0 } },
+    { model: 'm4', label: 'M4', scores: { A: 0.0, B: 0.1, C: 0.9 } },
+  ];
+
+  it('leafOrder.length equals N', () => {
+    const dist = cosineDistanceMatrix([[1, 0, 0], [0.9, 0.1, 0], [0, 0, 1], [0, 0.1, 0.9]]);
+    const { mergeHeights, snapshots } = upgma(dist, 4);
+    const merges = deriveDendrogram(snapshots, mergeHeights, models);
+    const allModelIds = models.map((m) => m.model);
+    const leafOrder = deriveLeafOrder(merges, allModelIds);
+    expect(leafOrder).toHaveLength(models.length);
+  });
+
+  it('leafOrder contains each model exactly once', () => {
+    const dist = cosineDistanceMatrix([[1, 0, 0], [0.9, 0.1, 0], [0, 0, 1], [0, 0.1, 0.9]]);
+    const { mergeHeights, snapshots } = upgma(dist, 4);
+    const merges = deriveDendrogram(snapshots, mergeHeights, models);
+    const allModelIds = models.map((m) => m.model);
+    const leafOrder = deriveLeafOrder(merges, allModelIds);
+    expect([...new Set(leafOrder)].sort()).toEqual([...allModelIds].sort());
+  });
+
+  it('returns all model IDs unchanged when no merges', () => {
+    const allModelIds = ['m1', 'm2', 'm3'];
+    const leafOrder = deriveLeafOrder([], allModelIds);
+    expect(leafOrder).toEqual(allModelIds);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeKappaClusterAnalysis — dendrogram/leafOrder/clusterIdByModelId
+// ---------------------------------------------------------------------------
+
+describe('computeKappaClusterAnalysis — kappa-specific fields', () => {
+  const models: ClusterModelInput[] = [
+    { model: 'm1', label: 'M1', scores: { A: 1.0, B: 0.0, C: 0.0 } },
+    { model: 'm2', label: 'M2', scores: { A: 0.9, B: 0.1, C: 0.0 } },
+    { model: 'm3', label: 'M3', scores: { A: 0.0, B: 0.0, C: 1.0 } },
+    { model: 'm4', label: 'M4', scores: { A: 0.0, B: 0.1, C: 0.9 } },
+  ];
+
+  // Kappa matrix: m1&m2 agree, m3&m4 agree, pairs across groups disagree
+  const kappaMatrix: Array<Array<number | null>> = [
+    [1,    0.85, 0.05, 0.1],
+    [0.85, 1,    0.1,  0.05],
+    [0.05, 0.1,  1,    0.8],
+    [0.1,  0.05, 0.8,  1],
+  ];
+
+  it('populates dendrogram with N-1 merges', () => {
+    const result = computeKappaClusterAnalysis(models, kappaMatrix);
+    expect(result.dendrogram).toBeDefined();
+    expect(result.dendrogram).toHaveLength(models.length - 1);
+  });
+
+  it('populates leafOrder with N entries', () => {
+    const result = computeKappaClusterAnalysis(models, kappaMatrix);
+    expect(result.leafOrder).toBeDefined();
+    expect(result.leafOrder).toHaveLength(models.length);
+  });
+
+  it('leafOrder contains each model exactly once', () => {
+    const result = computeKappaClusterAnalysis(models, kappaMatrix);
+    const allIds = models.map((m) => m.model);
+    expect([...(result.leafOrder ?? [])].sort()).toEqual([...allIds].sort());
+  });
+
+  it('populates clusterIdByModelId for each model when not skipped', () => {
+    const result = computeKappaClusterAnalysis(models, kappaMatrix);
+    if (result.skipped) return;
+    expect(result.clusterIdByModelId).toBeDefined();
+    for (const model of models) {
+      expect(result.clusterIdByModelId?.[model.model]).toBeDefined();
+    }
+  });
+
+  it('kappaDistanceMatrix maps kappa 1 to distance 0 and kappa -1 to distance 1', () => {
+    const km: Array<Array<number | null>> = [[1, -1], [-1, 1]];
+    const dist = kappaDistanceMatrix(km);
+    expect(dist[0]![1]).toBeCloseTo(1);
+    expect(dist[1]![0]).toBeCloseTo(1);
+    expect(dist[0]![0]).toBeCloseTo(0);
   });
 });

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -321,10 +321,30 @@ type CircumplexResult {
 
 type ClusterAnalysis {
   clusters: [DomainCluster!]!
+  clusterIdByModelId: JSON
   defaultPair: [String!]
+  dendrogram: [DendrogramMerge!]
   faultLinesByPair: JSON!
+  leafOrder: [String!]
   skipReason: String
   skipped: Boolean!
+}
+
+type DendrogramMerge {
+  height: Float!
+  leftMemberIds: [String!]!
+  rightMemberIds: [String!]!
+}
+
+type KappaClusterPayload {
+  clusterAnalysis: ClusterAnalysis!
+  kappaPairs: [KappaPair!]!
+}
+
+type KappaPair {
+  kappa: Float
+  modelAId: String!
+  modelBId: String!
 }
 
 type ClusterMember {
@@ -2721,7 +2741,7 @@ type Query {
 
   "\n      Get the currently authenticated user.\n      Returns null if not authenticated.\n    "
   me: User
-  modelAgreementClusterAnalysis(domainId: ID, method: String!, modelIds: [ID!]!, scope: String!, signature: String!): ClusterAnalysis!
+  modelAgreementClusterAnalysis(domainId: ID, method: String!, modelIds: [ID!]!, scope: String!, signature: String!): KappaClusterPayload!
   modelAgreementOnTradeoffs(domainId: ID, modelIds: [ID!]!, scope: String!, signature: String!): ModelAgreementResult!
   modelPairDivergenceBreakdown(domainId: ID, modelAId: ID!, modelBId: ID!, scope: String!, signature: String!): PairDivergenceBreakdown!
 

--- a/cloud/apps/web/src/api/operations/modelAgreementClusterAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/modelAgreementClusterAnalysis.graphql
@@ -12,23 +12,37 @@ query ModelAgreementClusterAnalysis(
     signature: $signature
     method: $method
   ) {
-    skipped
-    skipReason
-    defaultPair
-    clusters {
-      id
-      name
-      definingValues
-      centroid
-      members {
-        model
-        label
-        silhouetteScore
-        isOutlier
-        nearestClusterIds
-        distancesToNearestClusters
+    clusterAnalysis {
+      skipped
+      skipReason
+      defaultPair
+      clusters {
+        id
+        name
+        definingValues
+        centroid
+        members {
+          model
+          label
+          silhouetteScore
+          isOutlier
+          nearestClusterIds
+          distancesToNearestClusters
+        }
       }
+      faultLinesByPair
+      dendrogram {
+        leftMemberIds
+        rightMemberIds
+        height
+      }
+      leafOrder
+      clusterIdByModelId
     }
-    faultLinesByPair
+    kappaPairs {
+      modelAId
+      modelBId
+      kappa
+    }
   }
 }

--- a/cloud/apps/web/src/components/domains/ClusterDendrogram.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterDendrogram.tsx
@@ -1,0 +1,254 @@
+/**
+ * ClusterDendrogram — SVG hierarchical-clustering dendrogram.
+ *
+ * Leaves are arranged at y = maxHeight (bottom), internal nodes at their
+ * merge height. Lines are L-shaped: horizontal at the merge height,
+ * vertical down to each child.
+ */
+import type React from 'react';
+
+const COLORS = [
+  '#2563eb', // blue
+  '#d97706', // amber
+  '#059669', // emerald
+  '#e11d48', // rose
+  '#7c3aed', // violet
+  '#0ea5e9', // sky
+  '#ea580c', // orange
+  '#65a30d', // lime
+  '#d946ef', // fuchsia
+  '#4f46e5', // indigo
+  '#14b8a6', // teal
+  '#ca8a04', // yellow
+] as const;
+
+const CLUSTER_COLOR_ORDER = Object.values(COLORS);
+
+function getLeafColor(clusterIdByModelId: Record<string, string>, modelId: string, clusterIds: string[]): string {
+  const clusterId = clusterIdByModelId[modelId];
+  if (clusterId == null) return '#9ca3af';
+  const index = clusterIds.indexOf(clusterId);
+  return CLUSTER_COLOR_ORDER[index % CLUSTER_COLOR_ORDER.length] ?? '#9ca3af';
+}
+
+export type DendrogramMerge = {
+  leftMemberIds: string[];
+  rightMemberIds: string[];
+  height: number;
+};
+
+type ClusterDendrogramProps = {
+  merges: DendrogramMerge[];
+  leafOrder: string[];
+  modelLabels: Record<string, string>;
+  clusterIdByModelId: Record<string, string>;
+  cutLineHeight?: number;
+};
+
+// SVG layout constants
+const MARGIN = { top: 20, right: 20, bottom: 80, left: 20 };
+const SVG_HEIGHT = 420;
+const LABEL_FONT_SIZE = 10;
+const LEAF_CIRCLE_RADIUS = 3;
+
+export function ClusterDendrogram({
+  merges,
+  leafOrder,
+  modelLabels,
+  clusterIdByModelId,
+  cutLineHeight,
+}: ClusterDendrogramProps) {
+  const n = leafOrder.length;
+  if (n === 0 || merges.length === 0) {
+    return (
+      <div className="text-xs text-gray-500 italic">No dendrogram data available.</div>
+    );
+  }
+
+  // Unique cluster IDs in a stable order for color assignment
+  const clusterIds = [...new Set(Object.values(clusterIdByModelId))].sort();
+
+  // Layout dimensions
+  const innerWidth = Math.max(n * 28, 400);
+  const innerHeight = SVG_HEIGHT - MARGIN.top - MARGIN.bottom;
+  const svgWidth = innerWidth + MARGIN.left + MARGIN.right;
+  const svgHeight = SVG_HEIGHT;
+
+  // Compute max height for y-axis scaling
+  const maxHeight = Math.max(...merges.map((m) => m.height), 0.01);
+
+  // Map merge height to SVG y coordinate.
+  // height=0 → y = innerHeight (bottom), height=maxHeight → y = 0 (top)
+  function heightToY(h: number): number {
+    return innerHeight - (h / maxHeight) * innerHeight;
+  }
+
+  // Leaf x positions (evenly spaced)
+  const leafX = new Map<string, number>();
+  for (let i = 0; i < leafOrder.length; i++) {
+    const modelId = leafOrder[i]!;
+    leafX.set(modelId, ((i + 0.5) / n) * innerWidth);
+  }
+
+  // Build a map from sorted member ID set → merge, for bottom-up traversal
+  function memberKey(ids: string[]): string {
+    return [...ids].sort().join('|');
+  }
+
+  const mergeByKey = new Map<string, DendrogramMerge>();
+  for (const merge of merges) {
+    const combined = [...merge.leftMemberIds, ...merge.rightMemberIds];
+    mergeByKey.set(memberKey(combined), merge);
+  }
+
+  // Compute the center x of a subtree (average of its leaf positions)
+  function subtreeCenterX(memberIds: string[]): number {
+    let sum = 0;
+    let count = 0;
+    for (const id of memberIds) {
+      const x = leafX.get(id);
+      if (x != null) { sum += x; count++; }
+    }
+    return count > 0 ? sum / count : 0;
+  }
+
+  // Render all L-shaped connectors recursively
+  const lines: React.ReactElement[] = [];
+
+  function renderConnectors(memberIds: string[]): void {
+    if (memberIds.length <= 1) return;
+    const key = memberKey(memberIds);
+    const merge = mergeByKey.get(key);
+    if (merge == null) return;
+
+    const parentY = heightToY(merge.height);
+    const leftX = subtreeCenterX(merge.leftMemberIds);
+    const rightX = subtreeCenterX(merge.rightMemberIds);
+
+    // Left child connector
+    const leftChildH = merge.leftMemberIds.length > 1
+      ? mergeByKey.get(memberKey(merge.leftMemberIds))?.height ?? 0
+      : 0;
+    const leftChildY = heightToY(leftChildH);
+    lines.push(
+      <polyline
+        key={`left-${key}`}
+        points={`${leftX},${leftChildY} ${leftX},${parentY} ${rightX},${parentY}`}
+        fill="none"
+        stroke="#6b7280"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />,
+    );
+
+    // Right child connector (just the vertical part down from parentY)
+    const rightChildH = merge.rightMemberIds.length > 1
+      ? mergeByKey.get(memberKey(merge.rightMemberIds))?.height ?? 0
+      : 0;
+    const rightChildY = heightToY(rightChildH);
+    lines.push(
+      <line
+        key={`right-${key}`}
+        x1={rightX}
+        y1={parentY}
+        x2={rightX}
+        y2={rightChildY}
+        stroke="#6b7280"
+        strokeWidth={1.5}
+      />,
+    );
+
+    renderConnectors(merge.leftMemberIds);
+    renderConnectors(merge.rightMemberIds);
+  }
+
+  // Start from the root merge (last merge = all models)
+  const rootMerge = merges[merges.length - 1]!;
+  const rootMemberIds = [...rootMerge.leftMemberIds, ...rootMerge.rightMemberIds];
+  renderConnectors(rootMemberIds);
+
+  return (
+    <div className="overflow-x-auto">
+      <svg
+        width={svgWidth}
+        height={svgHeight}
+        role="img"
+        aria-label="Cluster dendrogram showing model merge tree by kappa distance"
+      >
+        <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+          {/* Y-axis ticks */}
+          {[0, 0.25, 0.5, 0.75, 1.0].map((frac) => {
+            const h = frac * maxHeight;
+            const y = heightToY(h);
+            return (
+              <g key={frac}>
+                <line x1={-6} y1={y} x2={-2} y2={y} stroke="#9ca3af" strokeWidth={1} />
+                <text
+                  x={-8}
+                  y={y}
+                  textAnchor="end"
+                  dominantBaseline="middle"
+                  fontSize={9}
+                  fill="#6b7280"
+                >
+                  {h.toFixed(2)}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* Y-axis label */}
+          <text
+            x={-MARGIN.left + 2}
+            y={innerHeight / 2}
+            textAnchor="middle"
+            fontSize={9}
+            fill="#6b7280"
+            transform={`rotate(-90, ${-MARGIN.left + 2}, ${innerHeight / 2})`}
+          >
+            kappa distance
+          </text>
+
+          {/* Dendrogram lines */}
+          {lines}
+
+          {/* Cut line */}
+          {cutLineHeight != null && (
+            <line
+              x1={0}
+              y1={heightToY(cutLineHeight)}
+              x2={innerWidth}
+              y2={heightToY(cutLineHeight)}
+              stroke="#0d9488"
+              strokeWidth={1.5}
+              strokeDasharray="5,3"
+            />
+          )}
+
+          {/* Leaf nodes and labels */}
+          {leafOrder.map((modelId) => {
+            const x = leafX.get(modelId) ?? 0;
+            const y = innerHeight;
+            const color = getLeafColor(clusterIdByModelId, modelId, clusterIds);
+            const label = modelLabels[modelId] ?? modelId;
+            return (
+              <g key={modelId}>
+                <circle cx={x} cy={y} r={LEAF_CIRCLE_RADIUS} fill={color} />
+                <text
+                  x={x}
+                  y={y + LEAF_CIRCLE_RADIUS + 4}
+                  textAnchor="end"
+                  fontSize={LABEL_FONT_SIZE}
+                  fill={color}
+                  transform={`rotate(-55, ${x}, ${y + LEAF_CIRCLE_RADIUS + 4})`}
+                >
+                  {label}
+                </text>
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/cloud/apps/web/src/components/domains/ClusterOrderedKappaHeatmap.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterOrderedKappaHeatmap.tsx
@@ -1,0 +1,311 @@
+/**
+ * ClusterOrderedKappaHeatmap — N×N kappa heatmap with rows and columns
+ * ordered by leaf order from the dendrogram, with cluster boundary boxes
+ * overlaid as outlined rectangles.
+ *
+ * Color scale: red (#dc2626) → white (#ffffff) at kappa=0 → green (#15803d)
+ * This matches the scale used in ModelAgreementHeatmap.tsx.
+ */
+
+// ---------------------------------------------------------------------------
+// Color helpers (mirrored from ModelAgreementHeatmap.tsx)
+// ---------------------------------------------------------------------------
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const normalized = hex.replace('#', '');
+  const red = Number.parseInt(normalized.slice(0, 2), 16);
+  const green = Number.parseInt(normalized.slice(2, 4), 16);
+  const blue = Number.parseInt(normalized.slice(4, 6), 16);
+  return [red, green, blue];
+}
+
+function rgbToHex(red: number, green: number, blue: number): string {
+  return `#${[red, green, blue].map((channel) => channel.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function interpolateHex(start: string, end: string, t: number): string {
+  const [startR, startG, startB] = hexToRgb(start);
+  const [endR, endG, endB] = hexToRgb(end);
+  const red = Math.round(startR + (endR - startR) * t);
+  const green = Math.round(startG + (endG - startG) * t);
+  const blue = Math.round(startB + (endB - startB) * t);
+  return rgbToHex(red, green, blue);
+}
+
+function getKappaColor(kappa: number): string {
+  const clamped = clamp(kappa, -1, 1);
+  if (clamped <= 0) {
+    return interpolateHex('#dc2626', '#ffffff', clamped + 1);
+  }
+  return interpolateHex('#ffffff', '#15803d', clamped);
+}
+
+function getRelativeLuminance(hex: string): number {
+  const [red8, green8, blue8] = hexToRgb(hex);
+  const toLinear = (channel: number): number => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * toLinear(red8) + 0.7152 * toLinear(green8) + 0.0722 * toLinear(blue8);
+}
+
+function getTextColor(backgroundHex: string): string {
+  return getRelativeLuminance(backgroundHex) > 0.55 ? '#111827' : '#ffffff';
+}
+
+function formatKappa(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return '—';
+  const sign = value >= 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type KappaPairInput = {
+  modelAId: string;
+  modelBId: string;
+  kappa?: number | null;
+};
+
+type ClusterOrderedKappaHeatmapProps = {
+  leafOrder: string[];
+  modelLabels: Record<string, string>;
+  kappaPairs: KappaPairInput[];
+  clusterIdByModelId: Record<string, string>;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildKappaLookup(
+  kappaPairs: KappaPairInput[],
+): Map<string, number | null> {
+  const map = new Map<string, number | null>();
+  for (const { modelAId, modelBId, kappa } of kappaPairs) {
+    const keyAB = `${modelAId}::${modelBId}`;
+    const keyBA = `${modelBId}::${modelAId}`;
+    map.set(keyAB, kappa ?? null);
+    map.set(keyBA, kappa ?? null);
+  }
+  return map;
+}
+
+type ClusterBlock = {
+  start: number;
+  end: number;  // exclusive
+  clusterId: string;
+};
+
+function findClusterBlocks(leafOrder: string[], clusterIdByModelId: Record<string, string>): ClusterBlock[] {
+  if (leafOrder.length === 0) return [];
+  const blocks: ClusterBlock[] = [];
+  let blockStart = 0;
+  let currentClusterId = clusterIdByModelId[leafOrder[0]!] ?? '';
+
+  for (let i = 1; i <= leafOrder.length; i++) {
+    const clusterId = i < leafOrder.length ? (clusterIdByModelId[leafOrder[i]!] ?? '') : '';
+    if (clusterId !== currentClusterId || i === leafOrder.length) {
+      blocks.push({ start: blockStart, end: i, clusterId: currentClusterId });
+      blockStart = i;
+      currentClusterId = clusterId;
+    }
+  }
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+// Target cell size; shrinks for large N
+const MAX_CELL = 36;
+const MIN_CELL = 14;
+const LABEL_AREA = 80; // px reserved for row/col labels
+
+function getCellSize(n: number): number {
+  if (n <= 20) return MAX_CELL;
+  if (n >= 80) return MIN_CELL;
+  return Math.round(MAX_CELL - ((n - 20) / 60) * (MAX_CELL - MIN_CELL));
+}
+
+export function ClusterOrderedKappaHeatmap({
+  leafOrder,
+  modelLabels,
+  kappaPairs,
+  clusterIdByModelId,
+}: ClusterOrderedKappaHeatmapProps) {
+  const n = leafOrder.length;
+
+  if (n === 0) {
+    return <div className="text-xs text-gray-500 italic">No kappa data available.</div>;
+  }
+
+  const kappaMap = buildKappaLookup(kappaPairs);
+  const clusterBlocks = findClusterBlocks(leafOrder, clusterIdByModelId);
+  const cellSize = getCellSize(n);
+  const fontSize = Math.max(8, Math.min(11, cellSize - 4));
+
+  const gridWidth = n * cellSize;
+  const gridHeight = n * cellSize;
+  const svgWidth = gridWidth + LABEL_AREA;
+  const svgHeight = gridHeight + LABEL_AREA;
+
+  return (
+    <div className="overflow-auto rounded-lg border border-gray-200 bg-white p-3">
+      <div className="mb-2 flex items-center justify-between gap-3 text-xs text-gray-500">
+        <span>Rows and columns ordered by dendrogram leaf order. Boxes outline cluster boundaries.</span>
+        <span>Color: red (negative) → white (0) → green (positive kappa)</span>
+      </div>
+      <svg
+        width={svgWidth}
+        height={svgHeight}
+        role="img"
+        aria-label="Cluster-ordered pairwise kappa heatmap"
+      >
+        {/* Column labels (rotated, at top) */}
+        <g>
+          {leafOrder.map((modelId, colIdx) => {
+            const x = LABEL_AREA + colIdx * cellSize + cellSize / 2;
+            const label = modelLabels[modelId] ?? modelId;
+            return (
+              <text
+                key={`col-${modelId}`}
+                x={x}
+                y={LABEL_AREA - 4}
+                textAnchor="start"
+                fontSize={fontSize}
+                fill="#374151"
+                transform={`rotate(-55, ${x}, ${LABEL_AREA - 4})`}
+              >
+                {label}
+              </text>
+            );
+          })}
+        </g>
+
+        {/* Row labels */}
+        <g>
+          {leafOrder.map((modelId, rowIdx) => {
+            const y = LABEL_AREA + rowIdx * cellSize + cellSize / 2;
+            const label = modelLabels[modelId] ?? modelId;
+            return (
+              <text
+                key={`row-${modelId}`}
+                x={LABEL_AREA - 4}
+                y={y}
+                textAnchor="end"
+                dominantBaseline="middle"
+                fontSize={fontSize}
+                fill="#374151"
+              >
+                {label}
+              </text>
+            );
+          })}
+        </g>
+
+        {/* Heat cells */}
+        <g transform={`translate(${LABEL_AREA}, ${LABEL_AREA})`}>
+          {leafOrder.map((rowModelId, rowIdx) =>
+            leafOrder.map((colModelId, colIdx) => {
+              const isSelf = rowModelId === colModelId;
+              const x = colIdx * cellSize;
+              const y = rowIdx * cellSize;
+
+              if (isSelf) {
+                return (
+                  <rect
+                    key={`${rowModelId}-${colModelId}`}
+                    x={x}
+                    y={y}
+                    width={cellSize}
+                    height={cellSize}
+                    fill="#f3f4f6"
+                    stroke="#e5e7eb"
+                    strokeWidth={0.5}
+                  />
+                );
+              }
+
+              const kappa = kappaMap.get(`${rowModelId}::${colModelId}`) ?? null;
+              if (kappa == null) {
+                return (
+                  <rect
+                    key={`${rowModelId}-${colModelId}`}
+                    x={x}
+                    y={y}
+                    width={cellSize}
+                    height={cellSize}
+                    fill="#e5e7eb"
+                    stroke="#e5e7eb"
+                    strokeWidth={0.5}
+                  />
+                );
+              }
+
+              const bg = getKappaColor(kappa);
+              const textColor = getTextColor(bg);
+              const label = formatKappa(kappa);
+
+              return (
+                <g key={`${rowModelId}-${colModelId}`}>
+                  <rect
+                    x={x}
+                    y={y}
+                    width={cellSize}
+                    height={cellSize}
+                    fill={bg}
+                    stroke={bg}
+                    strokeWidth={0.5}
+                  />
+                  {cellSize >= 20 && (
+                    <text
+                      x={x + cellSize / 2}
+                      y={y + cellSize / 2}
+                      textAnchor="middle"
+                      dominantBaseline="middle"
+                      fontSize={Math.max(7, fontSize - 2)}
+                      fill={textColor}
+                      fontWeight="600"
+                    >
+                      {label}
+                    </text>
+                  )}
+                </g>
+              );
+            }),
+          )}
+
+          {/* Cluster boundary boxes */}
+          {clusterBlocks.map(({ start, end, clusterId }) => {
+            const x = start * cellSize;
+            const y = start * cellSize;
+            const size = (end - start) * cellSize;
+            return (
+              <rect
+                key={`boundary-${clusterId}`}
+                x={x + 1}
+                y={y + 1}
+                width={size - 2}
+                height={size - 2}
+                fill="none"
+                stroke="#0d9488"
+                strokeWidth={2}
+                strokeLinejoin="round"
+              />
+            );
+          })}
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -9,6 +9,8 @@ import { ClusterBarPlot } from './ClusterBarPlot';
 import { ClusterDotPlot } from './ClusterDotPlot';
 import { ClusterRadarChart } from './ClusterRadarChart';
 import { buildIndividualClusters, getClusterMemberLabelText } from './clusterVisualizationUtils';
+import { ClusterDendrogram, type DendrogramMerge } from './ClusterDendrogram';
+import { ClusterOrderedKappaHeatmap, type KappaPairInput } from './ClusterOrderedKappaHeatmap';
 
 const LEGEND_COLORS = [
   { border: 'border-blue-500', text: 'text-blue-700', light: 'bg-blue-50', color: '#2563eb' },
@@ -41,6 +43,14 @@ type ModelGroupsSectionProps = {
    * `clusterAnalysisByMethod` map (which only covers score-based variants).
    */
   kappaClusterAnalysis?: ClusterAnalysis | null;
+  /** Dendrogram merges from the kappa cluster payload (kappa mode only). */
+  kappaDendrogram?: DendrogramMerge[] | null;
+  /** Leaf order for the kappa dendrogram/heatmap. */
+  kappaLeafOrder?: string[] | null;
+  /** Flat per-model cluster ID map (kappa mode only). */
+  kappaClusterIdByModelId?: Record<string, string> | null;
+  /** Flat kappa pair list for the heatmap (kappa mode only). */
+  kappaKappaPairs?: KappaPairInput[] | null;
   kappaClusterLoading?: boolean;
   kappaClusterError?: string | null;
   dataSource?: ClusterDataSource;
@@ -82,6 +92,10 @@ function getGroupLabel(cluster: DomainCluster): string {
 export function ModelGroupsSection({
   clusterAnalysisByMethod,
   kappaClusterAnalysis = null,
+  kappaDendrogram = null,
+  kappaLeafOrder = null,
+  kappaClusterIdByModelId = null,
+  kappaKappaPairs = null,
   kappaClusterLoading = false,
   kappaClusterError = null,
   dataSource = 'log-odds',
@@ -140,6 +154,14 @@ export function ModelGroupsSection({
       return current.length === 1 && current[0] === clusterId ? [] : [clusterId];
     });
   };
+
+  const modelLabels = useMemo<Record<string, string>>(() => {
+    const result: Record<string, string> = {};
+    for (const model of models) {
+      result[model.model] = model.label;
+    }
+    return result;
+  }, [models]);
 
   const copyLabel = `${groupDisplayMode} model groups ${
     viewMode === 'dot' ? 'dot map' : viewMode === 'bar' ? 'bar chart' : 'radar chart'
@@ -227,25 +249,27 @@ export function ModelGroupsSection({
             </>
           )}
 
-          <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
-            {CLUSTER_VIEW_OPTIONS.map((option) => {
-              const active = viewMode === option.value;
-              return (
-                <Button
-                  key={option.value}
-                  type="button"
-                  variant={active ? 'primary' : 'ghost'}
-                  size="sm"
-                  onClick={() => setViewMode(option.value)}
-                  className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
-                    active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-white hover:text-gray-900'
-                  }`}
-                >
-                  {option.label}
-                </Button>
-              );
-            })}
-          </div>
+          {dataSource !== 'kappa-agreement' && (
+            <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+              {CLUSTER_VIEW_OPTIONS.map((option) => {
+                const active = viewMode === option.value;
+                return (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    variant={active ? 'primary' : 'ghost'}
+                    size="sm"
+                    onClick={() => setViewMode(option.value)}
+                    className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
+                      active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-white hover:text-gray-900'
+                    }`}
+                  >
+                    {option.label}
+                  </Button>
+                );
+              })}
+            </div>
+          )}
 
           <CopyVisualButton targetRef={summaryTableRef} label={copyLabel} />
         </div>
@@ -319,20 +343,49 @@ export function ModelGroupsSection({
           </div>
         ) : (
           <>
-            {(() => {
-              // Plot dataSource only controls how centroids are scaled. Under
-              // 'kappa-agreement' the grouping is by kappa but centroids are
-              // still log-odds, so the plots use 'log-odds' for scaling.
-              const plotDataSource: 'log-odds' | 'win-rate' =
-                dataSource === 'win-rate' && groupDisplayMode === 'groups' ? 'win-rate' : 'log-odds';
-              return (
-                <>
-                  {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} activeGroupIds={activeGroupIds} dataSource={plotDataSource} />}
-                  {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} activeGroupIds={activeGroupIds} dataSource={plotDataSource} />}
-                  {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} activeGroupIds={activeGroupIds} dataSource={plotDataSource} />}
-                </>
-              );
-            })()}
+            {dataSource === 'kappa-agreement' && groupDisplayMode === 'groups' ? (
+              // In kappa mode, show the dendrogram and cluster-ordered heatmap
+              <div className="space-y-6">
+                {kappaDendrogram != null && kappaLeafOrder != null ? (
+                  <div>
+                    <p className="mb-2 text-xs font-semibold text-gray-700">Merge tree (dendrogram)</p>
+                    <ClusterDendrogram
+                      merges={kappaDendrogram}
+                      leafOrder={kappaLeafOrder}
+                      modelLabels={modelLabels}
+                      clusterIdByModelId={kappaClusterIdByModelId ?? {}}
+                    />
+                  </div>
+                ) : null}
+                {kappaLeafOrder != null && kappaKappaPairs != null ? (
+                  <div>
+                    <p className="mb-2 text-xs font-semibold text-gray-700">Cluster-ordered kappa heatmap</p>
+                    <ClusterOrderedKappaHeatmap
+                      leafOrder={kappaLeafOrder}
+                      modelLabels={modelLabels}
+                      kappaPairs={kappaKappaPairs}
+                      clusterIdByModelId={kappaClusterIdByModelId ?? {}}
+                    />
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              // Score modes: show the existing value-profile chart
+              (() => {
+                // Plot dataSource only controls how centroids are scaled. Under
+                // 'kappa-agreement' the grouping is by kappa but centroids are
+                // still log-odds, so the plots use 'log-odds' for scaling.
+                const plotDataSource: 'log-odds' | 'win-rate' =
+                  dataSource === 'win-rate' && groupDisplayMode === 'groups' ? 'win-rate' : 'log-odds';
+                return (
+                  <>
+                    {viewMode === 'dot' && <ClusterDotPlot clusters={clusters} activeGroupIds={activeGroupIds} dataSource={plotDataSource} />}
+                    {viewMode === 'bar' && <ClusterBarPlot clusters={clusters} activeGroupIds={activeGroupIds} dataSource={plotDataSource} />}
+                    {viewMode === 'radar' && <ClusterRadarChart clusters={clusters} activeGroupIds={activeGroupIds} dataSource={plotDataSource} />}
+                  </>
+                );
+              })()
+            )}
 
             <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
               {clusters.map((cluster, index) => {

--- a/cloud/apps/web/src/components/models/ModelAnalysisSettingsBar.tsx
+++ b/cloud/apps/web/src/components/models/ModelAnalysisSettingsBar.tsx
@@ -53,28 +53,30 @@ export function ModelAnalysisSettingsBar({
           </div>
         </div>
 
-        <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
-          <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Similarity method</span>
-          <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
-            {CALCULATION_METHODS.map((option) => {
-              const active = similarityMethod === option.value;
-              return (
-                <Button
-                  key={option.value}
-                  type="button"
-                  variant={active ? 'primary' : 'ghost'}
-                  size="sm"
-                  onClick={() => onSimilarityMethodChange(option.value)}
-                  className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
-                    active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                  }`}
-                >
-                  {option.label}
-                </Button>
-              );
-            })}
+        {dataSource !== 'kappa-agreement' && (
+          <div className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-1">
+            <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">Similarity method</span>
+            <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
+              {CALCULATION_METHODS.map((option) => {
+                const active = similarityMethod === option.value;
+                return (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    variant={active ? 'primary' : 'ghost'}
+                    size="sm"
+                    onClick={() => onSimilarityMethodChange(option.value)}
+                    className={`rounded-md px-3 py-1 text-xs font-medium min-h-0 ${
+                      active ? 'bg-teal-600 text-white hover:bg-teal-700' : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                    }`}
+                  >
+                    {option.label}
+                  </Button>
+                );
+              })}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </section>
   );

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -305,9 +305,12 @@ export type CircumplexResult = {
 
 export type ClusterAnalysis = {
   __typename?: 'ClusterAnalysis';
+  clusterIdByModelId?: Maybe<Scalars['JSON']['output']>;
   clusters: Array<DomainCluster>;
   defaultPair?: Maybe<Array<Scalars['String']['output']>>;
+  dendrogram?: Maybe<Array<DendrogramMerge>>;
   faultLinesByPair: Scalars['JSON']['output'];
+  leafOrder?: Maybe<Array<Scalars['String']['output']>>;
   skipReason?: Maybe<Scalars['String']['output']>;
   skipped: Scalars['Boolean']['output'];
 };
@@ -673,6 +676,13 @@ export type DeleteTagResult = {
   affectedDefinitions: Scalars['Int']['output'];
   /** Whether deletion was successful */
   success: Scalars['Boolean']['output'];
+};
+
+export type DendrogramMerge = {
+  __typename?: 'DendrogramMerge';
+  height: Scalars['Float']['output'];
+  leftMemberIds: Array<Scalars['String']['output']>;
+  rightMemberIds: Array<Scalars['String']['output']>;
 };
 
 /** Result of deprecating a model */
@@ -1388,6 +1398,19 @@ export type JobTypeStatus = {
   pending: Scalars['Int']['output'];
   /** Job type name (e.g., probe_scenario) */
   type: Scalars['String']['output'];
+};
+
+export type KappaClusterPayload = {
+  __typename?: 'KappaClusterPayload';
+  clusterAnalysis: ClusterAnalysis;
+  kappaPairs: Array<KappaPair>;
+};
+
+export type KappaPair = {
+  __typename?: 'KappaPair';
+  kappa?: Maybe<Scalars['Float']['output']>;
+  modelAId: Scalars['String']['output'];
+  modelBId: Scalars['String']['output'];
 };
 
 /** A named level preset defining the 5-word intensity scale for job-choice conditions */
@@ -2820,7 +2843,7 @@ export type Query = {
    *
    */
   me?: Maybe<User>;
-  modelAgreementClusterAnalysis: ClusterAnalysis;
+  modelAgreementClusterAnalysis: KappaClusterPayload;
   modelAgreementOnTradeoffs: ModelAgreementResult;
   modelPairDivergenceBreakdown: PairDivergenceBreakdown;
   /** Get token statistics for specific models. Useful for understanding prediction quality. */
@@ -4859,7 +4882,7 @@ export type ModelAgreementClusterAnalysisQueryVariables = Exact<{
 }>;
 
 
-export type ModelAgreementClusterAnalysisQuery = { __typename?: 'Query', modelAgreementClusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } };
+export type ModelAgreementClusterAnalysisQuery = { __typename?: 'Query', modelAgreementClusterAnalysis: { __typename?: 'KappaClusterPayload', clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, leafOrder?: Array<string> | null, clusterIdByModelId?: unknown | null, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }>, dendrogram?: Array<{ __typename?: 'DendrogramMerge', leftMemberIds: Array<string>, rightMemberIds: Array<string>, height: number }> | null }, kappaPairs: Array<{ __typename?: 'KappaPair', modelAId: string, modelBId: string, kappa?: number | null }> } };
 
 export type ModelAgreementOnTradeoffsQueryVariables = Exact<{
   modelIds: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
@@ -7353,24 +7376,38 @@ export const ModelAgreementClusterAnalysisDocument = gql`
     signature: $signature
     method: $method
   ) {
-    skipped
-    skipReason
-    defaultPair
-    clusters {
-      id
-      name
-      definingValues
-      centroid
-      members {
-        model
-        label
-        silhouetteScore
-        isOutlier
-        nearestClusterIds
-        distancesToNearestClusters
+    clusterAnalysis {
+      skipped
+      skipReason
+      defaultPair
+      clusters {
+        id
+        name
+        definingValues
+        centroid
+        members {
+          model
+          label
+          silhouetteScore
+          isOutlier
+          nearestClusterIds
+          distancesToNearestClusters
+        }
       }
+      faultLinesByPair
+      dendrogram {
+        leftMemberIds
+        rightMemberIds
+        height
+      }
+      leafOrder
+      clusterIdByModelId
     }
-    faultLinesByPair
+    kappaPairs {
+      modelAId
+      modelBId
+      kappa
+    }
   }
 }
     `;

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -235,7 +235,7 @@ export function ModelsGroups() {
 
   // Bridge codegen's optional-nullable fields to ClusterAnalysis's strict-nullable fields.
   const kappaClusterAnalysis = useMemo<ClusterAnalysis | null>(() => {
-    const raw = kappaClusterData?.modelAgreementClusterAnalysis;
+    const raw = kappaClusterData?.modelAgreementClusterAnalysis?.clusterAnalysis;
     if (raw == null) return null;
     return {
       skipped: raw.skipped,
@@ -244,6 +244,24 @@ export function ModelsGroups() {
       clusters: raw.clusters as ClusterAnalysis['clusters'],
       faultLinesByPair: (raw.faultLinesByPair ?? {}) as ClusterAnalysis['faultLinesByPair'],
     };
+  }, [kappaClusterData]);
+
+  const kappaDendrogram = useMemo(() => {
+    return kappaClusterData?.modelAgreementClusterAnalysis?.clusterAnalysis?.dendrogram ?? null;
+  }, [kappaClusterData]);
+
+  const kappaLeafOrder = useMemo(() => {
+    return kappaClusterData?.modelAgreementClusterAnalysis?.clusterAnalysis?.leafOrder ?? null;
+  }, [kappaClusterData]);
+
+  const kappaClusterIdByModelId = useMemo(() => {
+    const raw = kappaClusterData?.modelAgreementClusterAnalysis?.clusterAnalysis?.clusterIdByModelId;
+    if (raw == null) return null;
+    return raw as Record<string, string>;
+  }, [kappaClusterData]);
+
+  const kappaKappaPairs = useMemo(() => {
+    return kappaClusterData?.modelAgreementClusterAnalysis?.kappaPairs ?? null;
   }, [kappaClusterData]);
   const transcriptCount = useMemo(
     () => countAnalyzedTranscripts(data?.domainAnalysis.models ?? [], visibleModelIds),
@@ -386,6 +404,10 @@ export function ModelsGroups() {
           <ModelGroupsSection
             clusterAnalysisByMethod={data?.domainAnalysis.clusterAnalysisByMethod}
             kappaClusterAnalysis={kappaClusterAnalysis}
+            kappaDendrogram={kappaDendrogram}
+            kappaLeafOrder={kappaLeafOrder}
+            kappaClusterIdByModelId={kappaClusterIdByModelId}
+            kappaKappaPairs={kappaKappaPairs}
             kappaClusterLoading={kappaClusterFetching}
             kappaClusterError={kappaClusterError?.message ?? null}
             dataSource={dataSource}

--- a/cloud/apps/web/tests/components/domains/ClusterDendrogram.test.tsx
+++ b/cloud/apps/web/tests/components/domains/ClusterDendrogram.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ClusterDendrogram, type DendrogramMerge } from '../../../src/components/domains/ClusterDendrogram';
+
+// Minimal test data: 4 models with 3 merges
+const leafOrder = ['m1', 'm2', 'm3', 'm4'];
+const modelLabels: Record<string, string> = {
+  m1: 'Model 1',
+  m2: 'Model 2',
+  m3: 'Model 3',
+  m4: 'Model 4',
+};
+const clusterIdByModelId: Record<string, string> = {
+  m1: 'cluster-1',
+  m2: 'cluster-1',
+  m3: 'cluster-2',
+  m4: 'cluster-2',
+};
+const merges: DendrogramMerge[] = [
+  { leftMemberIds: ['m1'], rightMemberIds: ['m2'], height: 0.1 },
+  { leftMemberIds: ['m3'], rightMemberIds: ['m4'], height: 0.15 },
+  { leftMemberIds: ['m1', 'm2'], rightMemberIds: ['m3', 'm4'], height: 0.5 },
+];
+
+describe('ClusterDendrogram', () => {
+  it('renders an SVG with the expected aria label', () => {
+    render(
+      <ClusterDendrogram
+        merges={merges}
+        leafOrder={leafOrder}
+        modelLabels={modelLabels}
+        clusterIdByModelId={clusterIdByModelId}
+      />,
+    );
+    expect(screen.getByRole('img', { name: /cluster dendrogram/i })).toBeInTheDocument();
+  });
+
+  it('renders a leaf label for each model', () => {
+    render(
+      <ClusterDendrogram
+        merges={merges}
+        leafOrder={leafOrder}
+        modelLabels={modelLabels}
+        clusterIdByModelId={clusterIdByModelId}
+      />,
+    );
+    for (const label of Object.values(modelLabels)) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('renders N-1 internal node connectors (polylines)', () => {
+    const { container } = render(
+      <ClusterDendrogram
+        merges={merges}
+        leafOrder={leafOrder}
+        modelLabels={modelLabels}
+        clusterIdByModelId={clusterIdByModelId}
+      />,
+    );
+    // Each merge produces 1 polyline (left child) + 1 line (right child descent)
+    const polylines = container.querySelectorAll('polyline');
+    // N-1 = 3 merges → 3 polylines (one per merge for the left child connector)
+    expect(polylines.length).toBe(merges.length);
+  });
+
+  it('renders a fallback when merges is empty', () => {
+    render(
+      <ClusterDendrogram
+        merges={[]}
+        leafOrder={leafOrder}
+        modelLabels={modelLabels}
+        clusterIdByModelId={clusterIdByModelId}
+      />,
+    );
+    expect(screen.getByText(/no dendrogram data/i)).toBeInTheDocument();
+  });
+
+  it('renders a cut line when cutLineHeight is provided', () => {
+    const { container } = render(
+      <ClusterDendrogram
+        merges={merges}
+        leafOrder={leafOrder}
+        modelLabels={modelLabels}
+        clusterIdByModelId={clusterIdByModelId}
+        cutLineHeight={0.3}
+      />,
+    );
+    // Cut line is a dashed line with stroke-dasharray
+    const dashedLines = container.querySelectorAll('line[stroke-dasharray]');
+    expect(dashedLines.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/cloud/apps/web/tests/components/domains/ClusterOrderedKappaHeatmap.test.tsx
+++ b/cloud/apps/web/tests/components/domains/ClusterOrderedKappaHeatmap.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ClusterOrderedKappaHeatmap, type KappaPairInput } from '../../../src/components/domains/ClusterOrderedKappaHeatmap';
+
+// Minimal 3-model test data
+const leafOrder = ['m1', 'm2', 'm3'];
+const modelLabels: Record<string, string> = {
+  m1: 'Alpha',
+  m2: 'Beta',
+  m3: 'Gamma',
+};
+const clusterIdByModelId: Record<string, string> = {
+  m1: 'cluster-1',
+  m2: 'cluster-1',
+  m3: 'cluster-2',
+};
+const kappaPairs: KappaPairInput[] = [
+  { modelAId: 'm1', modelBId: 'm2', kappa: 0.8 },
+  { modelAId: 'm1', modelBId: 'm3', kappa: 0.1 },
+  { modelAId: 'm2', modelBId: 'm3', kappa: 0.15 },
+];
+
+describe('ClusterOrderedKappaHeatmap', () => {
+  it('renders an SVG with the expected aria label', () => {
+    render(
+      <ClusterOrderedKappaHeatmap
+        leafOrder={leafOrder}
+        modelLabels={modelLabels}
+        kappaPairs={kappaPairs}
+        clusterIdByModelId={clusterIdByModelId}
+      />,
+    );
+    expect(screen.getByRole('img', { name: /kappa heatmap/i })).toBeInTheDocument();
+  });
+
+  it('renders a label for each model', () => {
+    render(
+      <ClusterOrderedKappaHeatmap
+        leafOrder={leafOrder}
+        modelLabels={modelLabels}
+        kappaPairs={kappaPairs}
+        clusterIdByModelId={clusterIdByModelId}
+      />,
+    );
+    // Each model has a row label and a column label → 2 appearances each
+    for (const label of Object.values(modelLabels)) {
+      const elements = screen.getAllByText(label);
+      expect(elements.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('renders N×N grid cells (rects)', () => {
+    const n = leafOrder.length;
+    const { container } = render(
+      <ClusterOrderedKappaHeatmap
+        leafOrder={leafOrder}
+        modelLabels={modelLabels}
+        kappaPairs={kappaPairs}
+        clusterIdByModelId={clusterIdByModelId}
+      />,
+    );
+    // All cell rects are inside a <g> transform; cluster boundary rects are separate
+    // We count only the inner grid rects: exactly N*N of them
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    // Spot-check: there are at least n*n rects inside the grid group
+    const allRects = container.querySelectorAll('rect');
+    // n*n cell rects + boundary rects (one per cluster block)
+    const minExpected = n * n;
+    expect(allRects.length).toBeGreaterThanOrEqual(minExpected);
+  });
+
+  it('renders cluster boundary boxes (teal outline rects)', () => {
+    const { container } = render(
+      <ClusterOrderedKappaHeatmap
+        leafOrder={leafOrder}
+        modelLabels={modelLabels}
+        kappaPairs={kappaPairs}
+        clusterIdByModelId={clusterIdByModelId}
+      />,
+    );
+    // Boundary rects have stroke="#0d9488" (teal-600) and fill="none"
+    const boundaryRects = container.querySelectorAll('rect[fill="none"]');
+    // 2 cluster blocks → 2 boundary rects
+    expect(boundaryRects.length).toBe(2);
+  });
+
+  it('renders a fallback when leafOrder is empty', () => {
+    render(
+      <ClusterOrderedKappaHeatmap
+        leafOrder={[]}
+        modelLabels={{}}
+        kappaPairs={[]}
+        clusterIdByModelId={{}}
+      />,
+    );
+    expect(screen.getByText(/no kappa data/i)).toBeInTheDocument();
+  });
+});

--- a/cloud/scripts/file-size-allowlist.txt
+++ b/cloud/scripts/file-size-allowlist.txt
@@ -5,6 +5,10 @@
 
 # Production components / pages over 700
 cloud/apps/web/src/components/analysis/PairedRunComparisonCard.tsx
+# Clustering algorithms: UPGMA, Ward, 5 distance-matrix builders, silhouettes,
+# dendrogram helpers. All tightly coupled math — splitting adds indirection
+# without reducing complexity. Extract stat helpers when the file hits 900+.
+cloud/apps/api/src/graphql/queries/domain-clustering.ts
 # Pressure sensitivity resolver: inline helper fns (buildSourceRunToDefIdMap,
 # fetchTranscriptsFromSourceRuns, buildEmptyResult) exported for tests.
 # Split into resolver-helpers.ts when convenient.


### PR DESCRIPTION
## Summary

- When **Kappa Agreement** is selected as the data source on the Model Clusters chart, the value-profile chart (Radar/Dot/Bar) is now replaced with two stacked visualizations: a **dendrogram** showing the cluster merge tree, and a **cluster-ordered kappa heatmap** with cluster boundary boxes.
- The **View mode** (Radar/Dot/Bar) toggle is hidden in kappa mode — it doesn't apply since both charts always render.
- The **Similarity method** toggle in `ModelAnalysisSettingsBar` is hidden in kappa mode — kappa IS the distance, so there's no choice to make.
- The **Display** (Groups/Individual) and **Linkage** (UPGMA/Ward) toggles are preserved in both modes.
- In **score modes** (Log Odds / Win Rate), everything is exactly as before.

## Backend changes

- `domain-clustering.ts`: Added `DendrogramMerge` type. Added `deriveDendrogram` and `deriveLeafOrder` helper functions. `computeKappaClusterAnalysis` now populates `dendrogram`, `leafOrder`, and `clusterIdByModelId` on the returned `ClusterAnalysis`.
- `domain/types.ts`: Added Pothos types for `DendrogramMerge`, `KappaPair`, and `KappaClusterPayload`. `ClusterAnalysisRef` exposes the three new optional fields. The `modelAgreementClusterAnalysis` query now returns `KappaClusterPayload` (wrapper with `clusterAnalysis` + `kappaPairs` flat list).
- `model-agreement-cluster-analysis.ts`: Resolver builds `kappaPairs` from the kappa matrix and returns `KappaClusterPayload`.

## Frontend changes

- New `ClusterDendrogram.tsx`: SVG dendrogram with L-shaped merge connectors, leaf labels colored by cluster, and an optional horizontal cut-line.
- New `ClusterOrderedKappaHeatmap.tsx`: N×N kappa heatmap with leaf-order rows/columns, red→white→green color scale (same as `ModelAgreementHeatmap`), and teal cluster boundary boxes.
- `ModelGroupsSection.tsx`: In kappa + groups mode, renders the two new charts instead of the value-profile chart. Hides the View mode toggle in kappa mode.
- `ModelAnalysisSettingsBar.tsx`: Hides the Similarity method row when `dataSource === 'kappa-agreement'`.
- `ModelsGroups.tsx`: Extracts `dendrogram`, `leafOrder`, `clusterIdByModelId`, and `kappaPairs` from the new wrapper type and passes them to `ModelGroupsSection`.
- `schema.graphql` and `modelAgreementClusterAnalysis.graphql` updated; codegen re-run.

## Test plan

- [ ] All 163 web test files pass (`npm run test --workspace @valuerank/web`) — confirmed locally
- [ ] All 52 domain-clustering API tests pass including 15 new tests covering `deriveDendrogram`, `deriveLeafOrder`, `computeKappaClusterAnalysis` dendrogram fields — confirmed locally
- [ ] API builds cleanly (`npm run build --workspace @valuerank/api`)
- [ ] Web builds cleanly (`npm run build --workspace @valuerank/web`)
- [ ] No `@ts-ignore`, `eslint-disable`, or `any` casts introduced
- [ ] Score modes (Log Odds / Win Rate) render identically to before — the kappa path is gated by `dataSource === 'kappa-agreement'`
- [ ] In kappa mode: View mode toggle hidden, Similarity method toggle hidden, Dendrogram + Heatmap render
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)