### PR TITLE
fix(queue): harden probe queue against domain-fanout overflow

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts
+++ b/cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts
@@ -1,6 +1,9 @@
 import type { db } from '@valuerank/db';
 import type { RunCategory } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
 import { startRun as startRunService } from '../../../../services/run/index.js';
+import { getBoss, isBossRunning } from '../../../../queue/boss.js';
+import { isActiveProbeQueueName } from '../../../../services/queue/probe-queues.js';
 import { runMatchesSingleModel } from './resolve-backfill.js';
 import type {
   LaunchSlot,
@@ -9,6 +12,50 @@ import type {
   DomainTrialRunEntry,
 } from './types.js';
 import { ACTIVE_RUN_STATUSES } from './types.js';
+
+const backpressureLog = createLogger('domain-launch:backpressure');
+
+// Domain-level launches (e.g. "Run all 90 definitions") used to dump every probe job
+// for every run into PgBoss in a 3-second window. With 8 models × 200 probes × 90 runs
+// that is ~144k jobs hitting a 150-slot worker pool — most of the tail expired before
+// any worker reached it. We keep the existing batching at 25 runs per pass and add a
+// poll between batches that waits for the probe queue to drop below ~2x total
+// parallelism before submitting the next batch.
+const BACKPRESSURE_PROBE_THRESHOLD = 300;
+const BACKPRESSURE_POLL_MS = 5000;
+const BACKPRESSURE_MAX_WAIT_MS = 5 * 60 * 1000;
+
+async function waitForProbeQueueCapacity(): Promise<void> {
+  // In test or pre-boot contexts there is no PgBoss instance — skip without blocking.
+  if (!isBossRunning()) return;
+  const boss = getBoss();
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < BACKPRESSURE_MAX_WAIT_MS) {
+    const queues = await boss.getQueues();
+    const inFlight = queues
+      .filter((q) => isActiveProbeQueueName(q.name))
+      .reduce((sum, q) => sum + q.activeCount + q.queuedCount, 0);
+    if (inFlight < BACKPRESSURE_PROBE_THRESHOLD) {
+      return;
+    }
+    backpressureLog.info(
+      {
+        inFlightProbes: inFlight,
+        threshold: BACKPRESSURE_PROBE_THRESHOLD,
+        waitedMs: Date.now() - startedAt,
+      },
+      'Domain launch waiting for probe queue to drain before next batch'
+    );
+    await new Promise((resolve) => setTimeout(resolve, BACKPRESSURE_POLL_MS));
+  }
+  backpressureLog.warn(
+    {
+      thresholdJobs: BACKPRESSURE_PROBE_THRESHOLD,
+      maxWaitMs: BACKPRESSURE_MAX_WAIT_MS,
+    },
+    'Domain launch backpressure timed out — proceeding to next batch anyway'
+  );
+}
 
 type PrismaTransactionClient = Parameters<Parameters<typeof db.$transaction>[0]>[0];
 
