### PR TITLE
fix(win-rate): re-initialize model selection when domain/scope switch empties it

### DIFF
--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -290,12 +290,14 @@ export function DomainAnalysis() {
   useEffect(() => {
     if (!initializedModelSelection.current) return;
     setSelectedModelIds((current) => {
-      if (current.length === 0) return current;
+      if (current.length === 0) return current; // User explicitly cleared — preserve
       const validIds = new Set(models.map((model) => model.model));
       const next = current.filter((id) => validIds.has(id));
-      return next.length === current.length ? current : next;
+      if (next.length > 0) return next.length === current.length ? current : next;
+      // All prior selections are gone — domain/scope changed. Re-initialize to default.
+      return defaultSelection;
     });
-  }, [models]);
+  }, [models, defaultSelection]);
 
   const modelOptions = useMemo(
     () => models.map((model) => ({


### PR DESCRIPTION
## Summary
- Fixes a bug where switching domain or scope on the win rate page caused the model picker to show no active models
- Root cause: the filter effect removed all previously selected models when switching context (no overlap with the new domain's model list), and the initialization guard (`initializedModelSelection.current`) prevented the picker from refilling
- Fix: when filtering would produce an empty result (all prior models gone), fall back to `defaultSelection` instead of returning empty. An explicit user "clear all" (selection already `[]` on entry) is still preserved

## Test plan
- [ ] Load `/models/win-rate` — models initialize correctly
- [ ] Switch domain or scope — models picker re-populates with the new domain's defaults instead of going blank
- [ ] Manually deselect all models — empty state is preserved (not auto-refilled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)