### PR TITLE
feat(domain-analysis): show refresh progress counter in freshness badge

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/types.ts
@@ -65,6 +65,11 @@ export type DomainAnalysisModel = {
 
 export type DomainAnalysisCacheStatus = 'FRESH' | 'UPDATING' | 'OUT_OF_DATE';
 
+export type DomainAnalysisRefreshProgress = {
+  completedRuns: number;
+  totalRuns: number;
+};
+
 export type DomainAnalysisResult = {
   domainId: string;
   domainName: string;
@@ -83,8 +88,10 @@ export type DomainAnalysisResult = {
   rankingShapeBenchmarks: RankingShapeBenchmarks;
   clusterAnalysis: ClusterAnalysis;
   clusterAnalysisByMethod: Record<string, ClusterAnalysis>;
+  refreshProgress: DomainAnalysisRefreshProgress | null;
 };
 
+export const DomainAnalysisRefreshProgressRef = builder.objectRef<DomainAnalysisRefreshProgress>('DomainAnalysisRefreshProgress');
 export const RankingShapeRef = builder.objectRef<RankingShape>('RankingShape');
 export const RankingShapeBenchmarksRef = builder.objectRef<RankingShapeBenchmarks>('RankingShapeBenchmarks');
 export const ClusterMemberRef = builder.objectRef<ClusterMember>('ClusterMember');
@@ -350,6 +357,11 @@ builder.objectType(DomainAnalysisResultRef, {
       type: 'DateTime',
       resolve: (parent) => parent.generatedAt,
     }),
+    refreshProgress: t.field({
+      type: DomainAnalysisRefreshProgressRef,
+      nullable: true,
+      resolve: (parent) => parent.refreshProgress,
+    }),
     rankingShapeBenchmarks: t.field({
       type: RankingShapeBenchmarksRef,
       resolve: (parent) => parent.rankingShapeBenchmarks,
@@ -359,6 +371,13 @@ builder.objectType(DomainAnalysisResultRef, {
       resolve: (parent) => parent.clusterAnalysis,
     }),
     clusterAnalysisByMethod: t.expose('clusterAnalysisByMethod', { type: 'JSON' }),
+  }),
+});
+
+builder.objectType(DomainAnalysisRefreshProgressRef, {
+  fields: (t) => ({
+    completedRuns: t.exposeInt('completedRuns'),
+    totalRuns: t.exposeInt('totalRuns'),
   }),
 });
 

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -145,6 +145,7 @@ function buildEmptyDomainAnalysisResult(params: {
   generatedAt: Date;
   cacheStatus: DomainAnalysisCacheStatus;
   unavailableReason: string;
+  refreshProgress?: { completedRuns: number; totalRuns: number } | null;
 }): DomainAnalysisResult {
   return {
     domainId: params.domainId,
@@ -168,6 +169,7 @@ function buildEmptyDomainAnalysisResult(params: {
     cacheStatus: params.cacheStatus,
     contributionSummary: [],
     excludedDataSummary: [],
+    refreshProgress: params.refreshProgress ?? null,
   };
 }
 
@@ -270,6 +272,7 @@ function buildDomainAnalysisResultFromSnapshot(params: {
     cacheStatus: params.cacheStatus,
     contributionSummary: params.snapshot.contributionSummary ?? [],
     excludedDataSummary: params.snapshot.excludedDataSummary ?? [],
+    refreshProgress: null,
   };
 }
 
@@ -464,6 +467,7 @@ export async function getDomainAnalysisResult(params: {
           generatedAt: currentSnapshot.createdAt,
           cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.UPDATING,
           unavailableReason: `Domain analysis is rebuilding (${buildProgress.completedRuns}/${buildProgress.totalRuns} runs processed). Refresh in a moment.`,
+          refreshProgress: { completedRuns: buildProgress.completedRuns, totalRuns: buildProgress.totalRuns },
         });
       }
     }

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -852,6 +852,11 @@ type DomainAnalysisPairVignetteDetail {
   winRateCI95Low: Float
 }
 
