### PR TITLE
feat(status): heartbeat strip with 30m throughput, in-flight, oldest run

### DIFF
--- a/cloud/apps/api/src/graphql/types/health.ts
+++ b/cloud/apps/api/src/graphql/types/health.ts
@@ -88,6 +88,7 @@ export const QueueHealthType = builder.objectRef<{
   activeJobs: number;
   pendingJobs: number;
   completedLast24h: number;
+  completedLast30m: number;
   failedLast24h: number;
   successRate: number | null;
   error: string | null;
@@ -119,6 +120,9 @@ export const QueueHealthType = builder.objectRef<{
     }),
     completedLast24h: t.exposeInt('completedLast24h', {
       description: 'Jobs completed in the last 24 hours',
+    }),
+    completedLast30m: t.exposeInt('completedLast30m', {
+      description: 'Jobs completed in the last 30 minutes (rolling window)',
     }),
     failedLast24h: t.exposeInt('failedLast24h', {
       description: 'Jobs failed in the last 24 hours',
@@ -210,6 +214,7 @@ export const SystemHealthType = builder.objectRef<{
     activeJobs: number;
     pendingJobs: number;
     completedLast24h: number;
+    completedLast30m: number;
     failedLast24h: number;
     successRate: number | null;
     error: string | null;

--- a/cloud/apps/api/src/services/health/queue.ts
+++ b/cloud/apps/api/src/services/health/queue.ts
@@ -25,6 +25,7 @@ export type QueueHealthStatus = {
   activeJobs: number;
   pendingJobs: number;
   completedLast24h: number;
+  completedLast30m: number;
   failedLast24h: number;
   successRate: number | null; // null if no jobs completed
   jobTypes: JobTypeStatus[];
@@ -45,6 +46,7 @@ export async function getQueueHealth(): Promise<QueueHealthStatus> {
     const activeJobs = status.totals.active;
     const pendingJobs = status.totals.pending;
     const completedLast24h = status.totals.completed;
+    const completedLast30m = status.completedLast30m;
     const failedLast24h = status.totals.failed;
 
     // Calculate success rate (completed / (completed + failed))
@@ -73,6 +75,7 @@ export async function getQueueHealth(): Promise<QueueHealthStatus> {
       activeJobs,
       pendingJobs,
       completedLast24h,
+      completedLast30m,
       failedLast24h,
       successRate,
       jobTypes: status.jobTypes,
@@ -88,6 +91,7 @@ export async function getQueueHealth(): Promise<QueueHealthStatus> {
       activeJobs: 0,
       pendingJobs: 0,
       completedLast24h: 0,
+      completedLast30m: 0,
       failedLast24h: 0,
       successRate: null,
       jobTypes: [],

--- a/cloud/apps/api/src/services/queue/status.ts
+++ b/cloud/apps/api/src/services/queue/status.ts
@@ -61,7 +61,7 @@ export async function getQueueStatus(): Promise<QueueStatus> {
       SELECT COUNT(*) as count
       FROM pgboss.job
       WHERE state = 'completed'
-        AND completedon >= NOW() - INTERVAL '30 minutes'
+        AND completed_on >= NOW() - INTERVAL '30 minutes'
         AND (${ACTIVE_PROBE_QUEUE_SQL} OR name IN ('summarize_transcript', 'analyze_basic', 'analyze_deep', 'expand_scenarios'))
     `;
 

--- a/cloud/apps/api/src/services/queue/status.ts
+++ b/cloud/apps/api/src/services/queue/status.ts
@@ -132,7 +132,7 @@ export async function getQueueStatus(): Promise<QueueStatus> {
       isRunning: state.isRunning,
       isPaused: state.isPaused,
       jobTypes,
-      completedLast30m: Number(completedLast30mResult[0]?.count ?? 0n),
+      completedLast30m: Number(completedLast30mResult?.[0]?.count ?? 0n),
       totals,
     };
   } catch (error) {

--- a/cloud/apps/api/src/services/queue/status.ts
+++ b/cloud/apps/api/src/services/queue/status.ts
@@ -27,6 +27,7 @@ export type QueueStatus = {
   isRunning: boolean;
   isPaused: boolean;
   jobTypes: JobTypeStatus[];
+  completedLast30m: number;
   totals: {
     pending: number;
     active: number;
@@ -52,6 +53,16 @@ export async function getQueueStatus(): Promise<QueueStatus> {
       FROM pgboss.job
       WHERE (${ACTIVE_PROBE_QUEUE_SQL} OR name IN ('summarize_transcript', 'analyze_basic', 'analyze_deep', 'expand_scenarios'))
       GROUP BY name, state
+    `;
+
+    const completedLast30mResult = await db.$queryRaw<Array<{
+      count: bigint;
+    }>>`
+      SELECT COUNT(*) as count
+      FROM pgboss.job
+      WHERE state = 'completed'
+        AND completedon >= NOW() - INTERVAL '30 minutes'
+        AND (${ACTIVE_PROBE_QUEUE_SQL} OR name IN ('summarize_transcript', 'analyze_basic', 'analyze_deep', 'expand_scenarios'))
     `;
 
     // Note: PgBoss v10+ no longer uses a separate archive table.
@@ -121,6 +132,7 @@ export async function getQueueStatus(): Promise<QueueStatus> {
       isRunning: state.isRunning,
       isPaused: state.isPaused,
       jobTypes,
+      completedLast30m: Number(completedLast30mResult[0]?.count ?? 0n),
       totals,
     };
   } catch (error) {
@@ -138,6 +150,7 @@ export async function getQueueStatus(): Promise<QueueStatus> {
         { type: 'analyze_deep', pending: 0, active: 0, completed: 0, failed: 0 },
         { type: 'expand_scenarios', pending: 0, active: 0, completed: 0, failed: 0 },
       ],
+      completedLast30m: 0,
       totals: { pending: 0, active: 0, completed: 0, failed: 0 },
     };
   }

--- a/cloud/apps/api/tests/services/health/queue.test.ts
+++ b/cloud/apps/api/tests/services/health/queue.test.ts
@@ -39,6 +39,7 @@ describe('Queue Health Service', () => {
           { type: 'expand_scenarios', pending: 0, active: 0, completed: 50, failed: 1 },
         ],
         totals: { pending: 5, active: 2, completed: 150, failed: 4 },
+        completedLast30m: 12,
       });
 
       const result = await getQueueHealth();
@@ -49,6 +50,7 @@ describe('Queue Health Service', () => {
       expect(result.pendingJobs).toBe(5);
       expect(result.activeJobs).toBe(2);
       expect(result.completedLast24h).toBe(150);
+      expect(result.completedLast30m).toBe(12);
       expect(result.failedLast24h).toBe(4);
       expect(result.jobTypes).toHaveLength(2);
       expect(result.checkedAt).toBeInstanceOf(Date);
@@ -60,6 +62,7 @@ describe('Queue Health Service', () => {
         isPaused: false,
         jobTypes: [],
         totals: { pending: 0, active: 0, completed: 90, failed: 10 },
+        completedLast30m: 0,
       });
 
       const result = await getQueueHealth();
@@ -74,6 +77,7 @@ describe('Queue Health Service', () => {
         isPaused: false,
         jobTypes: [],
         totals: { pending: 0, active: 0, completed: 0, failed: 0 },
+        completedLast30m: 0,
       });
 
       const result = await getQueueHealth();
@@ -87,6 +91,7 @@ describe('Queue Health Service', () => {
         isPaused: false,
         jobTypes: [],
         totals: { pending: 0, active: 0, completed: 0, failed: 0 },
+        completedLast30m: 0,
       });
 
       const result = await getQueueHealth();
@@ -101,6 +106,7 @@ describe('Queue Health Service', () => {
         isPaused: true,
         jobTypes: [],
         totals: { pending: 10, active: 0, completed: 50, failed: 2 },
+        completedLast30m: 3,
       });
 
       const result = await getQueueHealth();

--- a/cloud/apps/web/src/api/operations/health.graphql
+++ b/cloud/apps/web/src/api/operations/health.graphql
@@ -19,6 +19,7 @@ query SystemHealth($refresh: Boolean) {
       activeJobs
       pendingJobs
       completedLast24h
+      completedLast30m
       failedLast24h
       successRate
       jobTypes {

--- a/cloud/apps/web/src/api/operations/health.ts
+++ b/cloud/apps/web/src/api/operations/health.ts
@@ -32,6 +32,7 @@ export type QueueHealth = {
   activeJobs: number;
   pendingJobs: number;
   completedLast24h: number;
+  completedLast30m: number;
   failedLast24h: number;
   successRate: number | null;
   jobTypes: JobTypeStatus[];

--- a/cloud/apps/web/src/components/status/HeartbeatStrip.tsx
+++ b/cloud/apps/web/src/components/status/HeartbeatStrip.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from 'urql';
+import { cn } from '../../lib/utils';
+import {
+  SYSTEM_HEALTH_QUERY,
+  type SystemHealthQueryResult,
+  type SystemHealthQueryVariables,
+} from '../../api/operations/health';
+import {
+  ACTIVE_EVALUATIONS_QUERY,
+  type ActiveEvaluationsQueryResult,
+  type ActiveEvaluationsQueryVariables,
+} from '../../api/operations/active-evaluation';
+
+const POLL_MS = 30_000;
+const STUCK_AMBER_MS = 10 * 60 * 1000;
+const STUCK_RED_MS = 30 * 60 * 1000;
+const PENDING_AMBER = 100;
+const SUCCESS_RATE_WARN = 0.9;
+
+type Tone = 'ok' | 'warn' | 'bad' | 'idle';
+
+const TONE_VALUE: Record<Tone, string> = {
+  ok: 'text-gray-900',
+  warn: 'text-amber-700',
+  bad: 'text-red-700',
+  idle: 'text-gray-400',
+};
+
+function formatAge(ms: number): string {
+  if (ms < 0) return '0s';
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes > 0 ? `${hours}h ${remMinutes}m` : `${hours}h`;
+}
+
+function formatPercent(value: number | null): string {
+  if (value == null) return '—';
+  return `${Math.round(value * 100)}%`;
+}
+
+type HeartbeatStripProps = {
+  domainId?: string | null;
+};
+
+export function HeartbeatStrip({ domainId }: HeartbeatStripProps) {
+  const normalizedDomainId = domainId != null && domainId.trim() !== '' ? domainId : null;
+
+  const [healthResult, reexecuteHealth] = useQuery<SystemHealthQueryResult, SystemHealthQueryVariables>({
+    query: SYSTEM_HEALTH_QUERY,
+    variables: { refresh: false },
+    requestPolicy: 'cache-and-network',
+  });
+
+  const [evalsResult, reexecuteEvals] = useQuery<ActiveEvaluationsQueryResult, ActiveEvaluationsQueryVariables>({
+    query: ACTIVE_EVALUATIONS_QUERY,
+    variables: { domainId: normalizedDomainId },
+    requestPolicy: 'cache-and-network',
+  });
+
+  const isFetchingRef = useRef(false);
+  useEffect(() => {
+    isFetchingRef.current = healthResult.fetching || evalsResult.fetching;
+  }, [healthResult.fetching, evalsResult.fetching]);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      if (isFetchingRef.current) return;
+      reexecuteHealth({ requestPolicy: 'network-only' });
+      reexecuteEvals({ requestPolicy: 'network-only' });
+    }, POLL_MS);
+    return () => window.clearInterval(id);
+  }, [reexecuteHealth, reexecuteEvals]);
+
+  const queue = healthResult.data?.systemHealth.queue ?? null;
+  const evaluations = useMemo(
+    () => evalsResult.data?.activeEvaluations ?? [],
+    [evalsResult.data?.activeEvaluations],
+  );
+  const hasError = healthResult.error != null || evalsResult.error != null;
+
+  const oldestInFlightMs = useMemo(() => {
+    let oldest: number | null = null;
+    for (const evaluation of evaluations) {
+      for (const member of evaluation.members) {
+        if (member.runStartedAt == null) continue;
+        if (member.runCompletedAt != null) continue;
+        const t = new Date(member.runStartedAt).getTime();
+        if (Number.isNaN(t)) continue;
+        if (oldest == null || t < oldest) oldest = t;
+      }
+    }
+    return oldest;
+  }, [evaluations]);
+
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
+  const healthDataRef = useRef(healthResult.data);
+  const evalsDataRef = useRef(evalsResult.data);
+  useEffect(() => {
+    const healthChanged = healthResult.data != null && healthResult.data !== healthDataRef.current;
+    const evalsChanged = evalsResult.data != null && evalsResult.data !== evalsDataRef.current;
+    if (healthChanged || evalsChanged) {
+      healthDataRef.current = healthResult.data;
+      evalsDataRef.current = evalsResult.data;
+      setLastUpdatedAt(Date.now());
+    }
+  }, [healthResult.data, evalsResult.data]);
+
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const updatedAgo = lastUpdatedAt != null ? formatAge(nowMs - lastUpdatedAt) : '—';
+
+  const throughputTone: Tone =
+    queue == null
+      ? 'idle'
+      : queue.successRate != null && queue.successRate < SUCCESS_RATE_WARN
+        ? 'bad'
+        : 'ok';
+
+  const inFlightTone: Tone =
+    queue == null ? 'idle' : queue.pendingJobs > PENDING_AMBER ? 'warn' : 'ok';
+
+  const oldestTone: Tone =
+    oldestInFlightMs == null
+      ? 'idle'
+      : nowMs - oldestInFlightMs > STUCK_RED_MS
+        ? 'bad'
+        : nowMs - oldestInFlightMs > STUCK_AMBER_MS
+          ? 'warn'
+          : 'ok';
+
+  const dotColor = hasError ? 'bg-red-500' : 'bg-emerald-500';
+
+  return (
+    <section
+      aria-label="System heartbeat"
+      className="rounded-lg border border-gray-200 bg-white shadow-sm"
+    >
+      <div className="grid grid-cols-2 gap-x-6 gap-y-4 px-6 py-4 md:grid-cols-4">
+        <Tile
+          label="Throughput · 30m"
+          value={queue ? queue.completedLast30m.toLocaleString() : '—'}
+          sub={queue ? `${formatPercent(queue.successRate)} success · 24h` : 'Loading…'}
+          tone={throughputTone}
+        />
+        <Tile
+          label="In flight"
+          value={queue ? `${queue.activeJobs}` : '—'}
+          sub={queue ? `${queue.pendingJobs.toLocaleString()} pending` : 'Loading…'}
+          tone={inFlightTone}
+        />
+        <Tile
+          label="Oldest run"
+          value={oldestInFlightMs != null ? formatAge(nowMs - oldestInFlightMs) : '—'}
+          sub={oldestInFlightMs != null ? 'longest active' : 'no active runs'}
+          tone={oldestTone}
+        />
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-wide text-gray-500">
+            <span
+              aria-hidden
+              className={cn('inline-block h-2 w-2 rounded-full animate-pulse', dotColor)}
+            />
+            Heartbeat
+          </div>
+          <div className={cn('text-2xl font-medium tabular-nums', hasError ? 'text-red-700' : 'text-gray-900')}>
+            {updatedAgo}
+          </div>
+          <div className="text-xs text-gray-500">
+            {hasError ? 'last poll failed' : 'since last update'}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type TileProps = {
+  label: string;
+  value: string;
+  sub: string;
+  tone: Tone;
+};
+
+function Tile({ label, value, sub, tone }: TileProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-gray-500">
+        {label}
+      </div>
+      <div className={cn('text-2xl font-medium tabular-nums', TONE_VALUE[tone])}>
+        {value}
+      </div>
+      <div className="text-xs text-gray-500">{sub}</div>
+    </div>
+  );
+}

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -3393,6 +3393,8 @@ export type QueueHealth = {
   checkedAt: Scalars['DateTime']['output'];
   /** Jobs completed in the last 24 hours */
   completedLast24h: Scalars['Int']['output'];
+  /** Jobs completed in the last 30 minutes (rolling window) */
+  completedLast30m: Scalars['Int']['output'];
   /** Error message if queue health check failed */
   error?: Maybe<Scalars['String']['output']>;
   /** Jobs failed in the last 24 hours */
@@ -4634,7 +4636,7 @@ export type SystemHealthQueryVariables = Exact<{
 }>;
 
 
-export type SystemHealthQuery = { __typename?: 'Query', systemHealth: { __typename?: 'SystemHealth', providers: { __typename?: 'ProviderHealth', checkedAt: string, providers: Array<{ __typename?: 'ProviderHealthStatus', id: string, name: string, configured: boolean, connected: boolean, error?: string | null, remainingBudgetUsd?: number | null, lastChecked?: string | null }> }, queue: { __typename?: 'QueueHealth', isHealthy: boolean, isRunning: boolean, isPaused: boolean, activeJobs: number, pendingJobs: number, completedLast24h: number, failedLast24h: number, successRate?: number | null, error?: string | null, checkedAt: string, jobTypes?: Array<{ __typename?: 'JobTypeStatus', type: string, pending: number, active: number, completed: number, failed: number }> | null }, worker: { __typename?: 'WorkerHealth', isHealthy: boolean, pythonVersion?: string | null, packages: unknown, apiKeys: unknown, warnings: Array<string>, error?: string | null, checkedAt: string } } };
+export type SystemHealthQuery = { __typename?: 'Query', systemHealth: { __typename?: 'SystemHealth', providers: { __typename?: 'ProviderHealth', checkedAt: string, providers: Array<{ __typename?: 'ProviderHealthStatus', id: string, name: string, configured: boolean, connected: boolean, error?: string | null, remainingBudgetUsd?: number | null, lastChecked?: string | null }> }, queue: { __typename?: 'QueueHealth', isHealthy: boolean, isRunning: boolean, isPaused: boolean, activeJobs: number, pendingJobs: number, completedLast24h: number, completedLast30m: number, failedLast24h: number, successRate?: number | null, error?: string | null, checkedAt: string, jobTypes?: Array<{ __typename?: 'JobTypeStatus', type: string, pending: number, active: number, completed: number, failed: number }> | null }, worker: { __typename?: 'WorkerHealth', isHealthy: boolean, pythonVersion?: string | null, packages: unknown, apiKeys: unknown, warnings: Array<string>, error?: string | null, checkedAt: string } } };
 
 export type GetLevelPresetsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -7018,6 +7020,7 @@ export const SystemHealthDocument = gql`
       activeJobs
       pendingJobs
       completedLast24h
+      completedLast30m
       failedLast24h
       successRate
       jobTypes {

--- a/cloud/apps/web/src/pages/Status.tsx
+++ b/cloud/apps/web/src/pages/Status.tsx
@@ -1,5 +1,6 @@
 import { useSearchParams } from 'react-router-dom';
 import { ActiveEvaluationsSection } from '../components/status/ActiveEvaluationsSection';
+import { HeartbeatStrip } from '../components/status/HeartbeatStrip';
 import { OpenAnomaliesSection } from '../components/status/OpenAnomaliesSection';
 import { StandaloneActiveRunsSection } from '../components/status/StandaloneActiveRunsSection';
 import { StatusFilters } from '../components/status/StatusFilters';
@@ -16,6 +17,7 @@ export function Status() {
     <div className="space-y-6">
       <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Status</h1>
       <StatusFilters />
+      <HeartbeatStrip domainId={normalizedDomainId} />
       <OpenAnomaliesSection domainId={normalizedDomainId} type={typeFilter} pollIntervalMs={POLL_MS} />
       <ActiveEvaluationsSection domainId={normalizedDomainId} pollIntervalMs={POLL_MS} />
       <StandaloneActiveRunsSection pollIntervalMs={POLL_MS} />


### PR DESCRIPTION
## Summary
- Adds `HeartbeatStrip` above Open Anomalies on the Status page so it's easy to tell at a glance whether the system is making progress
- Four tiles polled every 30s: **Throughput · 30m**, **In flight**, **Oldest run**, **Heartbeat** (seconds since last update with a pulsing dot)
- Stuck-run thresholds: oldest run goes amber after 10 min, red after 30 min. Pending > 100 → amber. Success rate < 90% → red
- New `completedLast30m` field on `SystemHealth.queue` — a true rolling 30-min window via `pgboss.job.completedon`, applying the same name filter as the existing queue status query (probe queues + `summarize_transcript`, `analyze_basic`, `analyze_deep`, `expand_scenarios`)
- Success rate stays sourced from the existing 24h field (30 min is too small a sample to be a meaningful %); sub-line says "X% success · 24h" to make that explicit

## Test plan
- [ ] Visit `/status` on a domain with active runs — strip renders above Open Anomalies, numbers populate
- [ ] Confirm Throughput · 30m matches `SELECT COUNT(*) FROM pgboss.job WHERE state='completed' AND completedon >= NOW() - INTERVAL '30 minutes' AND (probe queue OR analyze/summarize/expand)`
- [ ] Heartbeat tile "Updated Xs ago" ticks each second; resets to "0s" every ~30s when poll completes
- [ ] Oldest run age computes from `min(member.runStartedAt)` over members without `runCompletedAt`; amber > 10m, red > 30m
- [ ] Confirm strip survives empty state (no active evaluations) — Oldest run shows "no active runs"
- [ ] Confirm errored poll flips heartbeat dot red + "last poll failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)