### PR TITLE
dedup-catalog-discoverability: surface the catalog in AGENTS.md + cloud/CLAUDE.md, backfill 2 PR refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Canonical source: `docs/canonical-glossary.md`
 - Follow the Preflight Gate in `cloud/CLAUDE.md` before any `git push` or PR creation.
 - Invoked delivery actions (Feature Factory `deliver`, `/ship`, explicit "push and open the PR" instructions) do not need re-confirmation. The invocation is the consent. See `cloud/CLAUDE.md` for the full rule.
 - To merge a PR, invoke the `/ship` skill — not direct `gh pr merge` or passive "watch CI." `/ship` rebases onto main first, runs preflight, watches CI to completion, and squash-merges. Skipping the rebase step is the most common cause of stuck "CI failing on stale base" loops.
+- Before building a new component, service, or utility that may already exist, check `docs/tech-debt/dedup-inventory.md` — the curated catalog of known duplicate-module clusters with severity × lift triage. New duplicates discovered during work should be added there as new `DEDUP-N` entries (in the same PR that finds them).
 - One feature per branch. Do not stack new work on top of an open feature PR unless the human asks.
 - Fix the root cause when CI fails. Do not retry blindly.
 

--- a/cloud/CLAUDE.md
+++ b/cloud/CLAUDE.md
@@ -76,7 +76,11 @@ Enforced mechanically — do not treat these as soft guidance.
 
 Grandfathered files live in the allowlists next to each script. See
 [`docs/tech-debt/file-structure.md`](../docs/tech-debt/file-structure.md)
-for what to collapse when touching the area.
+for what to collapse when touching the area, and
+[`docs/tech-debt/dedup-inventory.md`](../docs/tech-debt/dedup-inventory.md)
+for the curated catalog of duplicate-module clusters (DEDUP-N IDs,
+triage status, PR refs). Check the dedup catalog before adding a new
+component or utility — the duplicate may already be tracked there.
 
 Guidance when the size warning fires: do not split just to silence it. Ask
 whether the file has one responsibility. If yes, keep it. If no, split by

--- a/docs/tech-debt/dedup-inventory.md
+++ b/docs/tech-debt/dedup-inventory.md
@@ -38,7 +38,7 @@ DEDUP-8 (`isRecord`) is independent of report output — pure type guard.
 
 | ID | Cluster | Slice | Severity | Lift | Status |
 |---|---|---|---|---|---|
-| ~~DEDUP-1~~ | ~~`pauseQueue` / `resumeQueue` — two implementations~~ | ~~API~~ | ~~High (bug risk)~~ | ~~Medium~~ | **Resolved — PR #TBD** |
+| ~~DEDUP-1~~ | ~~`pauseQueue` / `resumeQueue` — two implementations~~ | ~~API~~ | ~~High (bug risk)~~ | ~~Medium~~ | **Resolved — PR #963** |
 | ~~DEDUP-2~~ | ~~Schwartz + signature-preference forked web↔shared~~ | ~~Web/Shared~~ | ~~High~~ | ~~Small~~ | **Resolved (partial) — PR #937** |
 | ~~DEDUP-3~~ | ~~`useRuns` vs `useRunsWithAnalysis` (and infinite variants)~~ | ~~Web~~ | ~~High~~ | ~~Small~~ | **Resolved — PR #934** |
 | DEDUP-4 | Run vs Analysis list/card/folder views | Web | High | Large | Decision needed |
@@ -50,7 +50,7 @@ DEDUP-8 (`isRecord`) is independent of report output — pure type guard.
 | DEDUP-10 | Decision-summary utility sprawl | Web | Medium-High | Large | Decision needed |
 | ~~DEDUP-11~~ | ~~Shared `*-value-statements.ts` (4× boilerplate)~~ | ~~Shared~~ | ~~Medium~~ | ~~Small~~ | **Resolved — PR #955** |
 | DEDUP-12 | Run lifecycle / recovery sprawl | API | Medium-Low | Large | Decision needed |