+type DomainAnalysisRefreshProgress {
+  completedRuns: Int!
+  totalRuns: Int!
+}
+
 type DomainAnalysisRefreshResult {
   message: String!
   mode: String!
@@ -873,6 +878,7 @@ type DomainAnalysisResult {
   missingDefinitions: [DomainAnalysisMissingDefinition!]!
   models: [DomainAnalysisModel!]!
   rankingShapeBenchmarks: RankingShapeBenchmarks!
+  refreshProgress: DomainAnalysisRefreshProgress
   targetedDefinitions: Int!
   totalDefinitions: Int!
   unavailableModels: [DomainAnalysisUnavailableModel!]!
@@ -1587,6 +1593,35 @@ type ModelCostEstimate {
   totalCost: Float!
 }
 
+"""Derived bottleneck diagnosis for a specific model within a run"""
+type ModelExecutionBottleneck {
+  """Recommended tuning action for this model"""
+  action: String!
+
+  """Confidence in the diagnosis"""
+  confidence: String!
+
+  """Human-readable model name if available"""
+  displayName: String
+
+  """Model identifier"""
+  modelId: String!
+
+  """Dominant timing pressure for this model in milliseconds"""
+  pressureMs: Int!
+  probe: StageSummary!
+
+  """Provider name if available"""
+  providerName: String
+
+  """Human-readable recommendation"""
+  recommendation: String!
+
+  """Likely bottleneck stage for this model"""
+  stage: String!
+  summarize: StageSummary!
+}
+
 type ModelInfo {
   label: String!
   modelId: ID!
@@ -2236,6 +2271,12 @@ type ProbeResult {
 
   """Output tokens generated (for cost tracking)"""
   outputTokens: Int
+
+  """Time spent waiting in the queue before the probe result was recorded"""
+  queueWaitMs: Int
+
+  """When the probe job was enqueued"""
+  queuedAt: DateTime
 
   """Number of retries attempted before final result"""
   retryCount: Int!
@@ -2910,6 +2951,9 @@ type QueueHealth {
   """Jobs completed in the last 24 hours"""
   completedLast24h: Int!
 
+  """Jobs completed in the last 30 minutes (rolling window)"""
+  completedLast30m: Int!
+
   """Error message if queue health check failed"""
   error: String
 
@@ -3064,6 +3108,11 @@ type Run {
   estimatedCosts: CostEstimate
 
   """
+  Derived bottleneck diagnosis for probe and summarize work, useful for deciding whether to increase parallelism or investigate worker latency
+  """
+  executionBottleneck: RunExecutionBottleneck!
+
+  """
   Real-time execution metrics for monitoring parallel processing (only available during RUNNING state)
   """
   executionMetrics: ExecutionMetrics
@@ -3082,6 +3131,11 @@ type Run {
 
   """Mirrored runs in the same domain with matching signature"""
   mirroredRuns: [Run!]!
+
+  """
+  Derived bottleneck diagnosis broken down by model, useful for identifying a specific model that is causing slowdowns or failures
+  """
+  modelExecutionBottlenecks: [ModelExecutionBottleneck!]!
 
   """List of LLM models used in this run"""
   models: [LlmModel!]!
@@ -3268,6 +3322,23 @@ type RunConditionGridCell {
   trialCount: Int!
 }
 
+"""Derived bottleneck diagnosis for probe and summarize work on a run"""
+type RunExecutionBottleneck {
+  """Recommended tuning action"""
+  action: String!
+
+  """Confidence in the diagnosis"""
+  confidence: String!
+  probe: StageSummary!
+
+  """Human-readable recommendation"""
+  recommendation: String!
+
+  """Likely bottleneck stage"""
+  stage: String!
+  summarize: StageSummary!
+}
+
 """Priority level for run execution (affects job queue ordering)"""
 enum RunPriority {
   HIGH
@@ -3333,6 +3404,18 @@ type SetDefaultModelResult {
 
   """Always null when multiple defaults are allowed"""
   previousDefault: LlmModel
+}
+
+"""Timing summary for one run stage"""
+type StageSummary {
+  execution: TimingSummary!
+
+  """Number of failed rows in this stage"""
+  failedCount: Int!
+  queueWait: TimingSummary!
+
+  """Total rows considered for this stage"""
+  totalCount: Int!
 }
 
 """Input for starting a new evaluation run"""
@@ -3461,6 +3544,21 @@ enum TaskStatus {
   RUNNING
 }
 
+"""Timing statistics for a set of queue wait or execution samples"""
+type TimingSummary {
+  """Average duration in milliseconds"""
+  averageMs: Int
+
+  """Maximum duration in milliseconds"""
+  maxMs: Int
+
+  """95th percentile duration in milliseconds"""
+  p95Ms: Int
+
+  """Number of timing samples included in the summary"""
+  sampleCount: Int!
+}
+
 """A transcript from a model conversation during a run"""
 type Transcript {
   content: JSON!
@@ -3499,6 +3597,15 @@ type Transcript {
   sampleIndex: Int!
   scenario: Scenario
   scenarioId: String
+
+  """Time spent processing the summarize job"""
+  summarizeDurationMs: Int
+
+  """Time spent waiting in the queue before summarization completed"""
+  summarizeQueueWaitMs: Int
+
+  """When the summarize job was enqueued"""
+  summarizeQueuedAt: DateTime
   tokenCount: Int!
   turnCount: Int!
 }

--- a/cloud/apps/web/src/api/operations/domainAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.graphql
@@ -30,6 +30,10 @@ query DomainAnalysis($domainId: ID!, $scope: String, $signature: String) {
     definitionsWithAnalysis
     cacheStatus
     generatedAt
+    refreshProgress {
+      completedRuns
+      totalRuns
+    }
     models {
       model
       label

--- a/cloud/apps/web/src/api/operations/domainAnalysis.ts
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.ts
@@ -142,6 +142,7 @@ export type DomainAnalysisResult = {
   definitionsWithAnalysis: number;
   cacheStatus: 'FRESH' | 'UPDATING' | 'OUT_OF_DATE';
   generatedAt: string;
+  refreshProgress: { completedRuns: number; totalRuns: number } | null;
   models: DomainAnalysisModel[];
   unavailableModels: DomainAnalysisUnavailableModel[];
   rankingShapeBenchmarks?: RankingShapeBenchmarks;

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -784,6 +784,12 @@ export type DomainAnalysisPairVignetteDetail = {
   winRateCI95Low?: Maybe<Scalars['Float']['output']>;
 };
 
+export type DomainAnalysisRefreshProgress = {
+  __typename?: 'DomainAnalysisRefreshProgress';
+  completedRuns: Scalars['Int']['output'];
+  totalRuns: Scalars['Int']['output'];
+};
+
 export type DomainAnalysisRefreshResult = {
   __typename?: 'DomainAnalysisRefreshResult';
   message: Scalars['String']['output'];
@@ -807,6 +813,7 @@ export type DomainAnalysisResult = {
   missingDefinitions: Array<DomainAnalysisMissingDefinition>;
   models: Array<DomainAnalysisModel>;
   rankingShapeBenchmarks: RankingShapeBenchmarks;
+  refreshProgress?: Maybe<DomainAnalysisRefreshProgress>;
   targetedDefinitions: Scalars['Int']['output'];
   totalDefinitions: Scalars['Int']['output'];
   unavailableModels: Array<DomainAnalysisUnavailableModel>;
@@ -1490,6 +1497,29 @@ export type ModelCostEstimate = {
   scenarioCount: Scalars['Int']['output'];
   /** Total cost (inputCost + outputCost) in USD */
   totalCost: Scalars['Float']['output'];
+};
+
+/** Derived bottleneck diagnosis for a specific model within a run */
+export type ModelExecutionBottleneck = {
+  __typename?: 'ModelExecutionBottleneck';
+  /** Recommended tuning action for this model */
+  action: Scalars['String']['output'];
+  /** Confidence in the diagnosis */
+  confidence: Scalars['String']['output'];
+  /** Human-readable model name if available */
+  displayName?: Maybe<Scalars['String']['output']>;
+  /** Model identifier */
+  modelId: Scalars['String']['output'];
+  /** Dominant timing pressure for this model in milliseconds */
+  pressureMs: Scalars['Int']['output'];
+  probe: StageSummary;
+  /** Provider name if available */
+  providerName?: Maybe<Scalars['String']['output']>;
+  /** Human-readable recommendation */
+  recommendation: Scalars['String']['output'];
+  /** Likely bottleneck stage for this model */
+  stage: Scalars['String']['output'];
+  summarize: StageSummary;
 };
 
 export type ModelInfo = {
@@ -2548,6 +2578,10 @@ export type ProbeResult = {
   modelId: Scalars['String']['output'];
   /** Output tokens generated (for cost tracking) */
   outputTokens?: Maybe<Scalars['Int']['output']>;
+  /** Time spent waiting in the queue before the probe result was recorded */
+  queueWaitMs?: Maybe<Scalars['Int']['output']>;
+  /** When the probe job was enqueued */
+  queuedAt?: Maybe<Scalars['DateTime']['output']>;
   /** Number of retries attempted before final result */
   retryCount: Scalars['Int']['output'];
   runId: Scalars['String']['output'];
@@ -3530,6 +3564,8 @@ export type Run = {
   deletedBy?: Maybe<User>;
   /** Estimated cost calculated when run was created. Stored in run config for historical reference. */
   estimatedCosts?: Maybe<CostEstimate>;
+  /** Derived bottleneck diagnosis for probe and summarize work, useful for deciding whether to increase parallelism or investigate worker latency */
+  executionBottleneck: RunExecutionBottleneck;
   /** Real-time execution metrics for monitoring parallel processing (only available during RUNNING state) */
   executionMetrics?: Maybe<ExecutionMetrics>;
   experiment?: Maybe<Experiment>;
@@ -3542,6 +3578,8 @@ export type Run = {
   lastAccessedAt?: Maybe<Scalars['DateTime']['output']>;
   /** Mirrored runs in the same domain with matching signature */
   mirroredRuns: Array<Run>;
+  /** Derived bottleneck diagnosis broken down by model, useful for identifying a specific model that is causing slowdowns or failures */
+  modelExecutionBottlenecks: Array<ModelExecutionBottleneck>;
   /** List of LLM models used in this run */
   models: Array<LlmModel>;
   /** Optional user-defined name for this run */
@@ -3673,6 +3711,21 @@ export type RunConditionGridCell = {
   trialCount: Scalars['Int']['output'];
 };
 
+/** Derived bottleneck diagnosis for probe and summarize work on a run */
+export type RunExecutionBottleneck = {
+  __typename?: 'RunExecutionBottleneck';
+  /** Recommended tuning action */
+  action: Scalars['String']['output'];
+  /** Confidence in the diagnosis */
+  confidence: Scalars['String']['output'];
+  probe: StageSummary;
+  /** Human-readable recommendation */
+  recommendation: Scalars['String']['output'];
+  /** Likely bottleneck stage */
+  stage: Scalars['String']['output'];
+  summarize: StageSummary;
+};
+
 /** Priority level for run execution (affects job queue ordering) */
 export type RunPriority =
   | 'HIGH'
@@ -3735,6 +3788,17 @@ export type SetDefaultModelResult = {
   model: LlmModel;
   /** Always null when multiple defaults are allowed */
   previousDefault?: Maybe<LlmModel>;
+};
+
+/** Timing summary for one run stage */
+export type StageSummary = {
+  __typename?: 'StageSummary';
+  execution: TimingSummary;
+  /** Number of failed rows in this stage */
+  failedCount: Scalars['Int']['output'];
+  queueWait: TimingSummary;
+  /** Total rows considered for this stage */
+  totalCount: Scalars['Int']['output'];
 };
 
 /** Input for starting a new evaluation run */
@@ -3839,6 +3903,19 @@ export type TaskStatus =
   | 'PENDING'
   | 'RUNNING';
 
+/** Timing statistics for a set of queue wait or execution samples */
+export type TimingSummary = {
+  __typename?: 'TimingSummary';
+  /** Average duration in milliseconds */
+  averageMs?: Maybe<Scalars['Int']['output']>;
+  /** Maximum duration in milliseconds */
+  maxMs?: Maybe<Scalars['Int']['output']>;
+  /** 95th percentile duration in milliseconds */
+  p95Ms?: Maybe<Scalars['Int']['output']>;
+  /** Number of timing samples included in the summary */
+  sampleCount: Scalars['Int']['output'];
+};
+
 /** A transcript from a model conversation during a run */
 export type Transcript = {
   __typename?: 'Transcript';
@@ -3866,6 +3943,12 @@ export type Transcript = {
   sampleIndex: Scalars['Int']['output'];
   scenario?: Maybe<Scenario>;
   scenarioId?: Maybe<Scalars['String']['output']>;
+  /** Time spent processing the summarize job */
+  summarizeDurationMs?: Maybe<Scalars['Int']['output']>;
+  /** Time spent waiting in the queue before summarization completed */
+  summarizeQueueWaitMs?: Maybe<Scalars['Int']['output']>;
+  /** When the summarize job was enqueued */
+  summarizeQueuedAt?: Maybe<Scalars['DateTime']['output']>;
   tokenCount: Scalars['Int']['output'];
   turnCount: Scalars['Int']['output'];
 };
@@ -4373,7 +4456,7 @@ export type DomainAnalysisQueryVariables = Exact<{
 }>;
 
 
-export type DomainAnalysisQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, definitionsWithAnalysis: number, cacheStatus: string, generatedAt: string, clusterAnalysisByMethod: unknown, contributionSummary: Array<{ __typename?: 'DomainAnalysisContributionSummary', domainId: string, domainName: string, rawTrialCount: number, share: number }>, excludedDataSummary: Array<{ __typename?: 'DomainAnalysisExcludedDataSummary', domainId: string, domainName: string, reasonCode: string, count: number }>, missingDefinitions: Array<{ __typename?: 'DomainAnalysisMissingDefinition', definitionId: string, definitionName: string, reasonCode: string, reasonLabel: string, missingAllModels: boolean, missingModelIds: Array<string>, missingModelLabels: Array<string> }>, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number }>, rankingShape: { __typename?: 'RankingShape', topStructure: string, bottomStructure: string, topGap: number, bottomGap: number, spread: number, steepness: number, dominanceZScore?: number | null }, pairwiseWinRateModel?: { __typename?: 'PairwiseWinRateModel', valueOrder: Array<string>, winRateMatrix: Array<Array<number | null>>, trialCountMatrix: Array<Array<number>> } | null }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }>, rankingShapeBenchmarks: { __typename?: 'RankingShapeBenchmarks', domainMeanTopGap: number, domainStdTopGap?: number | null, medianSpread: number }, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } } };
+export type DomainAnalysisQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, definitionsWithAnalysis: number, cacheStatus: string, generatedAt: string, clusterAnalysisByMethod: unknown, contributionSummary: Array<{ __typename?: 'DomainAnalysisContributionSummary', domainId: string, domainName: string, rawTrialCount: number, share: number }>, excludedDataSummary: Array<{ __typename?: 'DomainAnalysisExcludedDataSummary', domainId: string, domainName: string, reasonCode: string, count: number }>, missingDefinitions: Array<{ __typename?: 'DomainAnalysisMissingDefinition', definitionId: string, definitionName: string, reasonCode: string, reasonLabel: string, missingAllModels: boolean, missingModelIds: Array<string>, missingModelLabels: Array<string> }>, refreshProgress?: { __typename?: 'DomainAnalysisRefreshProgress', completedRuns: number, totalRuns: number } | null, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number }>, rankingShape: { __typename?: 'RankingShape', topStructure: string, bottomStructure: string, topGap: number, bottomGap: number, spread: number, steepness: number, dominanceZScore?: number | null }, pairwiseWinRateModel?: { __typename?: 'PairwiseWinRateModel', valueOrder: Array<string>, winRateMatrix: Array<Array<number | null>>, trialCountMatrix: Array<Array<number>> } | null }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }>, rankingShapeBenchmarks: { __typename?: 'RankingShapeBenchmarks', domainMeanTopGap: number, domainStdTopGap?: number | null, medianSpread: number }, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } } };
 
 export type RefreshDomainAnalysisMutationVariables = Exact<{
   domainId: Scalars['ID']['input'];
@@ -6170,6 +6253,10 @@ export const DomainAnalysisDocument = gql`
     definitionsWithAnalysis
     cacheStatus
     generatedAt
+    refreshProgress {
+      completedRuns
+      totalRuns
+    }
     models {
       model
       label

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -232,9 +232,21 @@ export function DomainAnalysis() {
     [data?.domainAnalysis.models, selectedModelIds],
   );
   const cacheStatusCopy = useMemo(
-    () => getCacheStatusCopy(data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt, transcriptCount),
-    [data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt, transcriptCount],
+    () => getCacheStatusCopy(
+      data?.domainAnalysis.cacheStatus,
+      data?.domainAnalysis.generatedAt,
+      transcriptCount,
+      data?.domainAnalysis.refreshProgress,
+    ),
+    [data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt, data?.domainAnalysis.refreshProgress, transcriptCount],
   );
+
+  const isUpdating = data?.domainAnalysis.cacheStatus === 'UPDATING';
+  useEffect(() => {
+    if (!isUpdating) return;
+    const id = setInterval(() => { reexecuteScoredQuery({ requestPolicy: 'network-only' }); }, 20_000);
+    return () => { clearInterval(id); };
+  }, [isUpdating, reexecuteScoredQuery]);
   const showPageLoader = domainsLoading || (queryDomainId !== '' && data?.domainAnalysis == null && fetching);
 
   const models = useMemo<ModelEntry[]>(() => {

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -167,7 +167,7 @@ export function ModelsGroups() {
   }, [searchParams, selectedDomainIds, selectedSignature, setSearchParams]);
 
   const activeUseLegacyQuery = useLegacyQuery && !isAllDomains;
-  const [{ data: scoredData, fetching: scoredFetching, error: scoredError }] = useQuery<DomainAnalysisQueryResult, DomainAnalysisQueryVariables>({
+  const [{ data: scoredData, fetching: scoredFetching, error: scoredError }, reexecuteScoredQuery] = useQuery<DomainAnalysisQueryResult, DomainAnalysisQueryVariables>({
     query: DOMAIN_ANALYSIS_QUERY,
     variables: {
       domainId: queryDomainId,
@@ -289,9 +289,21 @@ export function ModelsGroups() {
     [data?.domainAnalysis.models, visibleModelIds],
   );
   const cacheStatusCopy = useMemo(
-    () => getCacheStatusCopy(data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt, transcriptCount),
-    [data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt, transcriptCount],
+    () => getCacheStatusCopy(
+      data?.domainAnalysis.cacheStatus,
+      data?.domainAnalysis.generatedAt,
+      transcriptCount,
+      data?.domainAnalysis.refreshProgress,
+    ),
+    [data?.domainAnalysis.cacheStatus, data?.domainAnalysis.generatedAt, data?.domainAnalysis.refreshProgress, transcriptCount],
   );
+
+  const isUpdating = data?.domainAnalysis.cacheStatus === 'UPDATING';
+  useEffect(() => {
+    if (!isUpdating) return;
+    const id = setInterval(() => { reexecuteScoredQuery({ requestPolicy: 'network-only' }); }, 20_000);
+    return () => { clearInterval(id); };
+  }, [isUpdating, reexecuteScoredQuery]);
   const domainSummary = useMemo(() => {
     if (isAllDomains) return 'All Domains';
     if (selectedDomainIds.length === 1) {

--- a/cloud/apps/web/src/utils/domainAnalysisUtils.ts
+++ b/cloud/apps/web/src/utils/domainAnalysisUtils.ts
@@ -68,6 +68,7 @@ export function getCacheStatusCopy(
   cacheStatus: 'FRESH' | 'UPDATING' | 'OUT_OF_DATE' | undefined,
   generatedAt: string | undefined,
   transcriptCount: number,
+  refreshProgress?: { completedRuns: number; totalRuns: number } | null,
 ): {
   badgeLabel: string;
   badgeClassName: string;
@@ -86,10 +87,13 @@ export function getCacheStatusCopy(
   }
 
   if (cacheStatus === 'UPDATING') {
+    const progressLabel = refreshProgress != null
+      ? `${refreshProgress.completedRuns} of ${refreshProgress.totalRuns} runs refreshed.`
+      : 'A refresh is running in the background.';
     return {
       badgeLabel: 'Cached',
       badgeClassName: 'border-amber-200 bg-amber-50 text-amber-800',
-      detail: `Showing saved results from ${generatedLabel}. ${transcriptLabel} A refresh is running in the background.`,
+      detail: `Showing saved results from ${generatedLabel}. ${transcriptLabel} ${progressLabel}`,
     };
   }
 


### PR DESCRIPTION
## Summary
- Adds a new `DomainAnalysisRefreshProgress` GraphQL type exposing `completedRuns` and `totalRuns` from the backend build-progress struct
- When `cacheStatus` is `UPDATING`, the freshness badge now shows **"X of Y runs refreshed."** instead of the static "A refresh is running in the background."
- The badge re-fetches from the server every 20 seconds while the refresh is in progress, so the counter advances in near-real-time
- Applies to both `DomainAnalysis` and `ModelsGroups` pages

## Test plan
- [ ] Trigger a domain-analysis rebuild and observe the freshness badge cycling through "X of Y runs refreshed." as runs complete
- [ ] Confirm the badge updates every ~20 s without a full page reload
- [ ] Confirm badge returns to normal "Cached" or "Fresh" once cacheStatus leaves UPDATING
- [ ] Preflight passed (lint + build, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)