### PR TITLE
fix(run-state): create non-empty runs in RUNNING to unstick PENDING regression

### DIFF
--- a/cloud/apps/api/src/queue/handlers/run-state-audit.ts
+++ b/cloud/apps/api/src/queue/handlers/run-state-audit.ts
@@ -24,11 +24,14 @@ async function findRunsForAudit(): Promise<RunAuditSnapshot[]> {
   const windowDays = getReconcileWindowDays();
   const cutoff = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
 
+  // PENDING is included as defense-in-depth — non-empty runs are now created
+  // directly in `RUNNING` (start.ts), but a run stuck in `PENDING` (the
+  // pre-fix bug condition) should still be audited for anomalies.
   return db.run.findMany({
     where: {
       deletedAt: null,
       OR: [
-        { status: { in: ['RUNNING', 'PAUSED', 'SUMMARIZING'] } },
+        { status: { in: ['PENDING', 'RUNNING', 'PAUSED', 'SUMMARIZING'] } },
         { status: 'COMPLETED', updatedAt: { gt: cutoff } },
       ],
     },

--- a/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
+++ b/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
@@ -233,7 +233,18 @@ export function createRunStateReconcileHandler(): PgBoss.WorkHandler<RunStateRec
           log.warn({ runId, err: error }, 'Late transcript rescue failed');
         }
 
-        if (run.status === 'RUNNING' || run.status === 'SUMMARIZING' || run.status === 'PAUSED') {
+        // PENDING is included as defense-in-depth: non-empty runs are now
+        // created directly in `RUNNING` (start.ts), but if anything ever
+        // leaves a run stuck in `PENDING` we still want the reconciler to
+        // attempt status advancement (the empty-run CAS will catch zero-probe
+        // runs; non-empty PENDING runs will not advance via maybeAdvanceRunStatus
+        // today, but will still trigger anomaly detection here).
+        if (
+          run.status === 'PENDING' ||
+          run.status === 'RUNNING' ||
+          run.status === 'SUMMARIZING' ||
+          run.status === 'PAUSED'
+        ) {
           try {
             const advanceResult = await maybeAdvanceRunStatus(runId);
             log.debug({ runId, advanceResult }, 'Reconciled run state');

--- a/cloud/apps/api/src/services/run/recovery.ts
+++ b/cloud/apps/api/src/services/run/recovery.ts
@@ -58,10 +58,14 @@ export type RecoveryResult = {
 export async function detectOrphanedRuns(): Promise<OrphanedRunInfo[]> {
   const orphaned: OrphanedRunInfo[] = [];
 
-  // Find runs that might be stuck
+  // Find runs that might be stuck.
+  // PENDING is included as defense-in-depth: post-PR #745, non-empty runs are
+  // created in `RUNNING` so they should not normally appear here, but if
+  // anything ever leaves a run stuck in `PENDING` we still want recovery to
+  // catch it instead of silently ignoring the row.
   const stuckRuns = await db.run.findMany({
     where: {
-      status: { in: ['RUNNING', 'SUMMARIZING'] },
+      status: { in: ['PENDING', 'RUNNING', 'SUMMARIZING'] },
       updatedAt: {
         lt: new Date(Date.now() - STUCK_THRESHOLD_MINUTES * 60 * 1000),
       },

--- a/cloud/apps/api/src/services/run/scheduler.ts
+++ b/cloud/apps/api/src/services/run/scheduler.ts
@@ -130,10 +130,13 @@ async function sweepRunForTopUp(run: { id: string; config: unknown }): Promise<b
 
 async function hasRecoveryActivity(): Promise<boolean> {
   const windowDays = getReconcileWindowDays();
+  // PENDING is included as defense-in-depth — non-empty runs are now created
+  // directly in `RUNNING` (start.ts), but if anything ever leaves a run stuck
+  // in `PENDING` we still want the recovery scheduler to wake up.
   const activeRuns = await db.run.findFirst({
     where: {
       deletedAt: null,
-      status: { in: ['RUNNING', 'SUMMARIZING', 'PAUSED'] },
+      status: { in: ['PENDING', 'RUNNING', 'SUMMARIZING', 'PAUSED'] },
     },
     select: { id: true },
   });
@@ -204,11 +207,14 @@ export async function enqueueRunStateReconcileJobs(): Promise<number> {
   const jobOptions = DEFAULT_JOB_OPTIONS['run_state_reconcile'];
   const windowDays = getReconcileWindowDays();
 
+  // PENDING is included as defense-in-depth so a run stuck in PENDING (the
+  // pre-fix bug condition) is still picked up by the reconciliation sweep.
+  // Non-empty runs are now created directly in `RUNNING` (start.ts).
   const runs = await db.$queryRaw<Array<{ run_id: string }>>`
     SELECT id AS run_id
     FROM runs
     WHERE deleted_at IS NULL
-      AND status IN ('RUNNING', 'SUMMARIZING', 'PAUSED')
+      AND status IN ('PENDING', 'RUNNING', 'SUMMARIZING', 'PAUSED')
 
     UNION
 

--- a/cloud/apps/api/src/services/run/start.ts
+++ b/cloud/apps/api/src/services/run/start.ts
@@ -263,14 +263,32 @@ export async function startRun(input: StartRunInput): Promise<StartRunResult> {
   const day = today.toLocaleDateString('en-US', { day: '2-digit' });
   const runName = `${month} ${day}-${suffix}`;
 
-  // Create run in transaction
+  // Create run in transaction.
+  //
+  // Status note: non-empty runs are created in `RUNNING` directly. Before this
+  // change, runs were created `PENDING` and relied on the probe handler to flip
+  // to `RUNNING` once the first probe completed. PR #745 (Feature 033) rewrote
+  // the state machine into derived-CAS form and removed that flip without
+  // replacing it, so non-empty runs got stuck in `PENDING` forever — and every
+  // safety net (recovery, audit, reconcile) gated on `IN ('RUNNING','SUMMARIZING','PAUSED')`,
+  // making them invisible. The #745 spec explicitly intended to keep
+  // `PENDING → RUNNING` as a non-drift-prone single-event transition, but the
+  // implementation lost it. By the time `startRun` returns, jobs are already
+  // enqueued and the run *is* running, so creating in `RUNNING` with `startedAt`
+  // set is the most direct fix.
+  //
+  // Empty runs (`totalJobs === 0`) keep `status: 'PENDING'` so the existing
+  // empty-run CAS shortcut in `progress.ts` (`PENDING + total=0 → COMPLETED`)
+  // still fires correctly.
+  const isEmptyRun = totalJobs === 0;
   const run = await db.$transaction(async (tx) => {
     const newRun = await tx.run.create({
       data: {
         name: runName,
         definitionId,
         experimentId: experimentId ?? null,
-        status: 'PENDING',
+        status: isEmptyRun ? 'PENDING' : 'RUNNING',
+        startedAt: isEmptyRun ? null : new Date(),
         runCategory: runCategory ?? 'UNKNOWN_LEGACY',
         config,
         progress: initialProgress,

--- a/cloud/apps/api/tests/graphql/mutations/run.test.ts
+++ b/cloud/apps/api/tests/graphql/mutations/run.test.ts
@@ -154,7 +154,10 @@ describe('GraphQL Run Mutations', () => {
       const result = response.body.data.startRun;
       createdRunIds.push(result.run.id);
 
-      expect(result.run.status).toBe('PENDING');
+      // Non-empty runs are now created directly in RUNNING (see start.ts).
+      // PENDING is reserved for empty (zero-probe) runs that take the empty-run
+      // CAS shortcut to COMPLETED.
+      expect(result.run.status).toBe('RUNNING');
       expect(result.run.definition.id).toBe(definition.id);
       expect(result.run.definition.name).toBe('Test Definition for StartRun');
       // progress is JSON, access as object
@@ -264,7 +267,8 @@ describe('GraphQL Run Mutations', () => {
       });
 
       expect(dbRun).toBeDefined();
-      expect(dbRun?.status).toBe('PENDING');
+      // Non-empty runs are now created directly in RUNNING (see start.ts).
+      expect(dbRun?.status).toBe('RUNNING');
       expect(dbRun?.definitionId).toBe(definition.id);
 
       // Verify scenario selections

--- a/cloud/apps/api/tests/mcp/tools/trigger-recovery.test.ts
+++ b/cloud/apps/api/tests/mcp/tools/trigger-recovery.test.ts
@@ -123,7 +123,11 @@ describe('trigger_recovery MCP Tool [T015]', () => {
       expect(result.detected.length).toBe(0);
     });
 
-    it('does not detect PENDING runs', async () => {
+    it('detects stuck PENDING runs (defense-in-depth)', async () => {
+      // Non-empty runs are now created directly in RUNNING (start.ts), so a
+      // PENDING run with total>0 that hasn't updated in a long time is itself
+      // a bug condition. Recovery widens its WHERE clause to include PENDING
+      // so any straggler still gets surfaced instead of staying invisible.
       const definition = await createTestDefinition();
       await createTestRun(
         definition.id,
@@ -134,7 +138,7 @@ describe('trigger_recovery MCP Tool [T015]', () => {
 
       const result = await recoverOrphanedRuns();
 
-      expect(result.detected.length).toBe(0);
+      expect(result.detected.length).toBe(1);
     });
 
     it('does not detect FAILED runs', async () => {

--- a/cloud/apps/api/tests/services/run/progress.test.ts
+++ b/cloud/apps/api/tests/services/run/progress.test.ts
@@ -251,4 +251,52 @@ describe('maybeAdvanceRunStatus', () => {
       'transcript-5',
     ]);
   });
+
+  it('completes empty (zero-probe) PENDING runs via the empty-run CAS shortcut', async () => {
+    // Empty runs are still created with status PENDING and total=0; the
+    // empty-run CAS shortcut in maybeAdvanceRunStatus is the path that takes
+    // them to COMPLETED. This test guards that path against regression.
+    runState = {
+      ...runState,
+      status: 'PENDING',
+      progress: { total: 0, completed: 0, failed: 0 },
+    };
+    transcriptState = [];
+
+    const result = await maybeAdvanceRunStatus(runState.id);
+
+    expect(result.completed).toBe(true);
+    expect(result.enteredSummarizing).toBe(false);
+    expect(runState.status).toBe('COMPLETED');
+    expect(transitionCounts.toCompleted).toBe(1);
+  });
+
+  it('does NOT silently advance a non-empty PENDING run (state is reachable only via creation bug)', async () => {
+    // Regression test for the bug fixed by setting status='RUNNING' at run
+    // creation time in start.ts. Pre-fix, non-empty runs were created PENDING
+    // and PR #745's state machine had no PENDING -> RUNNING gate, so they got
+    // stuck. The fix is at creation time (start.ts), not in
+    // maybeAdvanceRunStatus, so a run that somehow lands in PENDING with
+    // total>0 should NOT be silently advanced here -- recovery/audit/reconcile
+    // (now widened to include PENDING) are the safety nets that surface it.
+    runState = {
+      ...runState,
+      status: 'PENDING',
+      progress: { total: 5, completed: 5, failed: 0 },
+    };
+    // All transcripts already summarized — would advance to COMPLETED if a
+    // PENDING gate existed. None should.
+    transcriptState = transcriptState.map((t) => ({
+      ...t,
+      summarizedAt: new Date('2026-04-24T10:05:00.000Z'),
+    }));
+
+    const result = await maybeAdvanceRunStatus(runState.id);
+
+    expect(result.completed).toBe(false);
+    expect(result.enteredSummarizing).toBe(false);
+    expect(runState.status).toBe('PENDING');
+    expect(transitionCounts.toSummarizing).toBe(0);
+    expect(transitionCounts.toCompleted).toBe(0);
+  });
 });

--- a/cloud/apps/api/tests/services/run/recovery.test.ts
+++ b/cloud/apps/api/tests/services/run/recovery.test.ts
@@ -195,7 +195,12 @@ describe('run recovery service', () => {
       expect(orphaned.length).toBe(0);
     });
 
-    it('does not detect PENDING runs', async () => {
+    it('detects stuck PENDING runs (defense-in-depth)', async () => {
+      // Non-empty runs are now created directly in RUNNING (start.ts), so a
+      // PENDING run with total>0 that hasn't updated in a long time is itself
+      // a bug condition (the same one this commit fixes). Recovery widens its
+      // WHERE clause to include PENDING so any straggler still gets surfaced
+      // instead of staying silently invisible.
       const definition = await createTestDefinition();
       await createTestRun(
         definition.id,
@@ -205,7 +210,8 @@ describe('run recovery service', () => {
       );
 
       const orphaned = await detectOrphanedRuns();
-      expect(orphaned.length).toBe(0);
+      expect(orphaned.length).toBe(1);
+      expect(orphaned[0]?.status).toBe('PENDING');
     });
 
     it('does not detect recently updated RUNNING runs', async () => {

--- a/cloud/apps/api/tests/services/run/start.test.ts
+++ b/cloud/apps/api/tests/services/run/start.test.ts
@@ -1169,7 +1169,12 @@ describe('startRun service', () => {
   });
 
   describe('run record creation', () => {
-    it('creates run with PENDING status', async () => {
+    it('creates non-empty run with RUNNING status and startedAt set', async () => {
+      // Non-empty runs (totalJobs > 0) are created directly in RUNNING with
+      // startedAt = now. Before this fix, runs were created PENDING and
+      // relied on the probe handler to flip to RUNNING; PR #745 removed that
+      // flip without a replacement, so non-empty runs could get stuck in
+      // PENDING forever and become invisible to recovery/audit safety nets.
       const definition = await db.definition.create({
         data: {
           name: 'Status Test Definition',
@@ -1194,7 +1199,11 @@ describe('startRun service', () => {
 
       createdRunIds.push(result.run.id);
 
-      expect(result.run.status).toBe('PENDING');
+      expect(result.run.status).toBe('RUNNING');
+
+      const dbRun = await db.run.findUnique({ where: { id: result.run.id } });
+      expect(dbRun?.status).toBe('RUNNING');
+      expect(dbRun?.startedAt).not.toBeNull();
     });
 
     it('stores config with models and sampling info', async () => {


### PR DESCRIPTION
## Summary

- Non-empty runs are now created with `status: 'RUNNING'` and `startedAt: NOW()` directly in `start.ts`. Empty runs (`totalJobs === 0`) still create `PENDING` so the existing empty-run CAS shortcut keeps working.
- Defense-in-depth: `'PENDING'` added to the WHERE clauses in `recovery.detectOrphanedRuns`, `scheduler.hasRecoveryActivity`, `enqueueRunStateReconcileJobs`, `run-state-audit.findRunsForAudit`, and `run-state-reconcile`'s status guard. Each site has a comment explaining the safety-net intent.

## Why

PR #745 (Feature 033) rewrote run state transitions into atomic CAS gates and removed the old `done > 0 && PENDING → RUNNING` branch without replacing it. The Feature 033 spec at line 183 explicitly intended to keep that transition as a "non-drift-prone single-event" flip, but the implementation lost it. Runs created with `total > 0` had no exit from `PENDING`, and every safety net (recovery, audit, reconcile, `hasRecoveryActivity`) gated on `IN ('RUNNING','SUMMARIZING','PAUSED')` — so PENDING-stuck runs were invisible to all of them. Most visible symptom: paired batches launched on a new domain hung indefinitely.

By the time `startRun()` returns, jobs are already enqueued and the run *is* running, so creating in `RUNNING` is the most direct fix and avoids adding a third CAS gate.

## Test plan

- [x] Preflight passed: shared/db/api/web lint (0 errors), api build, web build
- [x] API tests pass: 2438 pass, 4 skipped, 0 failed (+2 new tests covering PENDING-with-total>0)
- [ ] Manual smoke: launch a paired batch on a new domain on staging/prod and confirm it transitions out of PENDING within a few seconds