### PR TITLE
feat(web): wrap domain table headers

### DIFF
--- a/cloud/apps/web/src/components/models/ConfidenceDomainBreakout.tsx
+++ b/cloud/apps/web/src/components/models/ConfidenceDomainBreakout.tsx
@@ -223,7 +223,7 @@ function SortableHeader({
         size="sm"
         onClick={() => onSort(nextSort)}
         className={cn(
-          'w-full gap-1 rounded-none bg-transparent px-0 py-0 min-h-0 text-[11px] font-semibold text-gray-500 shadow-none transition-colors hover:bg-transparent hover:text-gray-900 focus:ring-0 focus:ring-offset-0',
+          'w-full min-w-0 items-start gap-1 rounded-none bg-transparent px-0 py-0 min-h-0 text-[11px] font-semibold text-gray-500 shadow-none transition-colors hover:bg-transparent hover:text-gray-900 focus:ring-0 focus:ring-offset-0',
           align === 'left' && 'justify-start text-left',
           align === 'center' && 'justify-center text-center',
           align === 'right' && 'justify-end text-right',
@@ -233,9 +233,9 @@ function SortableHeader({
         )}
         aria-label={`Sort by ${label} ${nextSort.direction === 'asc' ? 'ascending' : 'descending'}`}
       >
-        <span className="whitespace-nowrap">{label}</span>
+        <span className="min-w-0 whitespace-normal break-words leading-tight">{label}</span>
         {isActive && (
-          <span aria-hidden="true" className="text-[11px] leading-none text-teal-600">
+          <span aria-hidden="true" className="shrink-0 pt-0.5 text-[11px] leading-none text-teal-600">
             {sort.direction === 'asc' ? '↑' : '↓'}
           </span>
         )}

--- a/cloud/apps/web/src/components/models/DomainShiftsReportSection.tsx
+++ b/cloud/apps/web/src/components/models/DomainShiftsReportSection.tsx
@@ -96,7 +96,7 @@ function SortableHeader({
         size="sm"
         onClick={() => onSort(getNextDomainShiftSort(sort, sortKey))}
         className={cn(
-          'w-full gap-1 rounded-none bg-transparent px-0 py-0 min-h-0 text-[11px] font-semibold uppercase tracking-wide text-gray-500 shadow-none transition-colors hover:bg-transparent hover:text-gray-900 focus:ring-0 focus:ring-offset-0',
+          'w-full min-w-0 items-start gap-1 rounded-none bg-transparent px-0 py-0 min-h-0 text-[11px] font-semibold uppercase tracking-wide text-gray-500 shadow-none transition-colors hover:bg-transparent hover:text-gray-900 focus:ring-0 focus:ring-offset-0',
           align === 'left' && 'justify-start text-left',
           align === 'center' && 'justify-center text-center',
           align === 'right' && 'justify-end text-right',
@@ -104,9 +104,9 @@ function SortableHeader({
         )}
         aria-label={`Sort by ${label} ${nextDirection}`}
       >
-        <span className="whitespace-nowrap">{label}</span>
+        <span className="min-w-0 whitespace-normal break-words leading-tight">{label}</span>
         {isActive && (
-          <span aria-hidden="true" className="text-[11px] leading-none text-gray-400">
+          <span aria-hidden="true" className="shrink-0 pt-0.5 text-[11px] leading-none text-gray-400">
             {sort.direction === 'desc' ? '↑' : '↓'}
           </span>
         )}

--- a/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
+++ b/cloud/apps/web/src/pages/DomainValueShiftHeatmap.tsx
@@ -82,7 +82,7 @@ function SortableHeader({
         size="sm"
         onClick={() => onSort(getNextDomainShiftSort(sort, sortKey))}
         className={cn(
-          'w-full gap-1 rounded-none bg-transparent px-0 py-0 min-h-0 text-[11px] font-semibold uppercase tracking-wide text-gray-500 shadow-none transition-colors hover:bg-transparent hover:text-gray-900 focus:ring-0 focus:ring-offset-0',
+          'w-full min-w-0 items-start gap-1 rounded-none bg-transparent px-0 py-0 min-h-0 text-[11px] font-semibold uppercase tracking-wide text-gray-500 shadow-none transition-colors hover:bg-transparent hover:text-gray-900 focus:ring-0 focus:ring-offset-0',
           align === 'left' && 'justify-start text-left',
           align === 'center' && 'justify-center text-center',
           align === 'right' && 'justify-end text-right',
@@ -90,9 +90,9 @@ function SortableHeader({
         )}
         aria-label={`Sort by ${label} ${nextDirection}`}
       >
-        <span className="whitespace-nowrap">{label}</span>
+        <span className="min-w-0 whitespace-normal break-words leading-tight">{label}</span>
         {isActive && (
-          <span aria-hidden="true" className="text-[11px] leading-none text-gray-400">
+          <span aria-hidden="true" className="shrink-0 pt-0.5 text-[11px] leading-none text-gray-400">
             {sort.direction === 'desc' ? '↑' : '↓'}
           </span>
         )}

--- a/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainValueShiftHeatmap.test.tsx
@@ -433,8 +433,9 @@ describe('DomainValueShiftHeatmap page', () => {
 
     renderPage();
 
-    await screen.findByRole('button', { name: /Sort by City Planning descending/i });
-    await user.click(screen.getByRole('button', { name: /Sort by City Planning descending/i }));
+    const cityPlanningHeader = await screen.findByRole('button', { name: /Sort by City Planning descending/i });
+    expect(cityPlanningHeader).toHaveClass('items-start');
+    await user.click(cityPlanningHeader);
 
     const firstDataRow = screen.getAllByRole('row')[1];
     expect(firstDataRow).toBeDefined();


### PR DESCRIPTION
## Summary
- Let long domain column headers wrap in the Win Rate by Domain by Value table so the columns can fit without forcing horizontal overflow.
- Apply the same wrapping treatment to the matching confidence breakout table headers for consistency.
- Add a regression test that checks the wrapped header styling and still verifies sorting behavior.

## Validation
- `npm run test -- --run tests/pages/DomainValueShiftHeatmap.test.tsx` - passed
- `npm run typecheck` - passed
- `npx turbo lint --filter=@valuerank/web` - passed with existing repo warnings only
- `npx turbo test --filter=@valuerank/web` - passed
- `npx turbo build --filter=@valuerank/web` - passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)