### PR TITLE
fix(model-clusters): use 1 - kappa as distance (drop the / 2 normalization)

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain-clustering.ts
+++ b/cloud/apps/api/src/graphql/queries/domain-clustering.ts
@@ -657,14 +657,19 @@ export function deriveLeafOrder(merges: DendrogramMerge[], allModelIds: string[]
 /**
  * Build a hierarchical-clustering distance matrix from a kappa matrix.
  *
- * Maps Cohen's kappa from [-1, 1] to a distance in [0, 1]:
- *   kappa =  1   →  distance = 0    (perfect agreement, identical players)
- *   kappa =  0   →  distance = 0.5  (chance agreement, no signal)
- *   kappa = -1   →  distance = 1    (worse than chance, opposite players)
+ * Maps Cohen's kappa from [-1, 1] directly to a distance in [0, 2]:
+ *   kappa =  1   →  distance = 0   (perfect agreement, identical players)
+ *   kappa =  0   →  distance = 1   (chance agreement, no signal)
+ *   kappa = -1   →  distance = 2   (worse than chance, opposite players)
+ *
+ * Reading: distance = 1 - kappa, so subtracting any merge's distance from 1
+ * recovers the kappa value directly. Hierarchical clustering is scale-
+ * invariant for the merge structure, so keeping the un-normalized form
+ * doesn't change which clusters form — only the dendrogram axis labels.
  *
  * Null kappa entries (no overlap or degenerate marginals) are mapped to
- * 0.5 — the same as "no signal" — which avoids breaking the distance
- * matrix while not pretending we know more than we do.
+ * distance = 1 — the same as "no signal" (kappa = 0) — which avoids
+ * breaking the distance matrix while not pretending we know more than we do.
  */
 export function kappaDistanceMatrix(kappaMatrix: ReadonlyArray<ReadonlyArray<number | null>>): number[][] {
   const n = kappaMatrix.length;
@@ -672,7 +677,7 @@ export function kappaDistanceMatrix(kappaMatrix: ReadonlyArray<ReadonlyArray<num
   for (let i = 0; i < n; i++) {
     for (let j = i + 1; j < n; j++) {
       const k = kappaMatrix[i]?.[j];
-      const dist = k == null ? 0.5 : Math.max(0, Math.min(1, (1 - k) / 2));
+      const dist = k == null ? 1 : Math.max(0, Math.min(2, 1 - k));
       matrix[i]![j] = dist;
       matrix[j]![i] = dist;
     }

--- a/cloud/apps/api/tests/graphql/queries/domain-clustering.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/domain-clustering.test.ts
@@ -604,11 +604,25 @@ describe('computeKappaClusterAnalysis — kappa-specific fields', () => {
     }
   });
 
-  it('kappaDistanceMatrix maps kappa 1 to distance 0 and kappa -1 to distance 1', () => {
-    const km: Array<Array<number | null>> = [[1, -1], [-1, 1]];
+  it('kappaDistanceMatrix maps kappa directly via 1 - kappa (range [0, 2])', () => {
+    const km: Array<Array<number | null>> = [
+      [1, -1, 0],
+      [-1, 1, null],
+      [0, null, 1],
+    ];
     const dist = kappaDistanceMatrix(km);
-    expect(dist[0]![1]).toBeCloseTo(1);
-    expect(dist[1]![0]).toBeCloseTo(1);
+    // kappa = 1 → distance = 0
     expect(dist[0]![0]).toBeCloseTo(0);
+    expect(dist[1]![1]).toBeCloseTo(0);
+    expect(dist[2]![2]).toBeCloseTo(0);
+    // kappa = -1 → distance = 2
+    expect(dist[0]![1]).toBeCloseTo(2);
+    expect(dist[1]![0]).toBeCloseTo(2);
+    // kappa = 0 → distance = 1
+    expect(dist[0]![2]).toBeCloseTo(1);
+    expect(dist[2]![0]).toBeCloseTo(1);
+    // null kappa → distance = 1 (treated as no signal)
+    expect(dist[1]![2]).toBeCloseTo(1);
+    expect(dist[2]![1]).toBeCloseTo(1);
   });
 });


### PR DESCRIPTION
## Summary

Drops the / 2 from the kappa-distance formula in hierarchical clustering. Distance is now \`1 - kappa\` directly, so the dendrogram X-axis can be read as \"1 minus this number is the kappa value\" without a mental halving step.

## Mapping change

| kappa | Old distance ((1 - k)/2) | New distance (1 - k) |
|-------|--------------------------|----------------------|
|  1.0  | 0.0                      | 0.0                  |
|  0.5  | 0.25                     | 0.5                  |
|  0    | 0.5                      | 1.0                  |
| -0.5  | 0.75                     | 1.5                  |
| -1.0  | 1.0                      | 2.0                  |

Null kappa (no overlap / degenerate marginals) now maps to distance = 1 (same \"no signal\" meaning, new scale).

## Why this is safe

Hierarchical clustering (UPGMA, Ward) is scale-invariant for merge structure. Multiplying every distance by a constant does NOT change which clusters form, the merge order, or any cluster member assignment. Only the axis labels on the dendrogram shift. So:

- Same clusters
- Same defaultPair
- Same fault-line ordering
- Same silhouette scores
- Different axis tick values on the dendrogram chart

## What changes for users

When viewing the dendrogram in kappa mode, the X-axis labels shift up. A merge that was previously rendered at distance 0.2 now renders at distance 0.4. To recover the kappa value: \`kappa = 1 - distance\`. The dendrogram component already auto-scales to the actual range of merge distances in the data, so no chart code change is needed.

## Validation

```
npm run lint --workspace @valuerank/api    ✅  0 errors
npm run build --workspace @valuerank/api   ✅  clean
npm run test --workspace @valuerank/api -- domain-clustering   ✅  52/52 pass
```

Updated 1 test (\`kappaDistanceMatrix maps kappa directly via 1 - kappa\`) to assert the new range \`[0, 2]\` and verify the kappa = 0 / null cases land at distance 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)