### PR TITLE
feat(win-rate): multi-select domain chip picker

### DIFF
--- a/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
+++ b/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
@@ -15,6 +15,7 @@ type ModelOption = Option & {
 
 type DomainSingleProp = {
   label?: string;
+  multi?: never;
   value: string;
   options: Option[];
   onChange: (value: string) => void;
@@ -23,6 +24,7 @@ type DomainSingleProp = {
 
 type DomainMultiProp = {
   label?: string;
+  multi: true;
   summary: string;
   selectedIds: string[];
   options: ChipPickerOption[];
@@ -32,7 +34,7 @@ type DomainMultiProp = {
 };
 
 function isMultiDomain(domain: DomainSingleProp | DomainMultiProp): domain is DomainMultiProp {
-  return 'selectedIds' in domain;
+  return domain.multi === true;
 }
 
 type AnalysisContextBarProps = {

--- a/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
+++ b/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
@@ -1,9 +1,7 @@
-import type { ReactNode } from 'react';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { useMemo } from 'react';
 import { cn } from '../../lib/utils';
-import { Button } from '../ui/Button';
-import { Select, selectTriggerVariants } from '../ui/Select';
+import { Select } from '../ui/Select';
+import { ChipPicker, type ChipPickerAction, type ChipPickerOption } from '../ui/ChipPicker';
 
 type Option = {
   value: string;
@@ -15,14 +13,30 @@ type ModelOption = Option & {
   isDefault?: boolean;
 };
 
+type DomainSingleProp = {
+  label?: string;
+  value: string;
+  options: Option[];
+  onChange: (value: string) => void;
+  disabled?: boolean;
+};
+
+type DomainMultiProp = {
+  label?: string;
+  summary: string;
+  selectedIds: string[];
+  options: ChipPickerOption[];
+  onChange: (ids: string[]) => void;
+  actions?: ChipPickerAction[];
+  disabled?: boolean;
+};
+
+function isMultiDomain(domain: DomainSingleProp | DomainMultiProp): domain is DomainMultiProp {
+  return 'selectedIds' in domain;
+}
+
 type AnalysisContextBarProps = {
-  domain: {
-    label?: string;
-    value: string;
-    options: Option[];
-    onChange: (value: string) => void;
-    disabled?: boolean;
-  };
+  domain: DomainSingleProp | DomainMultiProp;
   signature: {
     label?: string;
     value: string;
@@ -51,7 +65,7 @@ function ContextField({
   className,
 }: {
   label: string;
-  children: ReactNode;
+  children: React.ReactNode;
   className?: string;
 }) {
   return (
@@ -81,56 +95,32 @@ export function AnalysisContextBar({
           ? 'All models'
           : `${currentModelIds.length} of ${availableModelIds.length} selected`;
 
-  const [isOpen, setIsOpen] = useState(false);
-  const modelPickerRef = useRef<HTMLDivElement>(null);
-  const modelMenuRef = useRef<HTMLDivElement>(null);
-
-  const handleToggleModel = (modelId: string) => {
-    if (models == null) return;
-    const next = currentModelIds.includes(modelId)
-      ? currentModelIds.filter((id) => id !== modelId)
-      : [...currentModelIds, modelId];
-    models.onChange(next);
-  };
-
-  useEffect(() => {
-    if (!isOpen || models == null) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target as Node;
-      if (modelPickerRef.current?.contains(target) || modelMenuRef.current?.contains(target)) {
-        return;
-      }
-      setIsOpen(false);
-    };
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener('pointerdown', handlePointerDown);
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('pointerdown', handlePointerDown);
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [isOpen]);
-
   return (
     <section className={cn('sticky top-14 z-40 overflow-visible border-b border-gray-200 bg-[#FDFBF7]/95 backdrop-blur', className)}>
       <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-x-3 gap-y-2 overflow-visible px-4 py-3">
         <ContextField label={domain.label ?? 'Domain'} className="flex-1 min-w-[14rem]">
-          <Select
-            ariaLabel={domain.label ?? 'Domain'}
-            value={domain.value}
-            onChange={domain.onChange}
-            options={domain.options}
-            disabled={domain.disabled}
-            size="sm"
-            className="w-full min-w-0"
-          />
+          {isMultiDomain(domain) ? (
+            <ChipPicker
+              ariaLabel={domain.label ?? 'Domain'}
+              summary={domain.summary}
+              selectedIds={domain.selectedIds}
+              options={domain.options}
+              onChange={domain.onChange}
+              actions={domain.actions}
+              disabled={domain.disabled}
+              emptyMessage="No domains available."
+            />
+          ) : (
+            <Select
+              ariaLabel={domain.label ?? 'Domain'}
+              value={domain.value}
+              onChange={domain.onChange}
+              options={domain.options}
+              disabled={domain.disabled}
+              size="sm"
+              className="w-full min-w-0"
+            />
+          )}
         </ContextField>
 
         <ContextField label={signature.label ?? 'Signature'} className="flex-1 min-w-[14rem]">
@@ -148,85 +138,27 @@ export function AnalysisContextBar({
         {models != null && (
           <div className="ml-auto flex min-w-[14rem] flex-1 items-center gap-2">
             <span className="shrink-0 text-sm font-medium text-gray-700">{models.label ?? 'Models'}</span>
-            <div ref={modelPickerRef} className="relative min-w-0 flex-1">
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => setIsOpen((value) => !value)}
-                aria-expanded={isOpen}
-                aria-haspopup="listbox"
-                aria-label={`${models.label ?? 'Models'}: ${modelSummary}`}
-                className={cn(
-                  selectTriggerVariants({ size: 'sm' }),
-                  'w-full min-w-0 justify-between text-left focus:ring-teal-500 focus:border-teal-500 focus:ring-offset-0',
-                  availableModelIds.length === 0 && 'text-gray-400',
-                )}
-              >
-                <span className="min-w-0 flex-1 truncate">{modelSummary}</span>
-                <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 text-gray-400 transition-transform', isOpen && 'rotate-180')} />
-              </Button>
-
-              {isOpen && (
-                <div
-                  ref={modelMenuRef}
-                  className="absolute right-0 top-full z-50 mt-2 w-[min(32rem,calc(100vw-2rem))] rounded-lg border border-gray-200 bg-white p-3 shadow-xl"
-                >
-                  <div className="flex flex-wrap gap-1.5 pb-2 mb-2 border-b border-gray-200">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => models.onChange([...models.defaultModelIds])}
-                      className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
-                        isDefaultSelection
-                          ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
-                          : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
-                      }`}
-                    >
-                      Default Models
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => models.onChange([])}
-                      disabled={currentModelIds.length === 0}
-                      className="rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 transition-colors min-h-0 hover:border-teal-400 hover:text-teal-700 hover:bg-white disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      Clear all
-                    </Button>
-                  </div>
-
-                  <div className="flex flex-wrap gap-1.5">
-                    {models.options.map((model) => {
-                      const isSelected = currentModelIds.includes(model.value);
-                      return (
-                        <Button
-                          key={model.value}
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleToggleModel(model.value)}
-                          className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors min-h-0 ${
-                            isSelected
-                              ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
-                              : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:text-teal-700 hover:bg-white'
-                          }`}
-                          title={model.label}
-                        >
-                          {model.label}
-                        </Button>
-                      );
-                    })}
-                  </div>
-
-                  {models.options.length === 0 ? (
-                    <p className="text-xs text-gray-500">No active models are available yet.</p>
-                  ) : null}
-                </div>
-              )}
-            </div>
+            <ChipPicker
+              ariaLabel={models.label ?? 'Models'}
+              summary={modelSummary}
+              selectedIds={currentModelIds}
+              options={models.options}
+              onChange={models.onChange}
+              actions={[
+                {
+                  label: 'Default Models',
+                  isActive: isDefaultSelection,
+                  onClick: () => models.onChange([...models.defaultModelIds]),
+                },
+                {
+                  label: 'Clear all',
+                  isActive: false,
+                  onClick: () => models.onChange([]),
+                  disabled: currentModelIds.length === 0,
+                },
+              ]}
+              emptyMessage="No active models are available yet."
+            />
           </div>
         )}
       </div>

--- a/cloud/apps/web/src/components/ui/ChipPicker.tsx
+++ b/cloud/apps/web/src/components/ui/ChipPicker.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '../../lib/utils';
+import { Button } from './Button';
+import { selectTriggerVariants } from './Select';
+
+export type ChipPickerOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+export type ChipPickerAction = {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+};
+
+type ChipPickerProps = {
+  summary: string;
+  options: ChipPickerOption[];
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+  actions?: ChipPickerAction[];
+  disabled?: boolean;
+  ariaLabel: string;
+  emptyMessage?: string;
+};
+
+export function ChipPicker({
+  summary,
+  options,
+  selectedIds,
+  onChange,
+  actions,
+  disabled,
+  ariaLabel,
+  emptyMessage = 'No options available.',
+}: ChipPickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setIsOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  const handleToggle = (value: string) => {
+    const next = selectedIds.includes(value)
+      ? selectedIds.filter((id) => id !== value)
+      : [...selectedIds, value];
+    onChange(next);
+  };
+
+  return (
+    <div ref={triggerRef} className="relative min-w-0 flex-1">
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={() => setIsOpen((prev) => !prev)}
+        disabled={disabled}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-label={`${ariaLabel}: ${summary}`}
+        className={cn(
+          selectTriggerVariants({ size: 'sm' }),
+          'w-full min-w-0 justify-between text-left focus:ring-teal-500 focus:border-teal-500 focus:ring-offset-0',
+          options.length === 0 && 'text-gray-400',
+        )}
+      >
+        <span className="min-w-0 flex-1 truncate">{summary}</span>
+        <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 text-gray-400 transition-transform', isOpen && 'rotate-180')} />
+      </Button>
+
+      {isOpen && (
+        <div
+          ref={menuRef}
+          className="absolute left-0 top-full z-50 mt-2 w-[min(32rem,calc(100vw-2rem))] rounded-lg border border-gray-200 bg-white p-3 shadow-xl"
+        >
+          {actions != null && actions.length > 0 && (
+            <div className="mb-2 flex flex-wrap gap-1.5 border-b border-gray-200 pb-2">
+              {actions.map((action) => (
+                <Button
+                  key={action.label}
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                  className={cn(
+                    'min-h-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+                    action.isActive
+                      ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
+                      : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:bg-white hover:text-teal-700',
+                  )}
+                >
+                  {action.label}
+                </Button>
+              ))}
+            </div>
+          )}
+
+          {options.length === 0 ? (
+            <p className="text-xs text-gray-500">{emptyMessage}</p>
+          ) : (
+            <div className="flex flex-wrap gap-1.5">
+              {options.map((option) => {
+                const isSelected = selectedIds.includes(option.value);
+                return (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleToggle(option.value)}
+                    disabled={option.disabled}
+                    title={option.label}
+                    className={cn(
+                      'min-h-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+                      isSelected
+                        ? 'border-teal-600 bg-teal-600 text-white hover:bg-teal-700'
+                        : 'border-gray-300 bg-white text-gray-700 hover:border-teal-400 hover:bg-white hover:text-teal-700',
+                    )}
+                  >
+                    {option.label}
+                  </Button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -70,15 +70,26 @@ export function DomainAnalysis() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { domains, queryLoading: domainsLoading, error: domainsError } = useDomains();
-  const initialDomainId = searchParams.get('domainId') ?? '';
-  const [selectedScope, setSelectedScope] = useState<'DOMAIN' | 'ALL_DOMAINS'>(
-    searchParams.get('scope') === ALL_DOMAINS_SCOPE || initialDomainId.trim() === '' ? 'ALL_DOMAINS' : 'DOMAIN',
-  );
-  const [selectedDomainId, setSelectedDomainId] = useState<string>(initialDomainId);
+  const [selectedDomainIds, setSelectedDomainIds] = useState<string[]>(() => {
+    const domainIdsParam = searchParams.get('domainIds');
+    if (domainIdsParam != null && domainIdsParam !== '') {
+      return domainIdsParam.split(',').filter((id) => id !== '');
+    }
+    const legacyDomainId = searchParams.get('domainId') ?? '';
+    const legacyScope = searchParams.get('scope') ?? '';
+    if (legacyScope === ALL_DOMAINS_SCOPE || legacyDomainId === '') {
+      return [];
+    }
+    return [legacyDomainId];
+  });
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
   const initializedModelSelection = useRef(false);
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
+
+  const effectiveDomainId = selectedDomainIds.length === 1 ? (selectedDomainIds[0] ?? '') : '';
+  const isAllDomains = selectedDomainIds.length !== 1;
+  const queryDomainId = effectiveDomainId !== '' ? effectiveDomainId : (domains[0]?.id ?? '');
   const [exportLoading, setExportLoading] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [refreshNotice, setRefreshNotice] = useState<string | null>(null);
@@ -90,10 +101,10 @@ export function DomainAnalysis() {
   >({
     query: DOMAIN_AVAILABLE_SIGNATURES_QUERY,
     variables: {
-      domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
-      scope: selectedScope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined,
+      domainId: queryDomainId,
+      scope: isAllDomains ? ALL_DOMAINS_SCOPE : undefined,
     },
-    pause: selectedDomainId === '',
+    pause: queryDomainId === '',
     requestPolicy: 'cache-and-network',
   });
 
@@ -109,10 +120,13 @@ export function DomainAnalysis() {
   }, [signatureData]);
 
   useEffect(() => {
-    if (domains.length === 0) return;
-    if (selectedDomainId !== '' && domains.some((d) => d.id === selectedDomainId)) return;
-    setSelectedDomainId(domains[0]?.id ?? '');
-  }, [domains, selectedDomainId]);
+    if (domains.length === 0 || selectedDomainIds.length === 0) return;
+    const validIds = new Set(domains.map((d) => d.id));
+    const next = selectedDomainIds.filter((id) => validIds.has(id));
+    if (next.length !== selectedDomainIds.length) {
+      setSelectedDomainIds(next);
+    }
+  }, [domains, selectedDomainIds]);
 
   useEffect(() => {
     if (signatureOptions.length === 0) { setSelectedSignature(''); return; }
@@ -120,50 +134,52 @@ export function DomainAnalysis() {
     setSelectedSignature(signatureOptions[0]?.signature ?? '');
   }, [selectedSignature, signatureOptions]);
 
-  useEffect(() => { setExportError(null); }, [selectedDomainId, selectedSignature]);
+  useEffect(() => { setExportError(null); }, [effectiveDomainId, selectedSignature]);
 
   useEffect(() => {
     setRefreshNotice(null);
     setRefreshError(null);
-  }, [selectedDomainId, selectedSignature]);
+  }, [effectiveDomainId, selectedSignature]);
 
   useEffect(() => {
-    const currentScope = searchParams.get('scope') === ALL_DOMAINS_SCOPE ? 'ALL_DOMAINS' : 'DOMAIN';
-    const nextDomainId = selectedDomainId !== '' ? selectedDomainId : (domains[0]?.id ?? '');
-    if (nextDomainId === '' && selectedScope === 'DOMAIN') return;
-    if (
-      searchParams.get('domainId') === nextDomainId
-      && (searchParams.get('signature') ?? '') === selectedSignature
-      && currentScope === selectedScope
-    ) return;
     const next = new URLSearchParams(searchParams);
-    if (nextDomainId !== '') next.set('domainId', nextDomainId);
-    else next.delete('domainId');
-    if (selectedScope === 'ALL_DOMAINS') next.set('scope', ALL_DOMAINS_SCOPE);
-    else next.delete('scope');
+    if (selectedDomainIds.length === 0) {
+      next.delete('domainId');
+      next.delete('domainIds');
+      next.delete('scope');
+    } else if (selectedDomainIds.length === 1) {
+      next.set('domainId', selectedDomainIds[0]!);
+      next.delete('domainIds');
+      next.delete('scope');
+    } else {
+      next.set('domainIds', selectedDomainIds.join(','));
+      next.delete('domainId');
+      next.delete('scope');
+    }
     if (selectedSignature === '') next.delete('signature');
     else next.set('signature', selectedSignature);
+    if (next.toString() === searchParams.toString()) return;
     setSearchParams(next, { replace: true });
-  }, [domains, searchParams, selectedDomainId, selectedSignature, selectedScope, setSearchParams]);
+  }, [selectedDomainIds, selectedSignature, searchParams, setSearchParams]);
 
-  const activeUseLegacyQuery = useLegacyQuery && selectedScope !== 'ALL_DOMAINS';
+  const activeUseLegacyQuery = useLegacyQuery && !isAllDomains;
   const [
     { data: scoredData, fetching: scoredFetching, error: scoredError },
     reexecuteScoredQuery,
   ] = useQuery<DomainAnalysisQueryResult, DomainAnalysisQueryVariables>({
     query: DOMAIN_ANALYSIS_QUERY,
     variables: {
-      domainId: selectedDomainId === '' ? domains[0]?.id ?? '' : selectedDomainId,
-      scope: selectedScope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined,
+      domainId: queryDomainId,
+      scope: isAllDomains ? ALL_DOMAINS_SCOPE : undefined,
       signature: selectedSignature === '' ? undefined : selectedSignature,
     },
-    pause: selectedDomainId === '' || activeUseLegacyQuery,
+    pause: queryDomainId === '' || activeUseLegacyQuery,
     requestPolicy: 'cache-and-network',
   });
   const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<DomainAnalysisQueryResult, { domainId: string }>({
     query: DOMAIN_ANALYSIS_QUERY_LEGACY,
-    variables: { domainId: selectedDomainId },
-    pause: selectedDomainId === '' || !activeUseLegacyQuery,
+    variables: { domainId: effectiveDomainId },
+    pause: effectiveDomainId === '' || !activeUseLegacyQuery,
     requestPolicy: 'cache-and-network',
   });
   const [{ data: modelsAnalysisData, fetching: modelsAnalysisFetching, error: modelsAnalysisError }] = useQuery<
@@ -172,10 +188,10 @@ export function DomainAnalysis() {
   >({
     query: MODELS_ANALYSIS_QUERY,
     variables: {
-      ...(selectedScope === 'DOMAIN' && selectedDomainId !== '' ? { domainId: selectedDomainId } : {}),
+      ...(effectiveDomainId !== '' ? { domainId: effectiveDomainId } : {}),
       ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
     },
-    pause: selectedScope === 'DOMAIN' && selectedDomainId === '',
+    pause: !isAllDomains && effectiveDomainId === '',
     requestPolicy: 'cache-and-network',
   });
   const [{ data: llmModelsData }] = useQuery<LlmModelsQueryResult>({
@@ -189,10 +205,10 @@ export function DomainAnalysis() {
   >({
     query: MODELS_STABILITY_QUERY,
     variables: {
-      ...(selectedScope === 'DOMAIN' && selectedDomainId !== '' ? { domainId: selectedDomainId } : {}),
+      ...(effectiveDomainId !== '' ? { domainId: effectiveDomainId } : {}),
       ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
     },
-    pause: selectedScope === 'DOMAIN' && selectedDomainId === '',
+    pause: !isAllDomains && effectiveDomainId === '',
     requestPolicy: 'cache-and-network',
   });
   const [{ fetching: refreshFetching }, refreshDomainAnalysis] = useMutation<
@@ -205,8 +221,8 @@ export function DomainAnalysis() {
     const isFieldError = message.includes('Unknown argument "signature"')
       || message.includes('Cannot query field')
       || message.includes('Unknown field');
-    if (isFieldError && !useLegacyQuery && selectedScope !== 'ALL_DOMAINS') setUseLegacyQuery(true);
-  }, [scoredError, selectedScope, useLegacyQuery]);
+    if (isFieldError && !useLegacyQuery && !isAllDomains) setUseLegacyQuery(true);
+  }, [scoredError, isAllDomains, useLegacyQuery]);
 
   const data = activeUseLegacyQuery ? legacyData : scoredData;
   const fetching = activeUseLegacyQuery ? legacyFetching : scoredFetching;
@@ -219,8 +235,7 @@ export function DomainAnalysis() {
     () => getCacheStatusCopy(data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt, transcriptCount),
     [data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt, transcriptCount],
   );
-  const showPageLoader = domainsLoading || (selectedDomainId !== '' && data?.domainAnalysis == null && fetching);
-  const isAllDomains = selectedScope === 'ALL_DOMAINS';
+  const showPageLoader = domainsLoading || (queryDomainId !== '' && data?.domainAnalysis == null && fetching);
 
   const models = useMemo<ModelEntry[]>(() => {
     const sourceModels = data?.domainAnalysis.models ?? [];
@@ -312,8 +327,19 @@ export function DomainAnalysis() {
     () => filterSelectedModels(models, selectedModelIds, (model) => model.model),
     [models, selectedModelIds],
   );
+
+  const domainSummary = useMemo(() => {
+    if (selectedDomainIds.length === 0 || selectedDomainIds.length === domains.length) {
+      return 'All Domains';
+    }
+    if (selectedDomainIds.length === 1) {
+      const found = domains.find((d) => d.id === selectedDomainIds[0]);
+      return found?.name ?? selectedDomainIds[0] ?? 'Unknown';
+    }
+    return `${selectedDomainIds.length} of ${domains.length} domains`;
+  }, [selectedDomainIds, domains]);
   const selectedModelId = selectedModelIds.length === 1 ? (selectedModelIds[0] ?? null) : null;
-  const selectedDomainIdForDrawer = !isAllDomains && selectedDomainId !== '' ? selectedDomainId : null;
+  const selectedDomainIdForDrawer = effectiveDomainId !== '' ? effectiveDomainId : null;
   const selectedSignatureForDrawer = selectedSignature !== '' ? selectedSignature : null;
 
   useEffect(() => {
@@ -336,14 +362,14 @@ export function DomainAnalysis() {
   );
 
   const handleExport = async () => {
-    if (selectedDomainId === '' || isAllDomains) return;
+    if (effectiveDomainId === '') return;
     setExportLoading(true);
     setExportError(null);
     try {
-      await exportDomainTranscriptsAsCSV(selectedDomainId, selectedSignature !== '' ? selectedSignature : undefined);
+      await exportDomainTranscriptsAsCSV(effectiveDomainId, selectedSignature !== '' ? selectedSignature : undefined);
     } catch (err) {
       setExportError(formatQueryError('Export domain transcripts', err, {
-        domainId: selectedDomainId,
+        domainId: effectiveDomainId,
         signature: selectedSignature === '' ? '(none)' : selectedSignature,
       }));
     } finally {
@@ -352,19 +378,19 @@ export function DomainAnalysis() {
   };
 
   const handleRefreshAnalysis = async () => {
-    if (selectedDomainId === '' || isAllDomains) return;
+    if (effectiveDomainId === '') return;
     setRefreshNotice(null);
     setRefreshError(null);
 
     const result = await refreshDomainAnalysis({
-      domainId: selectedDomainId,
+      domainId: effectiveDomainId,
       signature: selectedSignature === '' ? undefined : selectedSignature,
     });
 
     if (result.error != null) {
       setRefreshError(
         formatQueryError('Refresh domain analysis mutation', result.error, {
-          domainId: selectedDomainId,
+          domainId: effectiveDomainId,
           signature: selectedSignature === '' ? '(none)' : selectedSignature,
         }),
       );
@@ -376,7 +402,7 @@ export function DomainAnalysis() {
   };
 
   const handleRunMissingVignettes = () => {
-    if (selectedDomainId === '' || allMissingDefinitionIds.length === 0 || isAllDomains) return;
+    if (effectiveDomainId === '' || allMissingDefinitionIds.length === 0) return;
     const query = new URLSearchParams();
     query.set('definitionIds', allMissingDefinitionIds.join(','));
     if (selectedSignature !== '') {
@@ -384,7 +410,7 @@ export function DomainAnalysis() {
       const t = parseTemperatureFromSignature(selectedSignature);
       if (t !== null) query.set('temperature', String(t));
     }
-    navigate(`/domains/status/${selectedDomainId}?${query.toString()}`);
+    navigate(`/domains/status/${effectiveDomainId}?${query.toString()}`);
   };
 
   return (
@@ -392,20 +418,18 @@ export function DomainAnalysis() {
       <AnalysisContextBar
         domain={{
           label: 'Domain',
-          value: isAllDomains ? ALL_DOMAINS_SCOPE : selectedDomainId,
-          options: [
-            { value: ALL_DOMAINS_SCOPE, label: 'All domains' },
-            ...domains.map((domain) => ({ value: domain.id, label: domain.name })),
+          summary: domainSummary,
+          selectedIds: selectedDomainIds,
+          options: domains.map((d) => ({ value: d.id, label: d.name })),
+          actions: [
+            {
+              label: 'All Domains',
+              isActive: selectedDomainIds.length === 0 || selectedDomainIds.length === domains.length,
+              onClick: () => setSelectedDomainIds([]),
+            },
           ],
-          onChange: (value) => {
-            if (value === ALL_DOMAINS_SCOPE) {
-              setSelectedScope('ALL_DOMAINS');
-              return;
-            }
-            setSelectedScope('DOMAIN');
-            setSelectedDomainId(value);
-          },
-          disabled: domainsLoading || (domains.length === 0 && !isAllDomains),
+          onChange: setSelectedDomainIds,
+          disabled: domainsLoading,
         }}
         signature={{
           label: 'Signature',
@@ -434,7 +458,7 @@ export function DomainAnalysis() {
       </div>
 
       {exportError !== null && <p className="mt-1 text-xs text-amber-700">{exportError}</p>}
-      {data?.domainAnalysis != null && missingDefinitionCount > 0 && !isAllDomains && (
+      {data?.domainAnalysis != null && missingDefinitionCount > 0 && effectiveDomainId !== '' && (
         <div className="mt-2 space-y-1 text-xs text-gray-500">
           <>
             <div className="flex flex-wrap items-center gap-2">
@@ -461,7 +485,7 @@ export function DomainAnalysis() {
               {cacheStatusCopy.badgeLabel}
             </span>
             <span>{cacheStatusCopy.detail}</span>
-            {!activeUseLegacyQuery && !isAllDomains && (
+            {!activeUseLegacyQuery && effectiveDomainId !== '' && (
               <Button
                 type="button"
                 variant="secondary"
@@ -478,8 +502,8 @@ export function DomainAnalysis() {
               variant="secondary"
               size="sm"
               onClick={handleExport}
-              disabled={selectedDomainId === '' || exportLoading || isAllDomains}
-              title={isAllDomains ? 'CSV export is unavailable in All domains mode' : undefined}
+              disabled={effectiveDomainId === '' || exportLoading}
+              title={effectiveDomainId === '' ? 'CSV export is unavailable in All domains mode' : undefined}
             >
               {exportLoading ? 'Exporting…' : 'Export CSV'}
             </Button>
@@ -493,14 +517,14 @@ export function DomainAnalysis() {
         <ErrorMessage
           message={`Failed to load win rate page: ${
             domainsError != null
-              ? formatQueryError('Win rate domains query', domainsError, { domainId: selectedDomainId })
+              ? formatQueryError('Win rate domains query', domainsError, { domainId: effectiveDomainId })
               : signaturesError != null
                 ? formatQueryError('Win rate signatures query', signaturesError, {
-                  domainId: selectedDomainId,
+                  domainId: effectiveDomainId,
                   signature: selectedSignature === '' ? '(none)' : selectedSignature,
                 })
                 : formatQueryError('Win rate analysis query', error, {
-                  domainId: selectedDomainId,
+                  domainId: effectiveDomainId,
                   signature: selectedSignature === '' ? '(none)' : selectedSignature,
                 })
           }`}
@@ -513,7 +537,7 @@ export function DomainAnalysis() {
         <>
           <ValuePrioritiesSection
             models={selectedModels}
-            selectedDomainId={selectedDomainId}
+            selectedDomainId={effectiveDomainId}
             selectedSignature={selectedSignature === '' ? null : selectedSignature}
             isReadOnly={isAllDomains}
             showStabilityDots
@@ -536,7 +560,7 @@ export function DomainAnalysis() {
             fetching={modelsAnalysisFetching}
             errorMessage={modelsAnalysisError != null
               ? formatQueryError('Win rate domain shifts query', modelsAnalysisError, {
-                domainId: selectedDomainId,
+                domainId: effectiveDomainId,
                 signature: selectedSignature === '' ? '(none)' : selectedSignature,
               })
               : null}
@@ -547,7 +571,7 @@ export function DomainAnalysis() {
             fetching={modelsStabilityFetching}
             errorMessage={modelsStabilityError != null
               ? formatQueryError('Win rate consistency query', modelsStabilityError, {
-                domainId: selectedDomainId,
+                domainId: effectiveDomainId,
                 signature: selectedSignature === '' ? '(none)' : selectedSignature,
               })
               : null}

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -418,6 +418,7 @@ export function DomainAnalysis() {
       <AnalysisContextBar
         domain={{
           label: 'Domain',
+          multi: true,
           summary: domainSummary,
           selectedIds: selectedDomainIds,
           options: domains.map((d) => ({ value: d.id, label: d.name })),


### PR DESCRIPTION
## Summary
- New generic `ChipPicker` component with action-row presets + individual chip grid (same visual style as the models picker)
- Win rate page domain picker replaced from `<Select>` dropdown → `ChipPicker` popover; supports all domains, single domain, or subset to exclude outliers
- `AnalysisContextBar` uses a discriminated union for the `domain` prop — other pages (Domains, PressureSensitivity, DomainCoverage, etc.) keep their existing `<Select>` unchanged
- Models picker in `AnalysisContextBar` also refactored to use `ChipPicker`, eliminating the inline `isOpen`/`useRef`/`useEffect` logic
- `DomainAnalysis` state: `selectedDomainId + selectedScope` → `selectedDomainIds: string[]`; URL backward-compatible (reads legacy `domainId` + `scope` params)
- Phase 1: subset of domains degrades gracefully to all-domains scope for backend queries (Phase 2 will add `domainIds` filter)

## Test plan
- [ ] Preflight passed: lint (0 errors) + build (clean)
- [ ] Domain picker opens as chip popover on `/models/win-rate`
- [ ] "All Domains" action chip selects all; individual domain chips toggle correctly
- [ ] Selecting one domain updates URL to `?domainId=<id>`, selecting all clears to no params
- [ ] Models picker still works (Default Models / Clear all / individual chips)
- [ ] Other pages (Domain Status, Pressure Sensitivity, etc.) still show a `<Select>` dropdown unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)