### PR TITLE
fix(domain-launch): gate all batches on backpressure, abort cleanly on timeout

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts
+++ b/cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts
@@ -18,29 +18,51 @@ const backpressureLog = createLogger('domain-launch:backpressure');
 // Domain-level launches (e.g. "Run all 90 definitions") used to dump every probe job
 // for every run into PgBoss in a 3-second window. With 8 models × 200 probes × 90 runs
 // that is ~144k jobs hitting a 150-slot worker pool — most of the tail expired before
-// any worker reached it. We keep the existing batching at 25 runs per pass and add a
-// poll between batches that waits for the probe queue to drop below ~2x total
-// parallelism before submitting the next batch.
-const BACKPRESSURE_PROBE_THRESHOLD = 300;
-const BACKPRESSURE_POLL_MS = 5000;
-const BACKPRESSURE_MAX_WAIT_MS = 5 * 60 * 1000;
+// any worker reached it. We keep the existing batching at 25 runs per pass and check
+// queue depth before every batch — including the first — so a launch fired on top of
+// an already-saturated queue waits rather than piling on. The pg-boss query reads
+// physical queue depth across all sources, so PAC backfills and direct `startRun`
+// calls also count against the budget.
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
-async function waitForProbeQueueCapacity(): Promise<void> {
+export const BACKPRESSURE_PROBE_THRESHOLD = parsePositiveInt(
+  process.env.DOMAIN_LAUNCH_BACKPRESSURE_THRESHOLD,
+  300,
+);
+export const BACKPRESSURE_POLL_MS = parsePositiveInt(
+  process.env.DOMAIN_LAUNCH_BACKPRESSURE_POLL_MS,
+  5_000,
+);
+export const BACKPRESSURE_MAX_WAIT_MS = parsePositiveInt(
+  process.env.DOMAIN_LAUNCH_BACKPRESSURE_MAX_WAIT_MS,
+  5 * 60 * 1000,
+);
+
+export type ProbeQueueCapacityResult =
+  | { ok: true; inFlight: number }
+  | { ok: false; reason: 'timeout'; lastInFlight: number; waitedMs: number };
+
+export async function waitForProbeQueueCapacity(): Promise<ProbeQueueCapacityResult> {
   // In test or pre-boot contexts there is no PgBoss instance — skip without blocking.
-  if (!isBossRunning()) return;
+  if (!isBossRunning()) return { ok: true, inFlight: 0 };
   const boss = getBoss();
   const startedAt = Date.now();
+  let lastInFlight = 0;
   while (Date.now() - startedAt < BACKPRESSURE_MAX_WAIT_MS) {
     const queues = await boss.getQueues();
-    const inFlight = queues
+    lastInFlight = queues
       .filter((q) => isActiveProbeQueueName(q.name))
       .reduce((sum, q) => sum + q.activeCount + q.queuedCount, 0);
-    if (inFlight < BACKPRESSURE_PROBE_THRESHOLD) {
-      return;
+    if (lastInFlight < BACKPRESSURE_PROBE_THRESHOLD) {
+      return { ok: true, inFlight: lastInFlight };
     }
     backpressureLog.info(
       {
-        inFlightProbes: inFlight,
+        inFlightProbes: lastInFlight,
         threshold: BACKPRESSURE_PROBE_THRESHOLD,
         waitedMs: Date.now() - startedAt,
       },
@@ -48,13 +70,16 @@ async function waitForProbeQueueCapacity(): Promise<void> {
     );
     await new Promise((resolve) => setTimeout(resolve, BACKPRESSURE_POLL_MS));
   }
+  const waitedMs = Date.now() - startedAt;
   backpressureLog.warn(
     {
       thresholdJobs: BACKPRESSURE_PROBE_THRESHOLD,
       maxWaitMs: BACKPRESSURE_MAX_WAIT_MS,
+      lastInFlight,
     },
-    'Domain launch backpressure timed out — proceeding to next batch anyway'
+    'Domain launch backpressure timed out — aborting remaining batches'
   );
+  return { ok: false, reason: 'timeout', lastInFlight, waitedMs };
 }
 
 type PrismaTransactionClient = Parameters<Parameters<typeof db.$transaction>[0]>[0];
@@ -92,8 +117,25 @@ export async function executeLaunchRuns(params: {
       continue;
     }
 
-    if (offset > 0) {
-      await waitForProbeQueueCapacity();
+    const capacity = await waitForProbeQueueCapacity();
+    if (!capacity.ok) {
+      const aborted = launchSlots.slice(offset);
+      failedDefinitions += aborted.length;
+      for (const slot of aborted) {
+        log.error(
+          {
+            domainId,
+            definitionId: slot.definition.id,
+            scopeCategory,
+            lastInFlight: capacity.lastInFlight,
+            threshold: BACKPRESSURE_PROBE_THRESHOLD,
+            waitedMs: capacity.waitedMs,
+            error: 'probe queue backpressure timeout',
+          },
+          'Aborted domain evaluation member run due to backpressure timeout'
+        );
+      }
+      break;
     }
 
     const runResults = await Promise.allSettled(
@@ -153,12 +195,44 @@ export async function executeBackfillRuns(params: {
   let failedDefinitions = 0;
   const runs: DomainTrialRunEntry[] = [];
 
-  let groupIndex = 0;
+  let aborted = false;
   for (const group of backfillGroups) {
-    if (groupIndex > 0) {
-      await waitForProbeQueueCapacity();
+    if (aborted) {
+      failedDefinitions += group.definitions.length;
+      for (const definition of group.definitions) {
+        log.error(
+          {
+            domainEvaluationId,
+            definitionId: definition.id,
+            modelId: group.modelId,
+            error: 'probe queue backpressure timeout',
+          },
+          'Aborted evaluation model backfill run due to backpressure timeout',
+        );
+      }
+      continue;
     }
-    groupIndex += 1;
+
+    const capacity = await waitForProbeQueueCapacity();
+    if (!capacity.ok) {
+      aborted = true;
+      failedDefinitions += group.definitions.length;
+      for (const definition of group.definitions) {
+        log.error(
+          {
+            domainEvaluationId,
+            definitionId: definition.id,
+            modelId: group.modelId,
+            lastInFlight: capacity.lastInFlight,
+            threshold: BACKPRESSURE_PROBE_THRESHOLD,
+            waitedMs: capacity.waitedMs,
+            error: 'probe queue backpressure timeout',
+          },
+          'Aborted evaluation model backfill run due to backpressure timeout',
+        );
+      }
+      continue;
+    }
     const activeEquivalentRuns = await tx.run.findMany({
       where: {
         definitionId: { in: group.definitions.map((definition) => definition.id) },

--- a/cloud/apps/api/tests/graphql/mutations/domain/launch/execute-runs.test.ts
+++ b/cloud/apps/api/tests/graphql/mutations/domain/launch/execute-runs.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const startRunMock = vi.hoisted(() => vi.fn());
+const getBossMock = vi.hoisted(() => vi.fn());
+const isBossRunningMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../../src/services/run/index.js', () => ({
+  startRun: startRunMock,
+}));
+
+vi.mock('../../../../../src/queue/boss.js', () => ({
+  getBoss: getBossMock,
+  isBossRunning: isBossRunningMock,
+}));
+
+import {
+  executeLaunchRuns,
+  waitForProbeQueueCapacity,
+  BACKPRESSURE_POLL_MS,
+  BACKPRESSURE_PROBE_THRESHOLD,
+  BACKPRESSURE_MAX_WAIT_MS,
+} from '../../../../../src/graphql/mutations/domain/launch/execute-runs.js';
+import type { LaunchSlot } from '../../../../../src/graphql/mutations/domain/launch/types.js';
+
+function makeSlots(count: number): LaunchSlot[] {
+  return Array.from({ length: count }, (_, i) => ({
+    definition: {
+      id: `def-${i}`,
+      name: `def-${i}`,
+      parentId: null,
+      version: 1,
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      content: {},
+    } as unknown as LaunchSlot['definition'],
+  }));
+}
+
+const baseParams = {
+  selectedModels: ['model-a'],
+  samplePercentage: 100,
+  samplesPerScenario: 1,
+  temperature: null,
+  scopeCategory: 'EVALUATION' as const,
+  userId: 'user-1',
+  domainId: 'domain-1',
+};
+
+describe('executeLaunchRuns backpressure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isBossRunningMock.mockReturnValue(false);
+    startRunMock.mockImplementation(async ({ definitionId }) => ({
+      run: {
+        id: `run-${definitionId}`,
+        status: 'RUNNING',
+        definitionId,
+        experimentId: null,
+        config: {},
+        progress: { total: 1, completed: 0, failed: 0 },
+        createdAt: new Date(0),
+      },
+      jobCount: 1,
+      estimatedCosts: { totalUsd: 0 },
+    }));
+  });
+
+  it('checks backpressure before the first batch', async () => {
+    let getQueuesCalls = 0;
+    isBossRunningMock.mockReturnValue(true);
+    getBossMock.mockReturnValue({
+      getQueues: vi.fn(async () => {
+        getQueuesCalls += 1;
+        return [{ name: 'probe_openai', activeCount: 1, queuedCount: 2 }];
+      }),
+    });
+
+    const launchSlots = makeSlots(3);
+    const logError = vi.fn();
+    const result = await executeLaunchRuns({
+      ...baseParams,
+      launchSlots,
+      log: { error: logError },
+    });
+
+    expect(getQueuesCalls).toBeGreaterThanOrEqual(1);
+    expect(result.startedRuns).toBe(3);
+    expect(result.failedDefinitions).toBe(0);
+  });
+
+  it('aborts remaining slots and counts them as failed when backpressure times out', async () => {
+    vi.useFakeTimers();
+    try {
+      isBossRunningMock.mockReturnValue(true);
+      getBossMock.mockReturnValue({
+        getQueues: vi.fn(async () => [
+          { name: 'probe_openai', activeCount: 5_000, queuedCount: 0 },
+        ]),
+      });
+
+      const launchSlots = makeSlots(50);
+      const logError = vi.fn();
+      const pending = executeLaunchRuns({
+        ...baseParams,
+        launchSlots,
+        log: { error: logError },
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await pending;
+
+      expect(startRunMock).not.toHaveBeenCalled();
+      expect(result.startedRuns).toBe(0);
+      expect(result.failedDefinitions).toBe(50);
+      expect(logError).toHaveBeenCalledTimes(50);
+      expect(logError.mock.calls[0]?.[0]).toMatchObject({
+        error: 'probe queue backpressure timeout',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('skips backpressure when boss is not running', async () => {
+    isBossRunningMock.mockReturnValue(false);
+
+    const launchSlots = makeSlots(2);
+    const result = await executeLaunchRuns({
+      ...baseParams,
+      launchSlots,
+      log: { error: vi.fn() },
+    });
+
+    expect(getBossMock).not.toHaveBeenCalled();
+    expect(result.startedRuns).toBe(2);
+  });
+});
+
+describe('waitForProbeQueueCapacity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns ok=true with inFlight=0 when boss is not running', async () => {
+    isBossRunningMock.mockReturnValue(false);
+    const result = await waitForProbeQueueCapacity();
+    expect(result).toEqual({ ok: true, inFlight: 0 });
+  });
+
+  it('returns ok=true when current depth is below threshold', async () => {
+    isBossRunningMock.mockReturnValue(true);
+    getBossMock.mockReturnValue({
+      getQueues: vi.fn(async () => [
+        { name: 'probe_openai', activeCount: 10, queuedCount: 5 },
+        { name: 'probe_dead_letter', activeCount: 9_000, queuedCount: 9_000 },
+      ]),
+    });
+
+    const result = await waitForProbeQueueCapacity();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.inFlight).toBe(15);
+    }
+  });
+
+  it('exports tunable constants with sane defaults', () => {
+    expect(BACKPRESSURE_PROBE_THRESHOLD).toBeGreaterThan(0);
+    expect(BACKPRESSURE_POLL_MS).toBeGreaterThan(0);
+    expect(BACKPRESSURE_MAX_WAIT_MS).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause:** `executeLaunchRuns` skipped the backpressure check for the first batch (`if (offset > 0)` guard), so a domain launch fired on top of an already-saturated queue (e.g. 4,600 PAC recovery jobs from direct `startRun` calls) immediately dumped 25 more runs. The resulting DB pressure on `boss.insert()` caused partial-insert failures that tripped the strict integrity check in `enqueueRunJobs`, producing zero-progress FAILED runs.
- **Secondary defect:** after the 5-minute wait, the system silently continued anyway into a still-saturated queue — multiplying broken runs rather than stopping.
- **Fix:** Apply `waitForProbeQueueCapacity()` before every batch (including the first). Change return type from `void` to `{ ok: true | false, ... }`. On timeout, abort remaining batches cleanly: count slots as `failedDefinitions`, log with context, create no new runs.
- **Env tunability:** `DOMAIN_LAUNCH_BACKPRESSURE_THRESHOLD`, `DOMAIN_LAUNCH_BACKPRESSURE_MAX_WAIT_MS`, `DOMAIN_LAUNCH_BACKPRESSURE_POLL_MS`.
- **Note:** The `getQueues()` call already reads physical depth across all sources (PAC direct-startRun calls included) — the check itself was correct; only the call-site placement and timeout behavior were wrong.

## Files changed

- `cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts` — main fix
- `cloud/apps/api/tests/graphql/mutations/domain/launch/execute-runs.test.ts` — new test file

## Test plan

- [x] `npx turbo build --filter=@valuerank/api` passes
- [x] `npm run test --workspace @valuerank/api` — 213 files, 2430 tests, 4 skipped, all pass
- [x] New tests: first-batch backpressure gating, timeout abort counts all remaining as failed, boss-not-running skip, dead-letter queue excluded from depth count

## Validation

```
npx turbo build --filter=@valuerank/api   ✅  7 tasks successful
npm run test --workspace @valuerank/api   ✅  213 passed, 2430 tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)