-| ~~DEDUP-13~~ | ~~`validate_input` pattern across 5 workers~~ | ~~Workers~~ | ~~Low~~ | ~~Small~~ | **Resolved — PR #TBD** |
+| ~~DEDUP-13~~ | ~~`validate_input` pattern across 5 workers~~ | ~~Workers~~ | ~~Low~~ | ~~Small~~ | **Resolved — PR #957** |
 | DEDUP-14 | `DomainAnalysisLegacy` GraphQL query — alive, feeds Models + Domains pages | Web | Medium | Large (migration, not delete) | Decision needed |
 | ~~DEDUP-15~~ | ~~`runsWithAnalysis(ids:)` resolver and query unused~~ | ~~API + Web~~ | ~~Medium~~ | ~~Small (deletion)~~ | **Resolved — PR #936** |
 
@@ -60,7 +60,7 @@ Status values: `Open` (mechanical, ready to do) · `Decision needed` (needs a di
 
 ### DEDUP-1 — `pauseQueue` / `resumeQueue` two implementations
 
-**Status: Resolved in PR #TBD (2026-05-05). Option A — semantically equivalent duplicates; orchestrator is canonical.**
+**Status: Resolved in PR #963 (2026-05-06). Option A — semantically equivalent duplicates; orchestrator is canonical.**
 
 Investigation confirmed both implementations intended the same semantics (stop processing new jobs, accumulate them, resume later). The implementations differed in mechanism: `control.ts` called `stopBoss()`/`startBoss()` (hard stop — destroys the PgBoss singleton), while `orchestrator.ts` used `boss.offWork()`/`registerHandlers()` (soft stop — PgBoss stays alive, workers unsubscribed). The orchestrator's approach is correct: resume re-registers handlers so jobs start flowing again. `control.ts`'s approach was broken: `resumeQueue` called `startBoss()` but never re-registered handlers, silently leaving workers unsubscribed after resume.
 
@@ -204,7 +204,7 @@ Consolidated the four 52-LOC files into `cloud/packages/shared/src/value-stateme
 
 ### DEDUP-13 — `validate_input` pattern across 5 workers
 
-**Status: Resolved in PR #TBD (2026-05-05).**
+**Status: Resolved in PR #957 (2026-05-06).**
 
 Extracted 4 helpers into `cloud/workers/common/validation.py`:
 - `require_fields(data, fields)` — missing-field loop with details (used by summarize, probe)


### PR DESCRIPTION
## Summary

The curated dedup catalog at `docs/tech-debt/dedup-inventory.md` exists and is being maintained, but discoverability is poor. Recently both orchestrator and operator forgot it existed and started building a parallel codebase-inventory tool (closed as PR #1008). This PR closes that gap.

## Changes

**Discoverability**:
- `AGENTS.md` — new line under Repo Rules pointing at the catalog. Auto-loaded by every AI session in this repo.
- `cloud/CLAUDE.md` — cross-reference added next to the existing `file-structure.md` reference.

**Backfill**:
- DEDUP-1 (`pauseQueue` / `resumeQueue`) → marked resolved by **PR #963**
- DEDUP-13 (`validate_input` pattern across workers) → marked resolved by **PR #957**
- Both detail sections also updated with these refs and corrected dates.

## Why

The catalog already has self-documented maintenance rules (edit in same PR that does the dedup work, don't renumber, etc.). The drift is in two specific places:

1. **PR #TBD never backfilled** — entries marked resolved but the actual PR number was never filled in. Makes the catalog audit-resistant.
2. **Other AI sessions don't know the catalog exists** — they're not auto-loading it. The fix is a one-liner in the docs that already auto-load.

## Test plan
- [x] Pure docs change, no tests to run
- [x] No code modified
- [x] All four `PR #TBD` markers in the catalog now resolved with real PR numbers
- [ ] Future AI sessions check the catalog before building new components (will validate empirically over the next few features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)