### PR TITLE
Add probe worker bottleneck timing

### DIFF
--- a/cloud/apps/api/src/graphql/types/index.ts
+++ b/cloud/apps/api/src/graphql/types/index.ts
@@ -10,6 +10,7 @@ import './refs.js';
 // Entity types - order no longer matters since refs are defined centrally
 import './definition.js';
 import './run.js';
+import './run-execution-bottleneck.js';
 import './run-anomaly.js';
 import './run-unresolvable.js';
 import './scenario.js';

--- a/cloud/apps/api/src/graphql/types/probe-result.ts
+++ b/cloud/apps/api/src/graphql/types/probe-result.ts
@@ -24,6 +24,11 @@ builder.objectType(ProbeResultRef, {
     status: t.exposeString('status', {
       description: 'SUCCESS or FAILED',
     }),
+    queuedAt: t.expose('queuedAt', {
+      type: 'DateTime',
+      nullable: true,
+      description: 'When the probe job was enqueued',
+    }),
     // Success fields
     transcriptId: t.exposeString('transcriptId', {
       nullable: true,
@@ -56,6 +61,17 @@ builder.objectType(ProbeResultRef, {
     // Timestamps
     createdAt: t.expose('createdAt', { type: 'DateTime' }),
     completedAt: t.expose('completedAt', { type: 'DateTime', nullable: true }),
+    queueWaitMs: t.int({
+      nullable: true,
+      description: 'Time spent waiting in the queue before the probe result was recorded',
+      resolve: (probeResult) => {
+        if (probeResult.queuedAt === null || probeResult.queuedAt === undefined) {
+          return null;
+        }
+        const completedAt = probeResult.completedAt ?? probeResult.createdAt;
+        return completedAt.getTime() - probeResult.queuedAt.getTime();
+      },
+    }),
   }),
 });
 

--- a/cloud/apps/api/src/graphql/types/run-execution-bottleneck.ts
+++ b/cloud/apps/api/src/graphql/types/run-execution-bottleneck.ts
@@ -1,0 +1,114 @@
+import { builder } from '../builder.js';
+import type {
+  RunExecutionBottleneck as RunExecutionBottleneckShape,
+  ModelExecutionBottleneck as ModelExecutionBottleneckShape,
+  StageSummary,
+  TimingSummary,
+} from '../../services/run/bottleneck.js';
+
+export const TimingSummaryRef = builder.objectRef<TimingSummary>('TimingSummary').implement({
+  description: 'Timing statistics for a set of queue wait or execution samples',
+  fields: (t) => ({
+    sampleCount: t.exposeInt('sampleCount', {
+      description: 'Number of timing samples included in the summary',
+    }),
+    averageMs: t.exposeInt('averageMs', {
+      nullable: true,
+      description: 'Average duration in milliseconds',
+    }),
+    p95Ms: t.exposeInt('p95Ms', {
+      nullable: true,
+      description: '95th percentile duration in milliseconds',
+    }),
+    maxMs: t.exposeInt('maxMs', {
+      nullable: true,
+      description: 'Maximum duration in milliseconds',
+    }),
+  }),
+});
+
+export const StageSummaryRef = builder.objectRef<StageSummary>('StageSummary').implement({
+  description: 'Timing summary for one run stage',
+  fields: (t) => ({
+    totalCount: t.exposeInt('totalCount', {
+      description: 'Total rows considered for this stage',
+    }),
+    failedCount: t.exposeInt('failedCount', {
+      description: 'Number of failed rows in this stage',
+    }),
+    queueWait: t.field({
+      type: TimingSummaryRef,
+      resolve: (stage) => stage.queueWait,
+    }),
+    execution: t.field({
+      type: TimingSummaryRef,
+      resolve: (stage) => stage.execution,
+    }),
+  }),
+});
+
+export const RunExecutionBottleneckRef = builder.objectRef<RunExecutionBottleneckShape>('RunExecutionBottleneck').implement({
+  description: 'Derived bottleneck diagnosis for probe and summarize work on a run',
+  fields: (t) => ({
+    stage: t.exposeString('stage', {
+      description: 'Likely bottleneck stage',
+    }),
+    action: t.exposeString('action', {
+      description: 'Recommended tuning action',
+    }),
+    confidence: t.exposeString('confidence', {
+      description: 'Confidence in the diagnosis',
+    }),
+    recommendation: t.exposeString('recommendation', {
+      description: 'Human-readable recommendation',
+    }),
+    probe: t.field({
+      type: StageSummaryRef,
+      resolve: (summary) => summary.probe,
+    }),
+    summarize: t.field({
+      type: StageSummaryRef,
+      resolve: (summary) => summary.summarize,
+    }),
+  }),
+});
+
+export const ModelExecutionBottleneckRef = builder.objectRef<ModelExecutionBottleneckShape>('ModelExecutionBottleneck').implement({
+  description: 'Derived bottleneck diagnosis for a specific model within a run',
+  fields: (t) => ({
+    modelId: t.exposeString('modelId', {
+      description: 'Model identifier',
+    }),
+    displayName: t.exposeString('displayName', {
+      nullable: true,
+      description: 'Human-readable model name if available',
+    }),
+    providerName: t.exposeString('providerName', {
+      nullable: true,
+      description: 'Provider name if available',
+    }),
+    pressureMs: t.exposeInt('pressureMs', {
+      description: 'Dominant timing pressure for this model in milliseconds',
+    }),
+    stage: t.exposeString('stage', {
+      description: 'Likely bottleneck stage for this model',
+    }),
+    action: t.exposeString('action', {
+      description: 'Recommended tuning action for this model',
+    }),
+    confidence: t.exposeString('confidence', {
+      description: 'Confidence in the diagnosis',
+    }),
+    recommendation: t.exposeString('recommendation', {
+      description: 'Human-readable recommendation',
+    }),
+    probe: t.field({
+      type: StageSummaryRef,
+      resolve: (summary) => summary.probe,
+    }),
+    summarize: t.field({
+      type: StageSummaryRef,
+      resolve: (summary) => summary.summarize,
+    }),
+  }),
+});

--- a/cloud/apps/api/src/graphql/types/run.ts
+++ b/cloud/apps/api/src/graphql/types/run.ts
@@ -5,7 +5,8 @@ import { UserRef } from './user.js';
 import { RunProgress, TaskResult } from './run-progress.js';
 import { ExecutionMetrics } from './execution-metrics.js';
 import { ProbeResultRef, ProbeResultModelSummary } from './probe-result.js';
-import { calculatePercentComplete, computeRunProgress } from '../../services/run/index.js';
+import { ModelExecutionBottleneckRef, RunExecutionBottleneckRef } from './run-execution-bottleneck.js';
+import { calculatePercentComplete, computeRunProgress, getRunExecutionBottleneck, getRunModelExecutionBottlenecks } from '../../services/run/index.js';
 import { ACTIVE_PROBE_QUEUE_SQL } from '../../services/queue/probe-queues.js';
 import { AnalysisResultRef } from './analysis.js';
 import { CostEstimateRef, type CostEstimateShape } from './cost-estimate.js';
@@ -571,6 +572,20 @@ builder.objectType(RunRef, {
           totalRetries,
         };
       },
+    }),
+
+    executionBottleneck: t.field({
+      type: RunExecutionBottleneckRef,
+      description:
+        'Derived bottleneck diagnosis for probe and summarize work, useful for deciding whether to increase parallelism or investigate worker latency',
+      resolve: async (run) => getRunExecutionBottleneck(run.id),
+    }),
+
+    modelExecutionBottlenecks: t.field({
+      type: [ModelExecutionBottleneckRef],
+      description:
+        'Derived bottleneck diagnosis broken down by model, useful for identifying a specific model that is causing slowdowns or failures',
+      resolve: async (run) => getRunModelExecutionBottlenecks(run.id),
     }),
 
     // Probe results - detailed success/failure info for each model/scenario with pagination

