### PR TITLE
feat(model-clusters): show dashed cut line on dendrogram

### DIFF
--- a/cloud/apps/web/src/components/domains/ClusterDendrogram.tsx
+++ b/cloud/apps/web/src/components/domains/ClusterDendrogram.tsx
@@ -215,17 +215,39 @@ export function ClusterDendrogram({
           {/* Dendrogram lines */}
           {lines}
 
-          {/* Cut line — vertical when oriented horizontally */}
+          {/* Cut line — vertical when oriented horizontally. Marks where the
+              clustering algorithm split into the displayed clusters. */}
           {cutLineHeight != null && (
-            <line
-              x1={heightToX(cutLineHeight)}
-              y1={0}
-              x2={heightToX(cutLineHeight)}
-              y2={innerHeight}
-              stroke="#0d9488"
-              strokeWidth={1.5}
-              strokeDasharray="5,3"
-            />
+            <g>
+              <line
+                x1={heightToX(cutLineHeight)}
+                y1={0}
+                x2={heightToX(cutLineHeight)}
+                y2={innerHeight}
+                stroke="#0d9488"
+                strokeWidth={1.5}
+                strokeDasharray="5,3"
+              />
+              <text
+                x={heightToX(cutLineHeight) + 4}
+                y={-4}
+                textAnchor="start"
+                fontSize={9}
+                fill="#0d9488"
+                fontWeight={600}
+              >
+                cluster cut
+              </text>
+              <text
+                x={heightToX(cutLineHeight) + 4}
+                y={6}
+                textAnchor="start"
+                fontSize={9}
+                fill="#0d9488"
+              >
+                {cutLineHeight.toFixed(2)}
+              </text>
+            </g>
           )}
 
           {/* Leaf nodes and labels (on the left side, label reads naturally) */}

--- a/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
+++ b/cloud/apps/web/src/components/domains/ModelGroupsSection.tsx
@@ -112,6 +112,23 @@ export function ModelGroupsSection({
     ? kappaClusterAnalysis
     : (clusterAnalysisByMethod?.[backendKey] ?? null);
 
+  // Derive the dendrogram cut-line height from where the algorithm decided
+  // to split. With N models there are N-1 merges. If the algorithm produced
+  // K clusters, the first N-K merges happened *within* clusters and the rest
+  // happened *between* clusters. The cut line sits at the midpoint between
+  // the last within-cluster merge and the first between-cluster merge.
+  const kappaCutLineHeight = useMemo<number | null>(() => {
+    if (kappaDendrogram == null || kappaDendrogram.length === 0) return null;
+    const clusterCount = kappaClusterAnalysis?.clusters.length ?? 0;
+    const totalMerges = kappaDendrogram.length;
+    const withinClusterMergeCount = totalMerges - clusterCount + 1;
+    if (withinClusterMergeCount <= 0 || withinClusterMergeCount > totalMerges) return null;
+    const lastWithin = kappaDendrogram[withinClusterMergeCount - 1]?.height;
+    const firstBetween = kappaDendrogram[withinClusterMergeCount]?.height;
+    if (lastWithin == null || firstBetween == null) return null;
+    return (lastWithin + firstBetween) / 2;
+  }, [kappaDendrogram, kappaClusterAnalysis]);
+
   const hasGroupedClusters = activeClusterAnalysis != null && !activeClusterAnalysis.skipped;
   const groupedClusters = useMemo(() => activeClusterAnalysis?.clusters ?? [], [activeClusterAnalysis]);
   const individualClusters = useMemo(() => buildIndividualClusters(models), [models]);
@@ -350,6 +367,7 @@ export function ModelGroupsSection({
                       leafOrder={kappaLeafOrder}
                       modelLabels={modelLabels}
                       clusterIdByModelId={kappaClusterIdByModelId ?? {}}
+                      cutLineHeight={kappaCutLineHeight ?? undefined}
                     />
                   </div>
                 ) : null}


### PR DESCRIPTION
## Summary

The dendrogram component already accepted a \`cutLineHeight\` prop with the rendering code in place — but the section never passed the prop, so the dashed line never appeared.

This PR computes the cut height from the cluster analysis result and passes it through. Adds a \"cluster cut\" label and the numeric height value next to the line for context.

## How the cut height is computed

With N models there are N − 1 merges in the dendrogram. If the algorithm produced K clusters, the first (N − K + 1) merges happened *within* clusters; the rest happened *between* clusters. The cut sits at the midpoint between the last within-cluster merge and the first between-cluster merge:

\`\`\`
cutLineHeight = (merges[N - K].height + merges[N - K + 1].height) / 2
\`\`\`

For the production data (8 models, 4 clusters): last within-cluster merge at distance 0.483, first between-cluster merge at distance 0.561 → cut line at 0.522.

## What appears in the chart

A vertical dashed teal line at the computed cut height, with a small \"cluster cut 0.52\" label at the top. Reading: the algorithm decided that any pair of models whose kappa-distance was below 0.522 belongs in the same cluster.

## Validation

- \`npm run lint --workspace @valuerank/web\` ✅ 0 errors
- \`npm run build --workspace @valuerank/web\` ✅ clean
- \`npm run test --workspace @valuerank/web -- ClusterDendrogram\` ✅ 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)