### PR TITLE
feat(ui): replace domain dropdown with models-picker style panel

### DIFF
--- a/cloud/apps/web/src/components/domains/DomainSwitcher.tsx
+++ b/cloud/apps/web/src/components/domains/DomainSwitcher.tsx
@@ -1,10 +1,12 @@
+import { Check } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useDomains } from '../../hooks/useDomains';
 
 const LAST_DOMAIN_KEY = 'valuerank:lastSelectedDomainId';
 
 type DomainSwitcherProps = {
-  currentDomainId: string;
+  /** null means "all domains" is the active selection */
+  currentDomainId: string | null;
   /** Path prefix before the domain ID, e.g. "/domains/status" */
   basePath: string;
 };
@@ -14,24 +16,55 @@ export function DomainSwitcher({ currentDomainId, basePath }: DomainSwitcherProp
   const navigate = useNavigate();
 
   if (domains.length <= 1) {
-    const name = domains.find((d) => d.id === currentDomainId)?.name ?? currentDomainId;
+    const name = domains[0]?.name ?? currentDomainId ?? '';
     return <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">{name}</h1>;
   }
 
+  const handleSelect = (domainId: string | null) => {
+    if (domainId !== null) {
+      localStorage.setItem(LAST_DOMAIN_KEY, domainId);
+      navigate(`${basePath}/${domainId}`);
+    } else {
+      navigate(basePath);
+    }
+  };
+
   return (
-    <select
-      value={currentDomainId}
-      onChange={(e) => {
-        const newId = e.target.value;
-        localStorage.setItem(LAST_DOMAIN_KEY, newId);
-        navigate(`${basePath}/${newId}`);
-      }}
-      className="text-2xl font-serif font-medium text-[#1A1A1A] bg-transparent border-none cursor-pointer pr-8 appearance-none"
-      style={{ backgroundImage: 'url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'12\' height=\'12\' viewBox=\'0 0 12 12\'%3E%3Cpath fill=\'%23666\' d=\'M6 8L1 3h10z\'/%3E%3C/svg%3E")', backgroundRepeat: 'no-repeat', backgroundPosition: 'right 0 center' }}
-    >
-      {domains.map((d) => (
-        <option key={d.id} value={d.id}>{d.name}</option>
-      ))}
-    </select>
+    <div className="border border-gray-200 rounded-lg overflow-hidden">
+      <div className="divide-y divide-gray-100">
+        {/* eslint-disable-next-line react/forbid-elements -- Navigation item requires custom full-width layout */}
+        <button
+          type="button"
+          onClick={() => handleSelect(null)}
+          className={`w-full text-left px-3 py-2 flex items-center justify-between transition-colors ${
+            currentDomainId == null
+              ? 'bg-teal-100 text-teal-900'
+              : 'bg-white hover:bg-gray-100 text-gray-900'
+          }`}
+        >
+          <span className="font-medium text-sm">All Domains</span>
+          {currentDomainId == null && <Check className="w-4 h-4 text-teal-600 ml-4" />}
+        </button>
+        {domains.map((domain) => {
+          const isSelected = currentDomainId === domain.id;
+          return (
+            // eslint-disable-next-line react/forbid-elements -- Navigation item requires custom full-width layout
+            <button
+              key={domain.id}
+              type="button"
+              onClick={() => handleSelect(domain.id)}
+              className={`w-full text-left px-3 py-2 flex items-center justify-between transition-colors ${
+                isSelected
+                  ? 'bg-teal-100 text-teal-900'
+                  : 'bg-white hover:bg-gray-100 text-gray-900'
+              }`}
+            >
+              <span className="font-medium text-sm">{domain.name}</span>
+              {isSelected && <Check className="w-4 h-4 text-teal-600 ml-4" />}
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the native `<select>` element in `DomainSwitcher` with a custom bordered panel matching the `ModelSelector` visual pattern
- Adds an **All Domains** option at the top that navigates to the base path (handled by the existing `StatusRedirect`/`StartRedirect` components)
- Active domain is highlighted with teal background and a check icon, consistent with how models are highlighted in the run form
- Changes `currentDomainId` prop from `string` to `string | null` — `null` means "All Domains" is active (callers always pass a string today; this opens the door for future all-domains views)

## Test plan
- [ ] Preflight passed (lint + build)
- [ ] Manual smoke test: domain switcher renders as a bordered list on Domain Status and Start Batches pages
- [ ] Clicking a domain navigates correctly; check icon appears on the active domain
- [ ] Clicking "All Domains" navigates to the base path and redirects to last-used domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)