### PR TITLE
fix(domain-analysis): show 0/N counter immediately when stale snapshot queued

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -460,18 +460,23 @@ export async function getDomainAnalysisResult(params: {
   }
 
   if (currentSnapshot != null && parsedCurrent != null) {
+    const totalRuns = state.resolvedSignatureRuns.filteredSourceRunIds.length;
     const queued = await queueDomainAnalysisRefresh({
       scope: state.scope,
       domainId: state.domain.id,
       signature: state.selectedSignature,
       reason: 'page-load-stale',
     });
-    return buildDomainAnalysisResultFromSnapshot({
+    const result = buildDomainAnalysisResultFromSnapshot({
       snapshot: parsedCurrent,
       activeModels,
       generatedAt: currentSnapshot.createdAt,
       cacheStatus: queued ? DOMAIN_ANALYSIS_CACHE_STATUS.UPDATING : DOMAIN_ANALYSIS_CACHE_STATUS.OUT_OF_DATE,
     });
+    if (queued) {
+      result.refreshProgress = { completedRuns: 0, totalRuns };
+    }
+    return result;
   }
 
   // A CURRENT snapshot may exist but only contain `buildProgress` — i.e., a


### PR DESCRIPTION
## Summary
- **Root cause:** The "X of Y runs refreshed" counter only appeared when the backend was mid-rebuild (path 2: progress-only snapshot). For the common case where a stale snapshot is returned while a background job is queued (path 1), `refreshProgress` was always `null`.
- **Fix:** In path 1, use `state.resolvedSignatureRuns.filteredSourceRunIds.length` (already computed) as `totalRuns` and immediately set `refreshProgress: { completedRuns: 0, totalRuns }`. This shows "0 of N runs refreshed." from the first page load, then subsequent 20 s polls show actual progress once the background job starts writing its progress snapshots.

## Test plan
- [ ] Load a domain with UPDATING status — badge should now show "0 of N runs refreshed." instead of the static "A refresh is running in the background."
- [ ] After ~20 s poll, counter should advance as the background job progresses
- [ ] Once rebuild finishes, badge disappears (FRESH)
- [ ] Preflight passed (API build: 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)