### PR TITLE
hotfix(model-groups): yield event loop in kappa bootstrap to unblock concurrent queries

### DIFF
--- a/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
@@ -195,7 +195,7 @@ export async function resolveModelAgreementOnTradeoffs(
       tiedCells += pairTiedCells;
       const metrics = summarizePairCells(cells);
       const cellsByVignette = groupCellsByVignette(cells);
-      const ci = bootstrapKappaConfidence(cellsByVignette, metrics.cohensKappa, KAPPA_BOOTSTRAP_ITERATIONS);
+      const ci = await bootstrapKappaConfidence(cellsByVignette, metrics.cohensKappa, KAPPA_BOOTSTRAP_ITERATIONS);
 
       pairwiseAgreementMatrix.push({
         modelAId: modelA.modelId,

--- a/cloud/apps/api/src/services/model-agreement/aggregation.ts
+++ b/cloud/apps/api/src/services/model-agreement/aggregation.ts
@@ -452,22 +452,42 @@ export function groupCellsByVignette(cells: ReadonlyArray<ComparableCell>): Map<
 }
 
 /**
+ * Yield to the Node event loop so other concurrently-issued requests can
+ * progress while a long-running CPU-bound bootstrap is in flight. Without
+ * this, the entire process blocks for tens of seconds on large all-domains
+ * scopes and other queries (e.g. domainAnalysis from the same page) time out
+ * at the proxy with a "Failed to fetch" browser error.
+ */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => { setImmediate(resolve); });
+}
+
+// Yield every N bootstrap iterations. Tuned so a single yield is rarely more
+// than ~50ms of CPU work even on the largest realistic input (≈360 vignettes
+// × ~6 cells each), keeping concurrent fast queries responsive.
+const BOOTSTRAP_YIELD_EVERY_ITERATIONS = 25;
+
+/**
  * Bootstrap 95% confidence interval for Cohen's kappa by resampling whole
  * vignettes with replacement (1000 iterations by default).
  *
  * Resampling at the vignette level (not cell level) respects the clustering
  * structure — cells within a vignette share context and aren't independent.
  *
+ * Async to keep the Node event loop responsive — yields every
+ * BOOTSTRAP_YIELD_EVERY_ITERATIONS iterations so concurrent requests are not
+ * starved while a long bootstrap runs.
+ *
  * Returns { low: null, high: null, isSymmetric: true } when:
  *   - The point estimate is null (no data to resample).
  *   - There are no vignettes (empty input).
  *   - Fewer than 100 valid bootstrap samples were produced (degenerate case).
  */
