### PR TITLE
[codex] overview supports one trial per condition

### DIFF
--- a/cloud/apps/web/src/components/analysis/tabs/OverviewSummaryTable.tsx
+++ b/cloud/apps/web/src/components/analysis/tabs/OverviewSummaryTable.tsx
@@ -125,8 +125,6 @@ export function OverviewSummaryTable({
   const isPooledAcrossRuns = repeatPatternSources.length > 1;
   const summaryUnavailableMessage = getOverviewUnavailableMessage(
     semantics,
-    analysisMode,
-    companionAnalysis != null,
   );
 
   const helperText = coverageBatchCount !== null && coverageBatchCount !== undefined

--- a/cloud/apps/web/src/components/analysis/tabs/OverviewTabHelpers.ts
+++ b/cloud/apps/web/src/components/analysis/tabs/OverviewTabHelpers.ts
@@ -79,8 +79,6 @@ export function getMetricUnavailableReason(model: ReliabilityViewModel): string 
 
 export function getOverviewUnavailableMessage(
   semantics: AnalysisSemanticsView,
-  analysisMode?: 'single' | 'paired',
-  hasCompanionAnalysis?: boolean,
 ): string | null {
   if (semantics.preference.rowAvailability.status === 'unavailable') {
     return semantics.preference.rowAvailability.message;
@@ -90,12 +88,8 @@ export function getOverviewUnavailableMessage(
     return null;
   }
 
-  if (
-    analysisMode === 'paired'
-    && hasCompanionAnalysis
-    && semantics.reliability.rowAvailability.reason === 'no-repeat-coverage'
-  ) {
-    return 'This paired view has no repeated measurements per condition, so baseline reliability is unavailable. Pooling both vignette orders does not add repeat coverage.';
+  if (semantics.reliability.rowAvailability.reason === 'no-repeat-coverage') {
+    return null;
   }
 
   return semantics.reliability.rowAvailability.message;

--- a/cloud/apps/web/tests/components/analysis/OverviewTab.overview.test.tsx
+++ b/cloud/apps/web/tests/components/analysis/OverviewTab.overview.test.tsx
@@ -206,7 +206,7 @@ describe('OverviewTab', () => {
     expect(screen.getByText('98.3%')).toBeInTheDocument();
   });
 
-  it('uses paired-specific no-repeat wording in overview summary', () => {
+  it('does not show a no-repeat warning in paired-mode overview', () => {
     const semantics = createSemantics();
     semantics.reliability.rowAvailability = {
       status: 'unavailable',
@@ -259,7 +259,68 @@ describe('OverviewTab', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText(/pooling both vignette orders does not add repeat coverage/i)).toBeInTheDocument();
+    expect(screen.getByText('Overview Summary')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/baseline reliability is unavailable/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show a no-repeat warning in single-mode overview', () => {
+    const semantics = createSemantics();
+    semantics.reliability.rowAvailability = {
+      status: 'unavailable',
+      reason: 'no-repeat-coverage',
+      message:
+        'This model has one sample per condition, so baseline reliability is unavailable. Recomputing the same run without repeated samples will not populate this section.',
+    };
+    semantics.reliability.byModel.model1 = {
+      ...semantics.reliability.byModel.model1,
+      availability: semantics.reliability.rowAvailability,
+      baselineReliability: null,
+      baselineNoise: null,
+      directionalAgreement: null,
+      neutralShare: null,
+      coverageCount: 0,
+      uniqueScenarios: 0,
+      repeatCoverageShare: null,
+      contributingRunCount: null,
+      weightedOverallSignedCenterSd: null,
+    };
+
+    render(
+      <MemoryRouter>
+        <OverviewTab
+          runId="run-1"
+          semantics={semantics}
+          completedBatches={3}
+          aggregateSourceRunCount={null}
+          isAggregate={false}
+          analysisMode="single"
+          perModel={{
+            model1: {
+              sampleSize: 3,
+              values: {},
+              overall: { mean: 3, stdDev: 0, min: 1, max: 5 },
+            },
+          }}
+          visualizationData={{
+            decisionDistribution: {},
+            scenarioDimensions: {
+              s1: { Freedom: 'a1', Harmony: 'b1' },
+            },
+            modelScenarioMatrix: {
+              model1: { s1: 5 },
+            },
+          }}
+          varianceAnalysis={createVarianceAnalysis()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Overview Summary')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/baseline reliability is unavailable/i),
+    ).not.toBeInTheDocument();
   });
 
   it('shows the custom header tooltip on focus', async () => {


### PR DESCRIPTION
## What changed
- Relaxed the overview availability guard so `no-repeat-coverage` no longer blocks the Overview tab.
- Updated the overview tests to cover both single and paired mode with one trial per condition.
- Removed the now-unused paired-specific override text from the overview summary path.

## Why
The overview was still acting like repeated trials were required before the page could render useful summary content. That made single-trial-per-condition runs awkward to inspect, even though the rest of the overview data was still available.

## Impact
- Overview now stays usable for one trial per condition in both single and paired mode.
- Reliability data can still show as unavailable where appropriate, but it no longer blocks the overview summary itself.

## Root cause
The overview helper treated `no-repeat-coverage` as a blocking state and surfaced a warning instead of letting the summary render.

## Validation
- `npx turbo lint --filter=@valuerank/web` ✅
- `npx turbo test --filter=@valuerank/web` ✅
- `npx turbo build --filter=@valuerank/web` ✅
- `npm run typecheck` in `cloud/apps/web` ✅