--- a/cloud/apps/api/src/graphql/types/transcript.ts
+++ b/cloud/apps/api/src/graphql/types/transcript.ts
@@ -25,6 +25,31 @@ builder.objectType(TranscriptRef, {
     turnCount: t.exposeInt('turnCount'),
     tokenCount: t.exposeInt('tokenCount'),
     durationMs: t.exposeInt('durationMs'),
+    summarizeQueuedAt: t.expose('summarizeQueuedAt', {
+      type: 'DateTime',
+      nullable: true,
+      description: 'When the summarize job was enqueued',
+    }),
+    summarizeDurationMs: t.exposeInt('summarizeDurationMs', {
+      nullable: true,
+      description: 'Time spent processing the summarize job',
+    }),
+    summarizeQueueWaitMs: t.int({
+      nullable: true,
+      description: 'Time spent waiting in the queue before summarization completed',
+      resolve: (transcript) => {
+        if (transcript.summarizeQueuedAt === null || transcript.summarizeQueuedAt === undefined) {
+          return null;
+        }
+
+        const completedAt = transcript.summarizedAt ?? transcript.summarizeFailedAt;
+        if (completedAt === null || completedAt === undefined) {
+          return null;
+        }
+
+        return completedAt.getTime() - transcript.summarizeQueuedAt.getTime();
+      },
+    }),
     decisionMetadata: t.expose('decisionMetadata', {
       type: 'JSON',
       nullable: true,

--- a/cloud/apps/api/src/queue/handlers/probe-dead-letter.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-dead-letter.ts
@@ -28,9 +28,19 @@ export function createProbeDeadLetterHandler(): PgBoss.WorkHandler<ProbeDeadLett
     for (const job of jobs) {
       const { runId, scenarioId, modelId, sampleIndex = 0 } = job.data;
       const jobId = job.id;
+      const queueWaitMs = (() => {
+        if (typeof job.data.enqueuedAt !== 'string' || job.data.enqueuedAt.trim() === '') {
+          return null;
+        }
+        const queuedAtMs = Date.parse(job.data.enqueuedAt);
+        if (Number.isNaN(queuedAtMs)) {
+          return null;
+        }
+        return Math.max(0, Date.now() - queuedAtMs);
+      })();
 
       log.error(
-        { jobId, runId, scenarioId, modelId, sampleIndex },
+        { phase: 'probe:dead-letter', jobId, runId, scenarioId, modelId, sampleIndex, queueWaitMs },
         'Probe job failed/expired - processing dead letter'
       );
 
@@ -49,6 +59,7 @@ export function createProbeDeadLetterHandler(): PgBoss.WorkHandler<ProbeDeadLett
           scenarioId,
           modelId,
           sampleIndex,
+          queuedAt: job.data.enqueuedAt ?? null,
           errorCode: 'JOB_EXPIRED',
           errorMessage: 'Job expired or failed without completing - moved to dead letter queue',
           retryCount: 0,
@@ -57,17 +68,19 @@ export function createProbeDeadLetterHandler(): PgBoss.WorkHandler<ProbeDeadLett
         const result = await maybeAdvanceRunStatus(runId);
 
         log.info(
-          { jobId, runId, scenarioId, modelId, sampleIndex, result },
+          { phase: 'probe:dead-letter:complete', jobId, runId, scenarioId, modelId, sampleIndex, queueWaitMs, result },
           'Dead letter job processed - run progress updated'
         );
       } catch (error) {
         log.error(
           {
+            phase: 'probe:dead-letter:failed',
             jobId,
             runId,
             scenarioId,
             modelId,
             sampleIndex,
+            queueWaitMs,
             err: error,
             jobData: job.data,
           },

--- a/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
@@ -34,6 +34,19 @@ const log = createLogger('queue:probe-scenario');
 // Retry limit from job options (default 3)
 const RETRY_LIMIT = DEFAULT_JOB_OPTIONS['probe_scenario'].retryLimit ?? 3;
 
+function computeQueueWaitMs(enqueuedAt: string | null | undefined, nowMs: number): number | null {
+  if (typeof enqueuedAt !== 'string' || enqueuedAt.trim() === '') {
+    return null;
+  }
+
+  const queuedAtMs = Date.parse(enqueuedAt);
+  if (Number.isNaN(queuedAtMs)) {
+    return null;
+  }
+
+  return Math.max(0, nowMs - queuedAtMs);
+}
+
 async function enqueueSummarizeTranscriptSingleton(runId: string, transcriptId: string): Promise<void> {
   const { getBoss } = await import('../../boss.js');
   const { DEFAULT_JOB_OPTIONS: jobOptions } = await import('../../types.js');
@@ -44,6 +57,7 @@ async function enqueueSummarizeTranscriptSingleton(runId: string, transcriptId: 
     {
       runId,
       transcriptId,
+      enqueuedAt: new Date().toISOString(),
     },
     {
       ...jobOptions['summarize_transcript'],
@@ -61,6 +75,8 @@ async function enqueueSummarizeTranscriptSingleton(runId: string, transcriptId: 
 async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<void> {
   const { runId, scenarioId, modelId, sampleIndex = 0, config } = job.data;
   const jobId = job.id;
+  const jobStartMs = Date.now();
+  const queueWaitMs = computeQueueWaitMs(job.data.enqueuedAt, jobStartMs);
   const probeResultKey = {
     runId_scenarioId_modelId_sampleIndex: {
       runId,
@@ -71,7 +87,17 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
   };
 
   log.info(
-    { jobId, runId, scenarioId, modelId, sampleIndex, config },
+    {
+      phase: 'probe:received',
+      jobId,
+      runId,
+      scenarioId,
+      modelId,
+      sampleIndex,
+      queueWaitMs,
+      enqueuedAt: job.data.enqueuedAt ?? null,
+      config,
+    },
     'Processing probe_scenario job'
   );
 
@@ -106,14 +132,24 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
       typeof existingProbeResult.transcriptId === 'string' &&
       existingProbeResult.transcriptId !== ''
     ) {
-      log.info(
-        { jobId, runId, scenarioId, modelId, sampleIndex, transcriptId: existingProbeResult.transcriptId },
-        'Skipping probe job - result already succeeded'
-      );
       if (job.data.manualReprobe !== true) {
         await enqueueTopUpProbesSingleton(runId);
       }
       await maybeAdvanceRunStatus(runId);
+      log.info(
+        {
+          phase: 'probe:skip:already-succeeded',
+          jobId,
+          runId,
+          scenarioId,
+          modelId,
+          sampleIndex,
+          queueWaitMs,
+          totalDurationMs: Date.now() - jobStartMs,
+          transcriptId: existingProbeResult.transcriptId,
+        },
+        'Skipping probe job - result already succeeded'
+      );
       return;
     }
 
@@ -124,14 +160,24 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
       existingProbeResult.status === 'FAILED' &&
       currentRetryCount > 0
     ) {
-      log.info(
-        { jobId, runId, scenarioId, modelId, sampleIndex, currentRetryCount },
-        'Skipping probe job - already terminal failed'
-      );
       if (job.data.manualReprobe !== true) {
         await enqueueTopUpProbesSingleton(runId);
       }
       await maybeAdvanceRunStatus(runId);
+      log.info(
+        {
+          phase: 'probe:skip:already-failed',
+          jobId,
+          runId,
+          scenarioId,
+          modelId,
+          sampleIndex,
+          queueWaitMs,
+          totalDurationMs: Date.now() - jobStartMs,
+          retryCount: currentRetryCount,
+        },
+        'Skipping probe job - already terminal failed'
+      );
       return;
     }
 
@@ -154,6 +200,7 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
     });
 
     if (existingTranscript !== null) {
+      const persistStartMs = Date.now();
       const tokenUsage = extractStoredTranscriptTokenUsage(
         existingTranscript.content,
         existingTranscript.tokenCount
@@ -164,11 +211,13 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
         scenarioId,
         modelId,
         sampleIndex,
+        queuedAt: job.data.enqueuedAt ?? null,
         transcriptId: existingTranscript.id,
         durationMs: existingTranscript.durationMs,
         inputTokens: tokenUsage.inputTokens,
         outputTokens: tokenUsage.outputTokens,
       });
+      const persistDurationMs = Date.now() - persistStartMs;
 
       const advanceResult = await maybeAdvanceRunStatus(runId);
       const currentRun = await db.run.findUnique({
@@ -179,7 +228,19 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
         await enqueueSummarizeTranscriptSingleton(runId, existingTranscript.id);
       }
       log.info(
-        { jobId, runId, scenarioId, modelId, sampleIndex, transcriptId: existingTranscript.id, advanceResult },
+        {
+          phase: 'probe:persist:recovered',
+          jobId,
+          runId,
+          scenarioId,
+          modelId,
+          sampleIndex,
+          queueWaitMs,
+          persistDurationMs,
+          totalDurationMs: Date.now() - jobStartMs,
+          transcriptId: existingTranscript.id,
+          advanceResult,
+        },
         'Recovered probe result from existing transcript'
       );
       return;
@@ -202,7 +263,19 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
       config
     );
 
-    log.debug({ jobId, workerInput }, 'Calling Python probe worker');
+    const workerStartMs = Date.now();
+    log.info(
+      {
+        phase: 'probe:worker:start',
+        jobId,
+        runId,
+        scenarioId,
+        modelId,
+        sampleIndex,
+        queueWaitMs,
+      },
+      'Calling Python probe worker'
+    );
 
     // Execute Python probe worker
     const result = await spawnPython<ProbeWorkerInput, ProbeWorkerOutput>(
@@ -210,10 +283,25 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
       workerInput,
       { cwd: path.resolve(process.cwd(), '../..') } // cloud/ directory
     );
+    const workerDurationMs = Date.now() - workerStartMs;
 
     // Handle spawn failure
     if (!result.success) {
-      log.error({ jobId, runId, error: result.error, stderr: result.stderr }, 'Python spawn failed');
+      log.error(
+        {
+          phase: 'probe:worker:spawn-failed',
+          jobId,
+          runId,
+          scenarioId,
+          modelId,
+          sampleIndex,
+          queueWaitMs,
+          workerDurationMs,
+          error: result.error,
+          stderr: result.stderr,
+        },
+        'Python spawn failed'
+      );
       throw new Error(`Python worker failed: ${result.error}`);
     }
 
@@ -221,7 +309,20 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
     const output = result.data;
     if (!output.success) {
       const err = output.error;
-      log.warn({ jobId, runId, error: err }, 'Probe worker returned error');
+      log.warn(
+        {
+          phase: 'probe:worker:failed',
+          jobId,
+          runId,
+          scenarioId,
+          modelId,
+          sampleIndex,
+          queueWaitMs,
+          workerDurationMs,
+          error: err,
+        },
+        'Probe worker returned error'
+      );
 
       // Use Python's retryable flag if available
       if (!err.retryable) {
@@ -231,23 +332,67 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
         // surface those failures), so this caller must wrap it. Keep the original
         // probe-failed semantics: never block job completion on a metadata write.
         try {
+          const persistStartMs = Date.now();
           await recordProbeFailure({
             runId,
             scenarioId,
             modelId,
             sampleIndex,
+            queuedAt: job.data.enqueuedAt ?? null,
             errorCode: err.code,
             errorMessage,
             retryCount: 0,
           });
+          const persistDurationMs = Date.now() - persistStartMs;
+          log.info(
+            {
+              phase: 'probe:persist:failure',
+              jobId,
+              runId,
+              scenarioId,
+              modelId,
+              sampleIndex,
+              queueWaitMs,
+              workerDurationMs,
+              persistDurationMs,
+              totalDurationMs: Date.now() - jobStartMs,
+              errorCode: err.code,
+            },
+            'Recorded probe failure'
+          );
         } catch (recordErr) {
           log.error(
-            { jobId, runId, scenarioId, modelId, err: recordErr },
+            {
+              phase: 'probe:persist:failure',
+              jobId,
+              runId,
+              scenarioId,
+              modelId,
+              sampleIndex,
+              queueWaitMs,
+              workerDurationMs,
+              error: recordErr,
+            },
             'Failed to record probe failure — continuing'
           );
         }
         const advanceResult = await maybeAdvanceRunStatus(runId);
-        log.error({ jobId, runId, advanceResult, error: err }, 'Probe job permanently failed');
+        log.error(
+          {
+            phase: 'probe:complete:failed',
+            jobId,
+            runId,
+            scenarioId,
+            modelId,
+            sampleIndex,
+            queueWaitMs,
+            workerDurationMs,
+            totalDurationMs: Date.now() - jobStartMs,
+            advanceResult,
+            error: err,
+          },
+          'Probe job permanently failed'
+        );
         return; // Complete job without retrying
       }
 
@@ -320,16 +465,19 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
     const completedAt = new Date(output.transcript.completedAt);
     const durationMs = completedAt.getTime() - startedAt.getTime();
 
+    const persistStartMs = Date.now();
     await recordProbeSuccess({
       runId,
       scenarioId,
       modelId,
       sampleIndex,
+      queuedAt: job.data.enqueuedAt ?? null,
       transcriptId: transcriptRecord.id,
       durationMs,
       inputTokens: output.transcript.totalInputTokens,
       outputTokens: output.transcript.totalOutputTokens,
     });
+    const persistDurationMs = Date.now() - persistStartMs;
 
     const advanceResult = await maybeAdvanceRunStatus(runId);
     const currentRun = await db.run.findUnique({
@@ -356,7 +504,7 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
       const boss = getBoss();
       await boss.send(
         'summarize_transcript',
-        { runId, transcriptId: transcriptRecord.id, anomalyId },
+        { runId, transcriptId: transcriptRecord.id, anomalyId, enqueuedAt: new Date().toISOString() },
         { ...jobOptions['summarize_transcript'], singletonKey: transcriptRecord.id },
       );
       await setReprobeStage(anomalyId, 'summarizing', { transcriptId: transcriptRecord.id });
@@ -364,7 +512,21 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
     }
 
     log.info(
-      { jobId, runId, scenarioId, modelId, sampleIndex, transcriptId: transcriptRecord.id, advanceResult, turns: output.transcript.turns.length },
+      {
+        phase: 'probe:complete',
+        jobId,
+        runId,
+        scenarioId,
+        modelId,
+        sampleIndex,
+        transcriptId: transcriptRecord.id,
+        queueWaitMs,
+        workerDurationMs,
+        persistDurationMs,
+        totalDurationMs: Date.now() - jobStartMs,
+        advanceResult,
+        turns: output.transcript.turns.length,
+      },
       'Probe job completed'
     );
   } catch (error) {
@@ -375,7 +537,7 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
 
     const retryCount = (job as unknown as { retrycount?: number }).retrycount ?? 0;
     const terminal = await handleJobError(
-      error, jobId, runId, scenarioId, modelId, sampleIndex, retryCount, RETRY_LIMIT, probeResultKey
+      error, jobId, runId, scenarioId, modelId, sampleIndex, retryCount, RETRY_LIMIT, job.data.enqueuedAt, probeResultKey
     );
     if (terminal) {
       return;

--- a/cloud/apps/api/src/queue/handlers/probe-scenario/retry.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-scenario/retry.ts
@@ -149,13 +149,24 @@ export async function handleJobError(
   sampleIndex: number,
   retryCount: number,
   retryLimit: number,
+  queuedAt: string | null | undefined,
   _probeResultKey: ProbeResultKey
 ): Promise<boolean> {
   const retryable = isRetryableError(error);
   const maxRetriesReached = retryCount >= retryLimit;
+  const queueWaitMs = (() => {
+    if (typeof queuedAt !== 'string' || queuedAt.trim() === '') {
+      return null;
+    }
+    const queuedAtMs = Date.parse(queuedAt);
+    if (Number.isNaN(queuedAtMs)) {
+      return null;
+    }
+    return Math.max(0, Date.now() - queuedAtMs);
+  })();
 
   log.warn(
-    { jobId, runId, scenarioId, modelId, retryable, retryCount, maxRetriesReached, err: error },
+    { phase: 'probe:error', jobId, runId, scenarioId, modelId, queueWaitMs, retryable, retryCount, maxRetriesReached, err: error },
     'Probe job error'
   );
 
@@ -168,6 +179,7 @@ export async function handleJobError(
         scenarioId,
         modelId,
         sampleIndex,
+        queuedAt: queuedAt ?? null,
         errorCode,
         errorMessage,
         retryCount,
@@ -175,12 +187,12 @@ export async function handleJobError(
       const result = await maybeAdvanceRunStatus(runId);
       await enqueueTopUpProbesSingleton(runId);
       log.error(
-        { jobId, runId, scenarioId, modelId, result, retryCount, err: error },
+        { phase: 'probe:complete:failed', jobId, runId, scenarioId, modelId, queueWaitMs, result, retryCount, err: error },
         'Probe job permanently failed'
       );
     } catch (progressError) {
       log.error(
-        { jobId, runId, err: progressError },
+        { phase: 'probe:complete:failed', jobId, runId, queueWaitMs, err: progressError },
         'Failed to update progress after job failure'
       );
     }
@@ -188,7 +200,7 @@ export async function handleJobError(
   }
 
   log.info(
-    { jobId, runId, retryCount, retriesRemaining: retryLimit - retryCount },
+    { phase: 'probe:retry', jobId, runId, queueWaitMs, retryCount, retriesRemaining: retryLimit - retryCount },
     'Job will be retried'
   );
   return false; // caller should rethrow

--- a/cloud/apps/api/src/queue/handlers/summarize-persistence.ts
+++ b/cloud/apps/api/src/queue/handlers/summarize-persistence.ts
@@ -15,6 +15,22 @@ import { isRecord } from '../../utils/isRecord.js';
 
 const log = createLogger('queue:summarize-transcript');
 
+export type SummarizeTimingInfo = {
+  queuedAt?: string | null;
+  queueWaitMs?: number | null;
+  durationMs?: number | null;
+};
+
+function buildSummarizeTimingUpdate(timing?: SummarizeTimingInfo): {
+  summarizeQueuedAt?: Date;
+  summarizeDurationMs?: number;
+} {
+  return {
+    summarizeQueuedAt: timing?.queuedAt != null ? new Date(timing.queuedAt) : undefined,
+    summarizeDurationMs: timing?.durationMs ?? undefined,
+  };
+}
+
 export function buildSummaryCacheRecord(
   summary: {
     decisionText: string | null;
@@ -148,6 +164,7 @@ export async function persistCachedSummary(
   responseSha256: string | null,
   parserVersion: string,
   modelId: string,
+  timing?: SummarizeTimingInfo,
 ): Promise<void> {
   const rawDecisionEvidence = buildRawDecisionEvidence(summaryCache.summary.decisionMetadata);
   const persistedSummaryCache = responseSha256
@@ -163,6 +180,7 @@ export async function persistCachedSummary(
       )
     : null;
 
+  const updateStartMs = Date.now();
   await db.transcript.update({
     where: { id: transcript.id },
     data: {
@@ -174,10 +192,38 @@ export async function persistCachedSummary(
       ),
       summarizeFailedAt: null,
       summarizedAt: new Date(),
+      ...buildSummarizeTimingUpdate(timing),
     },
   });
+  const updateDurationMs = Date.now() - updateStartMs;
 
+  log.info(
+    {
+      phase: 'summarize:persist:cached',
+      jobId: job.id,
+      runId: job.data.runId,
+      transcriptId: transcript.id,
+      queueWaitMs: timing?.queueWaitMs ?? null,
+      workerDurationMs: timing?.durationMs ?? null,
+      updateDurationMs,
+    },
+    'Persisted cached transcript summary'
+  );
+
+  const sideEffectsStartMs = Date.now();
   await refreshPostSummarySideEffects(job.data.runId, transcript.id);
+  log.info(
+    {
+      phase: 'summarize:persist:side-effects',
+      jobId: job.id,
+      runId: job.data.runId,
+      transcriptId: transcript.id,
+      queueWaitMs: timing?.queueWaitMs ?? null,
+      workerDurationMs: timing?.durationMs ?? null,
+      sideEffectsDurationMs: Date.now() - sideEffectsStartMs,
+    },
+    'Completed post-summary side effects'
+  );
 }
 
 export async function persistSuccessfulSummary(
@@ -188,6 +234,7 @@ export async function persistSuccessfulSummary(
   modelId: string,
   canonicalDecision: WinnerFirstSummaryCache | null,
   summary: { decisionText: string | null; decisionMetadata?: unknown },
+  timing?: SummarizeTimingInfo,
 ): Promise<void> {
   const rawDecisionEvidence = buildRawDecisionEvidence(summary.decisionMetadata);
   const freshSummaryCache = responseSha256
@@ -202,6 +249,7 @@ export async function persistSuccessfulSummary(
       )
     : null;
 
+  const updateStartMs = Date.now();
   await db.transcript.update({
     where: { id: transcript.id },
     data: {
@@ -213,18 +261,45 @@ export async function persistSuccessfulSummary(
       ),
       summarizeFailedAt: null,
       summarizedAt: new Date(),
+      ...buildSummarizeTimingUpdate(timing),
     },
   });
+  const updateDurationMs = Date.now() - updateStartMs;
 
-  log.info({ jobId: job.id, transcriptId: transcript.id }, 'Transcript summarized');
+  log.info(
+    {
+      phase: 'summarize:persist:success',
+      jobId: job.id,
+      runId: job.data.runId,
+      transcriptId: transcript.id,
+      queueWaitMs: timing?.queueWaitMs ?? null,
+      workerDurationMs: timing?.durationMs ?? null,
+      updateDurationMs,
+    },
+    'Transcript summarized'
+  );
 
+  const sideEffectsStartMs = Date.now();
   await refreshPostSummarySideEffects(job.data.runId, transcript.id);
+  log.info(
+    {
+      phase: 'summarize:persist:side-effects',
+      jobId: job.id,
+      runId: job.data.runId,
+      transcriptId: transcript.id,
+      queueWaitMs: timing?.queueWaitMs ?? null,
+      workerDurationMs: timing?.durationMs ?? null,
+      sideEffectsDurationMs: Date.now() - sideEffectsStartMs,
+    },
+    'Completed post-summary side effects'
+  );
 }
 
 export async function persistSummarizeFailure(
   job: { id: string; data: SummarizeTranscriptJobData; retrycount?: number },
   transcript: { id: string },
   error: { message: string; code: string; retryable: boolean; details?: unknown },
+  timing?: SummarizeTimingInfo,
 ): Promise<boolean> {
   const retryCount = job.retrycount ?? 0;
   const maxRetriesReached = retryCount >= (DEFAULT_JOB_OPTIONS['summarize_transcript'].retryLimit ?? 3);
@@ -242,14 +317,33 @@ export async function persistSummarizeFailure(
     ? `Summary failed after ${retryCount} retries: ${error.message}`
     : `Summary failed: ${error.message}`;
 
+  const updateStartMs = Date.now();
   await db.transcript.update({
     where: { id: transcript.id },
     data: {
       decisionText: failureText,
       decisionMetadata: Prisma.DbNull,
       summarizeFailedAt: new Date(),
+      ...buildSummarizeTimingUpdate(timing),
     },
   });
+  const updateDurationMs = Date.now() - updateStartMs;
+
+  log.warn(
+    {
+      phase: 'summarize:persist:failure',
+      jobId: job.id,
+      runId: job.data.runId,
+      transcriptId: transcript.id,
+      queueWaitMs: timing?.queueWaitMs ?? null,
+      workerDurationMs: timing?.durationMs ?? null,
+      updateDurationMs,
+      retryCount,
+      maxRetriesReached,
+      error,
+    },
+    'Persisted failed transcript summary'
+  );
 
   await maybeAdvanceRunStatus(job.data.runId);
   return false;

--- a/cloud/apps/api/src/queue/handlers/summarize-transcript.ts
+++ b/cloud/apps/api/src/queue/handlers/summarize-transcript.ts
@@ -31,6 +31,7 @@ import {
   persistCachedSummary,
   persistSummarizeFailure,
   persistSuccessfulSummary,
+  type SummarizeTimingInfo,
 } from './summarize-persistence.js';
 import { isRecord } from '../../utils/isRecord.js';
 
@@ -38,6 +39,19 @@ const log = createLogger('queue:summarize-transcript');
 let batchCounter = 0;
 const _RETRY_LIMIT = 3;
 const PYTHON_WORKER_PATH = 'workers/summarize.py';
+
+function computeQueueWaitMs(enqueuedAt: string | null | undefined, nowMs: number): number | null {
+  if (typeof enqueuedAt !== 'string' || enqueuedAt.trim() === '') {
+    return null;
+  }
+
+  const queuedAtMs = Date.parse(enqueuedAt);
+  if (Number.isNaN(queuedAtMs)) {
+    return null;
+  }
+
+  return Math.max(0, nowMs - queuedAtMs);
+}
 
 type SummarizeWorkerInput = {
   transcriptId: string;
@@ -101,8 +115,8 @@ type PreparedSummarizeJob = {
 
 type ResolveSummarizeJobResult =
   | { kind: 'missing' }
-  | { kind: 'cache-hit' }
-  | { kind: 'skipped' }
+  | { kind: 'cache-hit'; resolveDurationMs: number }
+  | { kind: 'skipped'; resolveDurationMs: number }
   | { kind: 'pending'; job: PreparedSummarizeJob };
 
 function getProviderNameFromModelId(modelId: string, fallbackProvider: string): string {
@@ -186,13 +200,24 @@ async function resolveSummarizeJob(
   job: PgBoss.Job<SummarizeTranscriptJobData>,
   infraModel: InfraModelConfig,
 ): Promise<ResolveSummarizeJobResult> {
+  const resolveStart = Date.now();
   const { db } = await import('@valuerank/db');
   const { transcriptId, summaryModelId } = job.data;
   const modelId = summaryModelId ?? `${infraModel.providerName}:${infraModel.modelId}`;
   const providerName = getProviderNameFromModelId(modelId, infraModel.providerName);
+  const queueWaitMs = computeQueueWaitMs(job.data.enqueuedAt, resolveStart);
 
   log.info(
-    { jobId: job.id, runId: job.data.runId, transcriptId, modelId },
+    {
+      phase: 'summarize:received',
+      jobId: job.id,
+      runId: job.data.runId,
+      transcriptId,
+      modelId,
+      providerName,
+      queueWaitMs,
+      enqueuedAt: job.data.enqueuedAt ?? null,
+    },
     'Processing summarize_transcript job'
   );
 
@@ -216,24 +241,73 @@ async function resolveSummarizeJob(
     : null;
   const parserVersion = config.SUMMARIZE_PARSER_VERSION;
   const forceSummarize = job.data.forceSummarize === true;
+  const resolveDurationMs = () => Date.now() - resolveStart;
 
   if (!forceSummarize && summaryCache && isCacheRecordMatch(summaryCache, responseSha256, parserVersion, modelId)) {
-    log.info({ jobId: job.id, transcriptId, modelId }, 'Transcript summary cache hit');
+    log.info(
+      {
+        phase: 'summarize:cache-hit',
+        jobId: job.id,
+        runId: job.data.runId,
+        transcriptId,
+        modelId,
+        providerName,
+        queueWaitMs,
+        resolveDurationMs: resolveDurationMs(),
+      },
+      'Transcript summary cache hit'
+    );
 
     if (!isTerminal) {
-      await persistCachedSummary(job, transcript, summaryCache, responseSha256, parserVersion, modelId);
+      await persistCachedSummary(
+        job,
+        transcript,
+        summaryCache,
+        responseSha256,
+        parserVersion,
+        modelId,
+        {
+          queuedAt: job.data.enqueuedAt ?? null,
+          queueWaitMs,
+          durationMs: resolveDurationMs(),
+        },
+      );
     }
 
-    return { kind: 'cache-hit' };
+    return { kind: 'cache-hit', resolveDurationMs: resolveDurationMs() };
   }
 
   if (!forceSummarize && !hasSummaryCacheField && isTerminal) {
-    log.info({ jobId: job.id, transcriptId }, 'Transcript already summarized, skipping');
-    return { kind: 'skipped' };
+    log.info(
+      {
+        phase: 'summarize:skip:already-terminal',
+        jobId: job.id,
+        runId: job.data.runId,
+        transcriptId,
+        modelId,
+        providerName,
+        queueWaitMs,
+        resolveDurationMs: resolveDurationMs(),
+      },
+      'Transcript already summarized, skipping'
+    );
+    return { kind: 'skipped', resolveDurationMs: resolveDurationMs() };
   }
 
   if (!forceSummarize && hasSummaryCacheField) {
-    log.info({ jobId: job.id, transcriptId, modelId }, 'Transcript summary cache miss, re-summarizing');
+    log.info(
+      {
+        phase: 'summarize:cache-miss',
+        jobId: job.id,
+        runId: job.data.runId,
+        transcriptId,
+        modelId,
+        providerName,
+        queueWaitMs,
+        resolveDurationMs: resolveDurationMs(),
+      },
+      'Transcript summary cache miss, re-summarizing'
+    );
   }
 
   return {
@@ -260,6 +334,7 @@ async function processSummarizeBatchGroup(
     return null;
   }
 
+  const groupStartTime = Date.now();
   const firstJob = pendingJobs[0];
   if (!firstJob) {
     return new Error('Python worker batch received no pending jobs');
@@ -275,18 +350,20 @@ async function processSummarizeBatchGroup(
     })),
   };
 
-  log.debug(
+  log.info(
     {
+      phase: 'summarize:worker:queued',
       batchId,
       groupIndex,
-      modelId,
       providerName,
+      modelId,
       transcriptIds: pendingJobs.map((pendingJob) => pendingJob.transcriptId),
     },
-    'Calling Python summarize worker for batch'
+    'Queued summarize worker batch'
   );
 
   const handleBatchFailure = async (error: Error): Promise<Error | null> => {
+    const durationMs = Date.now() - groupStartTime;
     let retryableError: Error | null = null;
     const transientFailure = {
       message: error.message,
@@ -300,6 +377,11 @@ async function processSummarizeBatchGroup(
         pendingJob.job,
         pendingJob.transcript,
         transientFailure,
+        {
+          queuedAt: pendingJob.job.data.enqueuedAt ?? null,
+          queueWaitMs: computeQueueWaitMs(pendingJob.job.data.enqueuedAt, Date.now()),
+          durationMs,
+        },
       );
 
       if (shouldRetry && retryableError === null) {
@@ -311,6 +393,7 @@ async function processSummarizeBatchGroup(
   };
 
   let result: SpawnPythonResult<SummarizeWorkerResponse> | null = null;
+  const limiterWaitStartMs = Date.now();
   try {
     result = await rateLimitSchedule(
       providerName,
@@ -318,16 +401,50 @@ async function processSummarizeBatchGroup(
       firstJob.job.data.runId,
       modelId,
       firstJob.transcriptId,
-      () => spawnPython<SummarizeWorkerBatchInput, SummarizeWorkerResponse>(
-        PYTHON_WORKER_PATH,
-        workerInput,
-        { cwd: path.resolve(process.cwd(), '../..') }
-      ),
+      async () => {
+        const workerStartMs = Date.now();
+        const limiterWaitMs = workerStartMs - limiterWaitStartMs;
+        log.info(
+          {
+            phase: 'summarize:worker:start',
+            batchId,
+            groupIndex,
+            providerName,
+            modelId,
+            transcriptIds: pendingJobs.map((pendingJob) => pendingJob.transcriptId),
+            queueWaitMs: pendingJobs.map((pendingJob) => computeQueueWaitMs(pendingJob.job.data.enqueuedAt, workerStartMs)),
+            limiterWaitMs,
+          },
+          'Calling Python summarize worker for batch'
+        );
+
+        const workerResult = await spawnPython<SummarizeWorkerBatchInput, SummarizeWorkerResponse>(
+          PYTHON_WORKER_PATH,
+          workerInput,
+          { cwd: path.resolve(process.cwd(), '../..') }
+        );
+
+        log.info(
+          {
+            phase: 'summarize:worker:end',
+            batchId,
+            groupIndex,
+            providerName,
+            modelId,
+            transcriptIds: pendingJobs.map((pendingJob) => pendingJob.transcriptId),
+            limiterWaitMs,
+            workerDurationMs: Date.now() - workerStartMs,
+          },
+          'Python summarize worker completed'
+        );
+
+        return workerResult;
+      },
       scheduleOptions,
     );
   } catch (error) {
     log.error(
-      { batchId, groupIndex, modelId, providerName, err: error },
+      { phase: 'summarize:worker:spawn-failed', batchId, groupIndex, modelId, providerName, err: error },
       'Python spawn failed'
     );
     return handleBatchFailure(error instanceof Error ? error : new Error(String(error)));
@@ -338,7 +455,10 @@ async function processSummarizeBatchGroup(
   }
 
   if (!result.success) {
-    log.error({ batchId, groupIndex, modelId, providerName, error: result.error, stderr: result.stderr }, 'Python spawn failed');
+    log.error(
+      { phase: 'summarize:worker:spawn-failed', batchId, groupIndex, modelId, providerName, error: result.error, stderr: result.stderr },
+      'Python spawn failed'
+    );
     return handleBatchFailure(new Error(`Python worker failed: ${result.error}`));
   }
 
@@ -401,6 +521,11 @@ async function processSummarizeBatchGroup(
         pendingJob.transcript,
         summaryResult.summary,
       );
+      const summarizeTiming: SummarizeTimingInfo = {
+        queuedAt: pendingJob.job.data.enqueuedAt ?? null,
+        queueWaitMs: computeQueueWaitMs(pendingJob.job.data.enqueuedAt, Date.now()),
+        durationMs: Date.now() - groupStartTime,
+      };
       await persistSuccessfulSummary(
         pendingJob.job,
         pendingJob.transcript,
@@ -409,6 +534,7 @@ async function processSummarizeBatchGroup(
         pendingJob.modelId,
         canonicalDecision,
         summaryResult.summary,
+        summarizeTiming,
       );
       continue;
     }
@@ -417,6 +543,11 @@ async function processSummarizeBatchGroup(
       pendingJob.job,
       pendingJob.transcript,
       summaryResult.error,
+      {
+        queuedAt: pendingJob.job.data.enqueuedAt ?? null,
+        queueWaitMs: computeQueueWaitMs(pendingJob.job.data.enqueuedAt, Date.now()),
+        durationMs: Date.now() - groupStartTime,
+      },
     );
 
     if (shouldRetry && retryableError === null) {

--- a/cloud/apps/api/src/queue/spawn.ts
+++ b/cloud/apps/api/src/queue/spawn.ts
@@ -42,6 +42,16 @@ export type ProgressUpdate = {
   message: string;
 };
 
+type PythonLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+
+type PythonStructuredLog = {
+  level: string;
+  msg: string;
+  context?: string;
+  time?: number;
+  [key: string]: unknown;
+};
+
 /**
  * Try to parse a line as a progress update JSON.
  * Returns null if the line is not a valid progress update.
@@ -61,6 +71,62 @@ function tryParseProgress(line: string): ProgressUpdate | null {
   }
 
   return null;
+}
+
+function tryParsePythonLog(line: string): PythonStructuredLog | null {
+  if (!line.trim().startsWith('{')) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(line.trim()) as unknown;
+    if (
+      typeof parsed === 'object'
+      && parsed !== null
+      && typeof (parsed as Record<string, unknown>).level === 'string'
+      && typeof (parsed as Record<string, unknown>).msg === 'string'
+    ) {
+      return parsed as PythonStructuredLog;
+    }
+  } catch {
+    // Not valid JSON, ignore
+  }
+
+  return null;
+}
+
+function forwardPythonLog(script: string, entry: PythonStructuredLog): void {
+  const level = entry.level.toLowerCase();
+  if (level === 'trace' || level === 'debug') {
+    return;
+  }
+  const details = {
+    script,
+    pythonContext: entry.context,
+    pythonTimeMs: entry.time,
+    ...Object.fromEntries(
+      Object.entries(entry).filter(([key]) => !['level', 'msg', 'context', 'time'].includes(key))
+    ),
+  };
+
+  switch (level as PythonLogLevel) {
+    case 'trace':
+      log.trace(details, entry.msg);
+      break;
+    case 'debug':
+      log.debug(details, entry.msg);
+      break;
+    case 'warn':
+      log.warn(details, entry.msg);
+      break;
+    case 'error':
+      log.error(details, entry.msg);
+      break;
+    case 'info':
+    default:
+      log.info(details, entry.msg);
+      break;
+  }
 }
 
 /**
@@ -123,27 +189,29 @@ export async function spawnPython<TInput, TOutput>(
       stdout += data.toString();
     });
 
-    // Collect stderr and parse progress updates
+    // Collect stderr and parse structured worker logs / progress updates
     pythonProcess.stderr.on('data', (data: Buffer) => {
       const chunk = data.toString();
       stderr += chunk;
+      stderrBuffer += chunk;
 
-      // Only process if we have a progress callback
-      if (onProgress) {
-        stderrBuffer += chunk;
+      // Process complete lines immediately so worker logs are available even on success.
+      const lines = stderrBuffer.split('\n');
+      const lastLine = lines.pop();
+      stderrBuffer = typeof lastLine === 'string' ? lastLine : '';
 
-        // Process complete lines
-        const lines = stderrBuffer.split('\n');
-        const lastLine = lines.pop();
-        stderrBuffer = typeof lastLine === 'string' ? lastLine : '';
+      for (const line of lines) {
+        const progress = tryParseProgress(line);
+        if (progress && onProgress) {
+          Promise.resolve(onProgress(progress)).catch((err: unknown) => {
+            log.warn({ err: err instanceof Error ? err : new Error(String(err)) }, 'Progress callback failed');
+          });
+          continue;
+        }
 
-        for (const line of lines) {
-          const progress = tryParseProgress(line);
-          if (progress) {
-            Promise.resolve(onProgress(progress)).catch((err: unknown) => {
-              log.warn({ err: err instanceof Error ? err : new Error(String(err)) }, 'Progress callback failed');
-            });
-          }
+        const pythonLog = tryParsePythonLog(line);
+        if (pythonLog) {
+          forwardPythonLog(script, pythonLog);
         }
       }
     });
@@ -163,12 +231,17 @@ export async function spawnPython<TInput, TOutput>(
       if (resolved) return;
 
       // Process any remaining buffered stderr
-      if (onProgress && stderrBuffer) {
+      if (stderrBuffer) {
         const progress = tryParseProgress(stderrBuffer);
-        if (progress) {
+        if (progress && onProgress) {
           Promise.resolve(onProgress(progress)).catch((err: unknown) => {
             log.warn({ err: err instanceof Error ? err : new Error(String(err)) }, 'Progress callback failed');
           });
+        } else {
+          const pythonLog = tryParsePythonLog(stderrBuffer);
+          if (pythonLog) {
+            forwardPythonLog(script, pythonLog);
+          }
         }
       }
 

--- a/cloud/apps/api/src/queue/types.ts
+++ b/cloud/apps/api/src/queue/types.ts
@@ -27,6 +27,7 @@ export type ProbeScenarioJobData = {
   modelId: string;
   modelVersion?: string;
   sampleIndex: number; // Index within sample set (0 to N-1) for multi-sample runs
+  enqueuedAt?: string;
   config: {
     temperature?: number;
     seed?: number;
@@ -49,6 +50,7 @@ export type SummarizeTranscriptJobData = {
   summaryModelId?: string; // Optional: defaults to configured summary model
   forceSummarize?: boolean; // Optional: bypasses cache and summarization short-circuits
   anomalyId?: string; // Set by reprobe pipeline to track stage progression
+  enqueuedAt?: string;
 };
 
 export type AnalyzeBasicJobData = {

--- a/cloud/apps/api/src/services/probe-result/index.ts
+++ b/cloud/apps/api/src/services/probe-result/index.ts
@@ -18,6 +18,7 @@ export type RecordSuccessInput = {
   scenarioId: string;
   modelId: string;
   sampleIndex?: number; // Index within sample set for multi-sample runs (0 to N-1), defaults to 0
+  queuedAt?: string | null;
   transcriptId: string;
   durationMs: number;
   inputTokens: number;
@@ -32,6 +33,7 @@ export type RecordFailureInput = {
   scenarioId: string;
   modelId: string;
   sampleIndex?: number; // Index within sample set for multi-sample runs (0 to N-1), defaults to 0
+  queuedAt?: string | null;
   errorCode: string;
   errorMessage: string;
   retryCount?: number;
@@ -42,7 +44,7 @@ export type RecordFailureInput = {
  * Creates or updates the probe_results record for this run/scenario/model/sampleIndex combination.
  */
 export async function recordProbeSuccess(input: RecordSuccessInput): Promise<void> {
-  const { runId, scenarioId, modelId, sampleIndex = 0, transcriptId, durationMs, inputTokens, outputTokens } = input;
+  const { runId, scenarioId, modelId, sampleIndex = 0, queuedAt, transcriptId, durationMs, inputTokens, outputTokens } = input;
 
   try {
     await db.probeResult.upsert({
@@ -59,6 +61,7 @@ export async function recordProbeSuccess(input: RecordSuccessInput): Promise<voi
         durationMs,
         inputTokens,
         outputTokens,
+        queuedAt: queuedAt != null ? new Date(queuedAt) : null,
         completedAt: new Date(),
       },
       update: {
@@ -69,6 +72,7 @@ export async function recordProbeSuccess(input: RecordSuccessInput): Promise<voi
         outputTokens,
         errorCode: null,
         errorMessage: null,
+        queuedAt: queuedAt != null ? new Date(queuedAt) : undefined,
         completedAt: new Date(),
       },
     });
@@ -85,7 +89,7 @@ export async function recordProbeSuccess(input: RecordSuccessInput): Promise<voi
  * Creates or updates the probe_results record with error details.
  */
 export async function recordProbeFailure(input: RecordFailureInput): Promise<void> {
-  const { runId, scenarioId, modelId, sampleIndex = 0, errorCode, errorMessage, retryCount = 0 } = input;
+  const { runId, scenarioId, modelId, sampleIndex = 0, queuedAt, errorCode, errorMessage, retryCount = 0 } = input;
 
   // Truncate error message if too long (to avoid DB issues)
   const truncatedMessage = errorMessage.length > 2000
@@ -108,6 +112,7 @@ export async function recordProbeFailure(input: RecordFailureInput): Promise<voi
       errorCode,
       errorMessage: truncatedMessage,
       retryCount,
+      queuedAt: queuedAt != null ? new Date(queuedAt) : null,
       completedAt: new Date(),
     },
     update: {
@@ -119,10 +124,10 @@ export async function recordProbeFailure(input: RecordFailureInput): Promise<voi
       durationMs: null,
       inputTokens: null,
       outputTokens: null,
+      queuedAt: queuedAt != null ? new Date(queuedAt) : undefined,
       completedAt: new Date(),
     },
   });
 
   log.debug({ runId, scenarioId, modelId, sampleIndex, errorCode }, 'Recorded probe failure');
 }
-

--- a/cloud/apps/api/src/services/run/bottleneck.ts
+++ b/cloud/apps/api/src/services/run/bottleneck.ts
@@ -1,0 +1,469 @@
+import { db } from '@valuerank/db';
+
+export type TimingSummary = {
+  sampleCount: number;
+  averageMs: number | null;
+  p95Ms: number | null;
+  maxMs: number | null;
+};
+
+export type StageSummary = {
+  totalCount: number;
+  failedCount: number;
+  queueWait: TimingSummary;
+  execution: TimingSummary;
+};
+
+export type BottleneckStage =
+  | 'insufficient_data'
+  | 'probe_queue'
+  | 'probe_execution'
+  | 'summarize_queue'
+  | 'summarize_execution'
+  | 'mixed';
+
+export type BottleneckAction =
+  | 'increase_probe_parallelism'
+  | 'increase_summarize_parallelism'
+  | 'investigate_worker_latency'
+  | 'hold';
+
+export type BottleneckConfidence = 'low' | 'medium' | 'high';
+
+export type RunExecutionBottleneck = {
+  stage: BottleneckStage;
+  action: BottleneckAction;
+  confidence: BottleneckConfidence;
+  recommendation: string;
+  probe: StageSummary;
+  summarize: StageSummary;
+};
+
+export type ModelExecutionBottleneck = {
+  modelId: string;
+  displayName: string | null;
+  providerName: string | null;
+  pressureMs: number;
+  stage: BottleneckStage;
+  action: BottleneckAction;
+  confidence: BottleneckConfidence;
+  recommendation: string;
+  probe: StageSummary;
+  summarize: StageSummary;
+};
+
+type ProbeResultRow = {
+  modelId: string;
+  status: 'SUCCESS' | 'FAILED';
+  queuedAt: Date | null;
+  createdAt: Date;
+  completedAt: Date | null;
+  durationMs: number | null;
+};
+
+type TranscriptRow = {
+  modelId: string;
+  summarizeQueuedAt: Date | null;
+  summarizedAt: Date | null;
+  summarizeFailedAt: Date | null;
+  summarizeDurationMs: number | null;
+};
+
+type ModelMetaRow = {
+  modelId: string;
+  displayName: string | null;
+  providerName: string | null;
+};
+
+function percentile(values: number[], quantile: number): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * quantile) - 1));
+  return sorted[index] ?? null;
+}
+
+function summarizeNumbers(values: number[]): TimingSummary {
+  if (values.length === 0) {
+    return {
+      sampleCount: 0,
+      averageMs: null,
+      p95Ms: null,
+      maxMs: null,
+    };
+  }
+
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return {
+    sampleCount: values.length,
+    averageMs: Math.round(total / values.length),
+    p95Ms: percentile(values, 0.95),
+    maxMs: Math.max(...values),
+  };
+}
+
+function classifyStage(
+  stage: 'probe' | 'summarize',
+  summary: StageSummary,
+): { stage: BottleneckStage; action: BottleneckAction; pressureMs: number; confidence: BottleneckConfidence } | null {
+  const queuePressure = summary.queueWait.p95Ms ?? summary.queueWait.averageMs;
+  const executionPressure = summary.execution.p95Ms ?? summary.execution.averageMs;
+
+  if (queuePressure == null && executionPressure == null) {
+    return null;
+  }
+
+  const queueCount = summary.queueWait.sampleCount;
+  const executionCount = summary.execution.sampleCount;
+  const sampleCount = Math.max(queueCount, executionCount);
+  const confidence: BottleneckConfidence = sampleCount >= 20 ? 'high' : sampleCount >= 5 ? 'medium' : 'low';
+
+  if (queuePressure != null && executionPressure != null) {
+    if (queuePressure >= executionPressure * 2) {
+      return {
+        stage: stage === 'probe' ? 'probe_queue' : 'summarize_queue',
+        action: stage === 'probe' ? 'increase_probe_parallelism' : 'increase_summarize_parallelism',
+        pressureMs: queuePressure,
+        confidence,
+      };
+    }
+
+    if (executionPressure >= queuePressure * 2) {
+      return {
+        stage: stage === 'probe' ? 'probe_execution' : 'summarize_execution',
+        action: 'investigate_worker_latency',
+        pressureMs: executionPressure,
+        confidence,
+      };
+    }
+
+    return {
+      stage: 'mixed',
+      action: 'hold',
+      pressureMs: Math.max(queuePressure, executionPressure),
+      confidence,
+    };
+  }
+
+  if (queuePressure != null) {
+    return {
+      stage: stage === 'probe' ? 'probe_queue' : 'summarize_queue',
+      action: stage === 'probe' ? 'increase_probe_parallelism' : 'increase_summarize_parallelism',
+      pressureMs: queuePressure,
+      confidence,
+    };
+  }
+
+  return {
+    stage: stage === 'probe' ? 'probe_execution' : 'summarize_execution',
+    action: 'investigate_worker_latency',
+    pressureMs: executionPressure ?? 0,
+    confidence,
+  };
+}
+
+function buildStageSummary<T>(
+  rows: T[],
+  getQueueWaitMs: (row: T) => number | null,
+  getExecutionMs: (row: T) => number | null,
+  getFailed: (row: T) => boolean,
+): StageSummary {
+  const queueWaitValues: number[] = [];
+  const executionValues: number[] = [];
+  let failedCount = 0;
+
+  for (const row of rows) {
+    const queueWaitMs = getQueueWaitMs(row);
+    if (queueWaitMs != null) {
+      queueWaitValues.push(queueWaitMs);
+    }
+
+    const executionMs = getExecutionMs(row);
+    if (executionMs != null) {
+      executionValues.push(executionMs);
+    }
+
+    if (getFailed(row)) {
+      failedCount++;
+    }
+  }
+
+  return {
+    totalCount: rows.length,
+    failedCount,
+    queueWait: summarizeNumbers(queueWaitValues),
+    execution: summarizeNumbers(executionValues),
+  };
+}
+
+function formatRecommendation(
+  label: string | null,
+  probeSummary: StageSummary,
+  summarizeSummary: StageSummary,
+  stage: BottleneckStage,
+): string {
+  const prefix = label != null && label.trim() !== '' ? `${label.trim()}: ` : '';
+  switch (stage) {
+    case 'probe_queue':
+      return `${prefix}probe queue wait is dominating probe execution time. Increase probe parallelism or provider capacity.`;
+    case 'probe_execution':
+      return `${prefix}probe execution time is dominating queue wait. More threads are unlikely to help; investigate provider latency or model slowness.`;
+    case 'summarize_queue':
+      return `${prefix}summarize queue wait is dominating summarize execution time. Increase summarize parallelism or worker capacity.`;
+    case 'summarize_execution':
+      return `${prefix}summarize execution time is dominating queue wait. More threads are unlikely to help; investigate summarizer latency or batch size.`;
+    case 'mixed':
+      return `${prefix}probe and summarize both show pressure. Probe queue p95=${probeSummary.queueWait.p95Ms ?? 'n/a'}ms, summarize queue p95=${summarizeSummary.queueWait.p95Ms ?? 'n/a'}ms.`;
+    case 'insufficient_data':
+    default:
+      return `${prefix}not enough completed timing data yet to identify a bottleneck.`;
+  }
+}
+
+function summarizeRunExecutionBottleneckFromSummaries(
+  probeSummary: StageSummary,
+  summarizeSummary: StageSummary,
+): Omit<RunExecutionBottleneck, 'recommendation'> & { pressureMs: number } {
+  const probeCandidate = classifyStage('probe', probeSummary);
+  const summarizeCandidate = classifyStage('summarize', summarizeSummary);
+
+  const candidates = [probeCandidate, summarizeCandidate].filter(
+    (candidate): candidate is NonNullable<typeof candidate> => candidate !== null,
+  );
+
+  const actionableCandidates = candidates.filter((candidate) => candidate.stage !== 'mixed');
+  const rankedCandidates = actionableCandidates.length > 0 ? actionableCandidates : candidates;
+
+  let chosen = rankedCandidates[0] ?? null;
+  for (const candidate of rankedCandidates.slice(1)) {
+    if (chosen === null || candidate.pressureMs > chosen.pressureMs) {
+      chosen = candidate;
+    }
+  }
+
+  return {
+    stage: chosen?.stage ?? 'insufficient_data',
+    action: chosen?.action ?? 'hold',
+    confidence: chosen?.confidence ?? 'low',
+    pressureMs: chosen?.pressureMs ?? 0,
+    probe: probeSummary,
+    summarize: summarizeSummary,
+  };
+}
+
+function summarizeModelExecutionBottleneckFromSummaries(
+  modelId: string,
+  displayName: string | null,
+  providerName: string | null,
+  probeSummary: StageSummary,
+  summarizeSummary: StageSummary,
+): ModelExecutionBottleneck {
+  const runSummary = summarizeRunExecutionBottleneckFromSummaries(probeSummary, summarizeSummary);
+  const label = displayName ?? modelId;
+  return {
+    modelId,
+    displayName: label,
+    providerName,
+    pressureMs: runSummary.pressureMs,
+    stage: runSummary.stage,
+    action: runSummary.action,
+    confidence: runSummary.confidence,
+    recommendation: formatRecommendation(label, probeSummary, summarizeSummary, runSummary.stage),
+    probe: probeSummary,
+    summarize: summarizeSummary,
+  };
+}
+
+function buildModelExecutionBottlenecks(
+  probeRows: ProbeResultRow[],
+  transcriptRows: TranscriptRow[],
+  modelMetadata: Map<string, ModelMetaRow>,
+): ModelExecutionBottleneck[] {
+  const modelBuckets = new Map<string, { probeRows: ProbeResultRow[]; transcriptRows: TranscriptRow[] }>();
+
+  const ensureBucket = (modelId: string) => {
+    const bucket = modelBuckets.get(modelId);
+    if (bucket !== undefined) {
+      return bucket;
+    }
+
+    const newBucket = { probeRows: [] as ProbeResultRow[], transcriptRows: [] as TranscriptRow[] };
+    modelBuckets.set(modelId, newBucket);
+    return newBucket;
+  };
+
+  for (const row of probeRows) {
+    ensureBucket(row.modelId).probeRows.push(row);
+  }
+
+  for (const row of transcriptRows) {
+    ensureBucket(row.modelId).transcriptRows.push(row);
+  }
+
+  const bottlenecks: ModelExecutionBottleneck[] = [];
+  for (const [modelId, bucket] of modelBuckets.entries()) {
+    const metadata = modelMetadata.get(modelId) ?? null;
+    const probeSummary = buildStageSummary(
+      bucket.probeRows,
+      (row) => {
+        const completedAt = row.completedAt ?? row.createdAt;
+        if (row.queuedAt == null) {
+          return null;
+        }
+        return completedAt.getTime() - row.queuedAt.getTime();
+      },
+      (row) => (row.status === 'SUCCESS' && row.durationMs != null ? row.durationMs : null),
+      (row) => row.status === 'FAILED',
+    );
+
+    const summarizeSummary = buildStageSummary(
+      bucket.transcriptRows,
+      (row) => {
+        const completedAt = row.summarizedAt ?? row.summarizeFailedAt;
+        if (row.summarizeQueuedAt == null || completedAt == null) {
+          return null;
+        }
+        return completedAt.getTime() - row.summarizeQueuedAt.getTime();
+      },
+      (row) => row.summarizeDurationMs,
+      (row) => row.summarizeFailedAt != null,
+    );
+
+    bottlenecks.push(
+      summarizeModelExecutionBottleneckFromSummaries(
+        modelId,
+        metadata?.displayName ?? null,
+        metadata?.providerName ?? null,
+        probeSummary,
+        summarizeSummary,
+      ),
+    );
+  }
+
+  return bottlenecks.sort((a, b) => {
+    if (b.pressureMs !== a.pressureMs) {
+      return b.pressureMs - a.pressureMs;
+    }
+    if (b.probe.totalCount !== a.probe.totalCount) {
+      return b.probe.totalCount - a.probe.totalCount;
+    }
+    return a.modelId.localeCompare(b.modelId);
+  });
+}
+
+function summarizeRunExecutionBottleneck(
+  probeRows: ProbeResultRow[],
+  transcriptRows: TranscriptRow[],
+): RunExecutionBottleneck {
+  const probeSummary = buildStageSummary(
+    probeRows,
+    (row) => {
+      const completedAt = row.completedAt ?? row.createdAt;
+      if (row.queuedAt == null) {
+        return null;
+      }
+      return completedAt.getTime() - row.queuedAt.getTime();
+    },
+    (row) => (row.status === 'SUCCESS' && row.durationMs != null ? row.durationMs : null),
+    (row) => row.status === 'FAILED',
+  );
+
+  const summarizeSummary = buildStageSummary(
+    transcriptRows,
+    (row) => {
+      const completedAt = row.summarizedAt ?? row.summarizeFailedAt;
+      if (row.summarizeQueuedAt == null || completedAt == null) {
+        return null;
+      }
+      return completedAt.getTime() - row.summarizeQueuedAt.getTime();
+    },
+    (row) => row.summarizeDurationMs,
+    (row) => row.summarizeFailedAt != null,
+  );
+
+  const summarized = summarizeRunExecutionBottleneckFromSummaries(probeSummary, summarizeSummary);
+  return {
+    stage: summarized.stage,
+    action: summarized.action,
+    confidence: summarized.confidence,
+    recommendation: formatRecommendation(null, probeSummary, summarizeSummary, summarized.stage),
+    probe: summarized.probe,
+    summarize: summarized.summarize,
+  };
+}
+
+async function loadRunExecutionTimingRows(runId: string): Promise<{ probeRows: ProbeResultRow[]; transcriptRows: TranscriptRow[] }> {
+  const [probeRows, transcriptRows] = await Promise.all([
+    db.probeResult.findMany({
+      where: { runId, deletedAt: null },
+      select: {
+        modelId: true,
+        status: true,
+        queuedAt: true,
+        createdAt: true,
+        completedAt: true,
+        durationMs: true,
+      },
+    }),
+    db.transcript.findMany({
+      where: { runId, deletedAt: null },
+      select: {
+        modelId: true,
+        summarizeQueuedAt: true,
+        summarizedAt: true,
+        summarizeFailedAt: true,
+        summarizeDurationMs: true,
+      },
+    }),
+  ]);
+  return { probeRows: probeRows as ProbeResultRow[], transcriptRows: transcriptRows as TranscriptRow[] };
+}
+
+export async function getRunExecutionBottleneck(runId: string): Promise<RunExecutionBottleneck> {
+  const { probeRows, transcriptRows } = await loadRunExecutionTimingRows(runId);
+  return summarizeRunExecutionBottleneck(probeRows, transcriptRows);
+}
+
+export async function getRunModelExecutionBottlenecks(runId: string): Promise<ModelExecutionBottleneck[]> {
+  const { probeRows, transcriptRows } = await loadRunExecutionTimingRows(runId);
+  const modelIds = new Set<string>();
+  for (const row of probeRows) {
+    modelIds.add(row.modelId);
+  }
+  for (const row of transcriptRows) {
+    modelIds.add(row.modelId);
+  }
+
+  if (modelIds.size === 0) {
+    return [];
+  }
+
+  const metadataRows = await db.llmModel.findMany({
+    where: { modelId: { in: [...modelIds] } },
+    select: {
+      modelId: true,
+      displayName: true,
+      provider: {
+        select: {
+          name: true,
+          displayName: true,
+        },
+      },
+    },
+  });
+
+  const metadataMap = new Map<string, ModelMetaRow>();
+  for (const row of metadataRows) {
+    if (!metadataMap.has(row.modelId)) {
+      metadataMap.set(row.modelId, {
+        modelId: row.modelId,
+        displayName: row.displayName,
+        providerName: row.provider.displayName ?? row.provider.name,
+      });
+    }
+  }
+
+  return buildModelExecutionBottlenecks(probeRows, transcriptRows, metadataMap);
+}

--- a/cloud/apps/api/src/services/run/index.ts
+++ b/cloud/apps/api/src/services/run/index.ts
@@ -15,6 +15,16 @@ export {
 export type { ProgressData } from './progress.js';
 export { computeRunProgress } from './derived-progress.js';
 export type { RunProgress } from './derived-progress.js';
+export { getRunExecutionBottleneck, getRunModelExecutionBottlenecks } from './bottleneck.js';
+export type {
+  RunExecutionBottleneck,
+  ModelExecutionBottleneck,
+  StageSummary,
+  TimingSummary,
+  BottleneckStage,
+  BottleneckAction,
+  BottleneckConfidence,
+} from './bottleneck.js';
 
 export {
   pauseRun,

--- a/cloud/apps/api/src/services/run/progress.ts
+++ b/cloud/apps/api/src/services/run/progress.ts
@@ -49,6 +49,7 @@ async function queueSummarizeJobs(runId: string): Promise<void> {
       {
         runId,
         transcriptId: transcript.id,
+        enqueuedAt: new Date().toISOString(),
       },
       {
         ...jobOptions,

--- a/cloud/apps/api/src/services/run/recovery-jobs.ts
+++ b/cloud/apps/api/src/services/run/recovery-jobs.ts
@@ -65,6 +65,7 @@ export async function requeueMissingProbes(
         scenarioId,
         modelId,
         sampleIndex,
+        enqueuedAt: new Date().toISOString(),
         config: {
           maxTurns: 10,
         },
@@ -106,6 +107,7 @@ export async function queueSummarizeJobsForRecovery(runId: string): Promise<numb
     await boss.send('summarize_transcript', {
       runId,
       transcriptId: transcript.id,
+      enqueuedAt: new Date().toISOString(),
     }, {
       ...jobOptions,
       singletonKey: transcript.id,

--- a/cloud/apps/api/src/services/run/start-queue.ts
+++ b/cloud/apps/api/src/services/run/start-queue.ts
@@ -61,6 +61,7 @@ export async function enqueueRunJobs(input: EnqueueRunJobsInput): Promise<string
           scenarioId: item.scenarioId,
           modelId: item.modelId,
           sampleIndex: i,
+          enqueuedAt: new Date().toISOString(),
           config: {
             maxTurns: 10,
             ...(temperature !== undefined && temperature !== null ? { temperature } : {}),

--- a/cloud/apps/api/src/services/run/summarization.ts
+++ b/cloud/apps/api/src/services/run/summarization.ts
@@ -271,6 +271,7 @@ export async function restartSummarization(
       {
         runId,
         transcriptId: transcript.id,
+        enqueuedAt: new Date().toISOString(),
         ...(force ? { forceSummarize: true } : {}),
       },
       {

--- a/cloud/apps/api/tests/queue/handlers/probe-dead-letter.test.ts
+++ b/cloud/apps/api/tests/queue/handlers/probe-dead-letter.test.ts
@@ -55,15 +55,18 @@ describe('createProbeDeadLetterHandler', () => {
     await handler([makeJob()]);
 
     expect(recordProbeFailure).toHaveBeenCalledTimes(1);
-    expect(recordProbeFailure).toHaveBeenCalledWith({
-      runId: 'run-123',
-      scenarioId: 'scenario-abc',
-      modelId: 'gpt-5.1',
-      sampleIndex: 0,
-      errorCode: 'JOB_EXPIRED',
-      errorMessage: expect.stringContaining('dead letter'),
-      retryCount: 0,
-    });
+    expect(recordProbeFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: 'run-123',
+        scenarioId: 'scenario-abc',
+        modelId: 'gpt-5.1',
+        sampleIndex: 0,
+        queuedAt: null,
+        errorCode: 'JOB_EXPIRED',
+        errorMessage: expect.stringContaining('dead letter'),
+        retryCount: 0,
+      })
+    );
     expect(maybeAdvanceRunStatus).toHaveBeenCalledWith('run-123');
   });
 

--- a/cloud/apps/api/tests/queue/spawn.test.ts
+++ b/cloud/apps/api/tests/queue/spawn.test.ts
@@ -17,6 +17,7 @@ const errorScript = join(testDir, 'error.py');
 const slowScript = join(testDir, 'slow.py');
 const invalidJsonScript = join(testDir, 'invalid_json.py');
 const stderrScript = join(testDir, 'stderr.py');
+const structuredLogScript = join(testDir, 'structured_log.py');
 
 describe('spawnPython', () => {
   beforeAll(() => {
@@ -86,6 +87,19 @@ sys.stderr.write("Warning: something happened\\n")
 print(json.dumps({"success": True}))
 `.trim()
     );
+
+    // Create structured log script - emits JSON logs to stderr and succeeds
+    writeFileSync(
+      structuredLogScript,
+      `
+import sys
+import json
+
+data = json.load(sys.stdin)
+print(json.dumps({"level": "info", "time": 123, "context": "probe", "msg": "Worker log", "turn": 1}), file=sys.stderr)
+print(json.dumps({"success": True}))
+`.trim()
+    );
   });
 
   describe('successful execution', () => {
@@ -121,6 +135,15 @@ print(json.dumps({"success": True}))
 
     it('handles stderr output but still succeeds', async () => {
       const result = await spawnPython(stderrScript, { test: true });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ success: true });
+      }
+    });
+
+    it('handles structured worker logs but still succeeds', async () => {
+      const result = await spawnPython(structuredLogScript, { test: true });
 
       expect(result.success).toBe(true);
       if (result.success) {

--- a/cloud/packages/db/prisma/migrations/20260511000000_add_run_timing_fields/migration.sql
+++ b/cloud/packages/db/prisma/migrations/20260511000000_add_run_timing_fields/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "probe_results"
+ADD COLUMN "queued_at" TIMESTAMPTZ;
+
+ALTER TABLE "transcripts"
+ADD COLUMN "summarize_queued_at" TIMESTAMPTZ,
+ADD COLUMN "summarize_duration_ms" INTEGER;

--- a/cloud/packages/db/prisma/schema.prisma
+++ b/cloud/packages/db/prisma/schema.prisma
@@ -535,6 +535,8 @@ model Transcript {
   // the single source of truth (PR #713, commit f86c2579).
   decisionText       String?   @map("decision_text")     // LLM-generated summary
   decisionMetadata   Json?     @map("decision_metadata") @db.JsonB
+  summarizeQueuedAt  DateTime? @map("summarize_queued_at")
+  summarizeDurationMs Int?     @map("summarize_duration_ms")
   summarizedAt       DateTime? @map("summarized_at")     // When summary was generated
   summarizeFailedAt  DateTime?  @map("summarize_failed_at")
   costDebitedAt      DateTime?  @map("cost_debited_at")
@@ -654,6 +656,7 @@ model ProbeResult {
   errorMessage String?          @map("error_message")
   retryCount   Int              @default(0) @map("retry_count")
   // Timestamps
+  queuedAt     DateTime?        @map("queued_at")
   createdAt    DateTime         @default(now()) @map("created_at")
   completedAt  DateTime?        @map("completed_at")
   deletedAt    DateTime?        @map("deleted_at")

--- a/cloud/workers/common/llm_adapters/base.py
+++ b/cloud/workers/common/llm_adapters/base.py
@@ -202,6 +202,19 @@ def get_current_request_metadata() -> Optional[dict[str, Any]]:
     return dict(metadata)
 
 
+def build_timing_summary(
+    request_started_at: float,
+    request_finished_at: float,
+    response_finished_at: float,
+) -> dict[str, int]:
+    """Build a compact timing summary for an LLM request lifecycle."""
+    return {
+        "requestMs": max(0, int(round((request_finished_at - request_started_at) * 1000))),
+        "parseMs": max(0, int(round((response_finished_at - request_finished_at) * 1000))),
+        "totalMs": max(0, int(round((response_finished_at - request_started_at) * 1000))),
+    }
+
+
 def _is_unsupported_temperature_response(
     status_code: int,
     response_text: str,

--- a/cloud/workers/common/llm_adapters/providers/anthropic.py
+++ b/cloud/workers/common/llm_adapters/providers/anthropic.py
@@ -3,12 +3,13 @@ Anthropic Messages API adapter.
 """
 
 from dataclasses import dataclass
+import time
 from typing import Any, Optional
 
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json, raise_if_empty_content
+from ..base import BaseLLMAdapter, build_timing_summary, post_json, raise_if_empty_content
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse
@@ -99,7 +100,9 @@ class AnthropicAdapter(BaseLLMAdapter):
 
         effective_timeout = timeout if timeout is not None else self.timeout
         log.debug("Calling Anthropic API", model=model, max_tokens=effective_max_tokens)
+        request_started_at = time.perf_counter()
         data = post_json(self.base_url, headers, payload, timeout=effective_timeout)
+        request_finished_at = time.perf_counter()
 
         try:
             content_list = data.get("content", [])
@@ -113,9 +116,15 @@ class AnthropicAdapter(BaseLLMAdapter):
 
             # Capture provider metadata
             raw_stop_reason = data.get("stop_reason")
+            response_finished_at = time.perf_counter()
             provider_metadata = {
                 "provider": "anthropic",
                 "finishReason": normalize_finish_reason("anthropic", raw_stop_reason),
+                "timing": build_timing_summary(
+                    request_started_at,
+                    request_finished_at,
+                    response_finished_at,
+                ),
                 "raw": {
                     "id": data.get("id"),
                     "stop_reason": raw_stop_reason,

--- a/cloud/workers/common/llm_adapters/providers/deepseek.py
+++ b/cloud/workers/common/llm_adapters/providers/deepseek.py
@@ -4,6 +4,7 @@ DeepSeek API adapter (OpenAI-compatible with streaming support).
 
 from dataclasses import dataclass
 import json
+import time
 from typing import Any, Generator, Optional
 
 import requests
@@ -11,7 +12,7 @@ import requests
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json, raise_if_empty_content
+from ..base import BaseLLMAdapter, build_timing_summary, post_json, raise_if_empty_content
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse, StreamChunk
@@ -104,7 +105,9 @@ class DeepSeekAdapter(BaseLLMAdapter):
             max_tokens=resolved_max_tokens,
             timeout=effective_timeout,
         )
+        request_started_at = time.perf_counter()
         data = post_json(self.base_url, headers, payload, timeout=effective_timeout)
+        request_finished_at = time.perf_counter()
 
         try:
             choice = data["choices"][0]
@@ -115,9 +118,15 @@ class DeepSeekAdapter(BaseLLMAdapter):
 
             # Capture provider metadata (OpenAI-compatible format)
             raw_finish_reason = choice.get("finish_reason")
+            response_finished_at = time.perf_counter()
             provider_metadata = {
                 "provider": "deepseek",
                 "finishReason": normalize_finish_reason("deepseek", raw_finish_reason),
+                "timing": build_timing_summary(
+                    request_started_at,
+                    request_finished_at,
+                    response_finished_at,
+                ),
                 "raw": {
                     "id": data.get("id"),
                     "finish_reason": raw_finish_reason,

--- a/cloud/workers/common/llm_adapters/providers/google.py
+++ b/cloud/workers/common/llm_adapters/providers/google.py
@@ -3,12 +3,13 @@ Google Gemini API adapter.
 """
 
 from dataclasses import dataclass
+import time
 from typing import Any, Optional
 
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json
+from ..base import BaseLLMAdapter, build_timing_summary, post_json
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse
@@ -116,7 +117,9 @@ class GeminiAdapter(BaseLLMAdapter):
 
         effective_timeout = timeout if timeout is not None else self.timeout
         log.debug("Calling Gemini API", model=model, max_tokens=resolved_max_tokens)
+        request_started_at = time.perf_counter()
         data = post_json(url, headers, payload, timeout=effective_timeout)
+        request_finished_at = time.perf_counter()
 
         try:
             # Check for prompt-level blocking first
@@ -125,9 +128,15 @@ class GeminiAdapter(BaseLLMAdapter):
 
             if prompt_block_reason:
                 # Prompt was blocked - no candidates will be returned
+                response_finished_at = time.perf_counter()
                 provider_metadata = {
                     "provider": "google",
                     "finishReason": normalize_finish_reason("google", prompt_block_reason),
+                    "timing": build_timing_summary(
+                        request_started_at,
+                        request_finished_at,
+                        response_finished_at,
+                    ),
                     "raw": {
                         "promptFeedback": prompt_feedback,
                         "candidates": [],
@@ -155,9 +164,15 @@ class GeminiAdapter(BaseLLMAdapter):
             candidates = data.get("candidates", [])
             if not candidates:
                 # No candidates but no block reason - unexpected
+                response_finished_at = time.perf_counter()
                 provider_metadata = {
                     "provider": "google",
                     "finishReason": "unknown",
+                    "timing": build_timing_summary(
+                        request_started_at,
+                        request_finished_at,
+                        response_finished_at,
+                    ),
                     "raw": {
                         "promptFeedback": prompt_feedback,
                         "candidates": [],
@@ -189,9 +204,15 @@ class GeminiAdapter(BaseLLMAdapter):
             thoughts_tokens = usage.get("thoughtsTokenCount")
 
             # Build comprehensive provider metadata
+            response_finished_at = time.perf_counter()
             provider_metadata = {
                 "provider": "google",
                 "finishReason": normalize_finish_reason("google", raw_finish_reason),
+                "timing": build_timing_summary(
+                    request_started_at,
+                    request_finished_at,
+                    response_finished_at,
+                ),
                 "raw": {
                     "finishReason": raw_finish_reason,
                     "safetyRatings": safety_ratings,

--- a/cloud/workers/common/llm_adapters/providers/mistral.py
+++ b/cloud/workers/common/llm_adapters/providers/mistral.py
@@ -3,12 +3,13 @@ Mistral API adapter (OpenAI-compatible).
 """
 
 from dataclasses import dataclass
+import time
 from typing import Any, Optional
 
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json, raise_if_empty_content
+from ..base import BaseLLMAdapter, build_timing_summary, post_json, raise_if_empty_content
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse
@@ -81,7 +82,9 @@ class MistralAdapter(BaseLLMAdapter):
         effective_timeout = timeout if timeout is not None else self.timeout
 
         log.debug("Calling Mistral API", model=model, max_tokens=resolved_max_tokens)
+        request_started_at = time.perf_counter()
         data = post_json(self.base_url, headers, payload, timeout=effective_timeout)
+        request_finished_at = time.perf_counter()
 
         try:
             choice = data["choices"][0]
@@ -90,9 +93,15 @@ class MistralAdapter(BaseLLMAdapter):
 
             # Capture provider metadata (OpenAI-compatible format)
             raw_finish_reason = choice.get("finish_reason")
+            response_finished_at = time.perf_counter()
             provider_metadata = {
                 "provider": "mistral",
                 "finishReason": normalize_finish_reason("mistral", raw_finish_reason),
+                "timing": build_timing_summary(
+                    request_started_at,
+                    request_finished_at,
+                    response_finished_at,
+                ),
                 "raw": {
                     "id": data.get("id"),
                     "finish_reason": raw_finish_reason,

--- a/cloud/workers/common/llm_adapters/providers/openai.py
+++ b/cloud/workers/common/llm_adapters/providers/openai.py
@@ -3,12 +3,13 @@ OpenAI Chat Completions API adapter.
 """
 
 from dataclasses import dataclass
+import time
 from typing import Any, Optional
 
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json, raise_if_empty_content
+from ..base import BaseLLMAdapter, build_timing_summary, post_json, raise_if_empty_content
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse
@@ -102,7 +103,9 @@ class OpenAIAdapter(BaseLLMAdapter):
             max_tokens_param=max_tokens_param,
             max_tokens=resolved_max_tokens,
         )
+        request_started_at = time.perf_counter()
         data = post_json(self.base_url, headers, payload, timeout=effective_timeout)
+        request_finished_at = time.perf_counter()
 
         try:
             choice = data["choices"][0]
@@ -114,9 +117,15 @@ class OpenAIAdapter(BaseLLMAdapter):
 
             # Capture provider metadata
             raw_finish_reason = choice.get("finish_reason")
+            response_finished_at = time.perf_counter()
             provider_metadata = {
                 "provider": "openai",
                 "finishReason": normalize_finish_reason("openai", raw_finish_reason),
+                "timing": build_timing_summary(
+                    request_started_at,
+                    request_finished_at,
+                    response_finished_at,
+                ),
                 "raw": {
                     "id": data.get("id"),
                     "finish_reason": raw_finish_reason,

--- a/cloud/workers/common/llm_adapters/providers/xai.py
+++ b/cloud/workers/common/llm_adapters/providers/xai.py
@@ -3,12 +3,13 @@ xAI Grok API adapter (OpenAI-compatible).
 """
 
 from dataclasses import dataclass
+import time
 from typing import Any, Optional
 
 from ...config import get_config
 from ...errors import ErrorCode, LLMError
 from ...logging import get_logger
-from ..base import BaseLLMAdapter, post_json, raise_if_empty_content
+from ..base import BaseLLMAdapter, build_timing_summary, post_json, raise_if_empty_content
 from ..config_utils import get_config_value, resolve_max_tokens, resolve_temperature
 from ..constants import DEFAULT_TIMEOUT, normalize_finish_reason
 from ..types import LLMResponse
@@ -88,7 +89,9 @@ class XAIAdapter(BaseLLMAdapter):
 
         effective_timeout = timeout if timeout is not None else self.timeout
         log.debug("Calling xAI API", model=model, max_tokens=resolved_max_tokens)
+        request_started_at = time.perf_counter()
         data = post_json(self.base_url, headers, payload, timeout=effective_timeout)
+        request_finished_at = time.perf_counter()
 
         try:
             choice = data["choices"][0]
@@ -99,9 +102,15 @@ class XAIAdapter(BaseLLMAdapter):
 
             # Capture provider metadata (OpenAI-compatible format)
             raw_finish_reason = choice.get("finish_reason")
+            response_finished_at = time.perf_counter()
             provider_metadata = {
                 "provider": "xai",
                 "finishReason": normalize_finish_reason("xai", raw_finish_reason),
+                "timing": build_timing_summary(
+                    request_started_at,
+                    request_finished_at,
+                    response_finished_at,
+                ),
                 "raw": {
                     "id": data.get("id"),
                     "finish_reason": raw_finish_reason,

--- a/cloud/workers/probe.py
+++ b/cloud/workers/probe.py
@@ -67,6 +67,7 @@ Error:
 
 import json
 import sys
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -131,6 +132,41 @@ def _ensure_non_empty_response(response: LLMResponse, *, model_id: str, turn_lab
             f"refusing to write empty transcript"
         ),
         code=ErrorCode.INVALID_RESPONSE,
+    )
+
+
+def _log_turn_timing(
+    *,
+    run_id: str,
+    scenario_id: str,
+    model_id: str,
+    turn_number: int,
+    turn_label: str,
+    response: LLMResponse,
+    turn_started_at: float,
+) -> None:
+    """Emit a compact per-turn timing summary for worker diagnostics."""
+    metadata = response.provider_metadata or {}
+    timing = metadata.get("timing")
+    if not isinstance(timing, dict):
+        return
+
+    log.info(
+        "Probe turn completed",
+        runId=run_id,
+        scenarioId=scenario_id,
+        modelId=model_id,
+        turnNumber=turn_number,
+        promptLabel=turn_label,
+        provider=metadata.get("provider"),
+        finishReason=metadata.get("finishReason"),
+        requestMs=timing.get("requestMs"),
+        parseMs=timing.get("parseMs"),
+        totalMs=timing.get("totalMs"),
+        turnDurationMs=int(round((time.perf_counter() - turn_started_at) * 1000)),
+        inputTokens=response.input_tokens,
+        outputTokens=response.output_tokens,
+        reasoningTokens=response.reasoning_tokens,
     )
 
 
@@ -295,6 +331,7 @@ def run_probe(data: dict[str, Any]) -> dict[str, Any]:
     try:
         # Turn 1: Initial prompt
         log.debug("Executing turn 1", modelId=model_id)
+        turn_started_at = time.perf_counter()
         generate_kwargs: dict[str, Any] = {
             "max_tokens": max_tokens,
             "model_config": model_config,
@@ -310,6 +347,15 @@ def run_probe(data: dict[str, Any]) -> dict[str, Any]:
             **generate_kwargs,
         )
         _ensure_non_empty_response(response, model_id=model_id, turn_label="scenario_prompt")
+        _log_turn_timing(
+            run_id=run_id,
+            scenario_id=scenario_id,
+            model_id=model_id,
+            turn_number=1,
+            turn_label="scenario_prompt",
+            response=response,
+            turn_started_at=turn_started_at,
+        )
 
         turn = Turn(
             turn_number=1,
@@ -341,12 +387,22 @@ def run_probe(data: dict[str, Any]) -> dict[str, Any]:
             # Add followup to conversation
             messages.append({"role": "user", "content": followup_prompt})
 
+            turn_started_at = time.perf_counter()
             response = generate(
                 model_id,
                 messages,
                 **generate_kwargs,
             )
             _ensure_non_empty_response(response, model_id=model_id, turn_label=followup_label)
+            _log_turn_timing(
+                run_id=run_id,
+                scenario_id=scenario_id,
+                model_id=model_id,
+                turn_number=turn_num,
+                turn_label=followup_label,
+                response=response,
+                turn_started_at=turn_started_at,
+            )
 
             turn = Turn(
                 turn_number=turn_num,


### PR DESCRIPTION
## Summary
- Add run-level and model-level bottleneck summaries for probe and summarize work.
- Persist queue and worker timing through the API and GraphQL so slow models are easier to spot.
- Forward structured Python worker logs through the Node spawn bridge and add per-turn timing logs.

## Validation
- [x] `python3 -m compileall cloud/workers` passed
- [x] `npm run typecheck --workspace=@valuerank/api` passed
- [x] `npm run test --workspace=@valuerank/api -- tests/queue/spawn.test.ts` passed
- [x] `npm run lint --workspace @valuerank/shared` passed with pre-existing warnings only
- [x] `npm run lint --workspace @valuerank/db` passed with pre-existing warnings only
- [x] `npm run lint --workspace @valuerank/api` passed with pre-existing warnings only
- [x] `npm run build --workspace @valuerank/api` passed
- [x] `npm run lint --workspace @valuerank/web` passed with pre-existing warnings only
- [x] `npm run build --workspace @valuerank/web` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)