-export function bootstrapKappaConfidence(
+export async function bootstrapKappaConfidence(
   cellsByVignette: Map<string, ComparableCell[]>,
   pointEstimateKappa: number | null,
   iterations: number = 1000,
-): KappaConfidenceInterval {
+): Promise<KappaConfidenceInterval> {
   if (pointEstimateKappa == null || cellsByVignette.size === 0) {
     return { low: null, high: null, isSymmetric: true };
   }
@@ -496,6 +516,10 @@ export function bootstrapKappaConfidence(
     const sampleKappa = summarizePairCells(resampledCells).cohensKappa;
     if (sampleKappa != null && Number.isFinite(sampleKappa)) {
       kappaSamples.push(sampleKappa);
+    }
+
+    if ((iter + 1) % BOOTSTRAP_YIELD_EVERY_ITERATIONS === 0 && iter + 1 < iterations) {
+      await yieldToEventLoop();
     }
   }
 

--- a/cloud/apps/api/tests/services/model-agreement/aggregation.test.ts
+++ b/cloud/apps/api/tests/services/model-agreement/aggregation.test.ts
@@ -47,18 +47,18 @@ describe('groupCellsByVignette', () => {
 });
 
 describe('bootstrapKappaConfidence', () => {
-  it('returns null/null when pointEstimateKappa is null', () => {
+  it('returns null/null when pointEstimateKappa is null', async () => {
     const grouped = groupCellsByVignette([cell('def-1', 'A::B', 'A', 'A')]);
-    const result = bootstrapKappaConfidence(grouped, null);
+    const result = await bootstrapKappaConfidence(grouped, null);
     expect(result).toEqual({ low: null, high: null, isSymmetric: true });
   });
 
-  it('returns null/null when there are no vignettes', () => {
-    const result = bootstrapKappaConfidence(new Map(), 0.5);
+  it('returns null/null when there are no vignettes', async () => {
+    const result = await bootstrapKappaConfidence(new Map(), 0.5);
     expect(result).toEqual({ low: null, high: null, isSymmetric: true });
   });
 
-  it('with a single vignette the CI collapses to near the point estimate', () => {
+  it('with a single vignette the CI collapses to near the point estimate', async () => {
     // One vignette with two cells of mixed outcome so kappa is non-degenerate.
     // Model A: A, B → marginals 50/50. Model B: A, B → same. Weighted kappa = 1.
     const cells = [
@@ -68,14 +68,14 @@ describe('bootstrapKappaConfidence', () => {
     const grouped = groupCellsByVignette(cells);
     const kappa = summarizePairCells(cells).cohensKappa;
     expect(kappa).not.toBeNull();
-    const result = bootstrapKappaConfidence(grouped, kappa!, 1000);
+    const result = await bootstrapKappaConfidence(grouped, kappa!, 1000);
     // With a single vignette every resample is the same → CI should be very tight.
     if (result.low != null && result.high != null && kappa != null) {
       expect(result.high - result.low).toBeLessThan(0.05);
     }
   });
 
-  it('returns CI that brackets the point estimate (low ≤ kappa ≤ high)', () => {
+  it('returns CI that brackets the point estimate (low ≤ kappa ≤ high)', async () => {
     // Build 20 vignettes with partial agreement (kappa around 0.5).
     const cells: ComparableCell[] = [];
     for (let i = 0; i < 20; i += 1) {
@@ -87,7 +87,7 @@ describe('bootstrapKappaConfidence', () => {
     const grouped = groupCellsByVignette(cells);
     const kappa = summarizePairCells(cells).cohensKappa;
     expect(kappa).not.toBeNull();
-    const result = bootstrapKappaConfidence(grouped, kappa!, 1000);
+    const result = await bootstrapKappaConfidence(grouped, kappa!, 1000);
     expect(result.low).not.toBeNull();
     expect(result.high).not.toBeNull();
     if (result.low != null && result.high != null && kappa != null) {
@@ -96,7 +96,7 @@ describe('bootstrapKappaConfidence', () => {
     }
   });
 
-  it('detects symmetric CI on uniform data (all cells perfectly agree)', () => {
+  it('detects symmetric CI on uniform data (all cells perfectly agree)', async () => {
     // All cells agree perfectly — kappa = 1, bootstrap samples all collapse to 1.
     const cells: ComparableCell[] = [];
     for (let i = 0; i < 30; i += 1) {
@@ -104,12 +104,12 @@ describe('bootstrapKappaConfidence', () => {
     }
     const grouped = groupCellsByVignette(cells);
     const kappa = summarizePairCells(cells).cohensKappa;
-    const result = bootstrapKappaConfidence(grouped, kappa!, 1000);
+    const result = await bootstrapKappaConfidence(grouped, kappa!, 1000);
     // All bootstrap samples will produce the same kappa → CI should be symmetric.
     expect(result.isSymmetric).toBe(true);
   });
 
-  it('flags isSymmetric=false for a skewed bootstrap distribution', () => {
+  it('flags isSymmetric=false for a skewed bootstrap distribution', async () => {
     // Construct a distribution where low samples are dense near 1 but
     // we force Math.random to return a controlled sequence that produces
     // an asymmetric result. We do this by spying on Math.random.
@@ -126,7 +126,7 @@ describe('bootstrapKappaConfidence', () => {
     const grouped = groupCellsByVignette(cells);
     const kappa = summarizePairCells(cells).cohensKappa;
     expect(kappa).not.toBeNull();
-    const result = bootstrapKappaConfidence(grouped, kappa!, 2000);
+    const result = await bootstrapKappaConfidence(grouped, kappa!, 2000);
     // With high kappa near +1 the upper tail is compressed; asymmetry may or may not
     // exceed the 0.01 threshold depending on exact distribution. We just verify the
     // function returns a valid shape.
@@ -140,7 +140,7 @@ describe('bootstrapKappaConfidence', () => {
     expect(KAPPA_CI_WIDE_THRESHOLD).toBe(0.30);
   });
 
-  it('uses Math.random — mocking it produces deterministic output', () => {
+  it('uses Math.random — mocking it produces deterministic output', async () => {
     // Build 10 vignettes, mock Math.random to always return 0 (always picks first vignette).
     const cells: ComparableCell[] = [];
     for (let i = 0; i < 10; i += 1) {
@@ -151,7 +151,7 @@ describe('bootstrapKappaConfidence', () => {
     const kappa = summarizePairCells(cells).cohensKappa;
 
     const spy = vi.spyOn(Math, 'random').mockReturnValue(0);
-    const result = bootstrapKappaConfidence(grouped, kappa!, 500);
+    const result = await bootstrapKappaConfidence(grouped, kappa!, 500);
     spy.mockRestore();
 
     // All iterations resample only def-0 (always agree). Each draw gets a
@@ -163,7 +163,7 @@ describe('bootstrapKappaConfidence', () => {
     }
   });
 
-  it('duplicate draws amplify their influence (regression for collapsed-duplicate bug)', () => {
+  it('duplicate draws amplify their influence (regression for collapsed-duplicate bug)', async () => {
     // The bug: when the same vignette is drawn multiple times in one bootstrap
     // iteration, the cells keep their original definitionId. summarizePairCells
     // groups cells by definitionId, so duplicate draws collapsed back into one
@@ -246,7 +246,7 @@ describe('bootstrapKappaConfidence', () => {
     //
     // Let's just verify the tight-CI property and that it matches kappaAllAgree:
     const spy = vi.spyOn(Math, 'random').mockReturnValue(0);
-    const result = bootstrapKappaConfidence(grouped, kappaMixed!, 500);
+    const result = await bootstrapKappaConfidence(grouped, kappaMixed!, 500);
     spy.mockRestore();
 
     expect(result.low).not.toBeNull();


### PR DESCRIPTION
## Summary

The Model Groups page (`/models?scope=all-domains`) was failing with a browser-level `[Network] Failed to fetch` error on the `domainAnalysis` query. The query itself is fast (~2s, snapshot is FRESH) — the failure was caused by a **second** query the same page issues alongside it: `modelAgreementOnTradeoffs`.

That resolver runs a synchronous 1000-iteration bootstrap CI for every model pair. With 8 default models = 28 pairs, and ~360 vignettes for the all-domains scope, the bootstrap blocks the Node event loop for tens of seconds. While it runs, no other request on the same API process can be served — including the page's own `domainAnalysis` query — so the browser fetch fails at the Railway edge timeout.

I reproduced this with curl: firing the agreement query (which times out at 90s itself) in parallel with five fast `domainAnalysis` probes — every probe timed out at 60s, even though `domainAnalysis` alone returns in ~2s.

## Fix

- Convert `bootstrapKappaConfidence` to `async` and yield to the event loop via `setImmediate` every 25 iterations (`cloud/apps/api/src/services/model-agreement/aggregation.ts`).
- `await` the call site in the resolver (`cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts:198`).
- Update the existing 9 unit tests to `await` the now-async function.

Total bootstrap time is unchanged. The yield points let concurrent requests interleave, so `domainAnalysis` (and any other fast query) completes within its normal latency budget while the agreement query computes in the background.

## Test plan

- [x] `npm run build --workspace @valuerank/api` — clean
- [x] `npm run lint --workspace @valuerank/api` — 0 errors (33 pre-existing warnings)
- [x] `npm run test --workspace @valuerank/api` — 2410 passed, 4 skipped (all 11 `bootstrapKappaConfidence` tests pass)
- [ ] Post-merge prod check: load `/models?scope=all-domains&signature=vnewtd` and confirm the page renders without "Failed to fetch"
- [ ] Post-merge prod check: confirm `modelAgreementOnTradeoffs` still returns the same kappa CIs (output values are unchanged — only the scheduling is different)

## Follow-ups (not in this PR)

- The agreement query itself still takes 60–90s on the all-domains scope. The proper long-term fix is to move the bootstrap to a background job and bake CIs into the snapshot, but that's a much larger change. This PR fixes the user-facing "page can't load" symptom; the agreement section will show its own loading state until its slow query completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)