### PR TITLE
feat(status): collapse open anomalies box when count is zero

### DIFF
--- a/cloud/apps/web/src/components/status/OpenAnomaliesSection.tsx
+++ b/cloud/apps/web/src/components/status/OpenAnomaliesSection.tsx
@@ -98,11 +98,6 @@ export function OpenAnomaliesSection({
   const isInitialLoading = result.fetching && result.data == null;
   const isRefreshing = result.fetching && result.data != null;
 
-  // Collapse when we know there are no anomalies and no error to display.
-  if (!isInitialLoading && result.error == null && !hasAnomalies) {
-    return null;
-  }
-
   // Track in-flight state via a ref so the interval callback always sees the latest
   // value without restarting on every render. This prevents overlapping fetches if
   // the network is slow enough that one request hasn't returned by the next tick.
@@ -132,6 +127,11 @@ export function OpenAnomaliesSection({
     }
     reexecuteRunQuery({ requestPolicy: 'cache-and-network' });
   }, [reexecuteRunQuery, selectedTranscriptTarget]);
+
+  // Collapse when we know there are no anomalies and no error to display.
+  if (!isInitialLoading && result.error == null && !hasAnomalies) {
+    return null;
+  }
 
   const sectionToneClasses = hasAnomalies
     ? 'rounded-lg border border-amber-300 bg-amber-50'

--- a/cloud/apps/web/src/components/status/OpenAnomaliesSection.tsx
+++ b/cloud/apps/web/src/components/status/OpenAnomaliesSection.tsx
@@ -98,6 +98,11 @@ export function OpenAnomaliesSection({
   const isInitialLoading = result.fetching && result.data == null;
   const isRefreshing = result.fetching && result.data != null;
 
+  // Collapse when we know there are no anomalies and no error to display.
+  if (!isInitialLoading && result.error == null && !hasAnomalies) {
+    return null;
+  }
+
   // Track in-flight state via a ref so the interval callback always sees the latest
   // value without restarting on every render. This prevents overlapping fetches if
   // the network is slow enough that one request hasn't returned by the next tick.
@@ -141,9 +146,6 @@ export function OpenAnomaliesSection({
               <h2 className={`text-lg font-medium ${hasAnomalies ? 'text-amber-900' : 'text-gray-900'}`}>
                 {formatRunAnomalyCount(openAnomalies.length)}
               </h2>
-              <p className={`text-sm ${hasAnomalies ? 'text-amber-800' : 'text-gray-500'}`}>
-                Open run anomalies across all domains.
-              </p>
             </div>
             <div className="flex items-center gap-2">
               {isRefreshing && (


### PR DESCRIPTION
## Summary
- When there are no open anomalies (and data has loaded), the Open Anomalies section now returns null and is hidden entirely instead of showing a green all-clear box
- Removed the subtitle text "Open run anomalies across all domains." from beneath the heading
- Error state and initial loading skeleton are unaffected — they still render normally

## Validation
- `npx turbo lint build --filter=@valuerank/web` — 0 errors, 134 pre-existing warnings, build succeeded

## Test plan
- [ ] Status page with 0 anomalies: section is absent
- [ ] Status page with 1+ anomalies: amber table renders as before
- [ ] Error state: section still renders with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)