### PR TITLE
paired-batch removal: Wave 2 + Wave 3 + Wave 4 spec

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/ensure-domain-vignette-pair.ts
+++ b/cloud/apps/api/src/graphql/mutations/ensure-domain-vignette-pair.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { db } from '@valuerank/db';
 import { NotFoundError, ValidationError } from '@valuerank/shared';
 import { builder } from '../builder.js';
@@ -141,10 +140,8 @@ builder.mutationField('ensureDomainVignettePair', (t) =>
       }
 
       // 4. Assemble expected pair content
-      const pairKey = randomUUID();
       const { contentAFirst, contentBFirst, componentsAFirst, componentsBFirst } =
         buildPairedVignetteContent(
-          pairKey,
           context.text,
           context.id,
           vf,

--- a/cloud/apps/api/src/graphql/mutations/paired-vignette-aliases.ts
+++ b/cloud/apps/api/src/graphql/mutations/paired-vignette-aliases.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { db, type Prisma } from '@valuerank/db';
 import { ValidationError, type TemplateConfig } from '@valuerank/shared';
 import { builder } from '../builder.js';
@@ -40,9 +39,8 @@ builder.mutationField('createJobChoicePair', (t) =>
         sentencePrefix: resolvedInputs.domainSentencePrefix,
         labelPrefix: resolvedInputs.domainLabelPrefix,
       };
-      const pairKey = randomUUID();
       const { contentAFirst, contentBFirst, componentsAFirst, componentsBFirst } = buildPairedVignetteContent(
-        pairKey, resolvedInputs.context.text, resolvedInputs.contextId,
+        resolvedInputs.context.text, resolvedInputs.contextId,
         resolvedInputs.valueFirst, resolvedInputs.valueSecond, resolvedInputs.levelPresetVersion,
         resolvedInputs.domainNormalizedName, domainTemplateConfig,
       );
@@ -70,8 +68,8 @@ builder.mutationField('createJobChoicePair', (t) =>
         });
         return [a, b] as const;
       });
-      void createAuditLog({ action: 'CREATE', entityType: 'Definition', entityId: defA.id, userId: ctx.user?.id ?? null, metadata: { name: defA.name, pairKey } });
-      void createAuditLog({ action: 'CREATE', entityType: 'Definition', entityId: defB.id, userId: ctx.user?.id ?? null, metadata: { name: defB.name, pairKey } });
+      void createAuditLog({ action: 'CREATE', entityType: 'Definition', entityId: defA.id, userId: ctx.user?.id ?? null, metadata: { name: defA.name } });
+      void createAuditLog({ action: 'CREATE', entityType: 'Definition', entityId: defB.id, userId: ctx.user?.id ?? null, metadata: { name: defB.name } });
       return { definitionA: defA as DefinitionShape, definitionB: defB as DefinitionShape };
     },
   }),
@@ -104,7 +102,7 @@ builder.mutationField('updateJobChoicePair', (t) =>
         labelPrefix: resolvedInputs.domainLabelPrefix,
       };
       const { contentAFirst, contentBFirst, componentsAFirst, componentsBFirst } = buildPairedVignetteContent(
-        existingPair.pairKey, resolvedInputs.context.text, resolvedInputs.contextId,
+        resolvedInputs.context.text, resolvedInputs.contextId,
         resolvedInputs.valueFirst, resolvedInputs.valueSecond, resolvedInputs.levelPresetVersion,
         resolvedInputs.domainNormalizedName, domainTemplateConfig,
       );
@@ -137,8 +135,8 @@ builder.mutationField('updateJobChoicePair', (t) =>
         });
         return [defs[0], defs[1]] as const;
       });
-      void createAuditLog({ action: 'UPDATE', entityType: 'Definition', entityId: updatedA.id, userId: ctx.user?.id ?? null, metadata: { name: updatedA.name, pairKey: existingPair.pairKey, sourceDefinitionId: definitionId } });
-      void createAuditLog({ action: 'UPDATE', entityType: 'Definition', entityId: updatedB.id, userId: ctx.user?.id ?? null, metadata: { name: updatedB.name, pairKey: existingPair.pairKey, sourceDefinitionId: definitionId } });
+      void createAuditLog({ action: 'UPDATE', entityType: 'Definition', entityId: updatedA.id, userId: ctx.user?.id ?? null, metadata: { name: updatedA.name, sourceDefinitionId: definitionId } });
+      void createAuditLog({ action: 'UPDATE', entityType: 'Definition', entityId: updatedB.id, userId: ctx.user?.id ?? null, metadata: { name: updatedB.name, sourceDefinitionId: definitionId } });
       return { definitionA: updatedA as DefinitionShape, definitionB: updatedB as DefinitionShape };
     },
   }),

--- a/cloud/apps/api/src/graphql/mutations/paired-vignette-helpers.ts
+++ b/cloud/apps/api/src/graphql/mutations/paired-vignette-helpers.ts
@@ -15,7 +15,7 @@ import {
   type TemplateConfig,
 } from '@valuerank/shared';
 import { applyLevelPresetToDefinitionContent } from '../../utils/definition-level-preset.js';
-import { findPairedCompanion } from '../../utils/auto-pair.js';
+import { findPairedCompanion, getComponentTokens } from '../../utils/auto-pair.js';
 
 export type PairedVignetteContent = DefinitionContentV1 & {
   components: DefinitionComponents;
@@ -65,7 +65,6 @@ export function buildPairedDefinitionName(_baseName: string, firstToken: string,
 }
 
 export function buildPairedVignetteContent(
-  pairKey: string,
   contextText: string,
   contextId: string,
   valueFirst: { token: string; body: string },
@@ -96,7 +95,6 @@ export function buildPairedVignetteContent(
     methodology: {
       family: familyName,
       response_scale: 'option_text',
-      pair_key: pairKey,
     },
     components: componentsAFirst,
   }, levelPresetVersion);
@@ -107,7 +105,6 @@ export function buildPairedVignetteContent(
     methodology: {
       family: familyName,
       response_scale: 'option_text',
-      pair_key: pairKey,
     },
     components: componentsBFirst,
   }, levelPresetVersion);
@@ -356,7 +353,12 @@ export async function resolvePairedVignette(definitionId: string) {
       ? contentRecord.methodology as Record<string, unknown>
       : null;
 
-  if (typeof methodology?.family !== 'string' || methodology.family === '' || typeof methodology.pair_key !== 'string') {
+  if (typeof methodology?.family !== 'string' || methodology.family === '') {
+    throw new ValidationError('Definition is not a paired vignette');
+  }
+
+  const primaryTokens = getComponentTokens(definition.content);
+  if (primaryTokens == null) {
     throw new ValidationError('Definition is not a paired vignette');
   }
 
@@ -365,10 +367,6 @@ export async function resolvePairedVignette(definitionId: string) {
       id: { not: definition.id },
       domainId: definition.domainId,
       deletedAt: null,
-      content: {
-        path: ['methodology', 'pair_key'],
-        equals: methodology.pair_key,
-      },
     },
     select: { id: true, name: true, content: true },
   });
@@ -385,7 +383,6 @@ export async function resolvePairedVignette(definitionId: string) {
   const definitionB = companion as { id: string; name: string; content: unknown };
 
   return {
-    pairKey: methodology.pair_key,
     definitionA: { id: definition.id, name: definition.name, content: definition.content },
     definitionB,
   };

--- a/cloud/apps/api/src/graphql/mutations/paired-vignette.ts
+++ b/cloud/apps/api/src/graphql/mutations/paired-vignette.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { db, type Prisma } from '@valuerank/db';
 import { ValidationError, type TemplateConfig } from '@valuerank/shared';
 import { builder } from '../builder.js';
@@ -44,7 +43,6 @@ builder.mutationField('createPairedVignette', (t) =>
         applyDomainDefault: true,
       });
 
-      const pairKey = randomUUID();
       const domainTemplateConfig: TemplateConfig = {
         sentencePrefix: resolvedInputs.domainSentencePrefix,
         labelPrefix: resolvedInputs.domainLabelPrefix,
@@ -55,7 +53,6 @@ builder.mutationField('createPairedVignette', (t) =>
         componentsAFirst,
         componentsBFirst,
       } = buildPairedVignetteContent(
-        pairKey,
         resolvedInputs.context.text,
         resolvedInputs.contextId,
         resolvedInputs.valueFirst,
@@ -115,7 +112,6 @@ builder.mutationField('createPairedVignette', (t) =>
         {
           definitionAId: defA.id,
           definitionBId: defB.id,
-          pairKey,
           levelPresetVersionId: resolvedInputs.resolvedLevelPresetVersionId,
           scenarioCount: resolvedInputs.levelPresetVersion != null ? 50 : 2,
         },
@@ -127,14 +123,14 @@ builder.mutationField('createPairedVignette', (t) =>
         entityType: 'Definition',
         entityId: defA.id,
         userId: ctx.user?.id ?? null,
-        metadata: { name: defA.name, pairKey },
+        metadata: { name: defA.name },
       });
       void createAuditLog({
         action: 'CREATE',
         entityType: 'Definition',
         entityId: defB.id,
         userId: ctx.user?.id ?? null,
-        metadata: { name: defB.name, pairKey },
+        metadata: { name: defB.name },
       });
 
       return {
@@ -190,7 +186,6 @@ builder.mutationField('updatePairedVignette', (t) =>
         componentsAFirst,
         componentsBFirst,
       } = buildPairedVignetteContent(
-        existingPair.pairKey,
         resolvedInputs.context.text,
         resolvedInputs.contextId,
         resolvedInputs.valueFirst,
@@ -256,14 +251,14 @@ builder.mutationField('updatePairedVignette', (t) =>
         entityType: 'Definition',
         entityId: updatedA.id,
         userId: ctx.user?.id ?? null,
-        metadata: { name: updatedA.name, pairKey: existingPair.pairKey, sourceDefinitionId: definitionId },
+        metadata: { name: updatedA.name, sourceDefinitionId: definitionId },
       });
       void createAuditLog({
         action: 'UPDATE',
         entityType: 'Definition',
         entityId: updatedB.id,
         userId: ctx.user?.id ?? null,
-        metadata: { name: updatedB.name, pairKey: existingPair.pairKey, sourceDefinitionId: definitionId },
+        metadata: { name: updatedB.name, sourceDefinitionId: definitionId },
       });
 
       ctx.log.info(
@@ -271,7 +266,6 @@ builder.mutationField('updatePairedVignette', (t) =>
           sourceDefinitionId: definitionId,
           definitionAId: updatedA.id,
           definitionBId: updatedB.id,
-          pairKey: existingPair.pairKey,
           levelPresetVersionId: resolvedInputs.resolvedLevelPresetVersionId,
           scenarioCount: resolvedInputs.levelPresetVersion != null ? 50 : 2,
         },

--- a/cloud/apps/api/src/graphql/queries/domain/evaluation/helpers.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/evaluation/helpers.ts
@@ -218,24 +218,6 @@ export function toShape(
   };
 }
 
-function extractPairKey(content: unknown): string | null {
-  if (content == null || typeof content !== 'object' || Array.isArray(content)) {
-    return null;
-  }
-
-  const methodology = (content as Record<string, unknown>).methodology;
-  if (methodology == null || typeof methodology !== 'object' || Array.isArray(methodology)) {
-    return null;
-  }
-
-  const record = methodology as Record<string, unknown>;
-  if (typeof record.family !== 'string' || record.family === '' || typeof record.pair_key !== 'string' || record.pair_key.trim() === '') {
-    return null;
-  }
-
-  return record.pair_key;
-}
-
 export async function resolveLaunchableDefinitions(
   launchableDefinitionIds: string[],
   members: DomainEvaluationMemberShape[],
@@ -249,7 +231,6 @@ export async function resolveLaunchableDefinitions(
     select: {
       id: true,
       name: true,
-      content: true,
     },
   });
 
@@ -258,7 +239,6 @@ export async function resolveLaunchableDefinitions(
       definition.id,
       {
         definitionName: definition.name ?? 'Untitled vignette',
-        pairKey: extractPairKey(definition.content),
       },
     ]),
   );
@@ -271,7 +251,6 @@ export async function resolveLaunchableDefinitions(
     return {
       definitionId,
       definitionName: definition?.definitionName ?? memberNameByDefinitionId.get(definitionId) ?? 'Untitled vignette',
-      pairKey: definition?.pairKey ?? null,
     };
   });
 }

--- a/cloud/apps/api/src/graphql/queries/domain/evaluation/types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/evaluation/types.ts
@@ -19,7 +19,6 @@ export type DomainEvaluationSnapshot = {
 export type DomainEvaluationLaunchableDefinitionShape = {
   definitionId: string;
   definitionName: string;
-  pairKey: string | null;
 };
 
 export type DomainEvaluationMemberShape = {
@@ -167,7 +166,6 @@ export const DomainEvaluationLaunchableDefinitionRef = builder
     fields: (t) => ({
       definitionId: t.exposeID('definitionId'),
       definitionName: t.exposeString('definitionName'),
-      pairKey: t.exposeString('pairKey', { nullable: true }),
     }),
   });
 

--- a/cloud/apps/api/src/graphql/types/definition-paired-sibling.ts
+++ b/cloud/apps/api/src/graphql/types/definition-paired-sibling.ts
@@ -3,7 +3,7 @@
  *
  * Extracted out of `definition.ts` to keep that file under the prod-warn
  * file-size threshold. Reuses `findPairedCompanion` from `utils/auto-pair`
- * so callers do not duplicate the canonical companion-resolution logic.
+ * so callers do not duplicate the canonical token-mirror companion logic.
  */
 
 import { db } from '@valuerank/db';
@@ -20,27 +20,13 @@ type DefinitionRow = Awaited<ReturnType<typeof db.definition.findFirst>>;
 export async function resolveDefinitionPairedSibling(
   definition: DefinitionInput,
 ): Promise<DefinitionRow> {
-  const contentRecord =
-    definition.content !== null && typeof definition.content === 'object' && !Array.isArray(definition.content)
-      ? (definition.content as Record<string, unknown>)
-      : null;
-  const methodology =
-    contentRecord?.methodology !== null && typeof contentRecord?.methodology === 'object' && !Array.isArray(contentRecord?.methodology)
-      ? (contentRecord.methodology as Record<string, unknown>)
-      : null;
-  const pairKey = typeof methodology?.pair_key === 'string' ? methodology.pair_key : null;
-  if (pairKey === null || pairKey.trim() === '') return null;
-
   const candidates = await db.definition.findMany({
     where: {
       id: { not: definition.id },
       domainId: definition.domainId,
       deletedAt: null,
-      content: {
-        path: ['methodology', 'pair_key'],
-        equals: pairKey,
-      },
     },
+    select: { id: true, content: true },
   });
 
   if (candidates.length === 0) return null;
@@ -51,5 +37,7 @@ export async function resolveDefinitionPairedSibling(
   );
   if (companion === null || companion === undefined) return null;
 
-  return candidates.find((row) => row.id === companion.id) ?? null;
+  return db.definition.findUnique({
+    where: { id: companion.id },
+  });
 }

--- a/cloud/apps/api/src/graphql/types/definition.ts
+++ b/cloud/apps/api/src/graphql/types/definition.ts
@@ -463,7 +463,7 @@ builder.objectType(DefinitionRef, {
       type: DefinitionRef,
       nullable: true,
       description:
-        'For paired vignettes, returns the companion vignette (same pair_key, same domain, mirrored value_first / value_second tokens). Returns null when this definition is not paired or when no companion exists. Reuses findPairedCompanion from utils/auto-pair so callers do not duplicate the companion-resolution logic.',
+        'For paired vignettes, returns the companion vignette (same domain, mirrored value_first / value_second tokens). Returns null when this definition is not paired or when no companion exists. Reuses findPairedCompanion from utils/auto-pair so callers do not duplicate the token-mirror companion logic.',
       resolve: (definition) => resolveDefinitionPairedSibling(definition),
     }),
 

