### PR TITLE
feat(kappa): replace bootstrap CI with per-domain kappa breakdown

### DIFF
--- a/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
@@ -11,15 +11,14 @@ import {
   type ValuePairDivergenceShape,
 } from '../types/model-agreement-on-tradeoffs.js';
 import {
-  bootstrapKappaConfidence,
   buildEmptyAgreementResult,
   buildEmptyPairBreakdown,
   buildPositionCells,
   buildSelectedModels,
   buildUnavailableModelInfo,
   collectComparableCells,
+  computePairwiseKappaWithBreakdown,
   computeProportionA,
-  groupCellsByVignette,
   normalizeModelIds,
   summarizePairCells,
   summarizeTrialConsistency,
@@ -44,8 +43,6 @@ const ALL_DOMAINS_SCOPE_ID = 'all-domains';
 const AGREEMENT_REFRESH_REASON = 'model-agreement-on-tradeoffs-page-load-missing';
 const DRILLDOWN_REFRESH_REASON = 'model-pair-divergence-breakdown-missing';
 const NON_BINARY_CELL_FALLBACK_COUNT = 0;
-const KAPPA_BOOTSTRAP_ITERATIONS = 1000;
-
 
 async function resolveAgreementScope(params: {
   scope: DomainAnalysisScope;
@@ -157,11 +154,14 @@ export async function resolveModelAgreementOnTradeoffs(
   const selectedModels = buildSelectedModels(selectedModelIds, labelByModelId);
   const selectedModelIdSet = new Set(selectedModels.map((model) => model.modelId));
 
-  await resolveAgreementScope({
+  const { scopeData } = await resolveAgreementScope({
     scope,
     domainId,
     signature,
   });
+  const domainsById = new Map(
+    scopeData.domains.map((domain) => [domain.id, { id: domain.id, name: domain.name }] as const),
+  );
 
   const snapshotResult = await readAgreementSnapshot({
     scope,
@@ -194,8 +194,11 @@ export async function resolveModelAgreementOnTradeoffs(
       });
       tiedCells += pairTiedCells;
       const metrics = summarizePairCells(cells);
-      const cellsByVignette = groupCellsByVignette(cells);
-      const ci = bootstrapKappaConfidence(cellsByVignette, metrics.cohensKappa, KAPPA_BOOTSTRAP_ITERATIONS);
+      const breakdown = computePairwiseKappaWithBreakdown(
+        cells,
+        scopeData.definitionDomainIdById,
+        domainsById,
+      );
 
       pairwiseAgreementMatrix.push({
         modelAId: modelA.modelId,
@@ -207,9 +210,9 @@ export async function resolveModelAgreementOnTradeoffs(
         cohensKappa: metrics.cohensKappa,
         kappaInterpretation: metrics.kappaInterpretation,
         meanAbsoluteDivergence: metrics.meanAbsoluteDivergence,
-        cohensKappaConfidenceLow: ci.low,
-        cohensKappaConfidenceHigh: ci.high,
-        cohensKappaConfidenceIsSymmetric: ci.isSymmetric,
+        kappaByDomain: breakdown.kappaByDomain,
+        kappaSpread: breakdown.spread,
+        domainCount: breakdown.domainCount,
       });
     }
   }

--- a/cloud/apps/api/src/graphql/types/model-agreement-on-tradeoffs.ts
+++ b/cloud/apps/api/src/graphql/types/model-agreement-on-tradeoffs.ts
@@ -11,6 +11,13 @@ export type UnavailableModelInfoShape = {
   reason: string;
 };
 
+export type DomainKappaEntryShape = {
+  domainId: string;
+  domainName: string;
+  kappa: number | null;
+  cellCount: number;
+};
+
 export type PairwiseAgreementRowShape = {
   modelAId: string;
   modelALabel: string;
@@ -21,9 +28,9 @@ export type PairwiseAgreementRowShape = {
   cohensKappa: number | null;
   kappaInterpretation: string | null;
   meanAbsoluteDivergence: number | null;
-  cohensKappaConfidenceLow: number | null;
-  cohensKappaConfidenceHigh: number | null;
-  cohensKappaConfidenceIsSymmetric: boolean;
+  kappaByDomain: DomainKappaEntryShape[];
+  kappaSpread: number | null;
+  domainCount: number;
 };
 
 export type ModelTrialConsistencyShape = {
@@ -73,6 +80,7 @@ export type PairDivergenceBreakdownShape = {
 
 const ModelInfoRef = builder.objectRef<ModelInfoShape>('ModelInfo');
 const UnavailableModelInfoRef = builder.objectRef<UnavailableModelInfoShape>('UnavailableModelInfo');
+const DomainKappaEntryRef = builder.objectRef<DomainKappaEntryShape>('DomainKappaEntry');
 const PairwiseAgreementRowRef = builder.objectRef<PairwiseAgreementRowShape>('PairwiseAgreementRow');
 const ModelTrialConsistencyRef = builder.objectRef<ModelTrialConsistencyShape>('ModelTrialConsistency');
 const ModelAgreementBuildProgressRef = builder.objectRef<ModelAgreementBuildProgressShape>('ModelAgreementBuildProgress');
@@ -95,6 +103,15 @@ builder.objectType(UnavailableModelInfoRef, {
   }),
 });
 
+builder.objectType(DomainKappaEntryRef, {
+  fields: (t) => ({
+    domainId: t.exposeID('domainId'),
+    domainName: t.exposeString('domainName'),
+    kappa: t.exposeFloat('kappa', { nullable: true }),
+    cellCount: t.exposeInt('cellCount'),
+  }),
+});
+
 builder.objectType(PairwiseAgreementRowRef, {
   fields: (t) => ({
     modelAId: t.exposeID('modelAId'),
@@ -106,9 +123,9 @@ builder.objectType(PairwiseAgreementRowRef, {
     cohensKappa: t.exposeFloat('cohensKappa', { nullable: true }),
     kappaInterpretation: t.exposeString('kappaInterpretation', { nullable: true }),
     meanAbsoluteDivergence: t.exposeFloat('meanAbsoluteDivergence', { nullable: true }),
-    cohensKappaConfidenceLow: t.exposeFloat('cohensKappaConfidenceLow', { nullable: true }),
-    cohensKappaConfidenceHigh: t.exposeFloat('cohensKappaConfidenceHigh', { nullable: true }),
-    cohensKappaConfidenceIsSymmetric: t.exposeBoolean('cohensKappaConfidenceIsSymmetric'),
+    kappaByDomain: t.expose('kappaByDomain', { type: [DomainKappaEntryRef] }),
+    kappaSpread: t.exposeFloat('kappaSpread', { nullable: true }),
+    domainCount: t.exposeInt('domainCount'),
   }),
 });
 

--- a/cloud/apps/api/src/services/model-agreement/aggregation.ts
+++ b/cloud/apps/api/src/services/model-agreement/aggregation.ts
@@ -63,6 +63,20 @@ export type PairMetrics = {
   meanAbsoluteDivergence: number | null;
 };
 
+export type DomainKappaEntry = {
+  domainId: string;
+  domainName: string;
+  kappa: number | null;
+  cellCount: number;
+};
+
+export type PairwiseKappaBreakdown = {
+  averageKappa: number | null;
+  kappaByDomain: DomainKappaEntry[];
+  spread: number | null;
+  domainCount: number;
+};
+
 export function normalizeModelIds(modelIds: ReadonlyArray<string | number>): string[] {
   return [...new Set(modelIds.map((modelId) => String(modelId).trim()).filter((modelId) => modelId.length > 0))]
     .sort((left, right) => left.localeCompare(right));
@@ -363,6 +377,82 @@ export function summarizePairCells(cells: ReadonlyArray<ComparableCell>): PairMe
 }
 
 /**
+ * Computes Cohen's kappa independently for each domain that has cells for this
+ * model pair. Uses the same three-level equal-weight aggregation as
+ * summarizePairCells, but scoped to one domain at a time.
+ *
+ * @param cells - All comparable cells for the model pair (across all domains)
+ * @param definitionDomainIdById - Maps definitionId → domainId
+ * @param domainsById - Maps domainId → { id, name }
+ */
+export function computeKappaPerDomain(
+  cells: ReadonlyArray<ComparableCell>,
+  definitionDomainIdById: ReadonlyMap<string, string>,
+  domainsById: ReadonlyMap<string, { id: string; name: string }>,
+): DomainKappaEntry[] {
+  const cellsByDomain = new Map<string, ComparableCell[]>();
+  for (const cell of cells) {
+    const domainId = definitionDomainIdById.get(cell.definitionId);
+    if (domainId == null) {
+      continue;
+    }
+
+    const bucket = cellsByDomain.get(domainId) ?? [];
+    bucket.push(cell);
+    cellsByDomain.set(domainId, bucket);
+  }
+
+  const entries: DomainKappaEntry[] = [];
+  for (const [domainId, domainCells] of cellsByDomain.entries()) {
+    const domain = domainsById.get(domainId);
+    const metrics = summarizePairCells(domainCells);
+    entries.push({
+      domainId,
+      domainName: domain?.name ?? domainId,
+      kappa: metrics.cohensKappa,
+      cellCount: domainCells.length,
+    });
+  }
+
+  entries.sort((a, b) => a.domainName.localeCompare(b.domainName));
+  return entries;
+}
+
+/**
+ * Computes the per-domain kappa breakdown and derives headline statistics.
+ *
+ * averageKappa is the equal-weighted mean of per-domain kappa values (only
+ * domains with non-null kappa are included in the mean). This matches the
+ * existing summarizePairCells headline because summarizePairCells already
+ * weights domains equally via three-level aggregation.
+ *
+ * spread is max(kappa) - min(kappa) across domains. Null when fewer than 2
+ * domains have a non-null kappa.
+ */
+export function computePairwiseKappaWithBreakdown(
+  cells: ReadonlyArray<ComparableCell>,
+  definitionDomainIdById: ReadonlyMap<string, string>,
+  domainsById: ReadonlyMap<string, { id: string; name: string }>,
+): PairwiseKappaBreakdown {
+  const kappaByDomain = computeKappaPerDomain(cells, definitionDomainIdById, domainsById);
+  const domainCount = kappaByDomain.length;
+
+  const validKappas = kappaByDomain
+    .map((entry) => entry.kappa)
+    .filter((kappa): kappa is number => kappa != null && Number.isFinite(kappa));
+
+  const averageKappa = validKappas.length > 0
+    ? validKappas.reduce((sum, kappa) => sum + kappa, 0) / validKappas.length
+    : null;
+
+  const spread = validKappas.length >= 2
+    ? Math.max(...validKappas) - Math.min(...validKappas)
+    : null;
+
+  return { averageKappa, kappaByDomain, spread, domainCount };
+}
+
+/**
  * Trial consistency for a single model with three-level equal-weight
  * aggregation (cell → vignette → value-pair → headline). Each value pair
  * contributes equally to the headline regardless of how many vignettes
@@ -414,109 +504,10 @@ export function buildUnavailableModelInfo(model: ModelSummary): UnavailableModel
 }
 
 /**
- * Symmetry tolerance: if the upper-distance from the point estimate and the
- * lower-distance differ by at most this amount, the CI is considered symmetric.
- * Defined here so tests can import it.
+ * Wide-spread threshold: a per-domain kappa spread is considered "wide" when
+ * the max-minus-min range exceeds this value.
  */
-export const KAPPA_CI_SYMMETRY_TOLERANCE = 0.01;
-
-/**
- * Wide-CI threshold: a confidence interval is considered "wide" (data too thin
- * to constrain the estimate) when its width exceeds this value or when it
- * crosses zero (low < 0).
- */
-export const KAPPA_CI_WIDE_THRESHOLD = 0.30;
-
-export type KappaConfidenceInterval = {
-  /** 2.5th percentile of bootstrap distribution, or null if not computable. */
-  low: number | null;
-  /** 97.5th percentile of bootstrap distribution, or null if not computable. */
-  high: number | null;
-  /** True when |upper-distance - lower-distance| ≤ KAPPA_CI_SYMMETRY_TOLERANCE. */
-  isSymmetric: boolean;
-};
-
-/**
- * Groups a flat array of ComparableCell[] by definitionId (vignette).
- * The returned Map keys are vignette IDs; values are the cells that belong to
- * that vignette for this pair.
- */
-export function groupCellsByVignette(cells: ReadonlyArray<ComparableCell>): Map<string, ComparableCell[]> {
-  const map = new Map<string, ComparableCell[]>();
-  for (const cell of cells) {
-    const bucket = map.get(cell.definitionId) ?? [];
-    bucket.push(cell);
-    map.set(cell.definitionId, bucket);
-  }
-  return map;
-}
-
-/**
- * Bootstrap 95% confidence interval for Cohen's kappa by resampling whole
- * vignettes with replacement (1000 iterations by default).
- *
- * Resampling at the vignette level (not cell level) respects the clustering
- * structure — cells within a vignette share context and aren't independent.
- *
- * Returns { low: null, high: null, isSymmetric: true } when:
- *   - The point estimate is null (no data to resample).
- *   - There are no vignettes (empty input).
- *   - Fewer than 100 valid bootstrap samples were produced (degenerate case).
- */
-export function bootstrapKappaConfidence(
-  cellsByVignette: Map<string, ComparableCell[]>,
-  pointEstimateKappa: number | null,
-  iterations: number = 1000,
-): KappaConfidenceInterval {
-  if (pointEstimateKappa == null || cellsByVignette.size === 0) {
-    return { low: null, high: null, isSymmetric: true };
-  }
-
-  const vignetteIds = Array.from(cellsByVignette.keys());
-  const n = vignetteIds.length;
-  const kappaSamples: number[] = [];
-
-  for (let iter = 0; iter < iterations; iter += 1) {
-    // Resample vignettes WITH REPLACEMENT.
-    // Each draw gets a unique synthetic vignette ID so that duplicate draws
-    // (e.g. drawing vignette A twice) are not collapsed back into one group
-    // by summarizePairCells. Without this, drawing {A, A, B} produces the
-    // same kappa as drawing {A, B} because cells keep their original
-    // definitionId and the 3-level aggregation deduplicates them.
-    const resampledCells: ComparableCell[] = [];
-    for (let i = 0; i < n; i += 1) {
-      const idx = Math.floor(Math.random() * n);
-      const sourceVignetteId = vignetteIds[idx]!;
-      const syntheticVignetteId = `bootstrap-${iter}-${i}`;
-      const cellsForVignette = cellsByVignette.get(sourceVignetteId) ?? [];
-      for (const c of cellsForVignette) {
-        resampledCells.push({ ...c, definitionId: syntheticVignetteId });
-      }
-    }
-    const sampleKappa = summarizePairCells(resampledCells).cohensKappa;
-    if (sampleKappa != null && Number.isFinite(sampleKappa)) {
-      kappaSamples.push(sampleKappa);
-    }
-  }
-
-  // Too few valid samples to make a meaningful CI
-  if (kappaSamples.length < 100) {
-    return { low: null, high: null, isSymmetric: true };
-  }
-
-  kappaSamples.sort((a, b) => a - b);
-  const lowIdx = Math.floor(kappaSamples.length * 0.025);
-  const highIdx = Math.floor(kappaSamples.length * 0.975);
-  const low = kappaSamples[lowIdx]!;
-  const high = kappaSamples[highIdx]!;
-
-  // Symmetry check: upper-distance from point estimate vs lower-distance.
-  const upperDist = high - pointEstimateKappa;
-  const lowerDist = pointEstimateKappa - low;
-  const isSymmetric = Math.abs(upperDist - lowerDist) <= KAPPA_CI_SYMMETRY_TOLERANCE;
-
-  return { low, high, isSymmetric };
-}
+export const KAPPA_SPREAD_WIDE_THRESHOLD = 0.30;
 
 export function buildEmptyAgreementResult(
   pending = true,

--- a/cloud/apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts
@@ -184,9 +184,14 @@ const agreementQuery = `
         cohensKappa
         kappaInterpretation
         meanAbsoluteDivergence
-        cohensKappaConfidenceLow
-        cohensKappaConfidenceHigh
-        cohensKappaConfidenceIsSymmetric
+        kappaByDomain {
+          domainId
+          domainName
+          kappa
+          cellCount
+        }
+        kappaSpread
+        domainCount
       }
       trialConsistency {
         modelId
@@ -664,28 +669,18 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
     expect(agreement.tiedCells).toBe(1);
   });
 
-  it('populates cohensKappaConfidenceLow/High that bracket the point estimate', async () => {
-    // Build enough vignettes that bootstrap produces a real CI (>= 100 valid samples).
-    // 20 vignettes: model-a always picks canonicalA, model-b alternates A/B.
-    const cellLevelOutcomes: Record<string, CellOutcome> = {};
-    for (let i = 1; i <= 20; i += 1) {
-      cellLevelOutcomes[`def-${i}::model-a::Achievement::Tradition::1::2`] = { aChoices: 6, bChoices: 0, neutrals: 0 };
-      // model-b alternates: even → A, odd → B
-      const bA = i % 2 === 0 ? 6 : 0;
-      const bB = i % 2 === 0 ? 0 : 6;
-      cellLevelOutcomes[`def-${i}::model-b::Achievement::Tradition::1::2`] = { aChoices: bA, bChoices: bB, neutrals: 0 };
-    }
-
-    // Also register def-1 through def-20 in the scope data (latestDefinitionIds).
-    const extendedScopeData = {
-      ...scopeData(),
-      latestDefinitionIds: Array.from({ length: 20 }, (_, i) => `def-${i + 1}`),
-    };
-    mocks.resolveDomainAnalysisScopeDefinitions.mockResolvedValue(extendedScopeData);
+  it('populates kappaByDomain, kappaSpread, and domainCount from scope data', async () => {
+    // def-1 and def-2 both belong to 'domain-1' in the default scopeData mock.
+    // With a single domain in scope, domainCount=1 and kappaSpread=null.
     mocks.readModelAgreementSnapshotStateFromSnapshot.mockResolvedValue({
-      cellLevelOutcomes: snapshot(cellLevelOutcomes),
+      cellLevelOutcomes: snapshot({
+        'def-1::model-a::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        'def-1::model-b::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        'def-2::model-a::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
+        'def-2::model-b::Achievement::Tradition::1::2': { aChoices: 6, bChoices: 0, neutrals: 0 },
+      }),
       buildProgress: null,
-      inputHash: 'hash-ci-test',
+      inputHash: 'hash-domain-breakdown',
     });
 
     const response = await graphqlRequest(agreementQuery, {
@@ -697,24 +692,23 @@ describe('model-agreement-on-tradeoffs GraphQL queries', () => {
     expect(response.body.errors).toBeUndefined();
     const matrix = response.body.data.modelAgreementOnTradeoffs.pairwiseAgreementMatrix as Array<{
       cohensKappa: number | null;
-      cohensKappaConfidenceLow: number | null;
-      cohensKappaConfidenceHigh: number | null;
-      cohensKappaConfidenceIsSymmetric: boolean;
+      kappaByDomain: Array<{ domainId: string; domainName: string; kappa: number | null; cellCount: number }>;
+      kappaSpread: number | null;
+      domainCount: number;
     }>;
 
     expect(matrix).toHaveLength(1);
     const row = matrix[0]!;
 
-    // The CI should be populated (20 vignettes → well above 100-sample threshold).
-    expect(row.cohensKappaConfidenceLow).not.toBeNull();
-    expect(row.cohensKappaConfidenceHigh).not.toBeNull();
-    expect(typeof row.cohensKappaConfidenceIsSymmetric).toBe('boolean');
-
-    if (row.cohensKappa != null && row.cohensKappaConfidenceLow != null && row.cohensKappaConfidenceHigh != null) {
-      // CI must bracket the point estimate (within floating-point tolerance).
-      expect(row.cohensKappaConfidenceLow).toBeLessThanOrEqual(row.cohensKappa + 0.01);
-      expect(row.cohensKappaConfidenceHigh).toBeGreaterThanOrEqual(row.cohensKappa - 0.01);
-    }
+    // Single domain in scope → domainCount=1, spread=null, kappaByDomain has 1 entry.
+    expect(row.domainCount).toBe(1);
+    expect(row.kappaSpread).toBeNull();
+    expect(row.kappaByDomain).toHaveLength(1);
+    expect(row.kappaByDomain[0]).toMatchObject({
+      domainId: 'domain-1',
+      domainName: 'Domain 1',
+    });
+    expect(typeof row.kappaByDomain[0]?.cellCount).toBe('number');
   });
 
   it('equal-weights value pairs in the headline kappa (no over-tested-pair bias)', async () => {

--- a/cloud/apps/api/tests/services/model-agreement/aggregation.test.ts
+++ b/cloud/apps/api/tests/services/model-agreement/aggregation.test.ts
@@ -1,10 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
-  bootstrapKappaConfidence,
-  groupCellsByVignette,
-  KAPPA_CI_SYMMETRY_TOLERANCE,
-  KAPPA_CI_WIDE_THRESHOLD,
-  summarizePairCells,
+  computePairwiseKappaWithBreakdown,
   type ComparableCell,
 } from '../../../src/services/model-agreement/aggregation.js';
 
@@ -28,236 +24,145 @@ function cell(
   };
 }
 
-describe('groupCellsByVignette', () => {
-  it('groups cells by definitionId', () => {
-    const cells: ComparableCell[] = [
-      cell('def-1', 'A::B', 'A', 'A'),
-      cell('def-1', 'A::B', 'B', 'B'),
-      cell('def-2', 'A::B', 'A', 'B'),
-    ];
-    const grouped = groupCellsByVignette(cells);
-    expect(grouped.size).toBe(2);
-    expect(grouped.get('def-1')).toHaveLength(2);
-    expect(grouped.get('def-2')).toHaveLength(1);
-  });
+describe('computePairwiseKappaWithBreakdown', () => {
+  function makeDomainMap(entries: Array<[string, string]>): Map<string, string> {
+    return new Map(entries);
+  }
 
-  it('returns an empty map for empty input', () => {
-    expect(groupCellsByVignette([]).size).toBe(0);
-  });
-});
+  function makeDomainsById(entries: Array<[string, string]>): Map<string, { id: string; name: string }> {
+    return new Map(entries.map(([id, name]) => [id, { id, name }]));
+  }
 
-describe('bootstrapKappaConfidence', () => {
-  it('returns null/null when pointEstimateKappa is null', () => {
-    const grouped = groupCellsByVignette([cell('def-1', 'A::B', 'A', 'A')]);
-    const result = bootstrapKappaConfidence(grouped, null);
-    expect(result).toEqual({ low: null, high: null, isSymmetric: true });
-  });
-
-  it('returns null/null when there are no vignettes', () => {
-    const result = bootstrapKappaConfidence(new Map(), 0.5);
-    expect(result).toEqual({ low: null, high: null, isSymmetric: true });
-  });
-
-  it('with a single vignette the CI collapses to near the point estimate', () => {
-    // One vignette with two cells of mixed outcome so kappa is non-degenerate.
-    // Model A: A, B → marginals 50/50. Model B: A, B → same. Weighted kappa = 1.
+  it('returns spread=null when only 1 domain has data', () => {
     const cells = [
-      cell('def-1', 'A::B', 'A', 'A'),
-      cell('def-1', 'A::B', 'B', 'B'),
+      cell('def-1-a', 'A::B', 'A', 'A'),
+      cell('def-1-b', 'A::B', 'B', 'B'),
     ];
-    const grouped = groupCellsByVignette(cells);
-    const kappa = summarizePairCells(cells).cohensKappa;
-    expect(kappa).not.toBeNull();
-    const result = bootstrapKappaConfidence(grouped, kappa!, 1000);
-    // With a single vignette every resample is the same → CI should be very tight.
-    if (result.low != null && result.high != null && kappa != null) {
-      expect(result.high - result.low).toBeLessThan(0.05);
-    }
+    const definitionDomainIdById = makeDomainMap([
+      ['def-1-a', 'dom-1'],
+      ['def-1-b', 'dom-1'],
+    ]);
+    const domainsById = makeDomainsById([['dom-1', 'Job Choice']]);
+
+    const result = computePairwiseKappaWithBreakdown(cells, definitionDomainIdById, domainsById);
+
+    expect(result.domainCount).toBe(1);
+    expect(result.spread).toBeNull();
+    expect(result.kappaByDomain).toHaveLength(1);
+    expect(result.kappaByDomain[0]?.domainName).toBe('Job Choice');
   });
 
-  it('returns CI that brackets the point estimate (low ≤ kappa ≤ high)', () => {
-    // Build 20 vignettes with partial agreement (kappa around 0.5).
-    const cells: ComparableCell[] = [];
-    for (let i = 0; i < 20; i += 1) {
-      const defId = `def-${i}`;
-      // Alternate agreement/disagreement so kappa is somewhere in the middle.
-      const choice: ComparableCell['modelAChoice'] = i % 3 === 0 ? 'B' : 'A';
-      cells.push(cell(defId, 'X::Y', 'A', choice));
-    }
-    const grouped = groupCellsByVignette(cells);
-    const kappa = summarizePairCells(cells).cohensKappa;
-    expect(kappa).not.toBeNull();
-    const result = bootstrapKappaConfidence(grouped, kappa!, 1000);
-    expect(result.low).not.toBeNull();
-    expect(result.high).not.toBeNull();
-    if (result.low != null && result.high != null && kappa != null) {
-      expect(result.low).toBeLessThanOrEqual(kappa + 0.001);
-      expect(result.high).toBeGreaterThanOrEqual(kappa - 0.001);
-    }
-  });
+  it('returns small spread when 4 domains all have kappa near 0.65', () => {
+    const makeAgree = (defPrefix: string): ComparableCell[] =>
+      Array.from({ length: 13 }, (_, index) => cell(`${defPrefix}-a${index}`, 'A::B', 'A', 'A'));
+    const makeDisagree = (defPrefix: string): ComparableCell[] =>
+      Array.from({ length: 7 }, (_, index) => cell(`${defPrefix}-d${index}`, 'A::B', 'A', 'B'));
 
-  it('detects symmetric CI on uniform data (all cells perfectly agree)', () => {
-    // All cells agree perfectly — kappa = 1, bootstrap samples all collapse to 1.
-    const cells: ComparableCell[] = [];
-    for (let i = 0; i < 30; i += 1) {
-      cells.push(cell(`def-${i}`, 'X::Y', 'A', 'A'));
-    }
-    const grouped = groupCellsByVignette(cells);
-    const kappa = summarizePairCells(cells).cohensKappa;
-    const result = bootstrapKappaConfidence(grouped, kappa!, 1000);
-    // All bootstrap samples will produce the same kappa → CI should be symmetric.
-    expect(result.isSymmetric).toBe(true);
-  });
+    const domain1Agree = makeAgree('def-1');
+    const domain1Disagree = makeDisagree('def-1');
+    const domain2Agree = makeAgree('def-2');
+    const domain2Disagree = makeDisagree('def-2');
+    const domain3Agree = makeAgree('def-3');
+    const domain3Disagree = makeDisagree('def-3');
+    const domain4Agree = makeAgree('def-4');
+    const domain4Disagree = makeDisagree('def-4');
 
-  it('flags isSymmetric=false for a skewed bootstrap distribution', () => {
-    // Construct a distribution where low samples are dense near 1 but
-    // we force Math.random to return a controlled sequence that produces
-    // an asymmetric result. We do this by spying on Math.random.
-    //
-    // Easier approach: use a real skewed setup. Build vignettes where
-    // kappa is forced very close to +1. The bootstrap distribution is
-    // bounded above at 1, so the upper tail is compressed → asymmetric.
-    const cells: ComparableCell[] = [];
-    for (let i = 0; i < 50; i += 1) {
-      // 90% agree, 10% disagree — kappa should be high and CI left-skewed.
-      const choice: ComparableCell['modelBChoice'] = i < 45 ? 'A' : 'B';
-      cells.push(cell(`def-${i}`, 'X::Y', 'A', choice));
-    }
-    const grouped = groupCellsByVignette(cells);
-    const kappa = summarizePairCells(cells).cohensKappa;
-    expect(kappa).not.toBeNull();
-    const result = bootstrapKappaConfidence(grouped, kappa!, 2000);
-    // With high kappa near +1 the upper tail is compressed; asymmetry may or may not
-    // exceed the 0.01 threshold depending on exact distribution. We just verify the
-    // function returns a valid shape.
-    expect(result.low).not.toBeNull();
-    expect(result.high).not.toBeNull();
-    expect(typeof result.isSymmetric).toBe('boolean');
-  });
-
-  it('KAPPA_CI_SYMMETRY_TOLERANCE is 0.01 and KAPPA_CI_WIDE_THRESHOLD is 0.30', () => {
-    expect(KAPPA_CI_SYMMETRY_TOLERANCE).toBe(0.01);
-    expect(KAPPA_CI_WIDE_THRESHOLD).toBe(0.30);
-  });
-
-  it('uses Math.random — mocking it produces deterministic output', () => {
-    // Build 10 vignettes, mock Math.random to always return 0 (always picks first vignette).
-    const cells: ComparableCell[] = [];
-    for (let i = 0; i < 10; i += 1) {
-      const choice: ComparableCell['modelBChoice'] = i === 0 ? 'A' : 'B';
-      cells.push(cell(`def-${i}`, 'X::Y', 'A', choice));
-    }
-    const grouped = groupCellsByVignette(cells);
-    const kappa = summarizePairCells(cells).cohensKappa;
-
-    const spy = vi.spyOn(Math, 'random').mockReturnValue(0);
-    const result = bootstrapKappaConfidence(grouped, kappa!, 500);
-    spy.mockRestore();
-
-    // All iterations resample only def-0 (always agree). Each draw gets a
-    // unique synthetic vignette ID, so N=10 synthetic groups are produced per
-    // iteration — but every group contains the same all-agree cell, so kappa
-    // remains 1 for every sample and the CI is tight.
-    if (result.low != null && result.high != null) {
-      expect(result.high - result.low).toBeLessThan(0.001);
-    }
-  });
-
-  it('duplicate draws amplify their influence (regression for collapsed-duplicate bug)', () => {
-    // The bug: when the same vignette is drawn multiple times in one bootstrap
-    // iteration, the cells keep their original definitionId. summarizePairCells
-    // groups cells by definitionId, so duplicate draws collapsed back into one
-    // group — drawing {A, A, B} produced the same kappa as drawing {A, B}.
-    //
-    // The fix: each draw gets a unique synthetic vignette ID so duplicates are
-    // preserved as separate slots in the equal-weight aggregation.
-    //
-    // Test strategy:
-    //   Build 2 vignettes:
-    //     def-agree: (A,A) — model A and B both choose A
-    //     def-disagree: (A,B) — model A chooses A, model B chooses B
-    //
-    //   We compute the kappa for two explicit sample configurations:
-    //     "duplicated":  {def-agree, def-agree} as 2 independent groups
-    //     "collapsed":   {def-agree} as 1 group (what the buggy code produced
-    //                    when you drew def-agree twice)
-    //
-    //   These must produce different kappas. We then mock Math.random to always
-    //   draw def-agree (index 0), run 500 iterations, and verify the bootstrap
-    //   CI sits near the "duplicated" kappa, not the "collapsed" one.
-
-    // Kappa for {def-agree, def-agree} treated as 2 distinct groups:
-    //   Both groups: model A=A, model B=A → weighted agreement=1, chance agreement=1
-    //   kappa = (1-1)/(1-1) → undefined (denominator 0). So we need richer fixtures.
-    //
-    // Use 2 vignettes with multiple cells each to get non-degenerate marginals.
-    //   def-1: 2 cells — (A,A) and (B,B)  → both models agree on both cells
-    //   def-2: 2 cells — (A,B) and (B,A)  → models always disagree
-    //
-    // kappa({def-1, def-1}) ≠ kappa({def-1, def-2}) when marginals differ.
-    // Let's verify what the actual numbers are by computing explicitly.
-
-    // Cells for def-1 (agreement):
-    const agreeVig = [
-      cell('def-1', 'X::Y', 'A', 'A'),
-      cell('def-1', 'X::Y', 'B', 'B'),
-    ];
-    // Cells for def-2 (disagreement):
-    const disagreeVig = [
-      cell('def-2', 'X::Y', 'A', 'B'),
-      cell('def-2', 'X::Y', 'B', 'A'),
+    const cells: ComparableCell[] = [
+      ...domain1Agree, ...domain1Disagree,
+      ...domain2Agree, ...domain2Disagree,
+      ...domain3Agree, ...domain3Disagree,
+      ...domain4Agree, ...domain4Disagree,
     ];
 
-    // Kappa when both groups are drawn = {def-1, def-2}: mixed, medium kappa
-    const kappaMixed = summarizePairCells([...agreeVig, ...disagreeVig]).cohensKappa;
+    const definitionDomainIdById = makeDomainMap([
+      ...domain1Agree.map((entry) => [entry.definitionId, 'dom-1'] as [string, string]),
+      ...domain1Disagree.map((entry) => [entry.definitionId, 'dom-1'] as [string, string]),
+      ...domain2Agree.map((entry) => [entry.definitionId, 'dom-2'] as [string, string]),
+      ...domain2Disagree.map((entry) => [entry.definitionId, 'dom-2'] as [string, string]),
+      ...domain3Agree.map((entry) => [entry.definitionId, 'dom-3'] as [string, string]),
+      ...domain3Disagree.map((entry) => [entry.definitionId, 'dom-3'] as [string, string]),
+      ...domain4Agree.map((entry) => [entry.definitionId, 'dom-4'] as [string, string]),
+      ...domain4Disagree.map((entry) => [entry.definitionId, 'dom-4'] as [string, string]),
+    ]);
+    const domainsById = makeDomainsById([
+      ['dom-1', 'Domain 1'],
+      ['dom-2', 'Domain 2'],
+      ['dom-3', 'Domain 3'],
+      ['dom-4', 'Domain 4'],
+    ]);
 
-    // Kappa when only def-1 is drawn twice, as 2 separate synthetic groups:
-    const kappaAllAgree = summarizePairCells([
-      cell('s0', 'X::Y', 'A', 'A'),
-      cell('s0', 'X::Y', 'B', 'B'),
-      cell('s1', 'X::Y', 'A', 'A'),
-      cell('s1', 'X::Y', 'B', 'B'),
-    ]).cohensKappa;
+    const result = computePairwiseKappaWithBreakdown(cells, definitionDomainIdById, domainsById);
 
-    // Both must be non-null and genuinely different
-    expect(kappaMixed).not.toBeNull();
-    expect(kappaAllAgree).not.toBeNull();
-    expect(Math.abs(kappaAllAgree! - kappaMixed!)).toBeGreaterThan(0.1);
+    expect(result.domainCount).toBe(4);
+    expect(result.spread).not.toBeNull();
+    expect(result.spread ?? Infinity).toBeLessThan(0.01);
+  });
 
-    // Build the grouped map for the bootstrap (2 vignettes)
-    const allCells = [...agreeVig, ...disagreeVig];
-    const grouped = groupCellsByVignette(allCells);
-    expect(grouped.size).toBe(2);
+  it('returns correct spread when domains span different kappa values', () => {
+    // Domain A: models agree most of the time — both alternate A/B together.
+    // Each vignette has 2 cells: (A,A) and (B,B) so the models track each other perfectly.
+    // This produces kappa = 1 for domain A.
+    const highAgreeCells: ComparableCell[] = Array.from({ length: 10 }, (_, index) => [
+      cell(`hi-${index}-a`, 'X::Y', 'A', 'A'),
+      cell(`hi-${index}-b`, 'X::Y', 'B', 'B'),
+    ]).flat();
 
-    // Mock Math.random to always return 0 → always picks def-1 (index 0).
-    // vignetteIds = ['def-1', 'def-2'] after Map.keys() ordering.
-    // With n=2 draws per iteration and Math.random()=0, both draws hit index 0 (def-1).
-    // After the fix: 2 synthetic groups (s.bootstrap-I-0, s.bootstrap-I-1), both from def-1.
-    //   → sample kappa = kappaAllAgree for every iteration.
-    // Before the fix: both cells pushed under 'def-1' → collapsed to 1 group.
-    //   → sample kappa = kappa({def-1}) which equals kappaAllAgree too (same cells).
-    //   Actually both should give the same since all draws are def-1.
-    //
-    // Better: mock to draw index 0 and index 1 alternately within each iteration
-    // so we can distinguish duplicate-of-0 vs {0, 1}.
-    // Pattern per iteration (2 draws): first call → 0, second call → 0 (both def-1).
-    // We want to compare against: first → 0, second → 0.999 (def-1 + def-2).
-    // The second scenario is what {A, B} produces (no duplication benefit).
-    //
-    // Let's just verify the tight-CI property and that it matches kappaAllAgree:
-    const spy = vi.spyOn(Math, 'random').mockReturnValue(0);
-    const result = bootstrapKappaConfidence(grouped, kappaMixed!, 500);
-    spy.mockRestore();
+    // Domain B: models disagree most of the time — (A,B) and (B,A) pairs.
+    // This produces kappa = -1 for domain B.
+    const lowAgreeCells: ComparableCell[] = Array.from({ length: 10 }, (_, index) => [
+      cell(`lo-${index}-a`, 'X::Y', 'A', 'B'),
+      cell(`lo-${index}-b`, 'X::Y', 'B', 'A'),
+    ]).flat();
 
-    expect(result.low).not.toBeNull();
-    expect(result.high).not.toBeNull();
-    if (result.low != null && result.high != null && kappaAllAgree != null) {
-      // CI must be tight (every iteration is identical with fixed random)
-      expect(result.high - result.low).toBeLessThan(0.001);
-      // CI must be near kappaAllAgree (both draws are def-1 = full agreement)
-      // and NOT near kappaMixed (which would imply def-2 was included somehow)
-      const ciMid = (result.low + result.high) / 2;
-      expect(Math.abs(ciMid - kappaAllAgree)).toBeLessThan(0.05);
-    }
+    // Assign each unique definitionId to its domain.
+    // Note: each cell has a unique definitionId, so each is its own vignette.
+    const definitionDomainIdById = new Map<string, string>();
+    highAgreeCells.forEach((entry) => definitionDomainIdById.set(entry.definitionId, 'dom-high'));
+    lowAgreeCells.forEach((entry) => definitionDomainIdById.set(entry.definitionId, 'dom-low'));
+
+    const domainsById = makeDomainsById([
+      ['dom-high', 'High Domain'],
+      ['dom-low', 'Low Domain'],
+    ]);
+    const allCells = [...highAgreeCells, ...lowAgreeCells];
+
+    const result = computePairwiseKappaWithBreakdown(allCells, definitionDomainIdById, domainsById);
+
+    expect(result.domainCount).toBe(2);
+    expect(result.spread).not.toBeNull();
+    const kappas = result.kappaByDomain.map((entry) => entry.kappa).filter((kappa): kappa is number => kappa != null);
+    expect(kappas).toHaveLength(2);
+    const expectedSpread = Math.max(...kappas) - Math.min(...kappas);
+    expect(result.spread).toBeCloseTo(expectedSpread, 10);
+    // High domain should have positive kappa, low domain negative — spread must be > 0
+    expect(result.spread ?? 0).toBeGreaterThan(0);
+  });
+
+  it('averageKappa is equal-weight mean of per-domain values', () => {
+    const cells: ComparableCell[] = [
+      cell('def-1-a', 'A::B', 'A', 'A'),
+      cell('def-1-b', 'A::B', 'B', 'B'),
+      cell('def-2-a', 'A::B', 'A', 'A'),
+      cell('def-2-b', 'A::B', 'B', 'B'),
+    ];
+    const definitionDomainIdById = new Map<string, string>([
+      ['def-1-a', 'dom-1'],
+      ['def-1-b', 'dom-1'],
+      ['def-2-a', 'dom-2'],
+      ['def-2-b', 'dom-2'],
+    ]);
+    const domainsById = makeDomainsById([
+      ['dom-1', 'Domain 1'],
+      ['dom-2', 'Domain 2'],
+    ]);
+
+    const result = computePairwiseKappaWithBreakdown(cells, definitionDomainIdById, domainsById);
+
+    const perDomainKappas = result.kappaByDomain
+      .map((entry) => entry.kappa)
+      .filter((kappa): kappa is number => kappa != null);
+    expect(perDomainKappas).toHaveLength(2);
+    const expected = perDomainKappas.reduce((sum, kappa) => sum + kappa, 0) / perDomainKappas.length;
+    expect(result.averageKappa).toBeCloseTo(expected, 10);
   });
 });

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -320,31 +320,14 @@ type CircumplexResult {
 }
 
 type ClusterAnalysis {
-  clusters: [DomainCluster!]!
   clusterIdByModelId: JSON
+  clusters: [DomainCluster!]!
   defaultPair: [String!]
   dendrogram: [DendrogramMerge!]
   faultLinesByPair: JSON!
   leafOrder: [String!]
   skipReason: String
   skipped: Boolean!
-}
-
-type DendrogramMerge {
-  height: Float!
-  leftMemberIds: [String!]!
-  rightMemberIds: [String!]!
-}
-
-type KappaClusterPayload {
-  clusterAnalysis: ClusterAnalysis!
-  kappaPairs: [KappaPair!]!
-}
-
-type KappaPair {
-  kappa: Float
-  modelAId: String!
-  modelBId: String!
 }
 
 type ClusterMember {
@@ -767,6 +750,12 @@ type DeleteTagResult {
   success: Boolean!
 }
 
+type DendrogramMerge {
+  height: Float!
+  leftMemberIds: [String!]!
+  rightMemberIds: [String!]!
+}
+
 """Result of deprecating a model"""
 type DeprecateModelResult {
   """The deprecated model"""
@@ -1142,6 +1131,13 @@ type DomainFindingsEligibility {
   summary: String!
 }
 
+type DomainKappaEntry {
+  cellCount: Int!
+  domainId: ID!
+  domainName: String!
+  kappa: Float
+}
+
 type DomainMutationResult {
   affectedDefinitions: Int!
   success: Boolean!
@@ -1469,6 +1465,17 @@ type JobTypeStatus {
 
   """Job type name (e.g., probe_scenario)"""
   type: String!
+}
+
+type KappaClusterPayload {
+  clusterAnalysis: ClusterAnalysis!
+  kappaPairs: [KappaPair!]!
+}
+
+type KappaPair {
+  kappa: Float
+  modelAId: String!
+  modelBId: String!
 }
 
 """
@@ -2146,10 +2153,10 @@ type PairDivergenceBreakdown {
 
 type PairwiseAgreementRow {
   cohensKappa: Float
-  cohensKappaConfidenceHigh: Float
-  cohensKappaConfidenceIsSymmetric: Boolean!
-  cohensKappaConfidenceLow: Float
+  domainCount: Int!
+  kappaByDomain: [DomainKappaEntry!]!
   kappaInterpretation: String
+  kappaSpread: Float
   meanAbsoluteDivergence: Float
   modelAId: ID!
   modelALabel: String!

--- a/cloud/apps/web/src/api/operations/modelAgreementOnTradeoffs.graphql
+++ b/cloud/apps/web/src/api/operations/modelAgreementOnTradeoffs.graphql
@@ -38,9 +38,14 @@ query ModelAgreementOnTradeoffs(
       cohensKappa
       kappaInterpretation
       meanAbsoluteDivergence
-      cohensKappaConfidenceLow
-      cohensKappaConfidenceHigh
-      cohensKappaConfidenceIsSymmetric
+      kappaByDomain {
+        domainId
+        domainName
+        kappa
+        cellCount
+      }
+      kappaSpread
+      domainCount
     }
     trialConsistency {
       modelId

--- a/cloud/apps/web/src/components/models/ModelAgreementSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelAgreementSection.tsx
@@ -348,6 +348,15 @@ export function ModelAgreementSection({ modelIds, scope, domainId, signature }: 
                 <li><strong>0.8 to 1.0 — Near-perfect</strong>: the two models almost always make the same call</li>
               </ul>
             </div>
+            <div>
+              <p className="mb-1 font-semibold text-gray-800">Per-domain spread</p>
+              <p>
+                We test each value pair across multiple domains (for example, Job Choice and National Priorities).
+                Per-domain spread shows the difference between the highest and lowest per-domain kappa for a model
+                pair. A small spread (under 0.30) means the agreement is consistent across contexts. A larger spread
+                (flagged with ⚠) means the answer depends on which domain you&apos;re looking at.
+              </p>
+            </div>
             <p>
               Aggregation is equal-weighted at every level: each cell counts the same regardless of trial count, each
               vignette the same regardless of cell count, and each value pair the same regardless of vignette count.

--- a/cloud/apps/web/src/components/models/ModelSimilarityMetrics.ts
+++ b/cloud/apps/web/src/components/models/ModelSimilarityMetrics.ts
@@ -38,20 +38,28 @@ export type PairMetric = {
   summaryLabel: string;
   summaryNote: string;
   summaryRows: Array<{ label: string; value: number | null }>;
-  confidenceLow?: number | null;
-  confidenceHigh?: number | null;
-  confidenceIsSymmetric?: boolean;
+  kappaSpread?: number | null;
+  kappaByDomain?: Array<{
+    domainId: string;
+    domainName: string;
+    kappa: number | null;
+    cellCount: number;
+  }>;
 };
 
 /**
- * Extended kappa entry that carries the point estimate plus bootstrap CI fields.
- * The Map passed to computePairMetric uses this shape when CI data is available.
+ * Extended kappa entry that carries the point estimate plus per-domain spread.
+ * The Map passed to computePairMetric uses this shape when breakdown data is available.
  */
 export type PairwiseKappaEntry = {
   kappa: number;
-  confidenceLow: number | null;
-  confidenceHigh: number | null;
-  confidenceIsSymmetric: boolean;
+  kappaSpread?: number | null;
+  kappaByDomain?: Array<{
+    domainId: string;
+    domainName: string;
+    kappa: number | null;
+    cellCount: number;
+  }>;
 };
 
 export const CALCULATION_METHODS: Array<{ value: CalculationMethod; label: string }> = [
@@ -287,7 +295,7 @@ export function computePairMetric(
       : typeof rawEntry === 'number' ? rawEntry
       : rawEntry.kappa;
 
-    const ciEntry: PairwiseKappaEntry | null =
+    const breakdownEntry: PairwiseKappaEntry | null =
       rawEntry != null && typeof rawEntry === 'object' ? rawEntry : null;
 
     if (kappaValue == null) {
@@ -324,9 +332,8 @@ export function computePairMetric(
         { label: "Cohen's kappa", value: clamped },
         { label: 'Distance (1 − kappa)', value: 1 - clamped },
       ],
-      confidenceLow: ciEntry?.confidenceLow ?? null,
-      confidenceHigh: ciEntry?.confidenceHigh ?? null,
-      confidenceIsSymmetric: ciEntry?.confidenceIsSymmetric ?? true,
+      kappaSpread: breakdownEntry?.kappaSpread ?? null,
+      kappaByDomain: breakdownEntry?.kappaByDomain ?? [],
     };
   }
 

--- a/cloud/apps/web/src/components/models/ModelSimilarityTableSection.test.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityTableSection.test.tsx
@@ -23,7 +23,7 @@ describe('ModelSimilarityTableSection', () => {
   it('renders kappa values when method is kappa and pairwiseKappa map is provided', () => {
     const modelA = makeModel('model-a', 'Model A', [100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
     const modelB = makeModel('model-b', 'Model B', [90, 80, 70, 60, 50, 40, 30, 20, 10, 0]);
-    const entry: PairwiseKappaEntry = { kappa: 0.75, confidenceLow: 0.60, confidenceHigh: 0.90, confidenceIsSymmetric: false };
+    const entry: PairwiseKappaEntry = { kappa: 0.75, kappaSpread: 0.30, kappaByDomain: [] };
     const pairwiseKappa = new Map([
       ['model-a', new Map([['model-b', entry]])],
       ['model-b', new Map([['model-a', entry]])],
@@ -46,7 +46,7 @@ describe('ModelSimilarityTableSection', () => {
     const modelA = makeModel('model-a', 'Model A', [100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
     const modelB = makeModel('model-b', 'Model B', [90, 80, 70, 60, 50, 40, 30, 20, 10, 0]);
     // kappa = 0.70 → distance = 0.30, similarity = 0.70
-    const entry070: PairwiseKappaEntry = { kappa: 0.70, confidenceLow: null, confidenceHigh: null, confidenceIsSymmetric: true };
+    const entry070: PairwiseKappaEntry = { kappa: 0.70, kappaSpread: null, kappaByDomain: [] };
     const pairwiseKappa = new Map([
       ['model-a', new Map([['model-b', entry070]])],
       ['model-b', new Map([['model-a', entry070]])],
@@ -142,11 +142,14 @@ describe('ModelSimilarityTableSection', () => {
     expect(drawerTable.getAllByText('10.00').length).toBeGreaterThan(0);
   });
 
-  it('renders symmetric CI as ± format for kappa method', () => {
+  it('renders 1-domain note for kappa method when only one domain is present', () => {
     const modelA = makeModel('model-a', 'Model A', [100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
     const modelB = makeModel('model-b', 'Model B', [90, 80, 70, 60, 50, 40, 30, 20, 10, 0]);
-    // kappa = 0.60, CI = [0.45, 0.75] → symmetric (width 0.30, half = 0.15)
-    const entry: PairwiseKappaEntry = { kappa: 0.60, confidenceLow: 0.45, confidenceHigh: 0.75, confidenceIsSymmetric: true };
+    const entry: PairwiseKappaEntry = {
+      kappa: 0.60,
+      kappaSpread: null,
+      kappaByDomain: [{ domainId: 'dom-1', domainName: 'Domain 1', kappa: 0.60, cellCount: 12 }],
+    };
     const pairwiseKappa = new Map([
       ['model-a', new Map([['model-b', entry]])],
       ['model-b', new Map([['model-a', entry]])],
@@ -160,16 +163,21 @@ describe('ModelSimilarityTableSection', () => {
       />,
     );
 
-    // Symmetric CI: half-width = (0.75 - 0.45) / 2 = 0.15 → "± 0.15"
-    const ciElements = screen.getAllByText(/±\s*0\.15/);
-    expect(ciElements.length).toBeGreaterThan(0);
+    const domainElements = screen.getAllByText('(1 domain)');
+    expect(domainElements.length).toBeGreaterThan(0);
   });
 
-  it('renders asymmetric CI as bracket format for kappa method', () => {
+  it('renders spread line for kappa method when multiple domains are present', () => {
     const modelA = makeModel('model-a', 'Model A', [100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
     const modelB = makeModel('model-b', 'Model B', [90, 80, 70, 60, 50, 40, 30, 20, 10, 0]);
-    // asymmetric CI
-    const entry: PairwiseKappaEntry = { kappa: 0.65, confidenceLow: 0.40, confidenceHigh: 0.80, confidenceIsSymmetric: false };
+    const entry: PairwiseKappaEntry = {
+      kappa: 0.65,
+      kappaSpread: 0.22,
+      kappaByDomain: [
+        { domainId: 'dom-1', domainName: 'Domain 1', kappa: 0.54, cellCount: 10 },
+        { domainId: 'dom-2', domainName: 'Domain 2', kappa: 0.76, cellCount: 10 },
+      ],
+    };
     const pairwiseKappa = new Map([
       ['model-a', new Map([['model-b', entry]])],
       ['model-b', new Map([['model-a', entry]])],
@@ -183,16 +191,21 @@ describe('ModelSimilarityTableSection', () => {
       />,
     );
 
-    // Asymmetric: should show [+0.40, +0.80]
-    const ciElements = screen.getAllByText(/\[.*0\.40.*0\.80.*\]/);
-    expect(ciElements.length).toBeGreaterThan(0);
+    const spreadElements = screen.getAllByText('(spread 0.22)');
+    expect(spreadElements.length).toBeGreaterThan(0);
   });
 
-  it('shows wide-CI warning for kappa cells with wide CI', () => {
+  it('shows wide-spread warning for kappa cells with wide spread', () => {
     const modelA = makeModel('model-a', 'Model A', [100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
     const modelB = makeModel('model-b', 'Model B', [90, 80, 70, 60, 50, 40, 30, 20, 10, 0]);
-    // wide CI: width = 0.80 > 0.30
-    const entry: PairwiseKappaEntry = { kappa: 0.50, confidenceLow: 0.10, confidenceHigh: 0.90, confidenceIsSymmetric: false };
+    const entry: PairwiseKappaEntry = {
+      kappa: 0.50,
+      kappaSpread: 0.80,
+      kappaByDomain: [
+        { domainId: 'dom-1', domainName: 'Domain 1', kappa: 0.10, cellCount: 10 },
+        { domainId: 'dom-2', domainName: 'Domain 2', kappa: 0.90, cellCount: 10 },
+      ],
+    };
     const pairwiseKappa = new Map([
       ['model-a', new Map([['model-b', entry]])],
       ['model-b', new Map([['model-a', entry]])],
@@ -206,7 +219,7 @@ describe('ModelSimilarityTableSection', () => {
       />,
     );
 
-    const warnings = screen.getAllByTitle('Wide CI — insufficient data to constrain estimate');
+    const warnings = screen.getAllByTitle('Kappa varies significantly by domain');
     expect(warnings.length).toBeGreaterThan(0);
   });
 });

--- a/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelSimilarityTableSection.tsx
@@ -18,12 +18,11 @@ import {
 } from './ModelSimilarityMetrics';
 import { PairDetailDrawer } from './ModelSimilarityPairDetailDrawer';
 
-/** Wide-CI threshold matches the backend constant. */
-const KAPPA_CI_WIDE_THRESHOLD = 0.30;
+const KAPPA_SPREAD_WIDE_THRESHOLD = 0.30;
 
-function isCIWide(low: number | null | undefined, high: number | null | undefined): boolean {
-  if (low == null || high == null) return false;
-  return (high - low) > KAPPA_CI_WIDE_THRESHOLD || low < 0;
+function isSpreadWide(spread: number | null | undefined): boolean {
+  if (spread == null) return false;
+  return spread > KAPPA_SPREAD_WIDE_THRESHOLD;
 }
 
 type ModelSimilarityTableSectionProps = {
@@ -63,7 +62,7 @@ export function ModelSimilarityTableSection({ models, method: methodProp, pairwi
     const maxSimilarity = similarities.length > 0 ? Math.max(...similarities) : 1;
 
     return { rows, minSimilarity, maxSimilarity };
-  }, [models, method]);
+  }, [models, method, pairwiseKappa]);
   const activeMetric = useMemo(() => {
     if (activePair == null) return null;
     const left = models.find((model) => model.model === activePair.left) ?? null;
@@ -195,23 +194,18 @@ export function ModelSimilarityTableSection({ models, method: methodProp, pairwi
                     // Kappa cells don't open a detail drawer (no step-by-step data).
                     const canOpenDetail = !isKappaMethod && !isUnavailable && !isSelf;
 
-                    // CI rendering for kappa method.
-                    const ciLow = isKappaMethod ? metric?.confidenceLow : undefined;
-                    const ciHigh = isKappaMethod ? metric?.confidenceHigh : undefined;
-                    const ciIsSymmetric = isKappaMethod ? (metric?.confidenceIsSymmetric ?? true) : true;
-                    const ciIsWide = isKappaMethod && isCIWide(ciLow, ciHigh);
-                    const hasCi = ciLow != null && ciHigh != null;
+                    const kappaSpread = isKappaMethod ? metric?.kappaSpread : undefined;
+                    const domainCount = isKappaMethod
+                      ? (metric?.kappaByDomain != null ? metric.kappaByDomain.length : null)
+                      : null;
+                    const spreadIsWide = isKappaMethod && isSpreadWide(kappaSpread);
 
-                    // Build the CI second line.
-                    let ciLine: string | null = null;
-                    if (isKappaMethod && hasCi && ciLow != null && ciHigh != null) {
-                      if (ciIsSymmetric) {
-                        const halfWidth = (ciHigh - ciLow) / 2;
-                        ciLine = `± ${halfWidth.toFixed(2)}`;
-                      } else {
-                        const lowStr = ciLow >= 0 ? `+${ciLow.toFixed(2)}` : ciLow.toFixed(2);
-                        const highStr = ciHigh >= 0 ? `+${ciHigh.toFixed(2)}` : ciHigh.toFixed(2);
-                        ciLine = `[${lowStr}, ${highStr}]`;
+                    let spreadLine: string | null = null;
+                    if (isKappaMethod && domainCount != null) {
+                      if (domainCount >= 2 && kappaSpread != null && Number.isFinite(kappaSpread)) {
+                        spreadLine = `(spread ${kappaSpread.toFixed(2)})`;
+                      } else if (domainCount === 1) {
+                        spreadLine = '(1 domain)';
                       }
                     }
 
@@ -221,7 +215,7 @@ export function ModelSimilarityTableSection({ models, method: methodProp, pairwi
                         className="px-1 py-1 text-right text-gray-800"
                         style={{
                           background: cellBackground,
-                          ...(ciIsWide ? { outline: '1.5px dashed #f9a8d4', outlineOffset: '-1px' } : {}),
+                          ...(spreadIsWide ? { outline: '1.5px dashed #f9a8d4', outlineOffset: '-1px' } : {}),
                         }}
                       >
                         {isSelf ? (
@@ -243,14 +237,14 @@ export function ModelSimilarityTableSection({ models, method: methodProp, pairwi
                         ) : (
                           <span className="relative block rounded-md px-2 py-1 text-right font-mono text-gray-900">
                             <span className="block">{displayValue}</span>
-                            {ciLine != null && (
-                              <span className="block text-[10px] leading-tight text-gray-500">{ciLine}</span>
+                            {spreadLine != null && (
+                              <span className="block text-[10px] leading-tight text-gray-500">{spreadLine}</span>
                             )}
-                            {ciIsWide && (
+                            {spreadIsWide && (
                               <span
                                 className="absolute right-1 top-1 text-[9px] leading-none text-pink-500"
-                                aria-label="Wide confidence interval"
-                                title="Wide CI — insufficient data to constrain estimate"
+                                aria-label="Wide per-domain spread"
+                                title="Kappa varies significantly by domain"
                               >
                                 ⚠
                               </span>

--- a/cloud/apps/web/src/components/models/PairwiseAgreementMatrixReport.test.tsx
+++ b/cloud/apps/web/src/components/models/PairwiseAgreementMatrixReport.test.tsx
@@ -17,9 +17,9 @@ function createRow(overrides: Partial<PairwiseAgreementRow> = {}): PairwiseAgree
     cohensKappa: 0.5,
     kappaInterpretation: 'Moderate',
     meanAbsoluteDivergence: 0.125,
-    cohensKappaConfidenceLow: 0.32,
-    cohensKappaConfidenceHigh: 0.68,
-    cohensKappaConfidenceIsSymmetric: true,
+    kappaByDomain: [],
+    kappaSpread: null,
+    domainCount: 1,
     ...overrides,
   };
 }
@@ -38,7 +38,8 @@ describe('PairwiseAgreementMatrixReport', () => {
     expect(screen.getByRole('columnheader', { name: /model b/i })).toBeDefined();
     expect(screen.getByRole('columnheader', { name: /cells/i })).toBeDefined();
     expect(screen.getByRole('columnheader', { name: /kappa/i })).toBeDefined();
-    expect(screen.getByRole('columnheader', { name: /95% ci/i })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: /per-domain spread/i })).toBeDefined();
+    expect(screen.getByRole('columnheader', { name: /domains/i })).toBeDefined();
     expect(screen.getByRole('columnheader', { name: /interpretation/i })).toBeDefined();
     expect(screen.getByRole('columnheader', { name: /% agreement/i })).toBeDefined();
     expect(screen.getByRole('columnheader', { name: /mean abs divergence/i })).toBeDefined();
@@ -84,58 +85,41 @@ describe('PairwiseAgreementMatrixReport', () => {
     expect(screen.getByText('No pairwise agreement data available for the current selection.')).toBeDefined();
   });
 
-  it('renders the 95% CI column with bracketed values', () => {
+  it('shows em-dash in spread column when domainCount is 1', () => {
     render(
       <PairwiseAgreementMatrixReport
-        rows={[createRow({ cohensKappaConfidenceLow: 0.32, cohensKappaConfidenceHigh: 0.68, cohensKappaConfidenceIsSymmetric: true })]}
+        rows={[createRow({ domainCount: 1, kappaSpread: null })]}
         selectedPair={null}
         onPairSelect={vi.fn()}
       />,
     );
 
-    // Should render [+0.32, +0.68].
-    expect(screen.getByText(/\+0\.32.*\+0\.68/)).toBeDefined();
-  });
-
-  it('shows em-dash in CI column when CI is null', () => {
-    render(
-      <PairwiseAgreementMatrixReport
-        rows={[createRow({ cohensKappaConfidenceLow: null, cohensKappaConfidenceHigh: null, cohensKappaConfidenceIsSymmetric: true })]}
-        selectedPair={null}
-        onPairSelect={vi.fn()}
-      />,
-    );
-
-    // The em-dash (—) should appear for the null CI.
     const dashes = screen.getAllByText('—');
     expect(dashes.length).toBeGreaterThan(0);
   });
 
-  it('shows wide-CI warning when CI width exceeds threshold', () => {
-    // CI width = 0.90 - 0.10 = 0.80 > 0.30 → wide.
+  it('renders spread value when domainCount >= 2', () => {
     render(
       <PairwiseAgreementMatrixReport
-        rows={[createRow({ cohensKappaConfidenceLow: 0.10, cohensKappaConfidenceHigh: 0.90, cohensKappaConfidenceIsSymmetric: false })]}
+        rows={[createRow({ domainCount: 4, kappaSpread: 0.16 })]}
         selectedPair={null}
         onPairSelect={vi.fn()}
       />,
     );
 
-    // ⚠ indicator should appear.
-    const warnings = screen.getAllByTitle('Wide CI — insufficient data to constrain estimate');
-    expect(warnings.length).toBeGreaterThan(0);
+    expect(screen.getByText('0.16')).toBeDefined();
   });
 
-  it('shows wide-CI warning when CI crosses zero (low < 0)', () => {
+  it('shows wide-spread warning when spread exceeds threshold', () => {
     render(
       <PairwiseAgreementMatrixReport
-        rows={[createRow({ cohensKappaConfidenceLow: -0.05, cohensKappaConfidenceHigh: 0.20, cohensKappaConfidenceIsSymmetric: false })]}
+        rows={[createRow({ domainCount: 4, kappaSpread: 0.45 })]}
         selectedPair={null}
         onPairSelect={vi.fn()}
       />,
     );
 
-    const warnings = screen.getAllByTitle('Wide CI — insufficient data to constrain estimate');
+    const warnings = screen.getAllByTitle('Wide spread — kappa varies significantly by domain');
     expect(warnings.length).toBeGreaterThan(0);
   });
 });

--- a/cloud/apps/web/src/components/models/PairwiseAgreementMatrixReport.tsx
+++ b/cloud/apps/web/src/components/models/PairwiseAgreementMatrixReport.tsx
@@ -11,10 +11,9 @@ type SelectedPair = {
   modelBId: string;
 };
 
-/** CI width threshold above which a row is flagged as wide/uncertain. */
-const KAPPA_CI_WIDE_THRESHOLD = 0.30;
+const KAPPA_SPREAD_WIDE_THRESHOLD = 0.30;
 
-type SortKey = 'modelA' | 'modelB' | 'cells' | 'kappa' | 'ci' | 'interpretation' | 'agreement' | 'divergence';
+type SortKey = 'modelA' | 'modelB' | 'cells' | 'kappa' | 'spread' | 'domains' | 'interpretation' | 'agreement' | 'divergence';
 type SortDirection = 'asc' | 'desc';
 
 type SortState = {
@@ -35,15 +34,14 @@ function formatKappa(value: number | null): string {
   return `${sign}${value.toFixed(2)}`;
 }
 
-function formatCIBound(value: number | null): string {
-  if (value == null || !Number.isFinite(value)) return '—';
-  const sign = value >= 0 ? '+' : '';
-  return `${sign}${value.toFixed(2)}`;
+function isSpreadWide(spread: number | null | undefined): boolean {
+  if (spread == null) return false;
+  return spread > KAPPA_SPREAD_WIDE_THRESHOLD;
 }
 
-function isCIWide(low: number | null | undefined, high: number | null | undefined): boolean {
-  if (low == null || high == null) return false;
-  return (high - low) > KAPPA_CI_WIDE_THRESHOLD || low < 0;
+function formatSpread(spread: number | null | undefined): string {
+  if (spread == null || !Number.isFinite(spread)) return '—';
+  return spread.toFixed(2);
 }
 
 function formatPercent(value: number | null): string {
@@ -84,15 +82,10 @@ function sortRows(rows: PairwiseAgreementRow[], sort: SortState): PairwiseAgreem
             ? compareNullableNumbers(left.totalCells, right.totalCells, direction)
             : sort.key === 'kappa'
               ? compareNullableNumbers(left.cohensKappa ?? null, right.cohensKappa ?? null, direction)
-              : sort.key === 'ci'
-                ? (() => {
-                  // Sort by CI lower bound first, then upper bound.
-                  const lLow = left.cohensKappaConfidenceLow ?? null;
-                  const rLow = right.cohensKappaConfidenceLow ?? null;
-                  const lowDelta = compareNullableNumbers(lLow, rLow, direction);
-                  if (lowDelta !== 0) return lowDelta;
-                  return compareNullableNumbers(left.cohensKappaConfidenceHigh ?? null, right.cohensKappaConfidenceHigh ?? null, direction);
-                })()
+              : sort.key === 'spread'
+                ? compareNullableNumbers(left.kappaSpread ?? null, right.kappaSpread ?? null, direction)
+                : sort.key === 'domains'
+                  ? compareNullableNumbers(left.domainCount, right.domainCount, direction)
                 : sort.key === 'interpretation'
                   ? compareNullableStrings(left.kappaInterpretation ?? null, right.kappaInterpretation ?? null, direction)
                   : sort.key === 'agreement'
@@ -214,7 +207,8 @@ export function PairwiseAgreementMatrixReport({ rows, selectedPair, onPairSelect
               <SortableHeader label="Model B" sortKey="modelB" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} />
               <SortableHeader label="Cells" sortKey="cells" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
               <SortableHeader label="Kappa" sortKey="kappa" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
-              <SortableHeader label="95% CI" sortKey="ci" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+              <SortableHeader label="Per-domain spread" sortKey="spread" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
+              <SortableHeader label="Domains" sortKey="domains" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
               <SortableHeader label="Interpretation" sortKey="interpretation" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} />
               <SortableHeader label="% Agreement" sortKey="agreement" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
               <SortableHeader label="Mean Abs Divergence" sortKey="divergence" sortState={sort} onSort={(key) => setSort((current) => getNextSort(current, key))} align="right" />
@@ -242,21 +236,22 @@ export function PairwiseAgreementMatrixReport({ rows, selectedPair, onPairSelect
                     align="right"
                     className={cn(
                       'font-mono tabular-nums text-gray-800',
-                      isCIWide(row.cohensKappaConfidenceLow, row.cohensKappaConfidenceHigh) && 'bg-pink-50',
+                      isSpreadWide(row.kappaSpread) && 'bg-pink-50',
                     )}
                   >
-                    {row.cohensKappaConfidenceLow == null || row.cohensKappaConfidenceHigh == null ? (
+                    {row.domainCount < 2 ? (
                       <span className="text-gray-400">—</span>
                     ) : (
                       <span className="inline-flex items-center gap-1">
-                        <span>
-                          [{formatCIBound(row.cohensKappaConfidenceLow)}, {formatCIBound(row.cohensKappaConfidenceHigh)}]
-                        </span>
-                        {isCIWide(row.cohensKappaConfidenceLow, row.cohensKappaConfidenceHigh) && (
-                          <span aria-label="Wide confidence interval" title="Wide CI — insufficient data to constrain estimate">⚠</span>
+                        <span>{formatSpread(row.kappaSpread)}</span>
+                        {isSpreadWide(row.kappaSpread) && (
+                          <span aria-label="Wide per-domain spread" title="Wide spread — kappa varies significantly by domain">⚠</span>
                         )}
                       </span>
                     )}
+                  </TableCell>
+                  <TableCell align="right" className="font-mono tabular-nums text-gray-800">
+                    {row.domainCount}
                   </TableCell>
                   <TableCell className="text-gray-700">
                     {row.totalCells === 0 ? 'no overlap' : row.kappaInterpretation ?? '—'}

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1087,6 +1087,14 @@ export type DomainFindingsEligibility = {
   summary: Scalars['String']['output'];
 };
 
+export type DomainKappaEntry = {
+  __typename?: 'DomainKappaEntry';
+  cellCount: Scalars['Int']['output'];
+  domainId: Scalars['ID']['output'];
+  domainName: Scalars['String']['output'];
+  kappa?: Maybe<Scalars['Float']['output']>;
+};
+
 export type DomainMutationResult = {
   __typename?: 'DomainMutationResult';
   affectedDefinitions: Scalars['Int']['output'];
@@ -2461,10 +2469,10 @@ export type PairDivergenceBreakdown = {
 export type PairwiseAgreementRow = {
   __typename?: 'PairwiseAgreementRow';
   cohensKappa?: Maybe<Scalars['Float']['output']>;
-  cohensKappaConfidenceHigh?: Maybe<Scalars['Float']['output']>;
-  cohensKappaConfidenceIsSymmetric: Scalars['Boolean']['output'];
-  cohensKappaConfidenceLow?: Maybe<Scalars['Float']['output']>;
+  domainCount: Scalars['Int']['output'];
+  kappaByDomain: Array<DomainKappaEntry>;
   kappaInterpretation?: Maybe<Scalars['String']['output']>;
+  kappaSpread?: Maybe<Scalars['Float']['output']>;
   meanAbsoluteDivergence?: Maybe<Scalars['Float']['output']>;
   modelAId: Scalars['ID']['output'];
   modelALabel: Scalars['String']['output'];
@@ -4895,7 +4903,7 @@ export type ModelAgreementOnTradeoffsQueryVariables = Exact<{
 }>;
 
 
-export type ModelAgreementOnTradeoffsQuery = { __typename?: 'Query', modelAgreementOnTradeoffs: { __typename?: 'ModelAgreementResult', pending: boolean, excludedNonBinaryCells: number, tiedCells: number, buildProgress?: { __typename?: 'ModelAgreementBuildProgress', completedRuns: number, totalRuns: number, currentRunId?: string | null, updatedAt: string } | null, models: Array<{ __typename?: 'ModelInfo', modelId: string, label: string }>, unavailableModels: Array<{ __typename?: 'UnavailableModelInfo', modelId: string, label: string, reason: string }>, pairwiseAgreementMatrix: Array<{ __typename?: 'PairwiseAgreementRow', modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, totalCells: number, percentAgreement?: number | null, cohensKappa?: number | null, kappaInterpretation?: string | null, meanAbsoluteDivergence?: number | null, cohensKappaConfidenceLow?: number | null, cohensKappaConfidenceHigh?: number | null, cohensKappaConfidenceIsSymmetric: boolean }>, trialConsistency: Array<{ __typename?: 'ModelTrialConsistency', modelId: string, modelLabel: string, cellsObserved: number, meanTrialConsistency?: number | null, noisy: boolean }> } };
+export type ModelAgreementOnTradeoffsQuery = { __typename?: 'Query', modelAgreementOnTradeoffs: { __typename?: 'ModelAgreementResult', pending: boolean, excludedNonBinaryCells: number, tiedCells: number, buildProgress?: { __typename?: 'ModelAgreementBuildProgress', completedRuns: number, totalRuns: number, currentRunId?: string | null, updatedAt: string } | null, models: Array<{ __typename?: 'ModelInfo', modelId: string, label: string }>, unavailableModels: Array<{ __typename?: 'UnavailableModelInfo', modelId: string, label: string, reason: string }>, pairwiseAgreementMatrix: Array<{ __typename?: 'PairwiseAgreementRow', modelAId: string, modelALabel: string, modelBId: string, modelBLabel: string, totalCells: number, percentAgreement?: number | null, cohensKappa?: number | null, kappaInterpretation?: string | null, meanAbsoluteDivergence?: number | null, kappaSpread?: number | null, domainCount: number, kappaByDomain: Array<{ __typename?: 'DomainKappaEntry', domainId: string, domainName: string, kappa?: number | null, cellCount: number }> }>, trialConsistency: Array<{ __typename?: 'ModelTrialConsistency', modelId: string, modelLabel: string, cellsObserved: number, meanTrialConsistency?: number | null, noisy: boolean }> } };
 
 export type ModelPairDivergenceBreakdownQueryVariables = Exact<{
   modelAId: Scalars['ID']['input'];
@@ -7449,9 +7457,14 @@ export const ModelAgreementOnTradeoffsDocument = gql`
       cohensKappa
       kappaInterpretation
       meanAbsoluteDivergence
-      cohensKappaConfidenceLow
-      cohensKappaConfidenceHigh
-      cohensKappaConfidenceIsSymmetric
+      kappaByDomain {
+        domainId
+        domainName
+        kappa
+        cellCount
+      }
+      kappaSpread
+      domainCount
     }
     trialConsistency {
       modelId

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -360,9 +360,13 @@ export function ModelsGroups() {
       if (row.cohensKappa == null || row.totalCells === 0) continue;
       const entry: PairwiseKappaEntry = {
         kappa: row.cohensKappa,
-        confidenceLow: row.cohensKappaConfidenceLow ?? null,
-        confidenceHigh: row.cohensKappaConfidenceHigh ?? null,
-        confidenceIsSymmetric: row.cohensKappaConfidenceIsSymmetric,
+        kappaSpread: row.kappaSpread ?? null,
+        kappaByDomain: row.kappaByDomain?.map((domain) => ({
+          domainId: domain.domainId,
+          domainName: domain.domainName,
+          kappa: domain.kappa ?? null,
+          cellCount: domain.cellCount,
+        })) ?? [],
       };
       if (!map.has(row.modelAId)) map.set(row.modelAId, new Map());
       if (!map.has(row.modelBId)) map.set(row.modelBId, new Map());


### PR DESCRIPTION
## Summary

- Removes the bootstrap confidence interval machinery from the kappa pipeline. The bootstrap was methodologically shaky with ~4 data points per pair (one vignette per domain).
- Replaces it with per-domain descriptive statistics: `kappaByDomain`, `kappaSpread` (max − min across domains), and `domainCount`.
- The "95% CI" column in the pairwise agreement matrix is replaced with "Per-domain spread" and "Domains" columns. Wide spread (> 0.30) gets the same flag treatment as wide CI did.

## Changes

**Backend (`aggregation.ts`)**
- Add `computeKappaPerDomain` and `computePairwiseKappaWithBreakdown`
- Remove `bootstrapKappaConfidence`, `groupCellsByVignette`, `KappaConfidenceInterval`, `KAPPA_CI_SYMMETRY_TOLERANCE`
- Rename `KAPPA_CI_WIDE_THRESHOLD` to `KAPPA_SPREAD_WIDE_THRESHOLD`

**GraphQL schema**
- Add `DomainKappaEntry` type with `domainId`, `domainName`, `kappa`, `cellCount`
- Replace `cohensKappaConfidenceLow/High/IsSymmetric` on `PairwiseAgreementRow` with `kappaByDomain`, `kappaSpread`, `domainCount`

**Frontend**
- `PairwiseAgreementMatrixReport`: replace "95% CI" column with "Per-domain spread" + "Domains"
- `ModelSimilarityTableSection`: show spread sub-label instead of CI
- `ModelsGroups`: update kappa map to carry `kappaSpread` and `kappaByDomain`
- `ModelAgreementSection`: help text updated to explain per-domain spread

## Test plan

- [x] All 212 API test files pass
- [x] All 161 web test files pass
- [x] API build clean
- [x] Web build clean
- [x] 0 new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)