@@ -43,6 +90,10 @@ export async function executeLaunchRuns(params: {
     const batch = launchSlots.slice(offset, offset + 25);
     if (batch.length === 0) {
       continue;
+    }
+
+    if (offset > 0) {
+      await waitForProbeQueueCapacity();
     }
 
     const runResults = await Promise.allSettled(
@@ -102,7 +153,12 @@ export async function executeBackfillRuns(params: {
   let failedDefinitions = 0;
   const runs: DomainTrialRunEntry[] = [];
 
+  let groupIndex = 0;
   for (const group of backfillGroups) {
+    if (groupIndex > 0) {
+      await waitForProbeQueueCapacity();
+    }
+    groupIndex += 1;
     const activeEquivalentRuns = await tx.run.findMany({
       where: {
         definitionId: { in: group.definitions.map((definition) => definition.id) },

--- a/cloud/apps/api/src/queue/handlers/probe-dead-letter.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-dead-letter.ts
@@ -34,8 +34,16 @@ export function createProbeDeadLetterHandler(): PgBoss.WorkHandler<ProbeDeadLett
         'Probe job failed/expired - processing dead letter'
       );
 
+      // Record the failure in ProbeResult table.
+      //
+      // Failures here are rethrown so the DLQ job goes to PgBoss "failed" state and the
+      // operator can see something went wrong. Previously this catch swallowed silently,
+      // which is why 15 zombie-killed probes on a known run never appeared in
+      // Run.failedProbes — recordProbeFailure was failing and nobody could tell.
+      //
+      // retryLimit on probe_dead_letter is 0, so a thrown error does NOT cause a retry
+      // loop; the DLQ job just fails once and stays visible.
       try {
-        // Record the failure in ProbeResult table
         await recordProbeFailure({
           runId,
           scenarioId,
@@ -46,7 +54,6 @@ export function createProbeDeadLetterHandler(): PgBoss.WorkHandler<ProbeDeadLett
           retryCount: 0,
         });
 
-        // Advance run state using derived counts
         const result = await maybeAdvanceRunStatus(runId);
 
         log.info(
@@ -54,11 +61,19 @@ export function createProbeDeadLetterHandler(): PgBoss.WorkHandler<ProbeDeadLett
           'Dead letter job processed - run progress updated'
         );
       } catch (error) {
-        // Log but don't throw - we don't want to retry dead letter jobs
         log.error(
-          { jobId, runId, scenarioId, modelId, err: error },
-          'Failed to process dead letter job'
+          {
+            jobId,
+            runId,
+            scenarioId,
+            modelId,
+            sampleIndex,
+            err: error,
+            jobData: job.data,
+          },
+          'Failed to process dead letter job — rethrowing so PgBoss marks it failed'
         );
+        throw error;
       }
     }
   };

--- a/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
@@ -226,16 +226,26 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
       // Use Python's retryable flag if available
       if (!err.retryable) {
         const errorMessage = formatWorkerErrorMessage(err);
-        // Non-retryable error - record failure and increment failed count
-        await recordProbeFailure({
-          runId,
-          scenarioId,
-          modelId,
-          sampleIndex,
-          errorCode: err.code,
-          errorMessage,
-          retryCount: 0,
-        });
+        // Non-retryable error - record failure and increment failed count.
+        // recordProbeFailure now throws on persistence error (so the DLQ handler can
+        // surface those failures), so this caller must wrap it. Keep the original
+        // probe-failed semantics: never block job completion on a metadata write.
+        try {
+          await recordProbeFailure({
+            runId,
+            scenarioId,
+            modelId,
+            sampleIndex,
+            errorCode: err.code,
+            errorMessage,
+            retryCount: 0,
+          });
+        } catch (recordErr) {
+          log.error(
+            { jobId, runId, scenarioId, modelId, err: recordErr },
+            'Failed to record probe failure — continuing'
+          );
+        }
         const advanceResult = await maybeAdvanceRunStatus(runId);
         log.error({ jobId, runId, advanceResult, error: err }, 'Probe job permanently failed');
         return; // Complete job without retrying

--- a/cloud/apps/api/src/queue/types.ts
+++ b/cloud/apps/api/src/queue/types.ts
@@ -131,7 +131,12 @@ export const DEFAULT_JOB_OPTIONS: Record<JobType, JobOptions> = {
     retryLimit: 3,
     retryDelay: 5,
     retryBackoff: true,
-    expireInSeconds: 420, // 7 minutes - covers 5m timeout + buffer
+    // 24 hours. The zombie watchdog (services/run/recovery.ts) is the active-execution
+    // timeout; this TTL just bounds how long a probe can sit in queue before PgBoss
+    // expires it. Domain-level launches can submit tens of thousands of probes at once,
+    // so queue wait can legitimately exceed an hour. Anything shorter silently strands
+    // the tail.
+    expireInSeconds: 86400,
   },
   'top_up_probes': {
     retryLimit: 0,
@@ -196,7 +201,9 @@ export const DEFAULT_JOB_OPTIONS: Record<JobType, JobOptions> = {
   },
   'probe_dead_letter': {
     retryLimit: 0, // Don't retry dead letter jobs - just log and record
-    expireInSeconds: 300,
+    // 30 minutes. DLQ jobs run a single DB upsert; we keep this generous so a brief
+    // DB stall during a large fanout doesn't drop failure records on the floor.
+    expireInSeconds: 1800,
   },
 };
 

--- a/cloud/apps/api/src/services/probe-result/index.ts
+++ b/cloud/apps/api/src/services/probe-result/index.ts
@@ -92,39 +92,37 @@ export async function recordProbeFailure(input: RecordFailureInput): Promise<voi
     ? errorMessage.substring(0, 2000) + '...'
     : errorMessage;
 
-  try {
-    await db.probeResult.upsert({
-      where: {
-        runId_scenarioId_modelId_sampleIndex: { runId, scenarioId, modelId, sampleIndex },
-      },
-      create: {
-        runId,
-        scenarioId,
-        modelId,
-        sampleIndex,
-        status: 'FAILED',
-        errorCode,
-        errorMessage: truncatedMessage,
-        retryCount,
-        completedAt: new Date(),
-      },
-      update: {
-        status: 'FAILED',
-        errorCode,
-        errorMessage: truncatedMessage,
-        retryCount,
-        transcriptId: null,
-        durationMs: null,
-        inputTokens: null,
-        outputTokens: null,
-        completedAt: new Date(),
-      },
-    });
+  // Failures here are rethrown. The dead-letter handler relies on this row to surface
+  // expired/zombie probes through Run.failedProbes; if the upsert silently swallows,
+  // operators see "0 failed probes" while the queue actually has dead jobs.
+  await db.probeResult.upsert({
+    where: {
+      runId_scenarioId_modelId_sampleIndex: { runId, scenarioId, modelId, sampleIndex },
+    },
+    create: {
+      runId,
+      scenarioId,
+      modelId,
+      sampleIndex,
+      status: 'FAILED',
+      errorCode,
+      errorMessage: truncatedMessage,
+      retryCount,
+      completedAt: new Date(),
+    },
+    update: {
+      status: 'FAILED',
+      errorCode,
+      errorMessage: truncatedMessage,
+      retryCount,
+      transcriptId: null,
+      durationMs: null,
+      inputTokens: null,
+      outputTokens: null,
+      completedAt: new Date(),
+    },
+  });
 
-    log.debug({ runId, scenarioId, modelId, sampleIndex, errorCode }, 'Recorded probe failure');
-  } catch (err) {
-    // Log but don't fail the job - probe result recording is supplementary
-    log.error({ runId, scenarioId, modelId, sampleIndex, err }, 'Failed to record probe failure');
-  }
+  log.debug({ runId, scenarioId, modelId, sampleIndex, errorCode }, 'Recorded probe failure');
 }
 

--- a/cloud/apps/api/src/services/run/recovery.ts
+++ b/cloud/apps/api/src/services/run/recovery.ts
@@ -308,8 +308,11 @@ export async function runStartupRecovery(): Promise<RecoveryResult> {
  * This is a failsafe for when PgBoss expiration mechanisms fail or job handlers crash silently.
  */
 export async function detectAndRecoverStuckJobs(): Promise<{ recovered: number; errors: number }> {
-  // Find jobs active for > 5 minutes (user requested tight watchdog)
-  const ZOMBIE_THRESHOLD_MINUTES = 5;
+  // Active-execution timeout. Slow models (Grok, DeepSeek Reasoner, Gemini Flash) with
+  // long outputs can legitimately take >5m, so the previous 5m threshold killed many
+  // probes that would have completed. 30m is generous enough for any single LLM call
+  // and still catches truly hung handlers.
+  const ZOMBIE_THRESHOLD_MINUTES = 30;
 
   const stuckJobs = await db.$queryRaw<Array<{ id: string; name: string; run_id: string }>>`
     SELECT id, name, data->>'runId' as run_id
@@ -323,18 +326,25 @@ export async function detectAndRecoverStuckJobs(): Promise<{ recovered: number; 
     return { recovered: 0, errors: 0 };
   }
 
-  log.warn({ count: stuckJobs.length }, 'Detected zombie jobs (active > 5m)');
+  log.warn(
+    { count: stuckJobs.length, thresholdMinutes: ZOMBIE_THRESHOLD_MINUTES },
+    'Detected zombie jobs'
+  );
 
   let recovered = 0;
   let errors = 0;
+
+  const errorOutput = JSON.stringify({
+    error: `Zombie job detected and killed by watchdog (active > ${ZOMBIE_THRESHOLD_MINUTES}m)`,
+  });
 
   for (const job of stuckJobs) {
     try {
       // Force fail the job
       await db.$executeRaw`
-        UPDATE pgboss.job 
-        SET state = 'failed', 
-            output = '{"error": "Zombie job detected and killed by watchdog (active > 15m)"}',
+        UPDATE pgboss.job
+        SET state = 'failed',
+            output = ${errorOutput}::jsonb,
             completed_on = NOW()
         WHERE id = ${job.id}::uuid
       `;

--- a/cloud/apps/api/tests/queue/handlers/probe-dead-letter.test.ts
+++ b/cloud/apps/api/tests/queue/handlers/probe-dead-letter.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the probe dead-letter handler.
+ *
+ * The handler must:
+ * 1. Call recordProbeFailure with the right job-data fields when a probe is dead-lettered.
+ * 2. Rethrow if recordProbeFailure (or any downstream call) fails. Previously this
+ *    catch swallowed the error, which is why 15 zombie-killed probes never appeared
+ *    in Run.failedProbes — recordProbeFailure was failing silently in production.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Job } from 'pg-boss';
+import type { ProbeDeadLetterJobData } from '../../../src/queue/types.js';
+
+const recordProbeFailure = vi.fn();
+const maybeAdvanceRunStatus = vi.fn();
+
+vi.mock('../../../src/services/probe-result/index.js', () => ({
+  recordProbeFailure: (...args: unknown[]) => recordProbeFailure(...args),
+}));
+
+vi.mock('../../../src/services/run/index.js', () => ({
+  maybeAdvanceRunStatus: (...args: unknown[]) => maybeAdvanceRunStatus(...args),
+}));
+
+const { createProbeDeadLetterHandler } = await import(
+  '../../../src/queue/handlers/probe-dead-letter.js'
+);
+
+function makeJob(overrides: Partial<ProbeDeadLetterJobData> = {}): Job<ProbeDeadLetterJobData> {
+  const data: ProbeDeadLetterJobData = {
+    runId: 'run-123',
+    scenarioId: 'scenario-abc',
+    modelId: 'gpt-5.1',
+    sampleIndex: 0,
+    config: { maxTurns: 1 },
+    ...overrides,
+  };
+  return {
+    id: 'dlq-job-1',
+    name: 'probe_dead_letter',
+    data,
+  } as unknown as Job<ProbeDeadLetterJobData>;
+}
+
+describe('createProbeDeadLetterHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recordProbeFailure.mockResolvedValue(undefined);
+    maybeAdvanceRunStatus.mockResolvedValue({ status: 'RUNNING' });
+  });
+
+  it('records a JOB_EXPIRED probe failure for each dead-lettered job', async () => {
+    const handler = createProbeDeadLetterHandler();
+    await handler([makeJob()]);
+
+    expect(recordProbeFailure).toHaveBeenCalledTimes(1);
+    expect(recordProbeFailure).toHaveBeenCalledWith({
+      runId: 'run-123',
+      scenarioId: 'scenario-abc',
+      modelId: 'gpt-5.1',
+      sampleIndex: 0,
+      errorCode: 'JOB_EXPIRED',
+      errorMessage: expect.stringContaining('dead letter'),
+      retryCount: 0,
+    });
+    expect(maybeAdvanceRunStatus).toHaveBeenCalledWith('run-123');
+  });
+
+  it('processes multiple dead-letter jobs in one batch', async () => {
+    const handler = createProbeDeadLetterHandler();
+    await handler([
+      makeJob({ runId: 'run-1' }),
+      makeJob({ runId: 'run-2' }),
+      makeJob({ runId: 'run-3' }),
+    ]);
+
+    expect(recordProbeFailure).toHaveBeenCalledTimes(3);
+  });
+
+  it('rethrows when recordProbeFailure fails so PgBoss marks the DLQ job failed', async () => {
+    const dbErr = new Error('probe_results FK violation');
+    recordProbeFailure.mockRejectedValueOnce(dbErr);
+
+    const handler = createProbeDeadLetterHandler();
+
+    // The handler must surface the error — silent swallow is the bug we are fixing.
+    await expect(handler([makeJob()])).rejects.toThrow('probe_results FK violation');
+    // Run-state advance is downstream of recordProbeFailure, so it should not have run.
+    expect(maybeAdvanceRunStatus).not.toHaveBeenCalled();
+  });
+
+  it('rethrows when run-state advance fails', async () => {
+    const advanceErr = new Error('maybeAdvanceRunStatus boom');
+    maybeAdvanceRunStatus.mockRejectedValueOnce(advanceErr);
+
+    const handler = createProbeDeadLetterHandler();
+    await expect(handler([makeJob()])).rejects.toThrow('maybeAdvanceRunStatus boom');
+    expect(recordProbeFailure).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Domain-level launches (e.g. "Run all 90 definitions" on a domain) silently dropped ~125 probes per run today on the *Motivation for Invasion Choice* domain — about 11,250 probes lost across the 90-run fanout. Root cause was three coupled timeouts that were too tight for the actual workload, plus a swallowed error path that hid the failures from operators.

Four changes in priority order:

1. **`probe_scenario.expireInSeconds`: 420 → 86400** (24h). The previous 7-min TTL was tuned for a 5-min worker timeout, but with ~18,000 probes hitting a 150-slot pool in a single fanout, queue wait exceeded 7 min and the tail expired before any worker reached it.
2. **Backpressure between domain-launch batches** in `execute-runs.ts`. The existing 25-runs-per-batch loop ran back-to-back; now we poll `boss.getQueues()` between batches and wait until total in-flight probes drop below 300 (or hit a 5-min hard cap and proceed).
3. **Stop swallowing errors** in the `probe_dead_letter` handler and `recordProbeFailure`. On the broken domain run, 15 zombie-killed probes never appeared in `Run.failedProbes` because `recordProbeFailure` was failing under the silent swallow. The DLQ handler now rethrows so PgBoss marks the DLQ job failed and the failure is visible. `probe-scenario/handler.ts` adds its own try/catch to preserve the "metadata write failure must not block job completion" semantics.
4. **`ZOMBIE_THRESHOLD_MINUTES`: 5 → 30** in `services/run/recovery.ts`. Slow models (Grok, DeepSeek Reasoner, Gemini Flash) with high output token counts can legitimately exceed 5m for a single probe; the watchdog was killing them mid-flight. Also fixed the error message that said "active > 15m" while the threshold was actually 5m.

## Test plan
- [x] New unit test: `probe-dead-letter.test.ts` covers the rethrow path, batch processing, and run-state-advance failure.
- [x] Full api suite: 2419 passed / 4 skipped (was 2415 / 4).
- [x] Lint clean: 0 errors (33 pre-existing warnings unrelated to touched files).
- [x] Build clean: `tsc` passes.
- [ ] Post-deploy: re-run the *Motivation for Invasion Choice* domain to verify a single fanout completes without strands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)