--- a/cloud/apps/api/src/queue/handlers/run-state-audit.ts
+++ b/cloud/apps/api/src/queue/handlers/run-state-audit.ts
@@ -5,7 +5,6 @@ import { getReconcileWindowDays } from '../../services/run/scheduler.js';
 import {
   detectModelTranscriptShortfall,
   detectOrphanTranscript,
-  detectPairAsymmetry,
   detectScheduledCountMismatch,
   detectStrandedTranscript,
   detectSummarizingStall,
@@ -65,15 +64,6 @@ async function inspectRun(run: RunAuditSnapshot): Promise<void> {
   }
 
   try {
-    const pair = await detectPairAsymmetry(run, 'audit');
-    if (pair !== null) {
-      addDraft(pair);
-    }
-  } catch (error) {
-    log.warn({ runId: run.id, err: error }, 'Audit pair asymmetry detection failed');
-  }
-
-  try {
     const shortfalls = await detectModelTranscriptShortfall(run, 'audit');
     for (const shortfall of shortfalls) {
       addDraft(shortfall);
@@ -93,7 +83,6 @@ async function inspectRun(run: RunAuditSnapshot): Promise<void> {
 
   const scannedTypes: AnomalyDraft['type'][] = [
     'ORPHAN_TRANSCRIPT',
-    'PAIR_ASYMMETRY',
     'MODEL_TRANSCRIPT_SHORTFALL',
     'INVALID_RESPONSE_FAILURE',
   ];

--- a/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
+++ b/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
@@ -5,7 +5,6 @@ import { DEFAULT_JOB_OPTIONS, type RunStateReconcileJobData } from '../types.js'
 import { maybeAdvanceRunStatus } from '../../services/run/index.js';
 import {
   detectModelTranscriptShortfall,
-  detectPairAsymmetry,
   detectScheduledCountMismatch,
   detectStrandedTranscript,
   detectSummarizingStall,
@@ -256,13 +255,6 @@ export function createRunStateReconcileHandler(): PgBoss.WorkHandler<RunStateRec
 
         if (run.status === 'COMPLETED') {
           try {
-            const pair = await detectPairAsymmetry(run);
-            await syncAnomalies(runId, 'PAIR_ASYMMETRY', pair === null ? [] : [pair], 'default');
-          } catch (error) {
-            log.warn({ runId, err: error }, 'Pair asymmetry detection failed');
-          }
-
-          try {
             const shortfalls = await detectModelTranscriptShortfall(run);
             await syncAnomalies(runId, 'MODEL_TRANSCRIPT_SHORTFALL', shortfalls, 'default');
           } catch (error) {
@@ -279,13 +271,6 @@ export function createRunStateReconcileHandler(): PgBoss.WorkHandler<RunStateRec
             log.warn({ runId, err: error }, 'Invalid response failure detection failed');
           }
         } else {
-          try {
-            const pair = await detectPairAsymmetry(run);
-            await syncAnomalies(runId, 'PAIR_ASYMMETRY', pair === null ? [] : [pair], 'default');
-          } catch (error) {
-            log.warn({ runId, err: error }, 'Pair asymmetry detection failed');
-          }
-
           try {
             const stall = detectSummarizingStall(run);
             await syncAnomalies(runId, 'SUMMARIZING_STALL', stall === null ? [] : [stall], 'default');

--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-builder.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-builder.ts
@@ -3,7 +3,7 @@ import { AppError, NotFoundError } from '@valuerank/shared';
 import { runMatchesSignature } from '../../graphql/queries/domain-coverage-gql-types.js';
 import type { DefinitionDimension } from '../../graphql/queries/scenarios-utils.js';
 import type { PressureSensitivityResultShape } from '../../graphql/types/pressure-sensitivity.js';
-import { findPairedCompanion } from '../../utils/auto-pair.js';
+import { findPairedCompanion, getComponentTokens } from '../../utils/auto-pair.js';
 import { type PressureSensitivityDecisionSnapshot } from './decision-snapshot.js';
 import { computeAggregateFingerprint } from '../analysis/aggregate/aggregate-helpers.js';
 import {
@@ -259,17 +259,8 @@ export async function expandToCompanionDefinition(definitionId: string): Promise
     throw new NotFoundError('Definition', definitionId);
   }
 
-  const content = definition.content as Record<string, unknown> | null;
-  const methodology =
-    content !== null && typeof content === 'object' && !Array.isArray(content)
-      ? (content.methodology as Record<string, unknown> | null)
-      : null;
-  const pairKey =
-    methodology !== null && typeof methodology.pair_key === 'string' && methodology.pair_key.length > 0
-      ? methodology.pair_key
-      : null;
-
-  if (pairKey === null) {
+  const definitionTokens = getComponentTokens(definition.content);
+  if (definitionTokens === null) {
     return { ids: [definitionId], status: 'not_paired' };
   }
 
@@ -278,24 +269,29 @@ export async function expandToCompanionDefinition(definitionId: string): Promise
       id: { not: definitionId },
       domainId: definition.domainId,
       deletedAt: null,
-      content: {
-        path: ['methodology', 'pair_key'],
-        equals: pairKey,
-      },
     },
     select: { id: true, content: true },
   });
 
-  if (candidates.length > 1) {
+  const mirroredCandidates = candidates.filter((candidate) => {
+    const candidateTokens = getComponentTokens(candidate.content);
+    return (
+      candidateTokens !== null
+      && candidateTokens.value_first.token === definitionTokens.value_second.token
+      && candidateTokens.value_second.token === definitionTokens.value_first.token
+    );
+  });
+
+  if (mirroredCandidates.length > 1) {
     throw new AppError(
-      'Multiple companion vignettes share this pair_key',
+      'Multiple companion vignettes share mirrored value tokens in this domain',
       PAIR_KEY_COMPANION_COLLISION,
       500,
-      { pairKey, definitionId, candidateCount: candidates.length },
+      { definitionId, domainId: definition.domainId, candidateCount: mirroredCandidates.length },
     );
   }
 
-  if (candidates.length === 0) {
+  if (mirroredCandidates.length === 0) {
     return { ids: [definitionId], status: 'companion_missing' };
   }
 
@@ -309,7 +305,7 @@ export async function expandToCompanionDefinition(definitionId: string): Promise
       'Paired vignette companion mirroring failed',
       PAIR_KEY_COMPANION_MIRROR_FAILURE,
       500,
-      { pairKey, definitionId },
+      { definitionId, domainId: definition.domainId },
     );
   }
 

--- a/cloud/apps/api/src/services/run/anomaly-detection.ts
+++ b/cloud/apps/api/src/services/run/anomaly-detection.ts
@@ -6,8 +6,6 @@ import {
   MODEL_SHORTFALL_PEER_RATE,
   MODEL_SHORTFALL_RELATIVE_RATE,
   ORPHAN_TRANSCRIPT_MIN_AGE_SECONDS,
-  PAIR_ASYMMETRY_MIN_PROBES,
-  PAIR_ASYMMETRY_THRESHOLD_PCT,
   SUMMARIZING_STALL_MINUTES,
 } from './anomaly-thresholds.js';
 
@@ -40,7 +38,6 @@ type RunSnapshot = {
 type RunConfig = {
   models?: string[];
   samplesPerScenario?: number;
-  jobChoiceBatchGroupId?: string | null;
 };
 
 type SuccessCountRow = {
@@ -59,20 +56,7 @@ type OrphanTranscriptRow = {
   content: unknown;
 };
 
-type PairAsymmetryCandidate = {
-  id: string;
-  config: unknown;
-};
-
-type PairAsymmetryMetrics = {
-  runId: string;
-  scheduled: number;
-  successCount: number;
-  successRate: number;
-};
-
 export type AnomalyThresholds = {
-  pairAsymmetryThresholdPct?: number;
   modelShortfallAbsoluteRate?: number;
   modelShortfallRelativeRate?: number;
   modelShortfallPeerRate?: number;
@@ -103,11 +87,6 @@ function getSamplesPerScenario(config: unknown): number {
   return typeof samples === 'number' && Number.isFinite(samples) && samples > 0 ? samples : 1;
 }
 
-function getGroupId(config: unknown): string | null {
-  const groupId = parseRunConfig(config).jobChoiceBatchGroupId;
-  return typeof groupId === 'string' && groupId.trim() !== '' ? groupId : null;
-}
-
 function getProgressTotal(progress: unknown): number {
   if (progress === null || progress === undefined || typeof progress !== 'object') {
     return 0;
@@ -127,7 +106,6 @@ function isThresholdOverrides(value: AnomalyDetectionMode | AnomalyThresholds | 
 
 function hasAuditThresholdOverrides(thresholds: AnomalyThresholds | null): boolean {
   return thresholds !== null
-    && thresholds.pairAsymmetryThresholdPct === 0
     && thresholds.modelShortfallAbsoluteRate === 0
     && thresholds.modelShortfallRelativeRate === 0
     && thresholds.modelShortfallPeerRate === 0;
@@ -248,114 +226,6 @@ export async function detectOrphanTranscript(runId: string): Promise<AnomalyDraf
     subject: '',
     details: toJsonValue({
       transcriptIds: orphans.map((transcript) => transcript.id),
-    }),
-  };
-}
-
-export async function detectPairAsymmetry(
-  run: RunSnapshot,
-  options?: AnomalyDetectionMode | AnomalyThresholds,
-): Promise<AnomalyDraft | null> {
-  const detection = normalizeDetectionOptions(options);
-  const groupId = getGroupId(run.config);
-  if (groupId === null) {
-    return null;
-  }
-
-  const siblings = await db.run.findMany({
-    where: {
-      deletedAt: null,
-      id: { not: run.id },
-      config: {
-        path: ['jobChoiceBatchGroupId'],
-        equals: groupId,
-      },
-    },
-    select: {
-      id: true,
-      config: true,
-    },
-    orderBy: { updatedAt: 'asc' },
-  });
-
-  if (siblings.length === 0) {
-    return null;
-  }
-
-  const comparisonRuns: PairAsymmetryCandidate[] = [run, ...siblings];
-  const metrics = await Promise.all(
-    comparisonRuns.map(async (candidate): Promise<PairAsymmetryMetrics> => {
-      const modelCount = getModelIds(candidate.config).length;
-      const scenarioCount = await db.runScenarioSelection.count({ where: { runId: candidate.id } });
-      const samplesPerScenario = getSamplesPerScenario(candidate.config);
-      const scheduled = scenarioCount * modelCount * samplesPerScenario;
-      const successCount = await db.probeResult.count({
-        where: { runId: candidate.id, deletedAt: null, status: 'SUCCESS' },
-      });
-      return {
-        runId: candidate.id,
-        scheduled,
-        successCount,
-        successRate: scheduled === 0 ? 0 : successCount / scheduled,
-      };
-    })
-  );
-
-  const currentMetrics = metrics.find((candidate) => candidate.runId === run.id) ?? null;
-  if (currentMetrics === null) {
-    return null;
-  }
-
-  const skippedUnderSampledRunIds: string[] = [];
-  let maxDeltaPct = -1;
-  let maxDeltaSibling: PairAsymmetryMetrics | null = null;
-
-  for (const siblingMetrics of metrics) {
-    if (siblingMetrics.runId === run.id) {
-      continue;
-    }
-
-    if (currentMetrics.scheduled < PAIR_ASYMMETRY_MIN_PROBES || siblingMetrics.scheduled < PAIR_ASYMMETRY_MIN_PROBES) {
-      skippedUnderSampledRunIds.push(siblingMetrics.runId);
-      continue;
-    }
-
-    const deltaPct = Math.abs(currentMetrics.successRate - siblingMetrics.successRate) * 100;
-    if (deltaPct > maxDeltaPct) {
-      maxDeltaPct = deltaPct;
-      maxDeltaSibling = siblingMetrics;
-    }
-  }
-
-  if (maxDeltaSibling === null) {
-    return null;
-  }
-
-  const thresholdPct =
-    detection.mode === 'audit'
-      ? 0
-      : detection.thresholds?.pairAsymmetryThresholdPct ?? PAIR_ASYMMETRY_THRESHOLD_PCT;
-
-  // <= so identical rates (deltaPct === 0) don't fire when threshold is 0.
-  // At threshold=0 the detector fires on any measurable asymmetry.
-  if (maxDeltaPct <= thresholdPct) {
-    return null;
-  }
-
-  return {
-    type: 'PAIR_ASYMMETRY',
-    subject: groupId,
-    details: toJsonValue({
-      runId: run.id,
-      siblingRunId: maxDeltaSibling.runId,
-      currentSuccessRate: currentMetrics.successRate,
-      siblingSuccessRate: maxDeltaSibling.successRate,
-      scheduled: currentMetrics.scheduled,
-      siblingScheduled: maxDeltaSibling.scheduled,
-      siblingRunIds: metrics.map((candidate) => candidate.runId),
-      siblingSuccessRates: metrics.map((candidate) => candidate.successRate),
-      maxDeltaPct,
-      skippedUnderSampledRunIds,
     }),
   };
 }
@@ -510,9 +380,6 @@ export async function detectRunAnomalies(run: RunSnapshot): Promise<AnomalyDraft
 
   const orphan = await detectOrphanTranscript(run.id);
   if (orphan !== null) drafts.push(orphan);
-
-  const pair = await detectPairAsymmetry(run);
-  if (pair !== null) drafts.push(pair);
 
   const stall = detectSummarizingStall(run);
   if (stall !== null) drafts.push(stall);

--- a/cloud/apps/api/src/services/run/anomaly-thresholds.ts
+++ b/cloud/apps/api/src/services/run/anomaly-thresholds.ts
@@ -1,8 +1,3 @@
-// Severity gates dropped to 0 per reviewer guidance (2026-04-23):
-// flag any measurable deviation; keep MIN_PROBES/AGE/STALL filters to skip
-// statistical noise and in-flight states.
-export const PAIR_ASYMMETRY_THRESHOLD_PCT = 0;
-export const PAIR_ASYMMETRY_MIN_PROBES = 10;
 export const SUMMARIZING_STALL_MINUTES = 30;
 export const MODEL_SHORTFALL_MIN_PROBES = 10;
 // Kept non-zero per adversarial review: this is the ONLY branch that detects

--- a/cloud/apps/api/tests/queue/handlers/run-state-audit.test.ts
+++ b/cloud/apps/api/tests/queue/handlers/run-state-audit.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockRunFindMany = vi.hoisted(() => vi.fn());
 const mockDetectOrphanTranscript = vi.hoisted(() => vi.fn());
-const mockDetectPairAsymmetry = vi.hoisted(() => vi.fn());
 const mockDetectModelTranscriptShortfall = vi.hoisted(() => vi.fn());
 const mockDetectStrandedTranscript = vi.hoisted(() => vi.fn());
 const mockDetectSummarizingStall = vi.hoisted(() => vi.fn());
@@ -33,7 +32,6 @@ vi.mock('../../../src/services/run/scheduler.js', () => ({
 
 vi.mock('../../../src/services/run/anomaly-detection.js', () => ({
   detectOrphanTranscript: mockDetectOrphanTranscript,
-  detectPairAsymmetry: mockDetectPairAsymmetry,
   detectModelTranscriptShortfall: mockDetectModelTranscriptShortfall,
   detectStrandedTranscript: mockDetectStrandedTranscript,
   detectSummarizingStall: mockDetectSummarizingStall,
@@ -64,7 +62,6 @@ describe('createRunStateAuditHandler', () => {
       },
     ]);
     mockDetectOrphanTranscript.mockResolvedValue(null);
-    mockDetectPairAsymmetry.mockResolvedValue(null);
     mockDetectModelTranscriptShortfall.mockResolvedValue([]);
     mockDetectStrandedTranscript.mockResolvedValue(null);
     mockDetectSummarizingStall.mockReturnValue(null);
@@ -74,11 +71,6 @@ describe('createRunStateAuditHandler', () => {
   });
 
   it('persists completed-run audit anomalies with the audit source', async () => {
-    mockDetectPairAsymmetry.mockResolvedValueOnce({
-      type: 'PAIR_ASYMMETRY',
-      subject: 'group-1',
-      details: { runId: 'run-1' },
-    });
     mockDetectModelTranscriptShortfall.mockResolvedValueOnce([
       {
         type: 'MODEL_TRANSCRIPT_SHORTFALL',
@@ -102,17 +94,6 @@ describe('createRunStateAuditHandler', () => {
     expect(mockDetectSummarizingStall).toHaveBeenCalledTimes(1);
     expect(mockDetectScheduledCountMismatch).toHaveBeenCalledTimes(1);
     expect(mockDetectInvalidResponseFailures).toHaveBeenCalledWith('run-1', 'audit');
-    expect(mockSyncAnomalies).toHaveBeenCalledWith(
-      'run-1',
-      'PAIR_ASYMMETRY',
-      [
-        expect.objectContaining({
-          type: 'PAIR_ASYMMETRY',
-          subject: 'group-1',
-        }),
-      ],
-      'audit'
-    );
     expect(mockSyncAnomalies).toHaveBeenCalledWith(
       'run-1',
       'MODEL_TRANSCRIPT_SHORTFALL',

--- a/cloud/apps/api/tests/queue/handlers/run-state-reconcile.test.ts
+++ b/cloud/apps/api/tests/queue/handlers/run-state-reconcile.test.ts
@@ -10,7 +10,6 @@ const mockLogWarn = vi.hoisted(() => vi.fn());
 const mockLogError = vi.hoisted(() => vi.fn());
 const mockMaybeAdvanceRunStatus = vi.hoisted(() => vi.fn());
 const mockDetectStrandedTranscript = vi.hoisted(() => vi.fn());
-const mockDetectPairAsymmetry = vi.hoisted(() => vi.fn());
 const mockDetectModelTranscriptShortfall = vi.hoisted(() => vi.fn());
 const mockDetectScheduledCountMismatch = vi.hoisted(() => vi.fn());
 const mockDetectInvalidResponseFailures = vi.hoisted(() => vi.fn());
@@ -57,7 +56,6 @@ vi.mock('../../../src/services/run/index.js', () => ({
 
 vi.mock('../../../src/services/run/anomaly-detection.js', () => ({
   detectStrandedTranscript: mockDetectStrandedTranscript,
-  detectPairAsymmetry: mockDetectPairAsymmetry,
   detectModelTranscriptShortfall: mockDetectModelTranscriptShortfall,
   detectScheduledCountMismatch: mockDetectScheduledCountMismatch,
   detectSummarizingStall: mockDetectSummarizingStall,
@@ -94,7 +92,6 @@ describe('createRunStateReconcileHandler', () => {
     mockTranscriptFindMany.mockResolvedValue([]);
     mockRunAnomalyFindMany.mockResolvedValue([]);
     mockDetectStrandedTranscript.mockResolvedValue(null);
-    mockDetectPairAsymmetry.mockResolvedValue(null);
     mockDetectModelTranscriptShortfall.mockResolvedValue([]);
     mockDetectScheduledCountMismatch.mockResolvedValue({
       draft: null,

--- a/cloud/apps/api/tests/services/pressure-sensitivity/snapshot-builder.test.ts
+++ b/cloud/apps/api/tests/services/pressure-sensitivity/snapshot-builder.test.ts
@@ -193,21 +193,12 @@ describe('expandToCompanionDefinition', () => {
     });
   });
 
-  it('returns not_paired when methodology.pair_key is absent', async () => {
-    const domain = await createDomain('snapshot-builder-not-paired');
-    const input = await createDefinition({
-      domainId: domain.id,
-      name: 'Unpaired Definition',
-      firstToken: 'Achievement',
-      secondToken: 'Benevolence_Dependability',
-      presentationOrder: 'A_first',
-    });
-
-    await expect(expandToCompanionDefinition(input.id)).resolves.toEqual({
-      ids: [input.id],
-      status: 'not_paired',
-    });
-  });
+  // Wave 2: "not_paired" now means the definition has no value_first/value_second
+  // tokens at all (i.e. it's not structured as a paired vignette). The earlier
+  // condition (missing methodology.pair_key) is no longer how pairing is detected.
+  // The unreachable case where a definition lacks tokens entirely is covered by
+  // unit tests on getComponentTokens; an integration test against a malformed
+  // fixture isn't worth maintaining.
 
   it('does not cross domain boundaries when matching companions', async () => {
     const domainA = await createDomain('snapshot-builder-cross-a');
@@ -235,7 +226,12 @@ describe('expandToCompanionDefinition', () => {
     });
   });
 
-  it('throws a mirror failure when the only candidate is not a mirrored pair', async () => {
+  it('returns companion_missing when the only domain candidate is not a mirrored pair', async () => {
+    // Wave 2: with pair_key prefilter removed, a domain neighbour whose tokens
+    // do not mirror is simply not selected as a companion. Returns
+    // companion_missing rather than throwing PAIR_KEY_COMPANION_MIRROR_FAILURE
+    // (the mirror-failure throw is preserved as a defensive safety net but is
+    // unreachable in normal flow now that candidates are filtered by tokens).
     const domain = await createDomain('snapshot-builder-mirror-failure');
     const input = await createDefinition({
       domainId: domain.id,
@@ -243,7 +239,6 @@ describe('expandToCompanionDefinition', () => {
       firstToken: 'Achievement',
       secondToken: 'Benevolence_Dependability',
       presentationOrder: 'A_first',
-      pairKey: 'pair-mirror-failure',
     });
     await createDefinition({
       domainId: domain.id,
@@ -251,11 +246,11 @@ describe('expandToCompanionDefinition', () => {
       firstToken: 'Care',
       secondToken: 'Freedom',
       presentationOrder: 'A_first',
-      pairKey: 'pair-mirror-failure',
     });
 
-    await expect(expandToCompanionDefinition(input.id)).rejects.toMatchObject({
-      code: 'pair_key_companion_mirror_failure',
+    await expect(expandToCompanionDefinition(input.id)).resolves.toEqual({
+      ids: [input.id],
+      status: 'companion_missing',
     });
   });
 });

--- a/cloud/apps/api/tests/services/run/anomaly-detection.test.ts
+++ b/cloud/apps/api/tests/services/run/anomaly-detection.test.ts
@@ -1,40 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
-  mockRunFindMany,
   mockRunScenarioSelectionCount,
-  mockProbeResultCount,
   mockProbeResultGroupBy,
   mockTranscriptFindMany,
-  mockRunAnomalyFindMany,
   mockQueryRaw,
 } = vi.hoisted(() => ({
-  mockRunFindMany: vi.fn(),
   mockRunScenarioSelectionCount: vi.fn(),
-  mockProbeResultCount: vi.fn(),
   mockProbeResultGroupBy: vi.fn(),
   mockTranscriptFindMany: vi.fn(),
-  mockRunAnomalyFindMany: vi.fn(),
   mockQueryRaw: vi.fn(),
 }));
 
 vi.mock('@valuerank/db', () => ({
   db: {
-    run: {
-      findMany: mockRunFindMany,
-    },
     runScenarioSelection: {
       count: mockRunScenarioSelectionCount,
     },
     probeResult: {
-      count: mockProbeResultCount,
       groupBy: mockProbeResultGroupBy,
     },
     transcript: {
       findMany: mockTranscriptFindMany,
-    },
-    runAnomaly: {
-      findMany: mockRunAnomalyFindMany,
     },
     $queryRaw: mockQueryRaw,
   },
@@ -58,7 +45,6 @@ vi.mock('@valuerank/shared', () => ({
 import {
   detectModelTranscriptShortfall,
   detectOrphanTranscript,
-  detectPairAsymmetry,
   detectScheduledCountMismatch,
   detectStrandedTranscript,
   detectSummarizingStall,
@@ -297,91 +283,6 @@ describe('run anomaly detection', () => {
     expect(auditDrafts).toEqual(defaultDrafts);
     expect(auditDrafts).toHaveLength(1);
     expect(auditDrafts[0].subject).toBe('run-1:scenario-1:model-1:0');
-  });
-
-  it('detects pair asymmetry when sibling success rates diverge enough', async () => {
-    // mockRunFindMany is called by detectPairAsymmetry with `id: { not: run.id }`,
-    // so it should return only siblings (not self).
-    mockRunFindMany.mockResolvedValue([
-      { id: 'run-2', config: { jobChoiceBatchGroupId: 'group-1', models: ['m1'], samplesPerScenario: 10 } },
-    ]);
-    mockRunScenarioSelectionCount.mockResolvedValue(1);
-    // Two candidates (self + 1 sibling). Each calls probeResult.count once.
-    // Order in Promise.all: run-1 (self, 3 successes), run-2 (sibling, 9 successes).
-    mockProbeResultCount
-      .mockResolvedValueOnce(3)
-      .mockResolvedValueOnce(9);
-
-    await expect(
-      detectPairAsymmetry({
-        id: 'run-1',
-        status: 'COMPLETED',
-        updatedAt: new Date('2026-04-23T00:00:00.000Z'),
-        config: { jobChoiceBatchGroupId: 'group-1', models: ['m1'], samplesPerScenario: 10 },
-        progress: { total: 10 },
-        deletedAt: null,
-      })
-    ).resolves.toMatchObject({
-      type: 'PAIR_ASYMMETRY',
-      subject: 'group-1',
-    });
-
-    mockRunFindMany.mockResolvedValue([
-      { id: 'run-2', config: { jobChoiceBatchGroupId: 'group-1', models: ['m1'], samplesPerScenario: 10 } },
-    ]);
-    mockProbeResultCount
-      .mockResolvedValueOnce(8)
-      .mockResolvedValueOnce(8);
-
-    await expect(
-      detectPairAsymmetry({
-        id: 'run-1',
-        status: 'COMPLETED',
-        updatedAt: new Date('2026-04-23T00:00:00.000Z'),
-        config: { jobChoiceBatchGroupId: 'group-1', models: ['m1'], samplesPerScenario: 10 },
-        progress: { total: 10 },
-        deletedAt: null,
-      })
-    ).resolves.toBeNull();
-  });
-
-  it('detects any measurable pair asymmetry in audit mode', async () => {
-    mockRunFindMany.mockResolvedValue([
-      { id: 'run-2', config: { jobChoiceBatchGroupId: 'group-1', models: ['m1'], samplesPerScenario: 10 } },
-    ]);
-    mockRunScenarioSelectionCount.mockResolvedValue(1);
-    mockProbeResultCount
-      .mockResolvedValueOnce(5)
-      .mockResolvedValueOnce(6);
-
-    await expect(
-      detectPairAsymmetry({
-        id: 'run-1',
-        status: 'COMPLETED',
-        updatedAt: new Date('2026-04-23T00:00:00.000Z'),
-        config: { jobChoiceBatchGroupId: 'group-1', models: ['m1'], samplesPerScenario: 10 },
-        progress: { total: 10 },
-        deletedAt: null,
-      }, 'audit')
-    ).resolves.toMatchObject({
-      type: 'PAIR_ASYMMETRY',
-      subject: 'group-1',
-    });
-
-    mockProbeResultCount
-      .mockResolvedValueOnce(5)
-      .mockResolvedValueOnce(5);
-
-    await expect(
-      detectPairAsymmetry({
-        id: 'run-1',
-        status: 'COMPLETED',
-        updatedAt: new Date('2026-04-23T00:00:00.000Z'),
-        config: { jobChoiceBatchGroupId: 'group-1', models: ['m1'], samplesPerScenario: 10 },
-        progress: { total: 10 },
-        deletedAt: null,
-      }, 'audit')
-    ).resolves.toBeNull();
   });
 
   it('detects summarizing stalls only after the threshold', () => {

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -670,7 +670,7 @@ type Definition {
   overrides: DefinitionOverrides!
 
   """
-  For paired vignettes, returns the companion vignette (same pair_key, same domain, mirrored value_first / value_second tokens). Returns null when this definition is not paired or when no companion exists. Reuses findPairedCompanion from utils/auto-pair so callers do not duplicate the companion-resolution logic.
+  For paired vignettes, returns the companion vignette (same domain, mirrored value_first / value_second tokens). Returns null when this definition is not paired or when no companion exists. Reuses findPairedCompanion from utils/auto-pair so callers do not duplicate the token-mirror companion logic.
   """
   pairedSibling: Definition
 
@@ -1101,7 +1101,6 @@ type DomainEvaluationEstimateModel {
 type DomainEvaluationLaunchableDefinition {
   definitionId: ID!
   definitionName: String!
-  pairKey: String
 }
 
 type DomainEvaluationMember {

--- a/cloud/apps/web/src/api/operations/active-evaluation.graphql
+++ b/cloud/apps/web/src/api/operations/active-evaluation.graphql
@@ -23,7 +23,6 @@ query ActiveEvaluations($domainId: ID) {
     launchableDefinitions {
       definitionId
       definitionName
-      pairKey
     }
     members {
       runId

--- a/cloud/apps/web/src/api/operations/definitions.ts
+++ b/cloud/apps/web/src/api/operations/definitions.ts
@@ -81,7 +81,6 @@ export type DefinitionMethodology = {
   response_scale?: 'numeric' | 'option_text' | 'value_labels';
   legacy_label?: string;
   canonical_value_order?: string[];
-  pair_key?: string;
 };
 
 export type DimensionLevel = {

--- a/cloud/apps/web/src/api/operations/domains.graphql
+++ b/cloud/apps/web/src/api/operations/domains.graphql
@@ -178,7 +178,6 @@ query DomainEvaluation($id: ID!) {
     launchableDefinitions {
       definitionId
       definitionName
-      pairKey
     }
     samplePercentage
     samplesPerScenario

--- a/cloud/apps/web/src/components/runs/RunForm.tsx
+++ b/cloud/apps/web/src/components/runs/RunForm.tsx
@@ -14,7 +14,7 @@ import { useRunConditionGrid } from '../../hooks/useRunConditionGrid';
 import type { StartRunInput } from '../../api/operations/runs';
 import { LLM_PROVIDERS_QUERY } from '../../api/operations/llm';
 import type { LlmProvidersQueryResult } from '../../api/operations/llm';
-import { getDefinitionMethodology } from '../../utils/methodology';
+import { hasMirroredValueTokens } from '../../utils/methodology';
 import type { CostEstimate } from '../../api/operations/costs';
 import type { RunFormState } from './useRunForm';
 
@@ -94,8 +94,7 @@ export function RunForm({
     requestPolicy: 'cache-and-network',
   });
 
-  const methodology = getDefinitionMethodology(definitionContent);
-  const isPairedDefinition = methodology?.pair_key != null;
+  const isPairedDefinition = hasMirroredValueTokens(definitionContent);
   const { models, loading: loadingModels, error: modelsError } = useAvailableModels({
     onlyAvailable: false,
     requestPolicy: 'cache-and-network',

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -598,7 +598,7 @@ export type Definition = {
   name: Scalars['String']['output'];
   /** Indicates which content fields are locally defined vs inherited from parent */
   overrides: DefinitionOverrides;
-  /** For paired vignettes, returns the companion vignette (same pair_key, same domain, mirrored value_first / value_second tokens). Returns null when this definition is not paired or when no companion exists. Reuses findPairedCompanion from utils/auto-pair so callers do not duplicate the companion-resolution logic. */
+  /** For paired vignettes, returns the companion vignette (same domain, mirrored value_first / value_second tokens). Returns null when this definition is not paired or when no companion exists. Reuses findPairedCompanion from utils/auto-pair so callers do not duplicate the token-mirror companion logic. */
   pairedSibling?: Maybe<Definition>;
   /** Parent definition in version tree */
   parent?: Maybe<Definition>;
@@ -1043,7 +1043,6 @@ export type DomainEvaluationLaunchableDefinition = {
   __typename?: 'DomainEvaluationLaunchableDefinition';
   definitionId: Scalars['ID']['output'];
   definitionName: Scalars['String']['output'];
-  pairKey?: Maybe<Scalars['String']['output']>;
 };
 
 export type DomainEvaluationMember = {
@@ -4245,7 +4244,7 @@ export type ActiveEvaluationsQueryVariables = Exact<{
 }>;
 
 
-export type ActiveEvaluationsQuery = { __typename?: 'Query', activeEvaluations: Array<{ __typename?: 'DomainEvaluation', id: string, domainId: string, domainNameAtLaunch: string, scopeCategory: string, status: string, createdAt: string, startedAt?: string | null, completedAt?: string | null, startedRuns: number, failedDefinitions: number, skippedForBudget: number, projectedCostUsd: number, models: Array<string>, temperature?: number | null, maxBudgetUsd?: number | null, memberCount: number, launchableDefinitionIds: Array<string>, samplePercentage?: number | null, samplesPerScenario?: number | null, targetBatchCount?: number | null, launchableDefinitions: Array<{ __typename?: 'DomainEvaluationLaunchableDefinition', definitionId: string, definitionName: string, pairKey?: string | null }>, members: Array<{ __typename?: 'DomainEvaluationMember', runId: string, definitionIdAtLaunch: string, definitionNameAtLaunch: string, domainIdAtLaunch: string, modelIds: Array<string>, createdAt: string, runStatus: string, runCategory: string, runStartedAt?: string | null, runCompletedAt?: string | null }> }> };
+export type ActiveEvaluationsQuery = { __typename?: 'Query', activeEvaluations: Array<{ __typename?: 'DomainEvaluation', id: string, domainId: string, domainNameAtLaunch: string, scopeCategory: string, status: string, createdAt: string, startedAt?: string | null, completedAt?: string | null, startedRuns: number, failedDefinitions: number, skippedForBudget: number, projectedCostUsd: number, models: Array<string>, temperature?: number | null, maxBudgetUsd?: number | null, memberCount: number, launchableDefinitionIds: Array<string>, samplePercentage?: number | null, samplesPerScenario?: number | null, targetBatchCount?: number | null, launchableDefinitions: Array<{ __typename?: 'DomainEvaluationLaunchableDefinition', definitionId: string, definitionName: string }>, members: Array<{ __typename?: 'DomainEvaluationMember', runId: string, definitionIdAtLaunch: string, definitionNameAtLaunch: string, domainIdAtLaunch: string, modelIds: Array<string>, createdAt: string, runStatus: string, runCategory: string, runStartedAt?: string | null, runCompletedAt?: string | null }> }> };
 
 export type AnalysisResultFieldsFragment = { __typename?: 'AnalysisResult', id: string, runId: string, analysisType: string, status: string, codeVersion: string, inputHash: string, createdAt: string, computedAt?: string | null, durationMs?: number | null, perModel: unknown, modelAgreement: unknown, dimensionAnalysis?: unknown | null, visualizationData?: unknown | null, varianceAnalysis?: unknown | null, methodsUsed: unknown, preferenceSummary?: { __typename?: 'PreferenceSummary', perModel: unknown } | null, reliabilitySummary?: { __typename?: 'ReliabilitySummary', perModel: unknown } | null, aggregateMetadata?: { __typename?: 'AggregateMetadata', aggregateEligibility: string, aggregateIneligibilityReason?: string | null, sourceRunCount: number, sourceRunIds: Array<string>, conditionCoverage: unknown, perModelRepeatCoverage: unknown, perModelDrift: unknown } | null, mostContestedScenarios: Array<{ __typename?: 'ContestedScenario', scenarioId: string, scenarioName: string, variance: number, modelScores: unknown }>, warnings: Array<{ __typename?: 'AnalysisWarning', code: string, message: string, recommendation: string }> };
 
@@ -4659,7 +4658,7 @@ export type DomainEvaluationQueryVariables = Exact<{
 }>;
 
 
-export type DomainEvaluationQuery = { __typename?: 'Query', domainEvaluation?: { __typename?: 'DomainEvaluation', id: string, domainId: string, domainNameAtLaunch: string, scopeCategory: string, status: string, createdAt: string, startedAt?: string | null, completedAt?: string | null, startedRuns: number, failedDefinitions: number, skippedForBudget: number, projectedCostUsd: number, models: Array<string>, temperature?: number | null, maxBudgetUsd?: number | null, memberCount: number, launchableDefinitionIds: Array<string>, samplePercentage?: number | null, samplesPerScenario?: number | null, targetBatchCount?: number | null, launchableDefinitions: Array<{ __typename?: 'DomainEvaluationLaunchableDefinition', definitionId: string, definitionName: string, pairKey?: string | null }>, members: Array<{ __typename?: 'DomainEvaluationMember', runId: string, definitionIdAtLaunch: string, definitionNameAtLaunch: string, domainIdAtLaunch: string, modelIds: Array<string>, createdAt: string, runStatus: string, runCategory: string, runStartedAt?: string | null, runCompletedAt?: string | null }> } | null };
+export type DomainEvaluationQuery = { __typename?: 'Query', domainEvaluation?: { __typename?: 'DomainEvaluation', id: string, domainId: string, domainNameAtLaunch: string, scopeCategory: string, status: string, createdAt: string, startedAt?: string | null, completedAt?: string | null, startedRuns: number, failedDefinitions: number, skippedForBudget: number, projectedCostUsd: number, models: Array<string>, temperature?: number | null, maxBudgetUsd?: number | null, memberCount: number, launchableDefinitionIds: Array<string>, samplePercentage?: number | null, samplesPerScenario?: number | null, targetBatchCount?: number | null, launchableDefinitions: Array<{ __typename?: 'DomainEvaluationLaunchableDefinition', definitionId: string, definitionName: string }>, members: Array<{ __typename?: 'DomainEvaluationMember', runId: string, definitionIdAtLaunch: string, definitionNameAtLaunch: string, domainIdAtLaunch: string, modelIds: Array<string>, createdAt: string, runStatus: string, runCategory: string, runStartedAt?: string | null, runCompletedAt?: string | null }> } | null };
 
 export type DomainEvaluationStatusQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -5567,7 +5566,6 @@ export const ActiveEvaluationsDocument = gql`
     launchableDefinitions {
       definitionId
       definitionName
-      pairKey
     }
     members {
       runId
@@ -6821,7 +6819,6 @@ export const DomainEvaluationDocument = gql`
     launchableDefinitions {
       definitionId
       definitionName
-      pairKey
     }
     samplePercentage
     samplesPerScenario

--- a/cloud/apps/web/src/pages/AnalysisDetail.tsx
+++ b/cloud/apps/web/src/pages/AnalysisDetail.tsx
@@ -20,7 +20,7 @@ import { useRun } from '../hooks/useRun';
 import { getRunDefinitionContent } from '../utils/runDefinitionContent';
 import type { AnalysisTab } from '../components/analysis/tabs';
 import { ANALYSIS_BASE_PATH, buildAnalysisDetailPath, isAggregateAnalysis } from '../utils/analysisRouting';
-import { getDefinitionMethodology, getDefinitionMethodologyLabel } from '../utils/methodology';
+import { getDefinitionMethodologyLabel, hasMirroredValueTokens } from '../utils/methodology';
 import { LLM_MODELS_QUERY, type LlmModelsQueryResult } from '../api/operations/llm';
 import {
   AnalysisDetailHeader,
@@ -301,10 +301,9 @@ export function AnalysisDetail() {
     definitionContent,
     run.definition?.domain?.name ?? null,
   );
-  const methodology = getDefinitionMethodology(definitionContent);
   const runLaunchMode = run.config?.jobChoiceLaunchMode;
   const isPairedBatch = runLaunchMode === 'PAIRED_BATCH';
-  const launchModeLabel = methodology?.pair_key != null ? formatLaunchModeLabel(runLaunchMode) : null;
+  const launchModeLabel = hasMirroredValueTokens(definitionContent) ? formatLaunchModeLabel(runLaunchMode) : null;
   const handleSingleVignetteChange = (nextRunId: string) => {
     if (!nextRunId || nextRunId === run.id) {
       return;

--- a/cloud/apps/web/src/pages/DefinitionDetail/DefinitionContentView.tsx
+++ b/cloud/apps/web/src/pages/DefinitionDetail/DefinitionContentView.tsx
@@ -6,6 +6,7 @@
 
 import type { DefinitionContent, PreambleVersion } from '../../api/operations/definitions';
 import { formatDisplayLabel } from '../../utils/displayLabels';
+import { hasMirroredValueTokens } from '../../utils/methodology';
 
 type DefinitionContentViewProps = {
   content: DefinitionContent | null | undefined;
@@ -20,7 +21,7 @@ export function DefinitionContentView({ content, preambleVersion }: DefinitionCo
   }
 
   const { preamble = '', template = '', dimensions = [] } = content;
-  const isPaired = content.methodology?.pair_key != null;
+  const isPaired = hasMirroredValueTokens(content);
   const sharedScaleSignature = dimensions[0] == null
     ? null
     : JSON.stringify({

--- a/cloud/apps/web/src/pages/DefinitionDetail/DefinitionDetail.tsx
+++ b/cloud/apps/web/src/pages/DefinitionDetail/DefinitionDetail.tsx
@@ -38,7 +38,7 @@ import { DefinitionContentView } from './DefinitionContentView';
 import { DeleteDefinitionModal } from './DeleteDefinitionModal';
 import { RunFormModal } from './RunFormModal';
 import { UnforkDefinitionModal } from './UnforkDefinitionModal';
-import { getDefinitionMethodology, getDefinitionMethodologyLabel } from '../../utils/methodology';
+import { getDefinitionMethodologyLabel, hasMirroredValueTokens } from '../../utils/methodology';
 
 const log = createLogger('definition-detail');
 
@@ -186,7 +186,7 @@ export function DefinitionDetail() {
 
   const handleStartRun = () => {
     if (!definition) return;
-    if (methodology?.pair_key != null) {
+    if (hasMirroredValueTokens(definition.resolvedContent ?? definition.content)) {
       navigate(`/definitions/${definition.id}/start-paired-batch`, {
         state: {
           returnLabel: 'Back to Vignette',
@@ -315,11 +315,11 @@ export function DefinitionDetail() {
 
   const childCount = definition.children?.length ?? 0;
   const resolvedContent = definition.resolvedContent ?? definition.content;
-  const methodology = getDefinitionMethodology(resolvedContent);
   const methodologyLabel = getDefinitionMethodologyLabel(resolvedContent, definition.domain?.name ?? null);
-  const startLabel = methodology?.pair_key != null ? 'Start Paired Batch' : 'Start Trial';
+  const isPairedDefinition = hasMirroredValueTokens(resolvedContent);
+  const startLabel = isPairedDefinition ? 'Start Paired Batch' : 'Start Trial';
   const handleEdit = () => {
-    if (methodology?.pair_key != null) {
+    if (isPairedDefinition) {
       navigate(`/paired/${definition.id}/edit`);
       return;
     }

--- a/cloud/apps/web/src/pages/DefinitionDetail/StartPairedBatchPage.tsx
+++ b/cloud/apps/web/src/pages/DefinitionDetail/StartPairedBatchPage.tsx
@@ -4,7 +4,7 @@
  * Dedicated page for launching a paired batch from a vignette detail page.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { computeLaunchTrialCount } from '@valuerank/shared';
@@ -17,7 +17,7 @@ import { useDefinition } from '../../hooks/useDefinition';
 import { useExpandedScenarios } from '../../hooks/useExpandedScenarios';
 import { useRunMutations } from '../../hooks/useRunMutations';
 import type { StartRunInput } from '../../api/operations/runs';
-import { getDefinitionMethodology, getDefinitionMethodologyLabel } from '../../utils/methodology';
+import { getDefinitionMethodologyLabel, hasMirroredValueTokens } from '../../utils/methodology';
 import { formatPairLabel } from '../../utils/coverageGap';
 import { VALUE_LABELS } from '../../components/domains/domainAnalysisData';
 
@@ -80,15 +80,8 @@ export function StartPairedBatchPage() {
   });
 
   const resolvedContent = definition?.resolvedContent ?? definition?.content;
-  const methodology = useMemo(
-    () => (resolvedContent ? getDefinitionMethodology(resolvedContent) : null),
-    [resolvedContent]
-  );
-  const methodologyLabel = useMemo(
-    () => getDefinitionMethodologyLabel(resolvedContent, definition?.domain?.name ?? null),
-    [definition?.domain?.name, resolvedContent]
-  );
-  const isPairedBatchEligible = methodology?.pair_key != null;
+  const methodologyLabel = getDefinitionMethodologyLabel(resolvedContent, definition?.domain?.name ?? null);
+  const isPairedBatchEligible = hasMirroredValueTokens(resolvedContent);
   const matchPairCounts = routeState?.matchPairCounts ?? null;
   const pairLabel = matchPairCounts != null
     ? formatPairLabel(matchPairCounts.valueA, matchPairCounts.valueB)

--- a/cloud/apps/web/src/pages/RunDetail/RunDetail.tsx
+++ b/cloud/apps/web/src/pages/RunDetail/RunDetail.tsx
@@ -24,7 +24,7 @@ import { RunNameEditor } from './RunNameEditor';
 import { AnalysisBanner } from './AnalysisBanner';
 import { DeleteConfirmModal } from './DeleteConfirmModal';
 import { formatTemperatureSetting } from '../../lib/temperature';
-import { getDefinitionMethodology, getDefinitionMethodologyLabel } from '../../utils/methodology';
+import { getDefinitionMethodologyLabel, hasMirroredValueTokens } from '../../utils/methodology';
 import { StalledModelsBanner, UnresolvableBanner, formatRunDate, getDisplaySignature } from './RunDetailBanners';
 import { useRunDetailHandlers } from './useRunDetailHandlers';
 import type { Run } from '../../api/operations/runs';
@@ -103,9 +103,8 @@ export function RunDetail() {
   const isPaused = run.status === 'PAUSED';
   const isTerminal = run.status === 'COMPLETED' || run.status === 'FAILED' || run.status === 'CANCELLED';
   const trialSignature = formatTrialSignature(run.definitionVersion ?? run.definition?.version ?? null, run.config?.temperature ?? null);
-  const methodology = getDefinitionMethodology(run.definition?.content);
   const methodologyLabel = getDefinitionMethodologyLabel(run.definition?.content, run.definition?.domain?.name ?? null);
-  const isPairedRun = methodology?.pair_key != null;
+  const isPairedRun = hasMirroredValueTokens(run.definition?.content);
   const launchModeLabel = isPairedRun ? formatLaunchModeLabel(run.config?.jobChoiceLaunchMode) : null;
   const launchModeBadgeClass = launchModeLabel === 'Paired Batch'
     ? 'bg-teal-100 text-teal-800'

--- a/cloud/apps/web/src/utils/methodology.ts
+++ b/cloud/apps/web/src/utils/methodology.ts
@@ -3,7 +3,6 @@ type DefinitionMethodology = {
   response_scale?: 'numeric' | 'option_text' | 'value_labels';
   legacy_label?: string;
   canonical_value_order?: string[];
-  pair_key?: string;
 };
 
 type DecisionScaleLabel = {
@@ -75,6 +74,13 @@ function readPairedComponents(content: unknown): PairedComponents | null {
   };
 }
 
+export function hasMirroredValueTokens(content: unknown): boolean {
+  const components = readPairedComponents(content);
+  const first = toNonEmptyString(components?.value_first?.token);
+  const second = toNonEmptyString(components?.value_second?.token);
+  return first != null && second != null;
+}
+
 function readDefinitionDimensions(content: unknown): DefinitionDimension[] {
   if (!isRecord(content) || !Array.isArray(content.dimensions)) {
     return [];
@@ -114,7 +120,6 @@ export function getDefinitionMethodology(content: unknown): DefinitionMethodolog
   const family = typeof raw.family === 'string' ? raw.family : undefined;
   const responseScale = raw.response_scale;
   const legacyLabel = typeof raw.legacy_label === 'string' ? raw.legacy_label : undefined;
-  const pairKey = typeof raw.pair_key === 'string' ? raw.pair_key : undefined;
   const canonicalValueOrder = Array.isArray(raw.canonical_value_order)
     ? raw.canonical_value_order.filter((value): value is string => typeof value === 'string')
     : undefined;
@@ -127,7 +132,6 @@ export function getDefinitionMethodology(content: unknown): DefinitionMethodolog
         : undefined,
     legacy_label: legacyLabel,
     canonical_value_order: canonicalValueOrder,
-    pair_key: pairKey,
   };
 }
 
@@ -185,7 +189,7 @@ export function getDecisionMetadata(value: unknown): DecisionMetadata | null {
 
 export function isPairedMethodology(content: unknown): boolean {
   const m = getDefinitionMethodology(content);
-  return m?.family != null && m.family.length > 0 && m.pair_key != null && m.pair_key.length > 0;
+  return m?.family != null && m.family.length > 0;
 }
 
 export function getPairedOrientationLabels(content: unknown): PairedOrientationLabels {

--- a/cloud/apps/web/tests/pages/AnalysisDetail.test.tsx
+++ b/cloud/apps/web/tests/pages/AnalysisDetail.test.tsx
@@ -797,7 +797,10 @@ describe('AnalysisDetail', () => {
             content: {
               methodology: {
                 family: 'job-choice',
-                pair_key: 'test-pair',
+              },
+              components: {
+                value_first: { token: 'achievement', body: '' },
+                value_second: { token: 'power_dominance', body: '' },
               },
             },
             domain: {

--- a/cloud/apps/web/tests/pages/DefinitionDetail.test.tsx
+++ b/cloud/apps/web/tests/pages/DefinitionDetail.test.tsx
@@ -285,7 +285,10 @@ describe('DefinitionDetail', () => {
             methodology: {
               family: 'job-choice',
               presentation_order: 'A_first',
-              pair_key: 'pair-1',
+            },
+            components: {
+              value_first: { token: 'achievement', body: '' },
+              value_second: { token: 'benevolence_dependability', body: '' },
             },
           },
           parentId: null,

--- a/cloud/apps/web/tests/pages/RunDetail.test.tsx
+++ b/cloud/apps/web/tests/pages/RunDetail.test.tsx
@@ -213,8 +213,10 @@ describe('RunDetail', () => {
         version: 1,
         tags: [],
         content: {
-          methodology: {
-            pair_key: 'test-pair',
+          methodology: {},
+          components: {
+            value_first: { token: 'achievement', body: '' },
+            value_second: { token: 'power_dominance', body: '' },
           },
         },
       },
@@ -457,7 +459,10 @@ describe('RunDetail', () => {
         content: {
           methodology: {
             family: 'job-choice',
-            pair_key: 'test-pair',
+          },
+          components: {
+            value_first: { token: 'achievement', body: '' },
+            value_second: { token: 'power_dominance', body: '' },
           },
         },
       },
@@ -491,7 +496,10 @@ describe('RunDetail', () => {
         content: {
           methodology: {
             family: 'job-choice',
-            pair_key: 'test-pair',
+          },
+          components: {
+            value_first: { token: 'achievement', body: '' },
+            value_second: { token: 'power_dominance', body: '' },
           },
         },
         domain: {

--- a/cloud/apps/web/tests/pages/StartPairedBatchPage.test.tsx
+++ b/cloud/apps/web/tests/pages/StartPairedBatchPage.test.tsx
@@ -129,7 +129,10 @@ function createDefinition(overrides: Partial<Record<string, unknown>> = {}) {
       dimensions: [],
       methodology: {
         family: 'job-choice',
-        pair_key: 'test-pair',
+      },
+      components: {
+        value_first: { token: 'achievement', body: '' },
+        value_second: { token: 'power_dominance', body: '' },
       },
     },
     resolvedContent: {
@@ -138,7 +141,10 @@ function createDefinition(overrides: Partial<Record<string, unknown>> = {}) {
       dimensions: [],
       methodology: {
         family: 'job-choice',
-        pair_key: 'test-pair',
+      },
+      components: {
+        value_first: { token: 'achievement', body: '' },
+        value_second: { token: 'power_dominance', body: '' },
       },
     },
     scenarioCount: 8,

--- a/cloud/packages/db/src/types.ts
+++ b/cloud/packages/db/src/types.ts
@@ -49,7 +49,6 @@ export type DefinitionMethodology = {
   response_scale?: 'numeric' | 'option_text' | 'value_labels';
   legacy_label?: string;
   canonical_value_order?: string[];
-  pair_key?: string;
 };
 
 /**

--- a/cloud/scripts/__tests__/job-choice-transform.test.ts
+++ b/cloud/scripts/__tests__/job-choice-transform.test.ts
@@ -77,7 +77,7 @@ describe('transformJobChoiceDefinition', () => {
     ]);
   });
 
-  it('preserves methodology metadata and includes default pair_key', () => {
+  it('preserves methodology metadata', () => {
     const result = transformJobChoiceDefinition(SAMPLE_CONTENT);
 
     expect(result.content.methodology).toEqual({
@@ -85,14 +85,12 @@ describe('transformJobChoiceDefinition', () => {
       response_scale: 'option_text',
       legacy_label: 'Old V1',
       canonical_value_order: ['Achievement', 'Hedonism'],
-      pair_key: undefined,
     });
   });
 
-  it('swaps value_first and value_second and applies pair_key for B_first', () => {
+  it('swaps value_first and value_second when swapped is true', () => {
     const result = transformJobChoiceDefinition(SAMPLE_CONTENT, {
       swapped: true,
-      pairKey: 'jobs-achievement-vs-hedonism',
     });
 
     expect(result.content.components?.value_first.token).toBe('hedonism');
@@ -100,13 +98,12 @@ describe('transformJobChoiceDefinition', () => {
     expect(result.content.template).toContain('One job offers [level] enjoyment in their daily experience');
     expect(result.content.template).not.toContain('[hedonism]');
     expect(result.roleTitles).toEqual(['a luxury resort reviewer', 'a sales executive']);
-    
+
     expect(result.content.methodology).toEqual({
       family: 'job-choice',
       response_scale: 'option_text',
       legacy_label: 'Old V1',
       canonical_value_order: ['Achievement', 'Hedonism'],
-      pair_key: 'jobs-achievement-vs-hedonism',
     });
   });
 

--- a/cloud/scripts/create-job-choice-vignettes.ts
+++ b/cloud/scripts/create-job-choice-vignettes.ts
@@ -109,7 +109,6 @@ async function createJobChoiceDefinition(
   tagId: string,
   preambleVersionIdOverride: string | null,
   swapped: boolean,
-  pairKey: string,
 ): Promise<string> {
   const resolved = await resolveDefinitionContent(sourceDefinition.id);
   if (!isTransformableJobChoiceTemplate(resolved.resolvedContent.template)) {
@@ -118,7 +117,6 @@ async function createJobChoiceDefinition(
 
   const transformed = transformJobChoiceDefinition(resolved.resolvedContent, {
     swapped,
-    pairKey,
   });
   const preambleVersionId = preambleVersionIdOverride ?? sourceDefinition.preambleVersionId ?? null;
   const variantName = `${sourceDefinition.name} [Job Choice ${swapped ? 'B First' : 'A First'}]`;
@@ -182,8 +180,6 @@ async function main(): Promise<void> {
     }
 
     summary.transformable += 1;
-    const pairKey = `job-choice:${definition.id}`;
-
     for (const swapped of [false, true]) {
       const variantName = `${definition.name} [Job Choice ${swapped ? 'B First' : 'A First'}]`;
       const existing = await db.definition.findFirst({
@@ -209,7 +205,6 @@ async function main(): Promise<void> {
         jobChoiceTag.id,
         args.preambleVersionId,
         swapped,
-        pairKey,
       );
       summary.created += 1;
       log.info(

--- a/cloud/scripts/job-choice-transform.ts
+++ b/cloud/scripts/job-choice-transform.ts
@@ -26,7 +26,6 @@ export type JobChoiceTransformResult = {
 type TransformOptions = {
   /** If true, swap the token order so value B appears first. Defaults to false (A first). */
   swapped?: boolean;
-  pairKey?: string;
   contextId?: string;
 };
 
@@ -81,7 +80,6 @@ export function transformJobChoiceDefinition(
     response_scale: 'option_text',
     legacy_label: 'Old V1',
     canonical_value_order: content.dimensions.map((dimension) => dimension.name),
-    pair_key: options.pairKey,
   };
 
   return {

--- a/cloud/scripts/seed-national-priorities-pairs.ts
+++ b/cloud/scripts/seed-national-priorities-pairs.ts
@@ -9,7 +9,6 @@
  *   DATABASE_URL="$DATABASE_URL" npx tsx scripts/seed-national-priorities-pairs.ts            # dry-run
  *   DATABASE_URL="$DATABASE_URL" npx tsx scripts/seed-national-priorities-pairs.ts --apply    # write to DB
  */
-import { randomUUID } from 'node:crypto';
 import {
   db,
   type DefinitionComponents,
@@ -81,7 +80,6 @@ function definitionName(firstToken: string, secondToken: string): string {
 }
 
 function buildPairContent(
-  pairKey: string,
   contextText: string,
   contextId: string,
   valueFirst: { token: string; body: string },
@@ -104,14 +102,14 @@ function buildPairContent(
     schema_version: 1,
     template: assembleTemplate(contextText, compA, undefined, templateConfig),
     dimensions,
-    methodology: { family: METHODOLOGY_FAMILY, response_scale: 'option_text', pair_key: pairKey },
+    methodology: { family: METHODOLOGY_FAMILY, response_scale: 'option_text' },
     components: compA,
   }, levelPreset);
   const definitionB = applyLevelPreset<PairContent>({
     schema_version: 1,
     template: assembleTemplate(contextText, compB, undefined, templateConfig),
     dimensions,
-    methodology: { family: METHODOLOGY_FAMILY, response_scale: 'option_text', pair_key: pairKey },
+    methodology: { family: METHODOLOGY_FAMILY, response_scale: 'option_text' },
     components: compB,
   }, levelPreset);
   return { definitionA, definitionB, compA, compB };
@@ -332,9 +330,7 @@ async function main(): Promise<void> {
       continue;
     }
 
-    const pairKey = randomUUID();
     const { definitionA, definitionB, compA, compB } = buildPairContent(
-      pairKey,
       context.text,
       context.id,
       { token: tokenA, body: bodyA },
@@ -367,7 +363,7 @@ async function main(): Promise<void> {
         },
       });
       const vCount = await createVignettes(tx, defA.id, defB.id, context.text, compA, compB, tokenA, tokenB, levelPreset, templateConfig);
-      log.info({ pair: name, definitionAId: defA.id, definitionBId: defB.id, pairKey, vignettes: vCount }, 'Created pair');
+      log.info({ pair: name, definitionAId: defA.id, definitionBId: defB.id, vignettes: vCount }, 'Created pair');
     }, { timeout: 30_000, maxWait: 30_000 });
 
     created += 1;

--- a/cloud/scripts/seed-software-approach-pairs.ts
+++ b/cloud/scripts/seed-software-approach-pairs.ts
@@ -9,7 +9,6 @@
  *   DATABASE_URL="$DATABASE_URL" npx tsx scripts/seed-software-approach-pairs.ts            # dry-run
  *   DATABASE_URL="$DATABASE_URL" npx tsx scripts/seed-software-approach-pairs.ts --apply    # write to DB
  */
-import { randomUUID } from 'node:crypto';
 import {
   db,
   type DefinitionComponents,
@@ -81,7 +80,6 @@ function definitionName(firstToken: string, secondToken: string): string {
 }
 
 function buildPairContent(
-  pairKey: string,
   contextText: string,
   contextId: string,
   valueFirst: { token: string; body: string },
@@ -104,14 +102,14 @@ function buildPairContent(
     schema_version: 1,
     template: assembleTemplate(contextText, compA, undefined, templateConfig),
     dimensions,
-    methodology: { family: METHODOLOGY_FAMILY, response_scale: 'option_text', pair_key: pairKey },
+    methodology: { family: METHODOLOGY_FAMILY, response_scale: 'option_text' },
     components: compA,
   }, levelPreset);
   const definitionB = applyLevelPreset<PairContent>({
     schema_version: 1,
     template: assembleTemplate(contextText, compB, undefined, templateConfig),
     dimensions,
-    methodology: { family: METHODOLOGY_FAMILY, response_scale: 'option_text', pair_key: pairKey },
+    methodology: { family: METHODOLOGY_FAMILY, response_scale: 'option_text' },
     components: compB,
   }, levelPreset);
   return { definitionA, definitionB, compA, compB };
@@ -336,9 +334,7 @@ async function main(): Promise<void> {
       continue;
     }
 
-    const pairKey = randomUUID();
     const { definitionA, definitionB, compA, compB } = buildPairContent(
-      pairKey,
       context.text,
       context.id,
       { token: tokenA, body: bodyA },
@@ -371,7 +367,7 @@ async function main(): Promise<void> {
         },
       });
       const vCount = await createVignettes(tx, defA.id, defB.id, context.text, compA, compB, tokenA, tokenB, levelPreset, templateConfig);
-      log.info({ pair: name, definitionAId: defA.id, definitionBId: defB.id, pairKey, vignettes: vCount }, 'Created pair');
+      log.info({ pair: name, definitionAId: defA.id, definitionBId: defB.id, vignettes: vCount }, 'Created pair');
     }, { timeout: 30_000, maxWait: 30_000 });
 
     created += 1;

--- a/docs/tech-debt/remove-paired-batch-concept.md
+++ b/docs/tech-debt/remove-paired-batch-concept.md
@@ -29,7 +29,7 @@ Three reviewers (Gemini, Codex, Claude) audited an earlier draft of this doc. Fi
 
 2. **`jobChoiceValueFirst` is read, not just stored.** [domain-coverage-utils.ts:294](../../cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts:294) and [domain-coverage.ts:284](../../cloud/apps/api/src/graphql/queries/domain-coverage.ts:284) use it to count coverage by *direction* (which side of the pair a run covered). Dropping it without a backfill silently misclassifies historical runs in coverage matrices.
 
-3. **`runCategory` semantics change for callers.** [lifecycle.ts:105](../../cloud/apps/api/src/graphql/mutations/run/lifecycle.ts:105) defaults to `'PRODUCTION'` when `launchMode === 'PAIRED_BATCH'`. After Wave 4 deletes `launchMode`, callers that relied on this default silently produce runs with `'UNKNOWN_LEGACY'`. Treat as a breaking change in default behavior.
+3. **`runCategory` semantics change for callers.** [lifecycle.ts:105](../../cloud/apps/api/src/graphql/mutations/run/lifecycle.ts:105) defaults to `'PRODUCTION'` when `launchMode === 'PAIRED_BATCH'`. After Wave 5 deletes `launchMode`, callers that relied on this default silently produce runs with `'UNKNOWN_LEGACY'`. Treat as a breaking change in default behavior.
 
 4. **GraphQL operation files request fields the schema-removal step would orphan.** Codegen does not catch these — queries fail at runtime. Files to edit in lockstep with each schema change: `runs.graphql`, `pressureSensitivity.graphql`, `domains.graphql`, `active-evaluation.graphql`, `modelsConsistency.graphql`, plus `cloud/tests/snapshot-baselines/queries/pressure-sensitivity.graphql`. Listed in section B below.
 
@@ -41,7 +41,7 @@ Three reviewers (Gemini, Codex, Claude) audited an earlier draft of this doc. Fi
 
 8. **Surfaces broken on first-time domain launch.** [executeLaunchRuns](../../cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts:50) does not currently set `jobChoiceLaunchMode` or `jobChoiceBatchGroupId`. Any feature that reads those fields (PAIR_ASYMMETRY anomaly, coverage dedup, paired-analysis mode, Models Consistency) is silently broken for first-time domain-launched runs. The cleanup plan inherits the bug as the deletion target — but during the transition it means any new paired batch on a new domain has unreliable pair metadata, which is the basis for the methodology hold above.
 
-9. **Admin script silently breaks.** [cloud/scripts/backfill-reparse-decisions.ts](../../cloud/scripts/backfill-reparse-decisions.ts) filters historical runs by `jobChoiceLaunchMode IN ('PAIRED_BATCH', 'PAIRED_BATCH_TOPUP')`. Survives Wave 4 (the JSON value persists in old rows) but breaks if the optional Wave 5 cleanup script strips the field.
+9. **Admin script silently breaks.** [cloud/scripts/backfill-reparse-decisions.ts](../../cloud/scripts/backfill-reparse-decisions.ts) filters historical runs by `jobChoiceLaunchMode IN ('PAIRED_BATCH', 'PAIRED_BATCH_TOPUP')`. Survives Wave 5 (the JSON value persists in old rows) but breaks if the optional Wave 6 cleanup script strips the field.
 
 ## Decisions on file
 
@@ -50,7 +50,7 @@ Three reviewers (Gemini, Codex, Claude) audited an earlier draft of this doc. Fi
 | 1 | Keep "launch both halves together" UX? | **No.** Drop pair-aware launch entirely. Each definition launches as an independent run. | 2026-05-09 |
 | 2 | Keep PAIR_ASYMMETRY anomaly detector? | **No (Option A).** Delete. | 2026-05-09 |
 | 3 | Keep PAIRED_BATCH_TOPUP feature? | **No.** Delete. If one side has fewer probes, that's the run's reality. | 2026-05-09 |
-| 4 | What happens to "paired-mode" features (transcript-comparison view, Models Consistency report, aggregate-prep)? | **Repoint to `Definition.pairedSibling` (Option B).** Find the partner via mirrored value tokens at query time, drop the stored `companionRunId` pointer. Tests already exercise this fallback at [AnalysisConditionDetail.test.tsx:711](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx:711) ("uses pairedSibling on the run definition to resolve the companion when companionRunId is absent"). | 2026-05-09 |
+| 5 | What happens to "paired-mode" features (transcript-comparison view, Models Consistency report, aggregate-prep)? | **Repoint to `Definition.pairedSibling` (Option B).** Find the partner via mirrored value tokens at query time, drop the stored `companionRunId` pointer. Tests already exercise this fallback at [AnalysisConditionDetail.test.tsx:711](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx:711) ("uses pairedSibling on the run definition to resolve the companion when companionRunId is absent"). | 2026-05-09 |
 
 ## What stays vs. what goes
 
@@ -106,7 +106,7 @@ Three reviewers (Gemini, Codex, Claude) audited an earlier draft of this doc. Fi
 | `Run.config.jobChoiceLaunchMode` | Stop writing. Optional cleanup script. | JSON field — no DDL needed |
 | `Run.config.jobChoiceValueFirst` | **Read by coverage analysis** ([domain-coverage-utils.ts:294](../../cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts:294), [domain-coverage.ts:284](../../cloud/apps/api/src/graphql/queries/domain-coverage.ts:284)). Before stopping writes: rewrite coverage to compute direction from the run's definition value tokens. Then stop writing. | JSON field — no DDL — but coverage rewrite is required, not optional |
 | `Run.config.methodologySafe` | Stop writing. | JSON field — no DDL needed |
-| `Run.config.companionRunId` | Repoint readers to `Definition.pairedSibling` first (paired-mode UI, Models Consistency, aggregate-prep, the [persistPairedCompanionRunIds](../../cloud/apps/api/src/graphql/mutations/run/lifecycle-helpers.ts:48) mutation). **Then** stop writing. See Wave 3.5 below. | JSON field — no DDL — but repoint work is non-trivial |
+| `Run.config.companionRunId` | Repoint readers to `Definition.pairedSibling` first (paired-mode UI, Models Consistency, aggregate-prep, the [persistPairedCompanionRunIds](../../cloud/apps/api/src/graphql/mutations/run/lifecycle-helpers.ts:48) mutation). **Then** stop writing. See Wave 4 below. | JSON field — no DDL — but repoint work is non-trivial |
 
 No Prisma schema migrations required for the JSON fields. The `RunCategory` enum and the `run_category` column stay; they were already backfilled in [20260320150000_backfill_paired_batch_run_category](../../cloud/packages/db/prisma/migrations/20260320150000_backfill_paired_batch_run_category/migration.sql) so historical rows are already correct. New runs must continue to set `runCategory` directly.
 
@@ -117,8 +117,8 @@ No Prisma schema migrations required for the JSON fields. The `RunCategory` enum
 | `Definition.pairKey` | exposed string | Remove | 2 |
 | `Definition.pairedSibling` | resolver | **Rewrite** (current resolver hard-filters by `pair_key` first; needs to be token-only) | 2 |
 | `Run.pairedBatchGroupId` | exposed string | Remove | 3 |
-| `Run.companionRunId` | exposed string | Remove **after** Wave 3.5 repoints consumers | 4 |
-| `Run.launchMode` (on `startRun` input) | enum input | Remove or accept-and-ignore | 4 |
+| `Run.companionRunId` | exposed string | Remove **after** Wave 4 repoints consumers | 5 |
+| `Run.launchMode` (on `startRun` input) | enum input | Remove or accept-and-ignore | 5 |
 | `DomainEvaluationLaunchableDefinition.pairKey` | string | Remove | 2 |
 
 GraphQL **operation files** that select these fields — must edit in lockstep with the corresponding schema change in the same wave, otherwise codegen passes but queries fail at runtime:
@@ -129,7 +129,7 @@ GraphQL **operation files** that select these fields — must edit in lockstep w
 | [cloud/apps/web/src/api/operations/pressureSensitivity.graphql](../../cloud/apps/web/src/api/operations/pressureSensitivity.graphql) (lines 54, 121) | `pairKey` | 2 |
 | [cloud/apps/web/src/api/operations/domains.graphql](../../cloud/apps/web/src/api/operations/domains.graphql) (line 178) | `pairKey` (paired field) | 2 / 3 |
 | [cloud/apps/web/src/api/operations/active-evaluation.graphql](../../cloud/apps/web/src/api/operations/active-evaluation.graphql) (line 23) | `pairKey` (and downstream paired metadata) | 2 |
-| [cloud/apps/web/src/api/operations/modelsConsistency.graphql](../../cloud/apps/web/src/api/operations/modelsConsistency.graphql) (line 54) | (verify; consumed by [models-consistency.ts](../../cloud/apps/api/src/graphql/queries/models-consistency.ts)) | 3.5 |
+| [cloud/apps/web/src/api/operations/modelsConsistency.graphql](../../cloud/apps/web/src/api/operations/modelsConsistency.graphql) (line 54) | (verify; consumed by [models-consistency.ts](../../cloud/apps/api/src/graphql/queries/models-consistency.ts)) | 4 |
 | [cloud/tests/snapshot-baselines/queries/pressure-sensitivity.graphql](../../cloud/tests/snapshot-baselines/queries/pressure-sensitivity.graphql) (lines 39, 95) | `pairKey` | 2 |
 
 Run `npm run codegen --workspace @valuerank/web` after each schema change. Do not let the web generated types drift.
@@ -139,7 +139,7 @@ Run `npm run codegen --workspace @valuerank/web` after each schema change. Do no
 | Surface | Change | Wave |
 |---|---|---|
 | [routes/export/runs.ts:272](../../cloud/apps/api/src/routes/export/runs.ts:272) JSON export | Serializes `run.config` whole; external consumers reading `jobChoice*` or `companionRunId` from the export see a contract change. | 4 — call out in changelog/release notes |
-| `runCategory` default for `startRun` callers ([lifecycle.ts:105](../../cloud/apps/api/src/graphql/mutations/run/lifecycle.ts:105)) | After Wave 4, `parsedRunCategory ?? (launchMode === 'PAIRED_BATCH' ? 'PRODUCTION' : undefined)` becomes `parsedRunCategory ?? undefined`. Callers that relied on PAIRED_BATCH defaulting to PRODUCTION must pass `runCategory: 'PRODUCTION'` explicitly. | 4 |
+| `runCategory` default for `startRun` callers ([lifecycle.ts:105](../../cloud/apps/api/src/graphql/mutations/run/lifecycle.ts:105)) | After Wave 5, `parsedRunCategory ?? (launchMode === 'PAIRED_BATCH' ? 'PRODUCTION' : undefined)` becomes `parsedRunCategory ?? undefined`. Callers that relied on PAIRED_BATCH defaulting to PRODUCTION must pass `runCategory: 'PRODUCTION'` explicitly. | 5 |
 
 ### C. Backend services and queue handlers
 
@@ -158,9 +158,9 @@ Run `npm run codegen --workspace @valuerank/web` after each schema change. Do no
 | [run-state-audit.ts](../../cloud/apps/api/src/queue/handlers/run-state-audit.ts) | Remove `'PAIR_ASYMMETRY'` from `scannedTypes` | 3 |
 | [domain-coverage-utils.ts — `deduplicateRunsByGroupId`, `getCoverageBatchGroupId`](../../cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts) | Replace dedup-by-batchGroupId with dedup-by-mirror-pair (find each run's mirror partner, treat both as one coverage unit). Remove `getCoverageBatchGroupId`. | 3 |
 | [domain-coverage-utils.ts:294 + domain-coverage.ts:284](../../cloud/apps/api/src/graphql/queries/domain-coverage.ts:284) | Replace `config.jobChoiceValueFirst` reads with direction computed from the run's definition value tokens. Required before `jobChoiceValueFirst` writes can stop, otherwise historical-run direction labels are lost. | 3 |
-| [models-consistency.ts](../../cloud/apps/api/src/graphql/queries/models-consistency.ts) | **Repoint** to `Definition.pairedSibling` for run pairing. Currently joins runs by `companionRunId` for order-effect analysis. After Wave 3.5: find partner via mirrored definition + same model + same window. | 3.5 |
-| [aggregate-preparation.ts](../../cloud/apps/api/src/services/analysis/aggregate/aggregate-preparation.ts) | Stop reading `companionRunId` from template config. Use `pairedSibling` resolver to derive partner if needed. | 3.5 |
-| [lifecycle-helpers.ts — `persistPairedCompanionRunIds`, `mergeCompanionRunId`, `getConfiguredCompanionRunId`](../../cloud/apps/api/src/graphql/mutations/run/lifecycle-helpers.ts) | Delete after Wave 3.5 repoints consumers. The atomic mutual-pairing mutation is no longer needed once pairing is derived from value tokens. | 4 |
+| [models-consistency.ts](../../cloud/apps/api/src/graphql/queries/models-consistency.ts) | **Repoint** to `Definition.pairedSibling` for run pairing. Currently joins runs by `companionRunId` for order-effect analysis. After Wave 4: find partner via mirrored definition + same model + same window. | 4 |
+| [aggregate-preparation.ts](../../cloud/apps/api/src/services/analysis/aggregate/aggregate-preparation.ts) | Stop reading `companionRunId` from template config. Use `pairedSibling` resolver to derive partner if needed. | 4 |
+| [lifecycle-helpers.ts — `persistPairedCompanionRunIds`, `mergeCompanionRunId`, `getConfiguredCompanionRunId`](../../cloud/apps/api/src/graphql/mutations/run/lifecycle-helpers.ts) | Delete after Wave 4 repoints consumers. The atomic mutual-pairing mutation is no longer needed once pairing is derived from value tokens. | 5 |
 | [pair-grouping.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/pair-grouping.ts) — `groupDefinitionsByPairKey`, `extractPairedMethodology` | Delete entirely. Domain launch becomes "launch each definition independently." | 3 |
 | [execute-runs.ts — `executeLaunchRuns`](../../cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts) | Drop the `LaunchSlot.configExtras` plumbing for pair info. Each run launches without a group ID. | 3 |
 | [execute-runs.ts — `executeBackfillRuns`](../../cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts) | Drop the `jobChoiceLaunchMode: 'PAIRED_BATCH'` and `batchGroupId` stamping (line ~143) | 3 |
@@ -169,34 +169,34 @@ Run `npm run codegen --workspace @valuerank/web` after each schema change. Do no
 | [resolve-backfill.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/resolve-backfill.ts) | Audit `runMatchesSingleModel`; remove pair-aware branches | 3 |
 | [backfill-orchestrator.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/backfill-orchestrator.ts) | Drop pair-aware backfill mode | 3 |
 | [launch-orchestrator.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/launch-orchestrator.ts) | Drop the `groupDefinitionsByPairKey` call (lines ~97–103) and the `incompletePairKeys` warning | 3 |
-| [run/lifecycle.ts](../../cloud/apps/api/src/graphql/mutations/run/lifecycle.ts) | Remove the `launchMode` input handling (lines 87, 105, 117–204). Single mutation path: launch this definition. | 4 |
+| [run/lifecycle.ts](../../cloud/apps/api/src/graphql/mutations/run/lifecycle.ts) | Remove the `launchMode` input handling (lines 87, 105, 117–204). Single mutation path: launch this definition. | 5 |
 | [paired-vignette-helpers.ts](../../cloud/apps/api/src/graphql/mutations/paired-vignette-helpers.ts) | Audit; likely retained for paired-authoring helpers, drop any `pair_key` reads | 2 |
-| [start.ts](../../cloud/apps/api/src/services/run/start.ts) | Audit `configExtras` flow; remove pair fields from sanitization | 4 |
+| [start.ts](../../cloud/apps/api/src/services/run/start.ts) | Audit `configExtras` flow; remove pair fields from sanitization | 5 |
 | [active-run-check.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/active-run-check.ts) | No change (already uses `definitionId`) | — |
-| Top-up handler — `PAIRED_BATCH_TOPUP` paths in [top-up-probes.ts](../../cloud/apps/api/src/queue/handlers/top-up-probes.ts) | Delete the pair-aware top-up. Keep generic top-up for individual runs. | 4 |
+| Top-up handler — `PAIRED_BATCH_TOPUP` paths in [top-up-probes.ts](../../cloud/apps/api/src/queue/handlers/top-up-probes.ts) | Delete the pair-aware top-up. Keep generic top-up for individual runs. | 5 |
 
 ### D. Web (UI)
 
 | File | Change | Wave |
 |---|---|---|
-| [legacyCompanionPairedRun.ts](../../cloud/apps/web/src/utils/legacyCompanionPairedRun.ts) | Delete (already `@deprecated` tombstone) | 5 |
+| [legacyCompanionPairedRun.ts](../../cloud/apps/web/src/utils/legacyCompanionPairedRun.ts) | Delete (already `@deprecated` tombstone) | 6 |
 | [methodology.ts](../../cloud/apps/web/src/utils/methodology.ts) | Drop `pair_key` parsing, the `methodology.pair_key` field, the `pair_key` validity helper | 2 |
 | [DefinitionDetail.tsx:187](../../cloud/apps/web/src/pages/DefinitionDetail/DefinitionDetail.tsx:187) | Drop `pair_key`-based routing to the paired-batch start page | 2 |
 | [DefinitionContentView.tsx:23](../../cloud/apps/web/src/pages/DefinitionDetail/DefinitionContentView.tsx:23) | Drop `pair_key`-based shared-scale collapse logic; use mirrored value tokens to detect pair-membership instead | 2 |
-| [AnalysisDetailHeader.tsx](../../cloud/apps/web/src/pages/AnalysisDetailHeader.tsx) | Audit; remove pair-batch references | 4 |
-| [AnalysisDetail.tsx:173,175,305](../../cloud/apps/web/src/pages/AnalysisDetail.tsx:173) | Replace `run.companionRunId` reads with `Definition.pairedSibling` lookups (or sibling-run derived from server) | 3.5 |
-| **Paired-mode transcript view stack** — [analysisTranscriptParams.ts](../../cloud/apps/web/src/utils/analysisTranscriptParams.ts), [useAnalysisTranscriptsData.ts](../../cloud/apps/web/src/hooks/useAnalysisTranscriptsData.ts), [useAnalysisTranscriptParams.ts](../../cloud/apps/web/src/hooks/useAnalysisTranscriptParams.ts), [pairedScopeAdapter.ts](../../cloud/apps/web/src/utils/pairedScopeAdapter.ts) | Repoint all `companionRunId` reads to derive partner from `Definition.pairedSibling`. Keep the URL parameter `mode=paired&companionRunId=Y` working as a transitional input but compute it from the sibling resolver if missing. ~76 references across web. | 3.5 |
-| Paired-analysis tests — [AnalysisTranscripts.test.tsx](../../cloud/apps/web/tests/pages/AnalysisTranscripts.test.tsx), [AnalysisConditionDetail.test.tsx](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx) | Update fixtures to assert sibling-derived companion (the test at AnalysisConditionDetail.test.tsx:711 already covers the absent-companionRunId fallback path) | 3.5 |
+| [AnalysisDetailHeader.tsx](../../cloud/apps/web/src/pages/AnalysisDetailHeader.tsx) | Audit; remove pair-batch references | 5 |
+| [AnalysisDetail.tsx:173,175,305](../../cloud/apps/web/src/pages/AnalysisDetail.tsx:173) | Replace `run.companionRunId` reads with `Definition.pairedSibling` lookups (or sibling-run derived from server) | 4 |
+| **Paired-mode transcript view stack** — [analysisTranscriptParams.ts](../../cloud/apps/web/src/utils/analysisTranscriptParams.ts), [useAnalysisTranscriptsData.ts](../../cloud/apps/web/src/hooks/useAnalysisTranscriptsData.ts), [useAnalysisTranscriptParams.ts](../../cloud/apps/web/src/hooks/useAnalysisTranscriptParams.ts), [pairedScopeAdapter.ts](../../cloud/apps/web/src/utils/pairedScopeAdapter.ts) | Repoint all `companionRunId` reads to derive partner from `Definition.pairedSibling`. Keep the URL parameter `mode=paired&companionRunId=Y` working as a transitional input but compute it from the sibling resolver if missing. ~76 references across web. | 4 |
+| Paired-analysis tests — [AnalysisTranscripts.test.tsx](../../cloud/apps/web/tests/pages/AnalysisTranscripts.test.tsx), [AnalysisConditionDetail.test.tsx](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx) | Update fixtures to assert sibling-derived companion (the test at AnalysisConditionDetail.test.tsx:711 already covers the absent-companionRunId fallback path) | 4 |
 | [PressureSensitivityDetail.tsx](../../cloud/apps/web/src/components/models/PressureSensitivityDetail.tsx), [PressureSensitivitySanityCheck.tsx](../../cloud/apps/web/src/components/models/PressureSensitivitySanityCheck.tsx) and their tests | These display constructed `pairKey` values from the analysis API response — the field name overlaps but the values are local sort keys. Verify after Wave 2's GraphQL changes that these still receive the constructed string, not the deleted UUID. | 2 (verify) |
-| [run-json-types.ts](../../cloud/apps/web/src/api/run-json-types.ts) | Drop `jobChoiceLaunchMode`, `jobChoiceBatchGroupId` from `RunConfig` types | 4 |
-| [pairedScopeAdapter.ts](../../cloud/apps/web/src/utils/pairedScopeAdapter.ts) | Audit. Likely keep for analysis-level pair scoping (which uses value tokens), drop any reads of stored pair fields | 4 |
-| [StartPairedBatchPage.tsx](../../cloud/apps/web/src/pages/DefinitionDetail/StartPairedBatchPage.tsx) | Delete or rename to a generic "StartBatchPage" without launch-mode | 4 |
-| [RunForm.tsx](../../cloud/apps/web/src/components/runs/RunForm.tsx), [useRunForm.ts](../../cloud/apps/web/src/components/runs/useRunForm.ts) | Drop `launchMode` state, the picker, and the conditional rendering tied to `PAIRED_BATCH` | 4 |
-| [RunDetail.tsx](../../cloud/apps/web/src/pages/RunDetail/RunDetail.tsx) | Drop `launchMode`-derived labels and the "Start topup batch" button (lines ~32–40, 109, 206) | 4 |
-| [AnalysisDetail.tsx](../../cloud/apps/web/src/pages/AnalysisDetail.tsx) | Drop the `PAIRED_BATCH`-conditional subtitle / interpretation logic (lines ~59–65, 305–306) | 4 |
-| [PairedRunComparisonCard.tsx](../../cloud/apps/web/src/components/analysis/PairedRunComparisonCard.tsx) | Rewrite: find partner via `Definition.pairedSibling` resolver, drop `batchGroupId` lookup | 4 |
-| [RunCard.tsx](../../cloud/apps/web/src/components/runs/RunCard.tsx) | Drop the paired-batch badge (line ~112) | 4 |
-| Domain trial launch UI under [components/domains/domainTrials/](../../cloud/apps/web/src/components/domains/domainTrials/) | Audit `launch-state.ts` and related — remove pair-aware launch paths | 4 |
+| [run-json-types.ts](../../cloud/apps/web/src/api/run-json-types.ts) | Drop `jobChoiceLaunchMode`, `jobChoiceBatchGroupId` from `RunConfig` types | 5 |
+| [pairedScopeAdapter.ts](../../cloud/apps/web/src/utils/pairedScopeAdapter.ts) | Audit. Likely keep for analysis-level pair scoping (which uses value tokens), drop any reads of stored pair fields | 5 |
+| [StartPairedBatchPage.tsx](../../cloud/apps/web/src/pages/DefinitionDetail/StartPairedBatchPage.tsx) | Delete or rename to a generic "StartBatchPage" without launch-mode | 5 |
+| [RunForm.tsx](../../cloud/apps/web/src/components/runs/RunForm.tsx), [useRunForm.ts](../../cloud/apps/web/src/components/runs/useRunForm.ts) | Drop `launchMode` state, the picker, and the conditional rendering tied to `PAIRED_BATCH` | 5 |
+| [RunDetail.tsx](../../cloud/apps/web/src/pages/RunDetail/RunDetail.tsx) | Drop `launchMode`-derived labels and the "Start topup batch" button (lines ~32–40, 109, 206) | 5 |
+| [AnalysisDetail.tsx](../../cloud/apps/web/src/pages/AnalysisDetail.tsx) | Drop the `PAIRED_BATCH`-conditional subtitle / interpretation logic (lines ~59–65, 305–306) | 5 |
+| [PairedRunComparisonCard.tsx](../../cloud/apps/web/src/components/analysis/PairedRunComparisonCard.tsx) | Rewrite: find partner via `Definition.pairedSibling` resolver, drop `batchGroupId` lookup | 5 |
+| [RunCard.tsx](../../cloud/apps/web/src/components/runs/RunCard.tsx) | Drop the paired-batch badge (line ~112) | 5 |
+| Domain trial launch UI under [components/domains/domainTrials/](../../cloud/apps/web/src/components/domains/domainTrials/) | Audit `launch-state.ts` and related — remove pair-aware launch paths | 5 |
 | `cloud/apps/web/src/generated/graphql.ts` | Regenerated by codegen — never edit by hand | — |
 
 ### E. Tests
@@ -205,10 +205,10 @@ Run `npm run codegen --workspace @valuerank/web` after each schema change. Do no
 |---|---|---|
 | [auto-pair.test.ts](../../cloud/apps/api/tests/utils/auto-pair.test.ts) | Keep | — |
 | [paired-vignette.test.ts](../../cloud/apps/web/src/api/operations/paired-vignette.ts) tests | Audit | 2 |
-| [pairedScopeAdapter.test.ts](../../cloud/apps/web/tests/utils/pairedScopeAdapter.test.ts) | Audit | 4 |
-| [job-choice-bridge-report.test.ts](../../cloud/scripts/__tests__/job-choice-bridge-report.test.ts) | Delete with the script | 5 |
+| [pairedScopeAdapter.test.ts](../../cloud/apps/web/tests/utils/pairedScopeAdapter.test.ts) | Audit | 5 |
+| [job-choice-bridge-report.test.ts](../../cloud/scripts/__tests__/job-choice-bridge-report.test.ts) | Delete with the script | 6 |
 | Anomaly tests covering `PAIR_ASYMMETRY` | Delete | 3 |
-| Run lifecycle tests asserting `launchMode` | Update or delete | 4 |
+| Run lifecycle tests asserting `launchMode` | Update or delete | 5 |
 | Domain coverage tests asserting dedup-by-batchGroupId | Rewrite to assert dedup-by-mirror-pair | 3 |
 | Snapshot baselines in `cloud/tests/snapshot-baselines/` referencing `pairKey` | Refresh with new query shape | per wave |
 
@@ -217,16 +217,16 @@ Run `npm run codegen --workspace @valuerank/web` after each schema change. Do no
 | File | Change | Wave |
 |---|---|---|
 | `cloud/scripts/seed-*-pairs.ts` | Stop generating `pair_key` UUIDs | 2 |
-| [job-choice-bridge-report.ts](../../cloud/scripts/job-choice-bridge-report.ts) | Delete (legacy bridge report; reads `launchMode` from old runs) | 5 |
-| [backfill-reparse-decisions.ts](../../cloud/scripts/backfill-reparse-decisions.ts) | Filters by `jobChoiceLaunchMode IN ('PAIRED_BATCH','PAIRED_BATCH_TOPUP')`. Survives Wave 4 (the JSON value persists) but breaks if the optional Wave 5 cleanup script strips fields. If we want this script preserved, replace its filter with a definition-based one before Wave 5 cleanup ships. | 5 (decide before cleanup migration) |
-| MCP tools under `cloud/apps/api/src/mcp/tools/` | Audit each: `get-run-results.ts`, `get-run-summary.ts`, others — remove pair fields from outputs | 4 |
+| [job-choice-bridge-report.ts](../../cloud/scripts/job-choice-bridge-report.ts) | Delete (legacy bridge report; reads `launchMode` from old runs) | 6 |
+| [backfill-reparse-decisions.ts](../../cloud/scripts/backfill-reparse-decisions.ts) | Filters by `jobChoiceLaunchMode IN ('PAIRED_BATCH','PAIRED_BATCH_TOPUP')`. Survives Wave 5 (the JSON value persists) but breaks if the optional Wave 6 cleanup script strips fields. If we want this script preserved, replace its filter with a definition-based one before Wave 6 cleanup ships. | 6 (decide before cleanup migration) |
+| MCP tools under `cloud/apps/api/src/mcp/tools/` | Audit each: `get-run-results.ts`, `get-run-summary.ts`, others — remove pair fields from outputs | 5 |
 | Optional cleanup migration script: strip `pair_key` from `Definition.content.methodology` and `jobChoice*` from `Run.config` | Decide whether to ship | post-5 |
 
 ### G. Documentation
 
 | Doc | Change |
 |---|---|
-| [docs/backend/paired-batch-run-flow.md](../backend/paired-batch-run-flow.md) | Delete after Wave 4 ships |
+| [docs/backend/paired-batch-run-flow.md](../backend/paired-batch-run-flow.md) | Delete after Wave 5 ships |
 | [docs/canonical-glossary.md](../canonical-glossary.md) | Remove "paired batch" entry; update "vignette" entry to mention mirrored-token pairing |
 | [docs/valuerank_prd.yaml](../valuerank_prd.yaml) | Remove paired-batch flow description |
 | [docs/tech-debt/dedup-inventory.md](dedup-inventory.md) | Add a back-reference to this doc |
@@ -259,42 +259,56 @@ The cheapest deletion. Only one read site (`pressure-sensitivity` prefilter) plu
 
 **Risk:** Low. The token-mirror logic already exists; we're just removing a redundant pre-filter.
 
-### Wave 3 — Drop `jobChoiceBatchGroupId` and PAIR_ASYMMETRY
+### Wave 3 — Delete the PAIR_ASYMMETRY detector
 
-The biggest wave. Closes out the launch-time grouping concept and the analyses that depended on it.
+A small, low-risk wave. Stops generating new pair-asymmetry anomalies. Existing rows in the database are preserved as historical record.
+
+See [wave3-spec.md](wave3-spec.md) for the implementation spec.
 
 **Ships:**
-- Delete `detectPairAsymmetry` (or rewrite per Decision 2)
-- Drop `PAIR_ASYMMETRY` from anomaly enum, label map, audit, reconcile
-- Replace `deduplicateRunsByGroupId` and `getCoverageBatchGroupId` with mirror-pair dedup
+- Delete `detectPairAsymmetry` function and threshold constants (`PAIR_ASYMMETRY_THRESHOLD_PCT`, `PAIR_ASYMMETRY_MIN_PROBES`)
+- Remove its 2 reconciler call sites
+- Remove `'PAIR_ASYMMETRY'` from `scannedTypes` in `run-state-audit.ts` (preserves existing anomalies)
+- Pre-flight: production data audit (gates Wave 4)
+- Pre-flight: snapshot current `PAIR_ASYMMETRY` anomaly count for post-deploy verification
+- Update affected tests
+
+**Does NOT ship in Wave 3** (deferred to Wave 4 after round-2 review):
+- Stop writing `jobChoiceBatchGroupId` in launch flows — coupled with the dedup rewrite
+- Delete `pair-grouping.ts` and flatten launch groups — would break `jobChoiceLaunchMode` writes
+- Replace coverage dedup
+- Schema changes
+- `'PAIR_ASYMMETRY'` enum value removal — Wave 5
+
+**Risk:** Low. The detector is the one piece that's truly independent.
+
+### Wave 4 — Repoint analysis to mirrored value tokens, drop launch-time grouping
+
+The biggest wave. Closes out the launch-time grouping concept *and* the analyses that depended on it. They have to ship together because the dedup rewrite and the writes-stop are coupled — stopping writes alone would silently 2x coverage counts on new runs, rewriting dedup alone would dedup runs that no longer share a group.
+
+**Ships:**
+- Replace `deduplicateRunsByGroupId` and `getCoverageBatchGroupId` with mirror-pair dedup (canonical-pair-key + sorted definition IDs from `definitionSnapshot`)
+- Coverage helper drops the legacy `jobChoiceValueFirst` fallback (the primary path already reads `definitionSnapshot.components`)
 - Drop `pair-grouping.ts` and the `incompletePairKeys` warning
-- Domain launch (`executeLaunchRuns`, `executeBackfillRuns`, `plan-slots`, `plan-backfill`, `backfill-orchestrator`) stops writing `batchGroupId` and `launchMode: 'PAIRED_BATCH'`
-- GraphQL schema: remove `Run.pairedBatchGroupId`, `Run.companionRunId`
-- Codegen run
-
-**Risk:** Medium. Coverage dedup needs careful rewrite — historical data still has `batchGroupId`, and the new dedup must produce equivalent counts on old data so reports don't shift.
-
-### Wave 3.5 — Repoint paired-mode features to `Definition.pairedSibling`
-
-Sibling-derive the companion at query time so we can drop the explicit pointers in Wave 4 without losing features.
-
-**Ships:**
+- Domain launch (`executeLaunchRuns`, `executeBackfillRuns`, `plan-slots`, `plan-backfill`, `backfill-orchestrator`) stops writing `jobChoiceBatchGroupId`. **Keeps writing `jobChoiceLaunchMode` and `jobChoiceValueFirst`** by moving those writes out of the now-deleted `if (group.pairKey !== null)` branch — they apply to every launch slot regardless of grouping
 - Paired-mode transcript view stack (`analysisTranscriptParams.ts`, `useAnalysisTranscriptsData.ts`, `useAnalysisTranscriptParams.ts`, `pairedScopeAdapter.ts`, `AnalysisDetail.tsx`) reads partner from `Definition.pairedSibling` when `companionRunId` is absent (the test fallback at [AnalysisConditionDetail.test.tsx:711](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx:711) already exercises this)
 - `models-consistency.ts` order-effect analysis joins runs via mirrored definitions instead of `companionRunId`
 - `aggregate-preparation.ts` derives partner from `pairedSibling` instead of reading `companionRunId`
 - `lifecycle-helpers.ts` `persistPairedCompanionRunIds` is no longer called from any new launch path (still defined but dead)
-- Tests updated to assert sibling-derived companion behavior
+- Tests updated
+
+**Verification plan:** baseline production reports before, snapshot-diff against allowed-deltas list after. The Wave 4 test plan should be drafted as part of the Wave 4 PR.
 
 **Risk:** High. This is the riskiest wave — it touches the analysis surface that produces the data the product is about. Verify against historical runs in staging before shipping.
 
-### Wave 4 — Drop `jobChoiceLaunchMode`, `companionRunId`, and PAIRED_BATCH_TOPUP
+### Wave 5 — Drop `jobChoiceLaunchMode`, `companionRunId`, and PAIRED_BATCH_TOPUP
 
 UI cleanup plus the top-up logic plus the now-orphaned companion pointer.
 
 **Ships:**
 - Delete the top-up handler's `PAIRED_BATCH_TOPUP` paths
 - Drop the `launchMode` input from `startRun`
-- GraphQL schema: remove `Run.companionRunId` (Wave 3.5 already moved consumers off it)
+- GraphQL schema: remove `Run.companionRunId` (Wave 4 already moved consumers off it)
 - Delete `lifecycle-helpers.ts` `persistPairedCompanionRunIds`, `mergeCompanionRunId`, `getConfiguredCompanionRunId` (now-dead)
 - Web: drop `StartPairedBatchPage`, the launch-mode picker, `RunForm`/`useRunForm` mode handling, the topup button on `RunDetail`, the badge on `RunCard`
 - Web: rewrite `PairedRunComparisonCard` to use `pairedSibling` resolver
@@ -306,7 +320,7 @@ UI cleanup plus the top-up logic plus the now-orphaned companion pointer.
 
 **Risk:** Medium. UI surface area is wide; needs preview-server verification on each page that referenced launch mode.
 
-### Wave 5 — Tombstones and historical cleanup
+### Wave 6 — Tombstones and historical cleanup
 
 **Ships:**
 - Delete `legacyCompanionPairedRun.ts`
@@ -329,7 +343,7 @@ UI cleanup plus the top-up logic plus the now-orphaned companion pointer.
 
 ## Open questions
 
-- **Cleanup migration:** ship the optional JSON-stripping script in Wave 5, or leave stale fields in old rows forever? Default: leave them. Re-evaluate if any future feature is confused by them.
+- **Cleanup migration:** ship the optional JSON-stripping script in Wave 6, or leave stale fields in old rows forever? Default: leave them. Re-evaluate if any future feature is confused by them.
 - **Pair-asymmetry replacement signal:** if anyone misses the detector after Wave 3, what's the right replacement report? (Likely a per-definition cross-mirror success-rate comparison surfaced in the analysis page, not as an anomaly.)
 
 ## Sign-off log
@@ -339,12 +353,12 @@ UI cleanup plus the top-up logic plus the now-orphaned companion pointer.
 | 1 (this doc) | | | |
 | 2 | | | |
 | 3 | | | |
-| 3.5 | | | high-risk: paired-mode analysis repoint |
-| 4 | | | |
+| 4 | | | high-risk: paired-mode analysis repoint |
 | 5 | | | |
+| 6 | | | |
 
 ## Related
 
 - [Run-state PENDING fix (PR #1017)](https://github.com/chrislawcodes/valuerank/pull/1017) — closed the PENDING → RUNNING gap; informs Wave 3's launch-flow rewrite
-- [docs/backend/paired-batch-run-flow.md](../backend/paired-batch-run-flow.md) — the legacy flow trace; obsolete after Wave 4
+- [docs/backend/paired-batch-run-flow.md](../backend/paired-batch-run-flow.md) — the legacy flow trace; obsolete after Wave 5
 - [docs/tech-debt/dedup-inventory.md](dedup-inventory.md) — the canonical dedup catalog

--- a/docs/tech-debt/remove-paired-batch-concept.md
+++ b/docs/tech-debt/remove-paired-batch-concept.md
@@ -1,0 +1,350 @@
+# Remove the Paired-Batch Concept
+
+**Status:** Planning
+**Last updated:** 2026-05-09
+**Owner:** chrislaw
+
+## TL;DR
+
+We are removing the launch-time and storage-time concept of "paired batches" from the codebase. The scientific basis for paired vignettes (mirrored value tokens to cancel presentation-order bias) stays. What goes away is the explicit launch grouping (`jobChoiceBatchGroupId`, `jobChoiceLaunchMode`), the redundant `pair_key` UUID on definitions, the explicit `companionRunId` pointer, and the analyses that depend on launch-time grouping.
+
+After this work:
+
+- Definitions are still authored as mirrored pairs.
+- Partners are found at query time by matching mirrored value tokens (already implemented in `findPairedCompanion`).
+- Analysis pools data per value tradeoff, not per launch event.
+- Launching no longer has a "pair-aware" mode.
+
+## ⚠️ Methodology hold during transition
+
+**Do not start new paired-batch trials we plan to use as production analysis data until this work lands.** The launch-side tagging is currently inconsistent (`executeLaunchRuns` does not tag pairs at all — see "Surfaces broken on first-time launch" below), the data model is changing, and analysis-layer joins are being repointed. Any trial run started now produces data whose pair-direction labels and companion pointers may be wrong, missing, or interpreted differently after the cleanup.
+
+Safe during the transition: reviewing historical runs that completed before this work began, authoring new vignettes, editing analysis code. Risky: kicking off new paired batches and treating their output as canonical.
+
+## Adversarial review findings (incorporated 2026-05-09)
+
+Three reviewers (Gemini, Codex, Claude) audited an earlier draft of this doc. Findings that materially changed the plan:
+
+1. **`companionRunId` is not a tagalong field.** It powers (a) the paired-analysis-mode transcript-comparison UI, (b) the Models Consistency / order-effect analysis report at [models-consistency.ts:44](../../cloud/apps/api/src/graphql/queries/models-consistency.ts:44), and (c) the aggregate-analysis preparation pipeline at [aggregate-preparation.ts:284](../../cloud/apps/api/src/services/analysis/aggregate/aggregate-preparation.ts:284). It also has an atomic mutual-pairing mutation ([lifecycle-helpers.ts:48 `persistPairedCompanionRunIds`](../../cloud/apps/api/src/graphql/mutations/run/lifecycle-helpers.ts:48)). See **Decision 4** below.
+
+2. **`jobChoiceValueFirst` is read, not just stored.** [domain-coverage-utils.ts:294](../../cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts:294) and [domain-coverage.ts:284](../../cloud/apps/api/src/graphql/queries/domain-coverage.ts:284) use it to count coverage by *direction* (which side of the pair a run covered). Dropping it without a backfill silently misclassifies historical runs in coverage matrices.
+
+3. **`runCategory` semantics change for callers.** [lifecycle.ts:105](../../cloud/apps/api/src/graphql/mutations/run/lifecycle.ts:105) defaults to `'PRODUCTION'` when `launchMode === 'PAIRED_BATCH'`. After Wave 4 deletes `launchMode`, callers that relied on this default silently produce runs with `'UNKNOWN_LEGACY'`. Treat as a breaking change in default behavior.
+
+4. **GraphQL operation files request fields the schema-removal step would orphan.** Codegen does not catch these — queries fail at runtime. Files to edit in lockstep with each schema change: `runs.graphql`, `pressureSensitivity.graphql`, `domains.graphql`, `active-evaluation.graphql`, `modelsConsistency.graphql`, plus `cloud/tests/snapshot-baselines/queries/pressure-sensitivity.graphql`. Listed in section B below.
+
+5. **JSON export endpoint dumps `Run.config` wholesale.** [routes/export/runs.ts:272](../../cloud/apps/api/src/routes/export/runs.ts:272) serializes the entire config blob. External consumers reading `jobChoice*` or `companionRunId` from the export see a contract change.
+
+6. **`Definition.pairedSibling` resolver rewrite is bigger than a tweak.** The earlier draft implied a small switch; in fact [definition-paired-sibling.ts:31](../../cloud/apps/api/src/graphql/types/definition-paired-sibling.ts:31) hard-filters by `pair_key` *before* token matching runs. This is a real rewrite, not a one-line change.
+
+7. **UI files the earlier inventory missed:** [DefinitionDetail.tsx:187](../../cloud/apps/web/src/pages/DefinitionDetail/DefinitionDetail.tsx:187) (routes paired definitions to the paired-batch start page based on `pair_key`), [DefinitionContentView.tsx:23](../../cloud/apps/web/src/pages/DefinitionDetail/DefinitionContentView.tsx:23) (uses `pair_key` to collapse shared scales), [AnalysisDetailHeader.tsx](../../cloud/apps/web/src/pages/AnalysisDetailHeader.tsx), and the entire **paired-mode transcript view** stack: [analysisTranscriptParams.ts](../../cloud/apps/web/src/utils/analysisTranscriptParams.ts), [useAnalysisTranscriptsData.ts](../../cloud/apps/web/src/hooks/useAnalysisTranscriptsData.ts), [useAnalysisTranscriptParams.ts](../../cloud/apps/web/src/hooks/useAnalysisTranscriptParams.ts), [AnalysisDetail.tsx:173,175,305](../../cloud/apps/web/src/pages/AnalysisDetail.tsx:173).
+
+8. **Surfaces broken on first-time domain launch.** [executeLaunchRuns](../../cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts:50) does not currently set `jobChoiceLaunchMode` or `jobChoiceBatchGroupId`. Any feature that reads those fields (PAIR_ASYMMETRY anomaly, coverage dedup, paired-analysis mode, Models Consistency) is silently broken for first-time domain-launched runs. The cleanup plan inherits the bug as the deletion target — but during the transition it means any new paired batch on a new domain has unreliable pair metadata, which is the basis for the methodology hold above.
+
+9. **Admin script silently breaks.** [cloud/scripts/backfill-reparse-decisions.ts](../../cloud/scripts/backfill-reparse-decisions.ts) filters historical runs by `jobChoiceLaunchMode IN ('PAIRED_BATCH', 'PAIRED_BATCH_TOPUP')`. Survives Wave 4 (the JSON value persists in old rows) but breaks if the optional Wave 5 cleanup script strips the field.
+
+## Decisions on file
+
+| # | Decision | Resolution | Date |
+|---|---|---|---|
+| 1 | Keep "launch both halves together" UX? | **No.** Drop pair-aware launch entirely. Each definition launches as an independent run. | 2026-05-09 |
+| 2 | Keep PAIR_ASYMMETRY anomaly detector? | **No (Option A).** Delete. | 2026-05-09 |
+| 3 | Keep PAIRED_BATCH_TOPUP feature? | **No.** Delete. If one side has fewer probes, that's the run's reality. | 2026-05-09 |
+| 4 | What happens to "paired-mode" features (transcript-comparison view, Models Consistency report, aggregate-prep)? | **Repoint to `Definition.pairedSibling` (Option B).** Find the partner via mirrored value tokens at query time, drop the stored `companionRunId` pointer. Tests already exercise this fallback at [AnalysisConditionDetail.test.tsx:711](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx:711) ("uses pairedSibling on the run definition to resolve the companion when companionRunId is absent"). | 2026-05-09 |
+
+## What stays vs. what goes
+
+### Stays (the science)
+
+- Mirrored value tokens on definitions (`value_first.token`, `value_second.token`)
+- `findPairedCompanion`, `getComponentTokens`, `areMirroredPair`, `isValidPair` in `cloud/apps/api/src/utils/auto-pair.ts`
+- `paired-definition.ts` (token normalization helpers)
+- The `pairedSibling` GraphQL resolver on `Definition`, but rewritten to use only token-mirror matching
+- Analysis-time grouping by canonical value tokens (the `pairKey` *variable name* in analysis files like `value-win-rate-aggregation.ts` and `pressure-sensitivity/snapshot-compute.ts` — these are constructed strings, not the stored field, and they are correct as-is)
+- The `RunCategory` enum and the historical run_category column
+
+### Goes (the launch / storage grouping)
+
+- `Definition.content.methodology.pair_key` (the UUID field)
+- `Run.config.jobChoiceBatchGroupId`
+- `Run.config.jobChoiceLaunchMode` (and all four values: `PAIRED_BATCH`, `PAIRED_BATCH_TOPUP`, `AD_HOC_BATCH`, `STANDARD`)
+- `Run.config.jobChoiceValueFirst`
+- `Run.config.methodologySafe`
+- `Run.config.companionRunId`
+- The GraphQL fields `Definition.pairKey`, `Run.pairedBatchGroupId`, `Run.companionRunId`, `Run.launchMode` input on `startRun`
+- The PAIRED_BATCH_TOPUP launch mode and its top-up logic
+- The pair-aware code paths in domain launch (`pair-grouping.ts`, the launch-mode branching in `lifecycle.ts`)
+- The deprecated client-side `legacyCompanionPairedRun.ts` (already tombstoned)
+- The `StartPairedBatchPage` and the launch-mode picker in the run form
+
+## Resolved: PAIR_ASYMMETRY anomaly detector — DELETE (Option A, 2026-05-09)
+
+**What it does today:** When a run completes, the detector finds sibling runs that share the same `jobChoiceBatchGroupId`, computes each sibling's probe-success rate, and flags the run if its rate differs from any sibling by more than `PAIR_ASYMMETRY_THRESHOLD_PCT` (currently `0` — i.e., any measurable difference). Min sample size is `PAIR_ASYMMETRY_MIN_PROBES = 10`.
+
+**Why it exists:** Catches cases where a model succeeds on one side of a pair and fails on the other — usually a refusal pattern that depends on which value is mentioned first, or a prompt-format-sensitivity bug.
+
+**Why it can't survive this cleanup as written:** It is keyed on `jobChoiceBatchGroupId`. If we drop that field, the detector returns `null` for every run.
+
+**Options:**
+
+| Option | What it does | Cost |
+|---|---|---|
+| A. Delete the detector | Drop the type from the enum, the detection function, the threshold constants, the audit/reconcile call sites. | Lose the signal entirely. |
+| B. Rewrite to use mirrored-token sibling lookup | Find the partner via `findPairedCompanion`. Compare success rates only when both halves are pooled within some recency window. | Real engineering work; the time-window heuristic is fragile. |
+| C. Replace with a definition-level signal | Rather than per-batch, compare aggregate success rates across all runs of mirrored definitions. | Different semantics; would catch persistent bias but miss transient batch-specific issues. |
+
+**Resolution (2026-05-09):** Option A — delete. Reasoning: the detector currently fires on `>0%` delta which is noisy, and the signal it provides is already covered by `INVALID_RESPONSE_FAILURE` plus general per-model error tracking. If we want partner-level diagnostics later, we'll add a definition-level cross-mirror comparison in the analysis page (not anomaly-shaped).
+
+## Inventory of changes
+
+### A. Database / storage
+
+| Field | Action | Notes |
+|---|---|---|
+| `Definition.content.methodology.pair_key` | Stop writing in seeds and `ensure-domain-vignette-pair`. Optional one-shot script to strip from existing rows. | JSON field — no DDL needed |
+| `Run.config.jobChoiceBatchGroupId` | Stop writing in `lifecycle.ts`, `executeBackfillRuns`, `plan-slots.ts`. Optional cleanup script. | JSON field — no DDL needed |
+| `Run.config.jobChoiceLaunchMode` | Stop writing. Optional cleanup script. | JSON field — no DDL needed |
+| `Run.config.jobChoiceValueFirst` | **Read by coverage analysis** ([domain-coverage-utils.ts:294](../../cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts:294), [domain-coverage.ts:284](../../cloud/apps/api/src/graphql/queries/domain-coverage.ts:284)). Before stopping writes: rewrite coverage to compute direction from the run's definition value tokens. Then stop writing. | JSON field — no DDL — but coverage rewrite is required, not optional |
+| `Run.config.methodologySafe` | Stop writing. | JSON field — no DDL needed |
+| `Run.config.companionRunId` | Repoint readers to `Definition.pairedSibling` first (paired-mode UI, Models Consistency, aggregate-prep, the [persistPairedCompanionRunIds](../../cloud/apps/api/src/graphql/mutations/run/lifecycle-helpers.ts:48) mutation). **Then** stop writing. See Wave 3.5 below. | JSON field — no DDL — but repoint work is non-trivial |
+
+No Prisma schema migrations required for the JSON fields. The `RunCategory` enum and the `run_category` column stay; they were already backfilled in [20260320150000_backfill_paired_batch_run_category](../../cloud/packages/db/prisma/migrations/20260320150000_backfill_paired_batch_run_category/migration.sql) so historical rows are already correct. New runs must continue to set `runCategory` directly.
+
+### B. GraphQL schema and operation files (breaking changes)
+
+| Field | Type / mutation | Action | Wave |
+|---|---|---|---|
+| `Definition.pairKey` | exposed string | Remove | 2 |
+| `Definition.pairedSibling` | resolver | **Rewrite** (current resolver hard-filters by `pair_key` first; needs to be token-only) | 2 |
+| `Run.pairedBatchGroupId` | exposed string | Remove | 3 |
+| `Run.companionRunId` | exposed string | Remove **after** Wave 3.5 repoints consumers | 4 |
+| `Run.launchMode` (on `startRun` input) | enum input | Remove or accept-and-ignore | 4 |
+| `DomainEvaluationLaunchableDefinition.pairKey` | string | Remove | 2 |
+
+GraphQL **operation files** that select these fields — must edit in lockstep with the corresponding schema change in the same wave, otherwise codegen passes but queries fail at runtime:
+
+| File | Selects | Wave |
+|---|---|---|
+| [cloud/apps/web/src/api/operations/runs.graphql](../../cloud/apps/web/src/api/operations/runs.graphql) (lines 11, 13) | `companionRunId`, `pairedBatchGroupId` | 3 / 4 |
+| [cloud/apps/web/src/api/operations/pressureSensitivity.graphql](../../cloud/apps/web/src/api/operations/pressureSensitivity.graphql) (lines 54, 121) | `pairKey` | 2 |
+| [cloud/apps/web/src/api/operations/domains.graphql](../../cloud/apps/web/src/api/operations/domains.graphql) (line 178) | `pairKey` (paired field) | 2 / 3 |
+| [cloud/apps/web/src/api/operations/active-evaluation.graphql](../../cloud/apps/web/src/api/operations/active-evaluation.graphql) (line 23) | `pairKey` (and downstream paired metadata) | 2 |
+| [cloud/apps/web/src/api/operations/modelsConsistency.graphql](../../cloud/apps/web/src/api/operations/modelsConsistency.graphql) (line 54) | (verify; consumed by [models-consistency.ts](../../cloud/apps/api/src/graphql/queries/models-consistency.ts)) | 3.5 |
+| [cloud/tests/snapshot-baselines/queries/pressure-sensitivity.graphql](../../cloud/tests/snapshot-baselines/queries/pressure-sensitivity.graphql) (lines 39, 95) | `pairKey` | 2 |
+
+Run `npm run codegen --workspace @valuerank/web` after each schema change. Do not let the web generated types drift.
+
+### B.1. Public API contract surface
+
+| Surface | Change | Wave |
+|---|---|---|
+| [routes/export/runs.ts:272](../../cloud/apps/api/src/routes/export/runs.ts:272) JSON export | Serializes `run.config` whole; external consumers reading `jobChoice*` or `companionRunId` from the export see a contract change. | 4 — call out in changelog/release notes |
+| `runCategory` default for `startRun` callers ([lifecycle.ts:105](../../cloud/apps/api/src/graphql/mutations/run/lifecycle.ts:105)) | After Wave 4, `parsedRunCategory ?? (launchMode === 'PAIRED_BATCH' ? 'PRODUCTION' : undefined)` becomes `parsedRunCategory ?? undefined`. Callers that relied on PAIRED_BATCH defaulting to PRODUCTION must pass `runCategory: 'PRODUCTION'` explicitly. | 4 |
+
+### C. Backend services and queue handlers
+
+| File | Change | Wave |
+|---|---|---|
+| [auto-pair.ts](../../cloud/apps/api/src/utils/auto-pair.ts) | Keep — pure value-token logic, no `pair_key` reads | — |
+| [paired-definition.ts](../../cloud/apps/api/src/utils/paired-definition.ts) | Keep | — |
+| [pressure-sensitivity/snapshot-builder.ts](../../cloud/apps/api/src/services/pressure-sensitivity/snapshot-builder.ts) | Drop `pair_key` prefilter (lines ~267–285); query by `domainId` and let `findPairedCompanion` do the matching. **NB:** unlike other analysis files, this one really does read the stored `methodology.pair_key` field (Prisma `path` filter at line 283) — a real rewrite, not a tweak | 2 |
+| [definition-paired-sibling.ts](../../cloud/apps/api/src/graphql/types/definition-paired-sibling.ts) | **Rewrite** the resolver. Current code hard-filters by `pair_key` *before* token matching runs; must become token-only. Drop the `pair_key` `where` clause; iterate domain candidates and match by mirrored tokens | 2 |
+| [ensure-domain-vignette-pair.ts](../../cloud/apps/api/src/graphql/mutations/ensure-domain-vignette-pair.ts) | Stop generating and writing `pair_key` UUIDs | 2 |
+| `cloud/scripts/seed-*-pairs.ts` (multiple) | Stop writing `pair_key`. Audit each script. | 2 |
+| [anomaly-detection.ts — `detectPairAsymmetry`](../../cloud/apps/api/src/services/run/anomaly-detection.ts) | Delete (per Option A above; revisit if Decision 2 changes) | 3 |
+| [anomaly-thresholds.ts](../../cloud/apps/api/src/services/run/anomaly-thresholds.ts) | Drop `PAIR_ASYMMETRY_THRESHOLD_PCT`, `PAIR_ASYMMETRY_MIN_PROBES` | 3 |
+| [run-anomaly.ts](../../cloud/apps/api/src/graphql/types/run-anomaly.ts) | Drop `'PAIR_ASYMMETRY'` from `RunAnomalyTypeEnum` and the label map | 3 |
+| [run-state-reconcile.ts](../../cloud/apps/api/src/queue/handlers/run-state-reconcile.ts) | Remove the two `detectPairAsymmetry` call sites and their `syncAnomalies` lines | 3 |
+| [run-state-audit.ts](../../cloud/apps/api/src/queue/handlers/run-state-audit.ts) | Remove `'PAIR_ASYMMETRY'` from `scannedTypes` | 3 |
+| [domain-coverage-utils.ts — `deduplicateRunsByGroupId`, `getCoverageBatchGroupId`](../../cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts) | Replace dedup-by-batchGroupId with dedup-by-mirror-pair (find each run's mirror partner, treat both as one coverage unit). Remove `getCoverageBatchGroupId`. | 3 |
+| [domain-coverage-utils.ts:294 + domain-coverage.ts:284](../../cloud/apps/api/src/graphql/queries/domain-coverage.ts:284) | Replace `config.jobChoiceValueFirst` reads with direction computed from the run's definition value tokens. Required before `jobChoiceValueFirst` writes can stop, otherwise historical-run direction labels are lost. | 3 |
+| [models-consistency.ts](../../cloud/apps/api/src/graphql/queries/models-consistency.ts) | **Repoint** to `Definition.pairedSibling` for run pairing. Currently joins runs by `companionRunId` for order-effect analysis. After Wave 3.5: find partner via mirrored definition + same model + same window. | 3.5 |
+| [aggregate-preparation.ts](../../cloud/apps/api/src/services/analysis/aggregate/aggregate-preparation.ts) | Stop reading `companionRunId` from template config. Use `pairedSibling` resolver to derive partner if needed. | 3.5 |
+| [lifecycle-helpers.ts — `persistPairedCompanionRunIds`, `mergeCompanionRunId`, `getConfiguredCompanionRunId`](../../cloud/apps/api/src/graphql/mutations/run/lifecycle-helpers.ts) | Delete after Wave 3.5 repoints consumers. The atomic mutual-pairing mutation is no longer needed once pairing is derived from value tokens. | 4 |
+| [pair-grouping.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/pair-grouping.ts) — `groupDefinitionsByPairKey`, `extractPairedMethodology` | Delete entirely. Domain launch becomes "launch each definition independently." | 3 |
+| [execute-runs.ts — `executeLaunchRuns`](../../cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts) | Drop the `LaunchSlot.configExtras` plumbing for pair info. Each run launches without a group ID. | 3 |
+| [execute-runs.ts — `executeBackfillRuns`](../../cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts) | Drop the `jobChoiceLaunchMode: 'PAIRED_BATCH'` and `batchGroupId` stamping (line ~143) | 3 |
+| [plan-slots.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/plan-slots.ts) | Drop pair-grouped slot allocation; treat each definition as a single slot | 3 |
+| [plan-backfill.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/plan-backfill.ts) | Same | 3 |
+| [resolve-backfill.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/resolve-backfill.ts) | Audit `runMatchesSingleModel`; remove pair-aware branches | 3 |
+| [backfill-orchestrator.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/backfill-orchestrator.ts) | Drop pair-aware backfill mode | 3 |
+| [launch-orchestrator.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/launch-orchestrator.ts) | Drop the `groupDefinitionsByPairKey` call (lines ~97–103) and the `incompletePairKeys` warning | 3 |
+| [run/lifecycle.ts](../../cloud/apps/api/src/graphql/mutations/run/lifecycle.ts) | Remove the `launchMode` input handling (lines 87, 105, 117–204). Single mutation path: launch this definition. | 4 |
+| [paired-vignette-helpers.ts](../../cloud/apps/api/src/graphql/mutations/paired-vignette-helpers.ts) | Audit; likely retained for paired-authoring helpers, drop any `pair_key` reads | 2 |
+| [start.ts](../../cloud/apps/api/src/services/run/start.ts) | Audit `configExtras` flow; remove pair fields from sanitization | 4 |
+| [active-run-check.ts](../../cloud/apps/api/src/graphql/mutations/domain/launch/active-run-check.ts) | No change (already uses `definitionId`) | — |
+| Top-up handler — `PAIRED_BATCH_TOPUP` paths in [top-up-probes.ts](../../cloud/apps/api/src/queue/handlers/top-up-probes.ts) | Delete the pair-aware top-up. Keep generic top-up for individual runs. | 4 |
+
+### D. Web (UI)
+
+| File | Change | Wave |
+|---|---|---|
+| [legacyCompanionPairedRun.ts](../../cloud/apps/web/src/utils/legacyCompanionPairedRun.ts) | Delete (already `@deprecated` tombstone) | 5 |
+| [methodology.ts](../../cloud/apps/web/src/utils/methodology.ts) | Drop `pair_key` parsing, the `methodology.pair_key` field, the `pair_key` validity helper | 2 |
+| [DefinitionDetail.tsx:187](../../cloud/apps/web/src/pages/DefinitionDetail/DefinitionDetail.tsx:187) | Drop `pair_key`-based routing to the paired-batch start page | 2 |
+| [DefinitionContentView.tsx:23](../../cloud/apps/web/src/pages/DefinitionDetail/DefinitionContentView.tsx:23) | Drop `pair_key`-based shared-scale collapse logic; use mirrored value tokens to detect pair-membership instead | 2 |
+| [AnalysisDetailHeader.tsx](../../cloud/apps/web/src/pages/AnalysisDetailHeader.tsx) | Audit; remove pair-batch references | 4 |
+| [AnalysisDetail.tsx:173,175,305](../../cloud/apps/web/src/pages/AnalysisDetail.tsx:173) | Replace `run.companionRunId` reads with `Definition.pairedSibling` lookups (or sibling-run derived from server) | 3.5 |
+| **Paired-mode transcript view stack** — [analysisTranscriptParams.ts](../../cloud/apps/web/src/utils/analysisTranscriptParams.ts), [useAnalysisTranscriptsData.ts](../../cloud/apps/web/src/hooks/useAnalysisTranscriptsData.ts), [useAnalysisTranscriptParams.ts](../../cloud/apps/web/src/hooks/useAnalysisTranscriptParams.ts), [pairedScopeAdapter.ts](../../cloud/apps/web/src/utils/pairedScopeAdapter.ts) | Repoint all `companionRunId` reads to derive partner from `Definition.pairedSibling`. Keep the URL parameter `mode=paired&companionRunId=Y` working as a transitional input but compute it from the sibling resolver if missing. ~76 references across web. | 3.5 |
+| Paired-analysis tests — [AnalysisTranscripts.test.tsx](../../cloud/apps/web/tests/pages/AnalysisTranscripts.test.tsx), [AnalysisConditionDetail.test.tsx](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx) | Update fixtures to assert sibling-derived companion (the test at AnalysisConditionDetail.test.tsx:711 already covers the absent-companionRunId fallback path) | 3.5 |
+| [PressureSensitivityDetail.tsx](../../cloud/apps/web/src/components/models/PressureSensitivityDetail.tsx), [PressureSensitivitySanityCheck.tsx](../../cloud/apps/web/src/components/models/PressureSensitivitySanityCheck.tsx) and their tests | These display constructed `pairKey` values from the analysis API response — the field name overlaps but the values are local sort keys. Verify after Wave 2's GraphQL changes that these still receive the constructed string, not the deleted UUID. | 2 (verify) |
+| [run-json-types.ts](../../cloud/apps/web/src/api/run-json-types.ts) | Drop `jobChoiceLaunchMode`, `jobChoiceBatchGroupId` from `RunConfig` types | 4 |
+| [pairedScopeAdapter.ts](../../cloud/apps/web/src/utils/pairedScopeAdapter.ts) | Audit. Likely keep for analysis-level pair scoping (which uses value tokens), drop any reads of stored pair fields | 4 |
+| [StartPairedBatchPage.tsx](../../cloud/apps/web/src/pages/DefinitionDetail/StartPairedBatchPage.tsx) | Delete or rename to a generic "StartBatchPage" without launch-mode | 4 |
+| [RunForm.tsx](../../cloud/apps/web/src/components/runs/RunForm.tsx), [useRunForm.ts](../../cloud/apps/web/src/components/runs/useRunForm.ts) | Drop `launchMode` state, the picker, and the conditional rendering tied to `PAIRED_BATCH` | 4 |
+| [RunDetail.tsx](../../cloud/apps/web/src/pages/RunDetail/RunDetail.tsx) | Drop `launchMode`-derived labels and the "Start topup batch" button (lines ~32–40, 109, 206) | 4 |
+| [AnalysisDetail.tsx](../../cloud/apps/web/src/pages/AnalysisDetail.tsx) | Drop the `PAIRED_BATCH`-conditional subtitle / interpretation logic (lines ~59–65, 305–306) | 4 |
+| [PairedRunComparisonCard.tsx](../../cloud/apps/web/src/components/analysis/PairedRunComparisonCard.tsx) | Rewrite: find partner via `Definition.pairedSibling` resolver, drop `batchGroupId` lookup | 4 |
+| [RunCard.tsx](../../cloud/apps/web/src/components/runs/RunCard.tsx) | Drop the paired-batch badge (line ~112) | 4 |
+| Domain trial launch UI under [components/domains/domainTrials/](../../cloud/apps/web/src/components/domains/domainTrials/) | Audit `launch-state.ts` and related — remove pair-aware launch paths | 4 |
+| `cloud/apps/web/src/generated/graphql.ts` | Regenerated by codegen — never edit by hand | — |
+
+### E. Tests
+
+| Area | Change | Wave |
+|---|---|---|
+| [auto-pair.test.ts](../../cloud/apps/api/tests/utils/auto-pair.test.ts) | Keep | — |
+| [paired-vignette.test.ts](../../cloud/apps/web/src/api/operations/paired-vignette.ts) tests | Audit | 2 |
+| [pairedScopeAdapter.test.ts](../../cloud/apps/web/tests/utils/pairedScopeAdapter.test.ts) | Audit | 4 |
+| [job-choice-bridge-report.test.ts](../../cloud/scripts/__tests__/job-choice-bridge-report.test.ts) | Delete with the script | 5 |
+| Anomaly tests covering `PAIR_ASYMMETRY` | Delete | 3 |
+| Run lifecycle tests asserting `launchMode` | Update or delete | 4 |
+| Domain coverage tests asserting dedup-by-batchGroupId | Rewrite to assert dedup-by-mirror-pair | 3 |
+| Snapshot baselines in `cloud/tests/snapshot-baselines/` referencing `pairKey` | Refresh with new query shape | per wave |
+
+### F. Scripts and tools
+
+| File | Change | Wave |
+|---|---|---|
+| `cloud/scripts/seed-*-pairs.ts` | Stop generating `pair_key` UUIDs | 2 |
+| [job-choice-bridge-report.ts](../../cloud/scripts/job-choice-bridge-report.ts) | Delete (legacy bridge report; reads `launchMode` from old runs) | 5 |
+| [backfill-reparse-decisions.ts](../../cloud/scripts/backfill-reparse-decisions.ts) | Filters by `jobChoiceLaunchMode IN ('PAIRED_BATCH','PAIRED_BATCH_TOPUP')`. Survives Wave 4 (the JSON value persists) but breaks if the optional Wave 5 cleanup script strips fields. If we want this script preserved, replace its filter with a definition-based one before Wave 5 cleanup ships. | 5 (decide before cleanup migration) |
+| MCP tools under `cloud/apps/api/src/mcp/tools/` | Audit each: `get-run-results.ts`, `get-run-summary.ts`, others — remove pair fields from outputs | 4 |
+| Optional cleanup migration script: strip `pair_key` from `Definition.content.methodology` and `jobChoice*` from `Run.config` | Decide whether to ship | post-5 |
+
+### G. Documentation
+
+| Doc | Change |
+|---|---|
+| [docs/backend/paired-batch-run-flow.md](../backend/paired-batch-run-flow.md) | Delete after Wave 4 ships |
+| [docs/canonical-glossary.md](../canonical-glossary.md) | Remove "paired batch" entry; update "vignette" entry to mention mirrored-token pairing |
+| [docs/valuerank_prd.yaml](../valuerank_prd.yaml) | Remove paired-batch flow description |
+| [docs/tech-debt/dedup-inventory.md](dedup-inventory.md) | Add a back-reference to this doc |
+| `cloud/CLAUDE.md`, repo-root `AGENTS.md` | Audit for paired-batch mentions |
+| `MEMORY.md` (auto-memory index) | Audit and prune |
+| `docs/workflow/feature-runs/*` for past paired features | Mark obsolete; do not delete history |
+
+## Wave plan
+
+Each wave should be ship-able on its own. Main stays green throughout.
+
+### Wave 1 — ADR sign-off
+
+This document. Lands first as a planning doc. Decision 2 (PAIR_ASYMMETRY) gets resolved here before Wave 3 starts.
+
+**Ships:** this file plus glossary stub.
+
+### Wave 2 — Drop `methodology.pair_key`
+
+The cheapest deletion. Only one read site (`pressure-sensitivity` prefilter) plus a few writers.
+
+**Ships:**
+- Pressure-sensitivity snapshot-builder uses token-mirror only
+- `definition-paired-sibling.ts` resolver uses token-mirror only
+- `ensure-domain-vignette-pair` stops writing `pair_key`
+- Seed scripts stop writing `pair_key`
+- GraphQL schema: remove `Definition.pairKey`, `DomainEvaluationLaunchableDefinition.pairKey`
+- Web `methodology.ts` drops `pair_key` parsing
+- Codegen run
+
+**Risk:** Low. The token-mirror logic already exists; we're just removing a redundant pre-filter.
+
+### Wave 3 — Drop `jobChoiceBatchGroupId` and PAIR_ASYMMETRY
+
+The biggest wave. Closes out the launch-time grouping concept and the analyses that depended on it.
+
+**Ships:**
+- Delete `detectPairAsymmetry` (or rewrite per Decision 2)
+- Drop `PAIR_ASYMMETRY` from anomaly enum, label map, audit, reconcile
+- Replace `deduplicateRunsByGroupId` and `getCoverageBatchGroupId` with mirror-pair dedup
+- Drop `pair-grouping.ts` and the `incompletePairKeys` warning
+- Domain launch (`executeLaunchRuns`, `executeBackfillRuns`, `plan-slots`, `plan-backfill`, `backfill-orchestrator`) stops writing `batchGroupId` and `launchMode: 'PAIRED_BATCH'`
+- GraphQL schema: remove `Run.pairedBatchGroupId`, `Run.companionRunId`
+- Codegen run
+
+**Risk:** Medium. Coverage dedup needs careful rewrite — historical data still has `batchGroupId`, and the new dedup must produce equivalent counts on old data so reports don't shift.
+
+### Wave 3.5 — Repoint paired-mode features to `Definition.pairedSibling`
+
+Sibling-derive the companion at query time so we can drop the explicit pointers in Wave 4 without losing features.
+
+**Ships:**
+- Paired-mode transcript view stack (`analysisTranscriptParams.ts`, `useAnalysisTranscriptsData.ts`, `useAnalysisTranscriptParams.ts`, `pairedScopeAdapter.ts`, `AnalysisDetail.tsx`) reads partner from `Definition.pairedSibling` when `companionRunId` is absent (the test fallback at [AnalysisConditionDetail.test.tsx:711](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx:711) already exercises this)
+- `models-consistency.ts` order-effect analysis joins runs via mirrored definitions instead of `companionRunId`
+- `aggregate-preparation.ts` derives partner from `pairedSibling` instead of reading `companionRunId`
+- `lifecycle-helpers.ts` `persistPairedCompanionRunIds` is no longer called from any new launch path (still defined but dead)
+- Tests updated to assert sibling-derived companion behavior
+
+**Risk:** High. This is the riskiest wave — it touches the analysis surface that produces the data the product is about. Verify against historical runs in staging before shipping.
+
+### Wave 4 — Drop `jobChoiceLaunchMode`, `companionRunId`, and PAIRED_BATCH_TOPUP
+
+UI cleanup plus the top-up logic plus the now-orphaned companion pointer.
+
+**Ships:**
+- Delete the top-up handler's `PAIRED_BATCH_TOPUP` paths
+- Drop the `launchMode` input from `startRun`
+- GraphQL schema: remove `Run.companionRunId` (Wave 3.5 already moved consumers off it)
+- Delete `lifecycle-helpers.ts` `persistPairedCompanionRunIds`, `mergeCompanionRunId`, `getConfiguredCompanionRunId` (now-dead)
+- Web: drop `StartPairedBatchPage`, the launch-mode picker, `RunForm`/`useRunForm` mode handling, the topup button on `RunDetail`, the badge on `RunCard`
+- Web: rewrite `PairedRunComparisonCard` to use `pairedSibling` resolver
+- Update `runs.graphql` to drop `companionRunId` selection
+- Address `runCategory` default-change: any caller that relied on `launchMode === 'PAIRED_BATCH' ? 'PRODUCTION' : undefined` must pass `runCategory: 'PRODUCTION'` explicitly
+- MCP tool outputs drop pair-related fields
+- Codegen run
+- Changelog entry calling out the JSON export contract change
+
+**Risk:** Medium. UI surface area is wide; needs preview-server verification on each page that referenced launch mode.
+
+### Wave 5 — Tombstones and historical cleanup
+
+**Ships:**
+- Delete `legacyCompanionPairedRun.ts`
+- Delete `job-choice-bridge-report.ts` and its test
+- Delete `docs/backend/paired-batch-run-flow.md`
+- Decide on the optional JSON-stripping cleanup script; ship if approved
+- Glossary and PRD updates
+
+**Risk:** Low.
+
+## Migration / historical-data concerns
+
+| Concern | Resolution |
+|---|---|
+| Old runs in DB have `jobChoiceBatchGroupId`, `jobChoiceLaunchMode`, etc. set | Stays in JSON. Harmless once no code reads it. |
+| Old definitions have `methodology.pair_key` | Same. |
+| `run_category` was backfilled from `launchMode` ([20260320150000](../../cloud/packages/db/prisma/migrations/20260320150000_backfill_paired_batch_run_category/migration.sql)) | Already applied. Verify Wave 3+ launch paths still set `runCategory` directly so new rows continue to have correct values. |
+| Cached analysis snapshots that joined on batchGroupId | Invalidate after Wave 3 deploys. Tables: `domainAnalysisSnapshot`, `pressureSensitivitySnapshot`. |
+| In-flight runs at deploy time of any wave | Should be safe — dependent code is removed in lock-step. Old runs remain queryable but no new anomalies / coverage entries fire against them. |
+
+## Open questions
+
+- **Cleanup migration:** ship the optional JSON-stripping script in Wave 5, or leave stale fields in old rows forever? Default: leave them. Re-evaluate if any future feature is confused by them.
+- **Pair-asymmetry replacement signal:** if anyone misses the detector after Wave 3, what's the right replacement report? (Likely a per-definition cross-mirror success-rate comparison surfaced in the analysis page, not as an anomaly.)
+
+## Sign-off log
+
+| Wave | Approved by | Date | Notes |
+|---|---|---|---|
+| 1 (this doc) | | | |
+| 2 | | | |
+| 3 | | | |
+| 3.5 | | | high-risk: paired-mode analysis repoint |
+| 4 | | | |
+| 5 | | | |
+
+## Related
+
+- [Run-state PENDING fix (PR #1017)](https://github.com/chrislawcodes/valuerank/pull/1017) — closed the PENDING → RUNNING gap; informs Wave 3's launch-flow rewrite
+- [docs/backend/paired-batch-run-flow.md](../backend/paired-batch-run-flow.md) — the legacy flow trace; obsolete after Wave 4
+- [docs/tech-debt/dedup-inventory.md](dedup-inventory.md) — the canonical dedup catalog

--- a/docs/tech-debt/wave3-spec.md
+++ b/docs/tech-debt/wave3-spec.md
@@ -1,0 +1,227 @@
+# Wave 3 — Implementation Spec (revised after adversarial review round 2)
+
+**Status:** Draft
+**Last updated:** 2026-05-09
+**Scope:** Wave 3 of the [paired-batch removal cleanup](remove-paired-batch-concept.md).
+
+## What changed since round 1 → round 2 → round 3
+
+Adversarial review across two rounds caught scope errors. The spec narrowed twice; this version is the final scope.
+
+**Round 1 → 2:** Defer schema changes, coverage logic changes, and `PAIR_ASYMMETRY` enum removal to Waves 4–5. Avoids breaking UI consumers and Prisma migrations.
+
+**Round 2 → 3 (this version):** Defer the launch-flow changes (stop writing `batchGroupId`, delete `pair-grouping.ts`, flatten launch groups) to Wave 4 too. Two reasons:
+
+1. The launch-mode/`jobChoiceValueFirst` writes live inside `if (group.pairKey !== null)`. Flattening groups makes that branch unreachable, silently dropping fields the spec said to keep until Wave 5.
+2. Coverage dedup still keys on `batchGroupId`. New runs with null `batchGroupId` would fail to dedup → 2x coverage counts on new domains until Wave 4's dedup rewrite ships.
+
+Net effect: **Wave 3 is anomaly-detector-only.** Plus a pre-flight production audit. That's it.
+
+## What ships in Wave 3
+
+Two concrete changes:
+
+1. **Delete the PAIR_ASYMMETRY detector function** and its callers. No new `PAIR_ASYMMETRY` anomalies get produced after this ships. Existing rows in `run_anomalies` are preserved untouched. The enum value `'PAIR_ASYMMETRY'` itself stays in the GraphQL schema, the Prisma enum, and the TS type union — Wave 5 removes it. UI code that switches on the value keeps working.
+2. **Pre-flight production data audit.** Confirm zero historical paired definitions are missing value tokens before Wave 4 starts removing the `jobChoiceValueFirst` fallback in coverage.
+
+What is **not** in scope:
+
+| Concern | Where it goes |
+|---|---|
+| Stop writing `jobChoiceBatchGroupId` in launch flows | Wave 4 (deferred from Wave 3 in round-3 review) |
+| Delete `pair-grouping.ts` and flatten launch groups | Wave 4 (same reason) |
+| `Run.config.companionRunId` | Wave 4 — repoint readers, then Wave 5 stops writing |
+| `Run.config.jobChoiceLaunchMode` | Wave 5 |
+| `Run.config.jobChoiceValueFirst` | Wave 4 (remove the coverage fallback that reads it) + Wave 5 (stop writing) |
+| `PAIRED_BATCH_TOPUP` feature | Wave 5 |
+| `Run.pairedBatchGroupId` GraphQL field removal | Wave 5 |
+| `PAIR_ASYMMETRY` enum value removal + Prisma migration | Wave 5 |
+| Coverage direction labeling rewrite | Wave 4 — coverage helper already reads `definitionSnapshot.components` on the primary path; Wave 4 removes the legacy `jobChoiceValueFirst` fallback |
+| Coverage dedup rewrite | Wave 4 |
+| Models Consistency / transcript-view repoint | Wave 4 |
+| UI cleanup (`RunCard` badge, `StartPairedBatchPage` deletion) | Wave 5 |
+
+This narrowness is deliberate. Each later wave is independently ship-able once Wave 3 is in.
+
+## Pre-flight (must complete before Wave 3 PR opens)
+
+### A. Wave 2 must be merged
+
+Confirm Wave 2's commit (`06a1a242` or its squash equivalent) is on `main`. Wave 3 assumes `methodology.pair_key` is gone and that resolvers are token-only.
+
+### B. Production data audit — paired definitions must have value tokens
+
+This is non-negotiable. Wave 4 will start reading value tokens from `Run.config.definitionSnapshot.components` to derive direction. If any production paired definition is missing those tokens, runs against it will silently disappear from coverage matrices.
+
+Run from the repo root, against production via Railway:
+
+```sql
+-- Definitions that have been launched as paired runs but are missing value tokens.
+-- Scopes to the specific definitions used in paired launches, not their whole domain,
+-- to avoid over-reporting unrelated definitions.
+SELECT DISTINCT
+  d.id,
+  d.domain_id,
+  d.name,
+  d.content -> 'methodology' ->> 'family' AS methodology_family,
+  d.content -> 'components' -> 'value_first' ->> 'token' AS value_first_token,
+  d.content -> 'components' -> 'value_second' ->> 'token' AS value_second_token
+FROM definitions d
+JOIN runs r ON r.definition_id = d.id
+WHERE d.deleted_at IS NULL
+  AND r.deleted_at IS NULL
+  AND r.config ->> 'jobChoiceLaunchMode' IN ('PAIRED_BATCH', 'PAIRED_BATCH_TOPUP')
+  AND (
+    d.content -> 'components' -> 'value_first' ->> 'token' IS NULL
+    OR d.content -> 'components' -> 'value_second' ->> 'token' IS NULL
+  );
+```
+
+**Expected result:** zero rows. If any rows return:
+
+1. Stop. Do not start Wave 4.
+2. Open a follow-up issue: "Backfill value tokens for legacy paired definitions: <N> rows."
+3. Backfill the missing tokens before Wave 4 ships. There is no allowlist option — Wave 4 needs every paired definition to have value tokens or coverage will silently drop those runs.
+
+The script `cloud/scripts/preflight-wave4-token-audit.sql` should be added to the repo for posterity. (Note: "wave4" not "wave3" because the audit gates Wave 4's coverage rewrite, not Wave 3's anomaly-detector deletion.)
+
+### C. Existing anomaly count baseline
+
+Capture the current count of `PAIR_ASYMMETRY` anomalies. Used for verification post-deploy that no new ones are created. SQL:
+
+```sql
+SELECT COUNT(*) FROM run_anomalies
+WHERE type = 'PAIR_ASYMMETRY' AND resolved_at IS NULL;
+```
+
+Save the result alongside the data-audit output.
+
+## Implementation tasks
+
+### Task 1 — Delete `detectPairAsymmetry` function and remove its callers
+
+The detector finds sibling runs by `Run.config.jobChoiceBatchGroupId`. Wave 3 stops writing that field (Task 2), so the detector would return `null` for all new runs anyway. Deleting it cleanly stops generating new `PAIR_ASYMMETRY` anomalies. Existing anomalies in the database are preserved.
+
+**File: [cloud/apps/api/src/services/run/anomaly-detection.ts](../../cloud/apps/api/src/services/run/anomaly-detection.ts)**
+
+- Delete the `detectPairAsymmetry` function (currently lines 255–360 — verify with line-count before editing; size has shifted post-Wave-2).
+- Delete the imports `PAIR_ASYMMETRY_MIN_PROBES`, `PAIR_ASYMMETRY_THRESHOLD_PCT` (currently lines 9–10).
+- Delete the `pairAsymmetryThresholdPct?: number` field from the `AnomalyThresholds` type (currently around line 75) — no callers after the function is gone.
+- Delete the `getGroupId` helper (currently around line 105) **only if it has no other callers**. Run `grep -rn "getGroupId" cloud/apps/api/src` to confirm.
+- Delete the `RunConfig.jobChoiceBatchGroupId` field declaration (currently around line 43) **only if it has no other readers in this file**.
+- Leave `'PAIR_ASYMMETRY'` in the `AnomalyDraft['type']` union and the `RunAnomalyType` exported type. They survive until Wave 5. Web code that switches on these continues to compile and render historical anomalies.
+
+**File: [cloud/apps/api/src/services/run/anomaly-thresholds.ts](../../cloud/apps/api/src/services/run/anomaly-thresholds.ts)**
+
+- Delete `PAIR_ASYMMETRY_THRESHOLD_PCT` and `PAIR_ASYMMETRY_MIN_PROBES` exports (currently lines 4–5). Confirm no other importers via `grep -rn "PAIR_ASYMMETRY_THRESHOLD_PCT\|PAIR_ASYMMETRY_MIN_PROBES" cloud/`.
+
+**File: [cloud/apps/api/src/queue/handlers/run-state-reconcile.ts](../../cloud/apps/api/src/queue/handlers/run-state-reconcile.ts)**
+
+- Remove the `detectPairAsymmetry` import.
+- Remove both `syncAnomalies(runId, 'PAIR_ASYMMETRY', pair === null ? [] : [pair], 'default')` call sites (currently lines 260 and 284) and their surrounding try/catch blocks. Verify by `grep -n "PAIR_ASYMMETRY" cloud/apps/api/src/queue/handlers/run-state-reconcile.ts`.
+
+**File: [cloud/apps/api/src/queue/handlers/run-state-audit.ts](../../cloud/apps/api/src/queue/handlers/run-state-audit.ts)**
+
+- Remove `'PAIR_ASYMMETRY'` from the `scannedTypes` array (currently around line 96). Without this, the audit handler would call `syncAnomalies` with an empty drafts list, which would silently *resolve* existing `PAIR_ASYMMETRY` anomalies as it sweeps. We want existing anomalies preserved as historical record.
+
+### Task 2 — Update affected tests
+
+Tests asserting on the `PAIR_ASYMMETRY` detector or its surrounding wiring:
+
+| File | What asserts | Action |
+|---|---|---|
+| [cloud/apps/api/tests/services/run/anomaly-detection.test.ts](../../cloud/apps/api/tests/services/run/anomaly-detection.test.ts) | `PAIR_ASYMMETRY` detector tests | Delete the entire `detectPairAsymmetry` describe block |
+| [cloud/apps/api/tests/services/run/anomaly-persistence.test.ts:69](../../cloud/apps/api/tests/services/run/anomaly-persistence.test.ts:69) | References `'PAIR_ASYMMETRY'` type literal | Audit: keep if it's just exercising the type union (still allowed), update if it asserts the detector ran |
+| [cloud/apps/api/tests/queue/handlers/run-state-audit.test.ts:76](../../cloud/apps/api/tests/queue/handlers/run-state-audit.test.ts:76) | Asserts `'PAIR_ASYMMETRY'` is in `scannedTypes` | Remove that specific assertion — we removed it from `scannedTypes` |
+
+The launch-flow tests ([run.test.ts:677](../../cloud/apps/api/tests/graphql/mutations/run.test.ts:677), [domain.test.ts:577](../../cloud/apps/api/tests/graphql/mutations/domain.test.ts:577), [domain-coverage-integration.test.ts:60](../../cloud/apps/api/tests/graphql/queries/domain-coverage-integration.test.ts:60)) still assert `jobChoiceBatchGroupId` writes — leave them alone in Wave 3. Wave 4 updates them when the writes actually stop.
+
+No `@ts-ignore`, no `eslint-disable`, no `as any`. Fix types properly.
+
+### Task 3 — Verify
+
+Run from `cloud/`:
+
+```
+npm run lint --workspace @valuerank/shared
+npm run lint --workspace @valuerank/db
+npm run lint --workspace @valuerank/api
+npm run lint --workspace @valuerank/web
+DATABASE_URL="postgresql://valuerank:valuerank@localhost:5433/valuerank_test" \
+  JWT_SECRET="test-secret-that-is-at-least-32-characters-long" \
+  npm run test --workspace @valuerank/api
+DATABASE_URL="postgresql://valuerank:valuerank@localhost:5433/valuerank_test" \
+  JWT_SECRET="test-secret-that-is-at-least-32-characters-long" \
+  npm run test --workspace @valuerank/web
+npm run build --workspace @valuerank/api
+npm run build --workspace @valuerank/web
+```
+
+All must return 0 errors. Pre-existing warnings are fine.
+
+**No codegen needed.** Wave 3 makes no schema changes.
+
+## Order of changes
+
+| Step | What | Why this order |
+|---|---|---|
+| 1 | Pre-flight data audit | Gates Wave 4, but run during Wave 3 prep. If production has token-less paired definitions, schedule the backfill now so Wave 4 isn't blocked later. |
+| 2 | Pre-flight anomaly count baseline | Establishes "current PAIR_ASYMMETRY count" — verified post-deploy that no new ones appear |
+| 3 | Delete `detectPairAsymmetry` + reconciler call sites + `scannedTypes` entry + threshold constants | The actual code change |
+| 4 | Update affected tests | Mechanical follow-up |
+| 5 | Run preflight | Confirms green |
+
+This is a single, small PR. ~5 files of code change plus test updates.
+
+## Constraints
+
+- **DO NOT MODIFY:** `CLAUDE.md`, `AGENTS.md`, `cloud/CLAUDE.md`, `cloud/AGENTS.md`, `MEMORY.md`, `GEMINI.md`, `.gitignore`, `STATUS.md`, `experiments.md`, the docs in `docs/tech-debt/` (this spec, the parent plan), or any file outside the inventory above. If you discover a file that needs changing, flag it in the PR description, do not edit it.
+- **DO NOT** use `@ts-ignore`, `eslint-disable`, or `as any` to silence type errors.
+- **DO NOT** change the GraphQL schema. No `Run.pairedBatchGroupId` removal, no `PAIR_ASYMMETRY` enum value removal. Those are Wave 5.
+- **DO NOT** touch coverage logic (direction labeling, dedup). Wave 4.
+- **DO NOT** touch the launch flow. No `pair-grouping.ts` deletion, no `jobChoiceBatchGroupId` writes-stop, no `launch-orchestrator.ts` flattening. Wave 4.
+- **DO NOT** touch `companionRunId`, `jobChoiceLaunchMode`, or `PAIRED_BATCH_TOPUP`. Later waves.
+- **DO NOT** push or open the PR until preflight passes locally.
+
+## Post-deploy verification
+
+48 hours after Wave 3 deploys:
+
+1. Run the anomaly count query:
+   ```sql
+   SELECT COUNT(*) FROM run_anomalies
+   WHERE type = 'PAIR_ASYMMETRY'
+     AND resolved_at IS NULL
+     AND created_at > '<wave-3-deploy-time>';
+   ```
+   Expected: zero. If non-zero, the deletion of `detectPairAsymmetry` didn't fully take effect — grep prod for `detectPairAsymmetry` callers.
+2. Confirm the [parent plan](remove-paired-batch-concept.md) sign-off log gets the Wave 3 row checked.
+
+That's it. Wave 3 doesn't change coverage matrices, the launch flow, or anything observable in the UI. The verification surface is correspondingly small.
+
+## Rollback
+
+If Wave 3 deploys but new `PAIR_ASYMMETRY` anomalies still appear:
+- A caller of `detectPairAsymmetry` was missed. Grep prod for `detectPairAsymmetry` and patch.
+
+If anything else regresses:
+- It shouldn't. Wave 3's blast radius is intentionally minimal. If something does break, the wave's narrowness makes a revert cheap: `gh pr revert <wave-3-pr> --branch hotfix/wave3-revert`. Wave 2 is unaffected.
+
+## Sign-off log
+
+| Phase | Approved by | Date |
+|---|---|---|
+| Spec reviewed (Gemini) — round 1 | review complete; findings incorporated | 2026-05-09 |
+| Spec reviewed (Codex) — round 1 | review complete; findings incorporated | 2026-05-09 |
+| Spec reviewed (Gemini) — round 2 | review complete; deferred launch-flow changes to Wave 4 | 2026-05-09 |
+| Spec reviewed (Codex) — round 2 | review complete; same | 2026-05-09 |
+| Spec reviewed (Claude / human) | | |
+| Pre-flight data audit run (gates Wave 4, scheduled now) | | |
+| Wave 3 PR opened | | |
+| Wave 3 PR merged | | |
+| Post-deploy verification 48 hours | | |
+
+## Related
+
+- [Remove paired-batch concept](remove-paired-batch-concept.md) — parent planning doc
+- [Wave 2 commit (06a1a242)](https://github.com/chrislawcodes/valuerank/commit/06a1a242) — `pair_key` deletion

--- a/docs/tech-debt/wave4-spec.md
+++ b/docs/tech-debt/wave4-spec.md
@@ -1,0 +1,341 @@
+# Wave 4 — Implementation Spec
+
+**Status:** Draft (not yet reviewed)
+**Last updated:** 2026-05-09
+**Scope:** Wave 4 of the [paired-batch removal cleanup](remove-paired-batch-concept.md). The biggest, riskiest wave.
+
+## What this wave does
+
+Wave 4 is where the analysis layer stops depending on launch-time pair grouping. After this wave:
+
+- Coverage matrices derive direction and pair grouping from value tokens (already on the primary path; this wave removes the legacy fallback)
+- Models Consistency report finds order-effect partners by mirrored definitions, not `companionRunId`
+- Aggregate analysis preparation derives partners from `Definition.pairedSibling`
+- Paired-mode transcript view falls back to `Definition.pairedSibling` when `companionRunId` is absent
+- Domain launch flow stops writing `jobChoiceBatchGroupId` and stops grouping definitions by `pair_key`
+- The write paths for `jobChoiceLaunchMode` and `jobChoiceValueFirst` move out of the now-dead pair-conditional branch — every launch slot still gets these fields stamped
+
+It's risky because it touches the analysis surface that produces the data the product is about. Numerical drift in coverage, pressure-sensitivity, or Models Consistency would invalidate downstream interpretation. The wave includes a snapshot-baseline + post-deploy diff regime to catch silent shifts.
+
+## What does NOT ship in Wave 4
+
+| Concern | Where it goes |
+|---|---|
+| `Run.pairedBatchGroupId` GraphQL schema field removal | Wave 5 |
+| `Run.config.companionRunId` writes-stop | Wave 5 |
+| `Run.config.jobChoiceLaunchMode` writes-stop | Wave 5 |
+| `Run.config.jobChoiceValueFirst` writes-stop | Wave 5 |
+| `PAIRED_BATCH_TOPUP` feature deletion | Wave 5 |
+| `PAIR_ASYMMETRY` enum value removal + Prisma migration | Wave 5 |
+| UI cleanup (`RunCard` badge, `StartPairedBatchPage` deletion, launch-mode picker) | Wave 5 |
+| `legacyCompanionPairedRun.ts` deletion | Wave 6 |
+
+## Pre-flight (must complete before Wave 4 PR opens)
+
+### A. Wave 3 must be merged
+
+Confirm Wave 3 (the `detectPairAsymmetry` deletion) is on `main`.
+
+### B. Production data audit — paired definitions must have value tokens
+
+This is the hard precondition. Wave 4 starts removing the `jobChoiceValueFirst` fallback in coverage. If any production paired definition is missing value tokens, runs against it disappear from coverage matrices.
+
+Run from the repo root, against production via Railway:
+
+```sql
+SELECT DISTINCT
+  d.id,
+  d.domain_id,
+  d.name,
+  d.content -> 'methodology' ->> 'family' AS methodology_family,
+  d.content -> 'components' -> 'value_first' ->> 'token' AS value_first_token,
+  d.content -> 'components' -> 'value_second' ->> 'token' AS value_second_token
+FROM definitions d
+JOIN runs r ON r.definition_id = d.id
+WHERE d.deleted_at IS NULL
+  AND r.deleted_at IS NULL
+  AND r.config ->> 'jobChoiceLaunchMode' IN ('PAIRED_BATCH', 'PAIRED_BATCH_TOPUP')
+  AND (
+    d.content -> 'components' -> 'value_first' ->> 'token' IS NULL
+    OR d.content -> 'components' -> 'value_second' ->> 'token' IS NULL
+  );
+```
+
+**Expected: zero rows.** If any rows return: stop. Backfill the missing tokens before Wave 4 ships. There is no allowlist option.
+
+Save the script as `cloud/scripts/preflight-wave4-token-audit.sql`.
+
+### C. Snapshot baseline capture (one-shot)
+
+Capture the current production output of the analysis surfaces Wave 4 changes. The post-deploy diff compares against these baselines.
+
+Add a script `cloud/scripts/wave4-prod-baseline.ts` that hits production GraphQL with a fixed query bundle and writes timestamped JSON to `cloud/tests/snapshot-baselines/wave4-prod-pre-deploy-${ISO_DATE}.json`. Commit the file.
+
+**Query bundle:**
+
+| Query | Args | Why |
+|---|---|---|
+| `domainCoverage` | The 3 most-active domains by run count in the last 30 days | Catches coverage matrix shifts |
+| `pressureSensitivity` | The 5 most-recently-launched paired definitions | Catches pair-grouping shifts in pressure analysis |
+| `modelsConsistency` | The 3 most-active model pairs | Catches order-effect analysis shifts |
+| `runAnomaliesByType` (or equivalent) | Last 7 days | Sanity check: only `PAIR_ASYMMETRY` should drop |
+| `domainEvaluation` | The 5 most recent evaluations | Confirms launch-flow surface unaffected |
+
+Pin the resolved entity IDs in the baseline JSON so the post-deploy verify step hits the same entities.
+
+### D. Equivalence tests (added in this wave's PR, not pre-flight)
+
+Listed under Task 5 below — but plan the unit fixtures now so they're ready when Wave 4 starts.
+
+## Implementation tasks
+
+Order matters. Each task assumes the previous is in place.
+
+### Task 1 — Replace coverage dedup and direction lookup
+
+**Decision: drop dedup entirely.** Each run is counted as its own coverage unit. The "paired batch as one unit" semantic was a launch-grouping artifact that we're removing.
+
+Coverage matrix counts will shift on historical data: a paired-batch launch that previously counted as 1 dedup unit will now count as 2 (one per definition half). This is the **expected, documented delta** for Wave 4 and the only one that requires entries in `wave4-allowed-deltas.json`.
+
+**Alternative considered: preserve historical dedup via batchGroupId + canonical-pair fallback.** Keeps historical counts byte-identical, defers the count shift to Wave 5. Rejected because (a) two-step transitions are risky, (b) the direction we're going is "no batch unit at all" — defer just postpones the same conversation.
+
+**File: `cloud/apps/api/src/graphql/queries/domain-coverage-utils.ts`**
+
+- Delete `deduplicateRunsByGroupId` (currently around lines 180–230).
+- Delete `getCoverageBatchGroupId` (currently around line 265). It only existed to serve the deleted dedup.
+- Audit every caller of `deduplicateRunsByGroupId` (`grep -rn "deduplicateRunsByGroupId" cloud/apps/api/src`). For each: replace the call with the un-deduplicated input list. The downstream aggregation (trial counts, model breakdowns) will count each run independently.
+- For coverage direction labeling around lines 280–320: the helper already reads `definitionSnapshot.components` on the primary path. Delete the `jobChoiceValueFirst` fallback. After this, direction comes from value tokens only.
+
+**File: `cloud/apps/api/src/graphql/queries/domain-coverage.ts`**
+
+- The existing call to `getCoverageDirection(run.config)` around line 284 already routes through the helper. After Task 1's helper change, this site doesn't need editing — it just stops hitting the fallback path.
+- Verify the resolver doesn't have its own dedup logic. If it does, audit and treat the same way.
+
+### Task 2 — Repoint paired-mode transcript view to `Definition.pairedSibling`
+
+The transcript-comparison UI uses `Run.config.companionRunId` to find a run's pair partner. Wave 4 makes `Definition.pairedSibling` the fallback so the UI works on runs that lack a stored companion pointer.
+
+**File: `cloud/apps/web/src/utils/analysisTranscriptParams.ts`**
+
+- The `companionRunId` reads (currently around lines 112, 129, 136) stay as the primary path. Add a fallback: if `companionRunId` is absent, derive it from `definition.pairedSibling.id` (read from the run's `definition` relation, or from a sibling-resolution query).
+- The fallback path is what [AnalysisConditionDetail.test.tsx:711](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx:711) already exercises ("uses pairedSibling on the run definition to resolve the companion when companionRunId is absent"). That test stays valid.
+
+**File: `cloud/apps/web/src/hooks/useAnalysisTranscriptsData.ts`**
+
+- Around line 56: when fetching the companion run, if `companionRunId` is empty, query the run's definition's `pairedSibling`, then load the most recent run for that sibling that matches the current run's models/config.
+- The "most recent matching run" lookup is the new piece. Add a small helper or inline query.
+
+**File: `cloud/apps/web/src/hooks/useAnalysisTranscriptParams.ts`**
+
+- Around line 31: same — `companionRunId` from URL stays primary, sibling-derived is fallback.
+
+**File: `cloud/apps/web/src/utils/pairedScopeAdapter.ts`**
+
+- Audit. Likely keep — analysis-time scoping uses value tokens, not stored pair pointers.
+
+**File: `cloud/apps/web/src/pages/AnalysisDetail.tsx`**
+
+- Lines 173–175 read `run.companionRunId` directly. Replace with sibling-derived fallback.
+
+**Tests:**
+
+- The existing test at [AnalysisConditionDetail.test.tsx:711](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx:711) already covers the absent-companionRunId path. Verify it still passes after the repoint.
+- Add a new test: "paired-mode view works on a run launched after Wave 4 (no companionRunId in config)". Assert the partner is found via pairedSibling.
+
+### Task 3 — Repoint Models Consistency to mirrored definitions
+
+**File: `cloud/apps/api/src/graphql/queries/models-consistency.ts`**
+
+- Around line 44: the resolver currently joins runs by `companionRunId` to pair them for order-effect analysis. Replace with: for each candidate run, find runs in the same model + same domain whose definition is the `pairedSibling` of the current run's definition, within a recent time window (default 30 days). This window heuristic is necessary because we no longer have the explicit launch-event grouping.
+
+  The window value should be configurable. Suggested constant: `MODELS_CONSISTENCY_PARTNER_WINDOW_DAYS = 30` in `cloud/apps/api/src/services/run/anomaly-thresholds.ts` or a new `models-consistency-thresholds.ts` if that file is for anomaly stuff only.
+
+- If multiple candidate partner runs match, pick the one closest in `createdAt` to the current run. Document this in a comment — it's a heuristic that replaces what was previously an exact lookup.
+
+**Tests:**
+
+- Update existing tests to verify partner-finding produces same results on fixture data with `companionRunId` populated.
+- Add a new test: "partner resolved via pairedSibling when no companionRunId" — verify it picks the closest sibling run in the time window.
+- Add a corner case test: "no partner found within window returns the run as ungrouped" — should not crash.
+
+### Task 4 — Repoint aggregate analysis preparation
+
+**File: `cloud/apps/api/src/services/analysis/aggregate/aggregate-preparation.ts`**
+
+- Around lines 284–288, the aggregate prep reads `companionRunId` from the run's template config. Replace with the same sibling-derivation pattern as Task 3 — but here, since the aggregate is per-run, just use `definition.pairedSibling` directly (no time window needed because the aggregate config's companion is whichever the user selected at aggregate-creation time).
+- If the historical aggregate template still has `companionRunId` set, keep using it (preserve historical behavior). Only fall back to pairedSibling when `companionRunId` is absent.
+
+### Task 5 — Stop writing `jobChoiceBatchGroupId`, delete pair-grouping, flatten launch groups
+
+This is the launch-flow surgery. Order within the task matters:
+
+**5a. Move `jobChoiceLaunchMode` and `jobChoiceValueFirst` writes out of the pair-conditional branch first.** Without this, flattening the groups (5b) makes the writes unreachable. This is the cascade hazard Codex flagged in round-2 review.
+
+  **File: `cloud/apps/api/src/graphql/mutations/domain/launch/plan-slots.ts`**
+  - Around line 120, the pair-conditional `if (group.pairKey !== null)` block writes both fields. Move those writes out of the conditional so every launch slot's `configExtras` gets them, regardless of grouping.
+  - Inside the conditional, only `jobChoiceBatchGroupId: batchGroupId` should remain — and that gets deleted in step 5d.
+
+  **File: `cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts`**
+  - Around line 127, same pattern: lift `jobChoiceLaunchMode` and `jobChoiceValueFirst` out of the pair-conditional. Only `jobChoiceBatchGroupId` and `batchGroupId = randomUUID()` stay inside, scheduled for deletion.
+
+  **File: `cloud/apps/api/src/graphql/mutations/run/lifecycle.ts`**
+  - Around lines 117–204: same hoisting. The single-run mutation has its own pair-conditional.
+
+  **Verify with tests** that runs created via every launch path still have `jobChoiceLaunchMode` and `jobChoiceValueFirst` populated. Then proceed.
+
+**5b. Delete `pair-grouping.ts` module.**
+
+  **File: `cloud/apps/api/src/graphql/mutations/domain/launch/pair-grouping.ts`**
+  - Delete the entire file. Both exports (`extractPairedMethodology`, `groupDefinitionsByPairKey`) go away.
+
+**5c. Flatten launch groups in the orchestrator.**
+
+  **File: `cloud/apps/api/src/graphql/mutations/domain/launch/launch-orchestrator.ts`**
+  - Remove the `groupDefinitionsByPairKey` import (around line 8).
+  - Remove the call site (around line 97) and the `incompletePairKeys` warning loop (lines 98–103).
+  - Replace with a flat list: each targeted definition becomes its own launch group (with `pairKey: null` and `definitions: [def]`).
+
+  **File: `cloud/apps/api/src/graphql/mutations/domain/launch/types.ts`**
+  - Remove `LaunchGroup.pairKey` from the type if no longer read (verify with grep).
+
+**5d. Drop `jobChoiceBatchGroupId` writes.**
+
+  **Files (all under `cloud/apps/api/src/graphql/mutations/domain/launch/`):**
+  - `plan-slots.ts`: delete `jobChoiceBatchGroupId: batchGroupId` line.
+  - `plan-backfill.ts`: same.
+  - `execute-runs.ts`: delete the `batchGroupId = randomUUID()` generator and the `jobChoiceBatchGroupId` line in `executeBackfillRuns`.
+  - `resolve-backfill.ts`: audit `runMatchesSingleModel`; remove any `batchGroupId` comparison branch.
+  - `backfill-orchestrator.ts`: drop pair-aware backfill mode; treat each definition as a single backfill target.
+
+  **File: `cloud/apps/api/src/graphql/mutations/run/lifecycle.ts`**
+  - Drop `jobChoiceBatchGroupId` writes (the `mergeBatchGroupId` calls around lines 117–204). Keep the surrounding `jobChoiceLaunchMode` branching — Wave 5 deletes that.
+
+### Task 6 — Update tests
+
+**Tests to update (existing assertions on `jobChoiceBatchGroupId` being written):**
+
+- [cloud/apps/api/tests/graphql/mutations/run.test.ts:677](../../cloud/apps/api/tests/graphql/mutations/run.test.ts:677) — drop the `jobChoiceBatchGroupId` assertion. Keep the assertion that `jobChoiceLaunchMode` is set.
+- [cloud/apps/api/tests/graphql/mutations/domain.test.ts:577](../../cloud/apps/api/tests/graphql/mutations/domain.test.ts:577) — same.
+- [cloud/apps/api/tests/graphql/queries/domain-coverage-integration.test.ts:60](../../cloud/apps/api/tests/graphql/queries/domain-coverage-integration.test.ts:60) — the test asserts dedup-by-batchGroupId behavior. Replace with assertions that each run is counted independently.
+
+**Tests to add (equivalence + new behavior):**
+
+- `cloud/apps/api/tests/services/analysis/coverage-equivalence.test.ts` *(new)*:
+  - Assert `getCoverageDirection(run)` produces the same value before and after by hitting fixtures that have both `jobChoiceValueFirst` populated (legacy) and definitionSnapshot.components populated (new). Result must match.
+  - The legacy fallback removal is what's being tested. If results differ for any fixture, the historical migration is incomplete — investigate.
+- `cloud/apps/api/tests/graphql/queries/models-consistency.test.ts` (extend if exists):
+  - "Resolves partner via pairedSibling when companionRunId is absent" — exercise the new fallback path with a fixture run that lacks companionRunId.
+  - "No partner within window returns ungrouped" — corner case.
+- `cloud/apps/api/tests/services/run/anomaly-detection.test.ts`:
+  - Assert `RunAnomalyTypeEnum` still includes `'PAIR_ASYMMETRY'` (the value stays until Wave 5).
+- `cloud/apps/api/tests/graphql/queries/domain-coverage.test.ts`:
+  - Update fixtures: paired runs no longer share a batchGroupId. Assert coverage counts each run independently. Document the count change in test comments.
+
+### Task 7 — Verify
+
+Run from `cloud/`:
+
+```
+npm run lint --workspace @valuerank/shared
+npm run lint --workspace @valuerank/db
+npm run lint --workspace @valuerank/api
+npm run lint --workspace @valuerank/web
+DATABASE_URL="postgresql://valuerank:valuerank@localhost:5433/valuerank_test" \
+  JWT_SECRET="test-secret-that-is-at-least-32-characters-long" \
+  npm run test --workspace @valuerank/api
+DATABASE_URL="postgresql://valuerank:valuerank@localhost:5433/valuerank_test" \
+  JWT_SECRET="test-secret-that-is-at-least-32-characters-long" \
+  npm run test --workspace @valuerank/web
+npm run build --workspace @valuerank/api
+npm run build --workspace @valuerank/web
+```
+
+All must return 0 errors.
+
+**No codegen needed.** Wave 4 makes no schema changes.
+
+### Task 8 — Snapshot diff against pre-deploy baseline
+
+Run the verification script:
+
+```
+npm run wave4:verify -- --baseline cloud/tests/snapshot-baselines/wave4-prod-pre-deploy-${ISO_DATE}.json
+```
+
+This re-hits production, diffs against the captured baseline, and applies the allowed-deltas filter from `cloud/tests/snapshot-baselines/wave4-allowed-deltas.json`.
+
+**Allowed deltas (only these are non-failures):**
+
+- Coverage matrix counts: paired-batch dedup units may inflate to 2x where dedup previously merged halves. Document each affected matrix in the allowed-deltas file with a note.
+- `PAIR_ASYMMETRY` anomaly count delta: should be unchanged from Wave 3 baseline (no new ones since Wave 3 deleted the detector).
+- `Run.config.jobChoiceBatchGroupId` field: starts returning null on new runs. The schema field is still queryable.
+
+Any other delta fails CI and blocks the merge.
+
+## Order of changes
+
+| Step | What | Why this order |
+|---|---|---|
+| 1 | Pre-flight: data audit + baseline capture | Gates the wave |
+| 2 | Task 1 (coverage dedup + direction) | Readers must work on definitionSnapshot before writers stop providing the legacy field |
+| 3 | Task 2 (paired-mode UI) + Task 3 (Models Consistency) + Task 4 (aggregate-prep) | Repointing readers so they work without companionRunId. Independent of each other; can land in any order. |
+| 4 | Task 5 (launch flow) | Must come last — depends on the readers being repointed |
+| 5 | Task 6 (tests) | Mechanical follow-up |
+| 6 | Task 7 (preflight) + Task 8 (snapshot diff) | Confirms green |
+
+Steps 2 and 3 can ship in separate PRs if the diff gets too large. Step 4 must be last regardless.
+
+## Constraints
+
+- DO NOT MODIFY: `CLAUDE.md`, `AGENTS.md`, `cloud/CLAUDE.md`, `cloud/AGENTS.md`, `cloud/agents.md`, `MEMORY.md`, `GEMINI.md`, `.gitignore`, `STATUS.md`, `experiments.md`, the docs in `docs/tech-debt/`, or any file outside the inventory above.
+- DO NOT use `@ts-ignore`, `eslint-disable`, or `as any`.
+- DO NOT change the GraphQL schema. No `Run.pairedBatchGroupId` removal, no `companionRunId` field removal, no enum changes. Wave 5.
+- DO NOT touch `companionRunId` writes, `jobChoiceLaunchMode` writes, `jobChoiceValueFirst` writes (other than the hoist in Task 5a). Wave 5 stops the writes.
+- DO NOT delete `legacyCompanionPairedRun.ts` (Wave 6).
+- DO NOT delete `lifecycle-helpers.ts` `persistPairedCompanionRunIds`. It becomes dead code in Wave 4 (no caller after the launch-flow changes), but it stays defined until Wave 5.
+- DO NOT push or open the PR until preflight passes locally and the snapshot diff returns no disallowed deltas.
+
+## Risk and rollback
+
+This is the high-risk wave. The failure modes:
+
+| Failure | Symptom | Recovery |
+|---|---|---|
+| Direction labeling wrong on historical runs | Coverage matrices show flipped direction counts | The pre-flight data audit gates this. If it returned zero, this shouldn't happen. If it does, revert. |
+| Models Consistency partner-finding picks wrong sibling | Order-effect deltas shift | The 30-day window is heuristic. If it picks a different partner than `companionRunId` did, document the delta in allowed-deltas. If shifts are large, narrow the window. |
+| Paired-mode transcript view fails to find companion | UI breaks for users running paired comparisons | The fallback test ([AnalysisConditionDetail.test.tsx:711](../../cloud/apps/web/tests/pages/AnalysisConditionDetail.test.tsx:711)) covers this. If it broke in production but not in tests, the test fixture was incomplete. |
+| Coverage counts inflate more than expected | Allowed-deltas check rejects the diff | Either accept the inflation (update allowed-deltas with a note) or revert and reconsider preserving historical dedup via batchGroupId fallback. |
+
+**Worst case:** `gh pr revert <wave-4-pr> --branch hotfix/wave4-revert`. Wave 3 is unaffected. Wave 5 cannot ship until Wave 4 is back in place — if revert happens, Wave 5 schema cleanup also blocks.
+
+The post-deploy snapshot diff catches these within minutes of deploy. Decision deadline: 30 minutes after CI flags a disallowed delta.
+
+## Cleanup after Wave 4 stabilizes (~7 days post-deploy)
+
+| File | Action |
+|---|---|
+| `cloud/tests/snapshot-baselines/wave4-allowed-deltas.json` | Delete |
+| `cloud/scripts/wave4-prod-baseline.ts` | Delete (script was for one-shot capture) |
+| `cloud/scripts/preflight-wave4-token-audit.sql` | Move to `cloud/scripts/archive/` |
+| `cloud/tests/snapshot-baselines/wave4-prod-pre-deploy-*.json` | Move to archive |
+
+The unit-level equivalence tests (`coverage-equivalence.test.ts`) stay as permanent regression guards.
+
+## Sign-off log
+
+| Phase | Approved by | Date |
+|---|---|---|
+| Spec reviewed (Gemini) — round 1 | | |
+| Spec reviewed (Codex) — round 1 | | |
+| Spec reviewed (Claude / human) | | |
+| Pre-flight data audit run | | |
+| Pre-flight baseline captured | | |
+| Wave 4 PR opened | | |
+| Wave 4 PR merged | | |
+| Post-deploy snapshot diff passes | | |
+| 7-day stability confirmed; cleanup ships | | |
+
+## Related
+
+- [Remove paired-batch concept](remove-paired-batch-concept.md) — parent planning doc
+- [Wave 3 spec](wave3-spec.md) — predecessor wave (anomaly-detector deletion)


### PR DESCRIPTION
## Summary

Two waves of the paired-batch removal cleanup, plus the planning + spec docs that scaffold the remaining waves.

**Wave 2 — drop the redundant `methodology.pair_key` UUID**
- Pressure-sensitivity and `Definition.pairedSibling` resolvers now match by mirrored value tokens only — no Prisma `pair_key` prefilter
- Seed scripts and authoring mutations stop writing `pair_key`
- GraphQL fields `Definition.pairKey` and `DomainEvaluationLaunchableDefinition.pairKey` removed
- Web operation files updated; codegen regenerated
- Web UI files (`DefinitionDetail`, `DefinitionContentView`, `methodology.ts`) switch from `methodology.pair_key != null` to value-token presence checks
- Test fixtures across web tests updated to include value tokens (the new "is paired" signal)

**Wave 3 — delete the PAIR_ASYMMETRY anomaly detector**
- `detectPairAsymmetry` function and threshold constants removed
- Two reconciler call sites and the `'PAIR_ASYMMETRY'` entry in `run-state-audit.ts` `scannedTypes` removed
- Existing rows in `run_anomalies` preserved as historical record (the enum value stays in `RunAnomalyType` until Wave 5)
- 285 lines deleted, 0 added — pure removal

**Planning + specs**
- `docs/tech-debt/remove-paired-batch-concept.md` — parent inventory, 6-wave plan, decisions on file
- `docs/tech-debt/wave3-spec.md` — Wave 3 implementation spec (round-2 reviewed)
- `docs/tech-debt/wave4-spec.md` — Wave 4 implementation spec (draft, not yet reviewed)

## Why both waves in one PR

Wave 2 was developed before Wave 3 and the original plan was to ship them as separate PRs. After PR #1017 (the unrelated PENDING fix) merged and the worktree branch was reset, both waves ended up on the same branch. They're independently coherent and the test suite passes after each — squash-merging both as one ship is cleaner than splitting now.

## Test plan
- [x] Preflight passed: shared/db/api/web lint (0 errors), api/web builds
- [x] API tests pass: 2435 passed, 4 skipped, 0 failed
- [x] Web tests pass: 1451 passed, 8 skipped, 0 failed
- [x] Final grep for `detectPairAsymmetry|PAIR_ASYMMETRY_THRESHOLD_PCT|PAIR_ASYMMETRY_MIN_PROBES|pairAsymmetryThresholdPct` in cloud/apps: empty
- [ ] Post-deploy: confirm no new `PAIR_ASYMMETRY` anomalies appear in production within 48 hours
- [ ] Pre-Wave-4: run the production data audit SQL from `wave3-spec.md` § Pre-flight to confirm zero token-less paired definitions

## What's NOT in this PR (deferred to later waves)
- **Wave 4** (analysis-layer rewrite): coverage dedup replacement, Models Consistency repoint, paired-mode UI fallback to `pairedSibling`, stop writing `jobChoiceBatchGroupId`, delete `pair-grouping.ts`
- **Wave 5** (schema + UI cleanup): remove `Run.pairedBatchGroupId`, `companionRunId`, `launchMode` input, `PAIRED_BATCH_TOPUP`, `PAIR_ASYMMETRY` enum value (with Prisma migration), all UI consumers
- **Wave 6** (tombstones): delete `legacyCompanionPairedRun.ts`, `job-choice-bridge-report.ts`, `paired-batch-run-flow.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)