### PR TITLE
hotfix(domain-analysis): short-circuit on in-progress rebuild

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -104,6 +104,12 @@ function buildPairwiseWinRateModel(
   return { valueOrder: order, winRateMatrix, trialCountMatrix };
 }
 
+// A `buildProgress` snapshot whose `updatedAt` is older than this is treated
+// as a dead rebuild (e.g., the API process restarted mid-rebuild). Recent
+// progress means a rebuild is actively running and we should NOT supersede it
+// with a new synchronous rebuild — that creates a thundering-herd loop.
+const DOMAIN_ANALYSIS_BUILD_PROGRESS_FRESH_MS = 5 * 60 * 1000;
+
 function parseBuildProgress(raw: unknown): DomainAnalysisBuildProgress | null {
   if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) {
     return null;
@@ -129,6 +135,39 @@ function parseBuildProgress(raw: unknown): DomainAnalysisBuildProgress | null {
     totalRuns: progressCandidate.totalRuns,
     currentRunId: typeof progressCandidate.currentRunId === 'string' ? progressCandidate.currentRunId : null,
     updatedAt: progressCandidate.updatedAt,
+  };
+}
+
+function buildEmptyDomainAnalysisResult(params: {
+  domainId: string;
+  domainName: string;
+  activeModels: Array<{ modelId: string; displayName: string; isDefault: boolean }>;
+  generatedAt: Date;
+  cacheStatus: DomainAnalysisCacheStatus;
+  unavailableReason: string;
+}): DomainAnalysisResult {
+  return {
+    domainId: params.domainId,
+    domainName: params.domainName,
+    totalDefinitions: 0,
+    targetedDefinitions: 0,
+    coveredDefinitions: 0,
+    missingDefinitionIds: [],
+    missingDefinitions: [],
+    definitionsWithAnalysis: 0,
+    models: [],
+    unavailableModels: params.activeModels.map((model) => ({
+      model: model.modelId,
+      label: model.displayName,
+      reason: params.unavailableReason,
+    })),
+    generatedAt: params.generatedAt,
+    rankingShapeBenchmarks: { domainMeanTopGap: 0, domainStdTopGap: null, medianSpread: 0 },
+    clusterAnalysis: { clusters: [], faultLinesByPair: {}, defaultPair: null, skipped: true, skipReason: params.unavailableReason },
+    clusterAnalysisByMethod: {},
+    cacheStatus: params.cacheStatus,
+    contributionSummary: [],
+    excludedDataSummary: [],
   };
 }
 
@@ -367,29 +406,14 @@ export async function getDomainAnalysisResult(params: {
   });
 
   if (state.definitions.length === 0) {
-    return {
+    return buildEmptyDomainAnalysisResult({
       domainId: state.domain.id,
       domainName: state.domain.name,
-      totalDefinitions: 0,
-      targetedDefinitions: 0,
-      coveredDefinitions: 0,
-      missingDefinitionIds: [],
-      missingDefinitions: [],
-      definitionsWithAnalysis: 0,
-      models: [],
-      unavailableModels: activeModels.map((model) => ({
-        model: model.modelId,
-        label: model.displayName,
-        reason: 'No analyzed vignettes found in this scope.',
-      })),
+      activeModels,
       generatedAt: new Date(),
-      rankingShapeBenchmarks: { domainMeanTopGap: 0, domainStdTopGap: null, medianSpread: 0 },
-      clusterAnalysis: { clusters: [], faultLinesByPair: {}, defaultPair: null, skipped: true, skipReason: 'No vignettes found in this scope.' },
-      clusterAnalysisByMethod: {},
       cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.FRESH,
-      contributionSummary: [],
-      excludedDataSummary: [],
-    };
+      unavailableReason: 'No analyzed vignettes found in this scope.',
+    });
   }
 
   const currentSnapshot = await getCurrentSnapshot(db, state.scope, state.domain.id, state.configSignature);
@@ -417,6 +441,32 @@ export async function getDomainAnalysisResult(params: {
       generatedAt: currentSnapshot.createdAt,
       cacheStatus: queued ? DOMAIN_ANALYSIS_CACHE_STATUS.UPDATING : DOMAIN_ANALYSIS_CACHE_STATUS.OUT_OF_DATE,
     });
+  }
+
+  // A CURRENT snapshot may exist but only contain `buildProgress` — i.e., a
+  // prior request kicked off a synchronous rebuild and that rebuild is still
+  // running (or recently died). Falling through to refreshDomainAnalysisSnapshot
+  // here would supersede the in-progress snapshot and start a NEW rebuild,
+  // creating a thundering-herd loop where every page load stomps on the
+  // previous rebuild and never finishes. Instead: if buildProgress is recent
+  // (last DOMAIN_ANALYSIS_BUILD_PROGRESS_FRESH_MS), return UPDATING and let
+  // the existing rebuild finish. Only fall through to refresh if the prior
+  // rebuild has gone stale (likely died from a process restart).
+  if (currentSnapshot != null) {
+    const buildProgress = parseBuildProgress(currentSnapshot.output);
+    if (buildProgress != null) {
+      const progressAgeMs = Date.now() - new Date(buildProgress.updatedAt).getTime();
+      if (Number.isFinite(progressAgeMs) && progressAgeMs < DOMAIN_ANALYSIS_BUILD_PROGRESS_FRESH_MS) {
+        return buildEmptyDomainAnalysisResult({
+          domainId: state.domain.id,
+          domainName: state.domain.name,
+          activeModels,
+          generatedAt: currentSnapshot.createdAt,
+          cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.UPDATING,
+          unavailableReason: `Domain analysis is rebuilding (${buildProgress.completedRuns}/${buildProgress.totalRuns} runs processed). Refresh in a moment.`,
+        });
+      }
+    }
   }
 
   const refreshed = await refreshDomainAnalysisSnapshot({


### PR DESCRIPTION
## Summary
The Models > Win Rate page on `scope=all-domains` was failing to load — every request timed out at >60s.

### Root cause
\`getDomainAnalysisResult\` has a code path that triggers a SYNCHRONOUS rebuild when no parseable snapshot exists. \`parseSnapshotOutput\` returns null when the CURRENT snapshot contains only \`{buildProgress: ...}\` — i.e., a prior request started a rebuild that's still running. The synchronous-rebuild branch then calls \`refreshDomainAnalysisSnapshot\`, which marks every matching CURRENT snapshot SUPERSEDED and creates a new buildProgress placeholder, stomping on the rebuild already in flight. Each new page load repeats the cycle. Thundering herd.

### Evidence
On prod, the \`domain-analysis:all-domains\` / \`vnewtd\` row was 147 bytes (buildProgress only). Two back-to-back rebuild snapshots created 8 seconds apart, both still mid-rebuild at the time of the diagnosis (1148 of 1735 runs, then 1185 of 1735 runs).

### Fix
Before falling through to the synchronous refresh, check whether the CURRENT snapshot is a buildProgress placeholder with a recent \`updatedAt\` (<5 min). If so, return UPDATING with an empty result. The existing rebuild keeps running; new page loads see UPDATING and refresh on their own. If \`updatedAt\` is older than 5 minutes (the prior rebuild likely died from a process restart), the code falls through to the existing refresh path so a stuck snapshot eventually heals.

Also factored the empty-result construction into \`buildEmptyDomainAnalysisResult\` so the in-progress and no-vignettes paths share the same shape.

## Test plan
- [x] API build clean
- [x] Affected service-layer tests pass
- [ ] Production smoke: \`/models/win-rate?scope=all-domains&signature=vnewtd\` returns within seconds (will verify after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)