### PR TITLE
Speed up domain win rate cache builds

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
@@ -1,5 +1,6 @@
-import { db } from '@valuerank/db';
-import { getMissingReasonLabel, resolveSignatureRuns, resolveValuePairsInChunks } from '../../graphql/queries/domain/shared.js';
+import { db, resolveDefinitionContent } from '@valuerank/db';
+import { getMissingReasonLabel, resolveSignatureRuns } from '../../graphql/queries/domain/shared.js';
+import { extractValuePair, type DomainAnalysisValuePair } from '../../graphql/queries/domain-analysis-values.js';
 import { computeAggregateFingerprint } from './aggregate/aggregate-helpers.js';
 import {
   DOMAIN_ANALYSIS_ASSUMPTION_PREFIX,
@@ -16,6 +17,9 @@ import { computeCellWeightedDomainRates } from './domain-analysis-cell-win-rates
 import { accumulateTranscriptCells, type CellCounts } from './transcript-cell-accumulator.js';
 import { type DomainAnalysisScope } from './domain-analysis-scope.js';
 import { resolveDomainAnalysisScopeDefinitions } from './domain-analysis-scope-loader.js';
+import { buildPressureSensitivityDecisionSnapshot } from '../pressure-sensitivity/decision-snapshot.js';
+
+const DEFINITION_SNAPSHOT_RESOLVE_CHUNK_SIZE = 20;
 
 export function buildAssumptionKey(scope: DomainAnalysisScope, domainId: string): string {
   return scope === 'ALL_DOMAINS'
@@ -129,7 +133,71 @@ export async function buildSnapshotOutput(
     onProgress?: (progress: DomainAnalysisBuildProgress) => Promise<void> | void;
   },
 ): Promise<{ output: DomainAnalysisSnapshotOutput; excNeutralValueWinRatesByModel: Map<string, Record<string, number>> }> {
-  const valuePairByDefinition = await resolveValuePairsInChunks(state.latestDefinitionIds);
+  type TranscriptBatchRow = {
+    id: string;
+    runId: string;
+    modelId: string;
+    decisionMetadata: unknown;
+    deletedAt: Date | null;
+    scenario: {
+      id: string;
+      content: unknown;
+      orientationFlipped: boolean;
+      deletedAt: Date | null;
+    } | null;
+  };
+
+  const valuePairByDefinition = new Map<string, DomainAnalysisValuePair>();
+  const definitionDecisionSnapshotById = new Map<string, unknown>();
+  for (let offset = 0; offset < state.latestDefinitionIds.length; offset += DEFINITION_SNAPSHOT_RESOLVE_CHUNK_SIZE) {
+    const batch = state.latestDefinitionIds.slice(offset, offset + DEFINITION_SNAPSHOT_RESOLVE_CHUNK_SIZE);
+    const settled = await Promise.allSettled(
+      batch.map(async (definitionId) => {
+        const resolved = await resolveDefinitionContent(definitionId);
+        return {
+          definitionId,
+          valuePair: extractValuePair(resolved.resolvedContent),
+          decisionSnapshot: buildPressureSensitivityDecisionSnapshot(resolved.resolvedContent),
+        };
+      }),
+    );
+
+    for (const result of settled) {
+      if (result.status !== 'fulfilled') {
+        continue;
+      }
+      if (result.value.valuePair != null) {
+        valuePairByDefinition.set(result.value.definitionId, result.value.valuePair);
+      }
+      if (result.value.decisionSnapshot != null) {
+        definitionDecisionSnapshotById.set(result.value.definitionId, result.value.decisionSnapshot);
+      }
+    }
+  }
+  const definitionsMissingDecisionSnapshot = new Set(
+    state.latestDefinitionIds.filter((definitionId) => !definitionDecisionSnapshotById.has(definitionId)),
+  );
+  for (const [runId, definitionId] of state.resolvedSignatureRuns.filteredSourceRunDefinitionById.entries()) {
+    if (!definitionsMissingDecisionSnapshot.has(definitionId)) {
+      continue;
+    }
+    const fallbackSnapshot = await db.transcript.findFirst({
+      where: {
+        runId,
+        deletedAt: null,
+      },
+      select: {
+        definitionSnapshot: true,
+      },
+      orderBy: {
+        id: 'asc',
+      },
+    });
+    if (fallbackSnapshot?.definitionSnapshot != null) {
+      definitionDecisionSnapshotById.set(definitionId, fallbackSnapshot.definitionSnapshot);
+      definitionsMissingDecisionSnapshot.delete(definitionId);
+    }
+  }
 
   const TRANSCRIPT_BATCH_SIZE = 500;
   const cellMap = new Map<string, CellCounts>();
@@ -140,11 +208,11 @@ export async function buildSnapshotOutput(
     // Keep each transcript read bounded so large domains do not exhaust memory
     // or the Prisma bridge. Aggregate each batch into the shared cell map.
     for (const runId of state.resolvedSignatureRuns.filteredSourceRunIds) {
-      let offset = 0;
-      let fetchedCount = TRANSCRIPT_BATCH_SIZE;
+      let cursorTranscriptId: string | null = null;
+      let hasMore = true;
 
-      while (fetchedCount >= TRANSCRIPT_BATCH_SIZE) {
-        const batch = await db.transcript.findMany({
+      while (hasMore) {
+        const batch = (await db.transcript.findMany({
           where: {
             runId,
             deletedAt: null,
@@ -154,7 +222,6 @@ export async function buildSnapshotOutput(
             runId: true,
             modelId: true,
             decisionMetadata: true,
-            definitionSnapshot: true,
             deletedAt: true,
             scenario: {
               select: {
@@ -167,15 +234,20 @@ export async function buildSnapshotOutput(
           },
           orderBy: { id: 'asc' },
           take: TRANSCRIPT_BATCH_SIZE,
-          skip: offset,
-        });
+          ...(cursorTranscriptId != null
+            ? {
+                cursor: { id: cursorTranscriptId },
+                skip: 1,
+              }
+            : {}),
+        })) as TranscriptBatchRow[];
 
-        fetchedCount = batch.length;
-        if (fetchedCount === 0) break;
+        if (batch.length === 0) break;
 
         const batchCellMap = accumulateTranscriptCells({
           transcripts: batch,
           filteredSourceRunDefinitionById: state.resolvedSignatureRuns.filteredSourceRunDefinitionById,
+          decisionSnapshotByDefinitionId: definitionDecisionSnapshotById,
         });
 
         for (const [key, counts] of batchCellMap.entries()) {
@@ -186,7 +258,10 @@ export async function buildSnapshotOutput(
           cellMap.set(key, existing);
         }
 
-        offset += fetchedCount;
+        cursorTranscriptId = batch[batch.length - 1]?.id ?? null;
+        if (batch.length < TRANSCRIPT_BATCH_SIZE) {
+          hasMore = false;
+        }
       }
 
       completedRuns += 1;

--- a/cloud/apps/api/src/services/analysis/transcript-cell-accumulator.ts
+++ b/cloud/apps/api/src/services/analysis/transcript-cell-accumulator.ts
@@ -65,7 +65,8 @@ export type TranscriptForAccumulation = {
   runId: string;
   modelId: string;
   decisionMetadata: unknown;
-  definitionSnapshot: unknown;
+  decisionSnapshot?: unknown;
+  definitionSnapshot?: unknown;
   deletedAt: Date | null;
   scenario: {
     id: string;
@@ -148,6 +149,7 @@ function addCellCounts(cellMap: Map<string, CellCounts>, key: string, outcome: A
 export function accumulateTranscriptCells(params: {
   transcripts: TranscriptForAccumulation[];
   filteredSourceRunDefinitionById: Map<string, string>;
+  decisionSnapshotByDefinitionId?: ReadonlyMap<string, unknown>;
 }): Map<string, CellCounts> {
   const cellMap = new Map<string, CellCounts>();
 
@@ -159,12 +161,13 @@ export function accumulateTranscriptCells(params: {
       const definitionId = params.filteredSourceRunDefinitionById.get(transcript.runId);
       if (definitionId === undefined) continue;
 
-      const valuePair = getSnapshotValuePair(transcript.definitionSnapshot);
+      const definitionSnapshot = params.decisionSnapshotByDefinitionId?.get(definitionId) ?? transcript.decisionSnapshot ?? transcript.definitionSnapshot;
+      const valuePair = getSnapshotValuePair(definitionSnapshot);
       if (valuePair == null) continue;
       const [firstValueToken, secondValueToken] = valuePair;
       if (!isDomainAnalysisValueKey(firstValueToken) || !isDomainAnalysisValueKey(secondValueToken)) continue;
 
-      const dimensions = getDefinitionDimensions(transcript.definitionSnapshot, firstValueToken, secondValueToken);
+      const dimensions = getDefinitionDimensions(definitionSnapshot, firstValueToken, secondValueToken);
       if (dimensions == null || dimensions.ownDimension == null || dimensions.opponentDimension == null) continue;
 
       const ownLookup = buildSafeLevelLookup(dimensions.ownDimension);
@@ -189,7 +192,7 @@ export function accumulateTranscriptCells(params: {
 
       const resolved = resolveTranscriptDecisionModel({
         decisionMetadata: transcript.decisionMetadata,
-        definitionSnapshot: transcript.definitionSnapshot,
+        definitionSnapshot,
         orientationFlipped: transcript.scenario.orientationFlipped,
         pairOverride: { valueA: firstValueToken, valueB: secondValueToken },
       });

--- a/cloud/apps/api/tests/services/analysis/domain-analysis-snapshot-builder-batching.test.ts
+++ b/cloud/apps/api/tests/services/analysis/domain-analysis-snapshot-builder-batching.test.ts
@@ -2,13 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   transcriptFindMany,
+  transcriptFindFirst,
+  resolveDefinitionContentMock,
   accumulateTranscriptCellsMock,
-  resolveValuePairsInChunksMock,
   computeCellWeightedDomainRatesMock,
 } = vi.hoisted(() => ({
   transcriptFindMany: vi.fn(),
+  transcriptFindFirst: vi.fn(),
+  resolveDefinitionContentMock: vi.fn(),
   accumulateTranscriptCellsMock: vi.fn(() => new Map()),
-  resolveValuePairsInChunksMock: vi.fn(async () => new Map()),
   computeCellWeightedDomainRatesMock: vi.fn(() => ({
     models: [],
     analyzedDefinitionIds: new Set<string>(),
@@ -19,12 +21,15 @@ vi.mock('@valuerank/db', () => ({
   db: {
     transcript: {
       findMany: transcriptFindMany,
+      findFirst: transcriptFindFirst,
     },
   },
+  resolveDefinitionContent: resolveDefinitionContentMock,
 }));
 
 vi.mock('../../../src/graphql/queries/domain/shared.js', () => ({
-  resolveValuePairsInChunks: resolveValuePairsInChunksMock,
+  getMissingReasonLabel: vi.fn(() => 'Missing analysis'),
+  resolveSignatureRuns: vi.fn(),
 }));
 
 vi.mock('../../../src/services/analysis/transcript-cell-accumulator.js', () => ({
@@ -43,7 +48,6 @@ function makeTranscript(runId: string, index: number) {
     runId,
     modelId: 'model-1',
     decisionMetadata: {},
-    definitionSnapshot: {},
     deletedAt: null,
     scenario: {
       id: `${runId}-scenario-${index}`,
@@ -54,14 +58,43 @@ function makeTranscript(runId: string, index: number) {
   };
 }
 
+function makeDefinitionContent() {
+  return {
+    template: ['Which job would you choose?', '- Strongly support achievement', '- Somewhat support security'].join('\n'),
+    dimensions: [
+      {
+        name: 'Achievement',
+        levels: [{ score: 1, label: '1' }],
+      },
+      {
+        name: 'Security_Personal',
+        levels: [{ score: 1, label: '1' }],
+      },
+    ],
+    components: {
+      context_id: 'context-1',
+      value_first: {
+        token: 'Achievement',
+        body: 'achievement body',
+      },
+      value_second: {
+        token: 'Security_Personal',
+        body: 'security body',
+      },
+    },
+  };
+}
+
 describe('buildSnapshotOutput batching', () => {
   beforeEach(() => {
     transcriptFindMany.mockReset();
+    transcriptFindFirst.mockReset();
+    resolveDefinitionContentMock.mockReset();
     accumulateTranscriptCellsMock.mockReset();
-    resolveValuePairsInChunksMock.mockReset();
     computeCellWeightedDomainRatesMock.mockReset();
 
-    resolveValuePairsInChunksMock.mockResolvedValue(new Map());
+    resolveDefinitionContentMock.mockResolvedValue({ resolvedContent: makeDefinitionContent() });
+    transcriptFindFirst.mockResolvedValue(null);
     accumulateTranscriptCellsMock.mockReturnValue(new Map());
     computeCellWeightedDomainRatesMock.mockReturnValue({
       models: [],
@@ -70,17 +103,17 @@ describe('buildSnapshotOutput batching', () => {
   });
 
   it('pages transcripts in bounded batches per run', async () => {
-    transcriptFindMany.mockImplementation(async (args: { where?: { runId?: string }; skip?: number }) => {
+    transcriptFindMany.mockImplementation(async (args: { where?: { runId?: string }; cursor?: { id?: string | null }; skip?: number }) => {
       const runId = args.where?.runId;
-      const skip = args.skip ?? 0;
+      const cursorId = args.cursor?.id;
 
-      if (runId === 'run-1' && skip === 0) {
+      if (runId === 'run-1' && cursorId == null) {
         return Array.from({ length: 500 }, (_, index) => makeTranscript(runId, index));
       }
-      if (runId === 'run-1' && skip === 500) {
+      if (runId === 'run-1' && cursorId === 'run-1-transcript-499') {
         return [makeTranscript(runId, 500)];
       }
-      if (runId === 'run-2' && skip === 0) {
+      if (runId === 'run-2' && cursorId == null) {
         return [makeTranscript(runId, 0)];
       }
       return [];
@@ -120,17 +153,17 @@ describe('buildSnapshotOutput batching', () => {
     expect(transcriptFindMany).toHaveBeenNthCalledWith(1, expect.objectContaining({
       where: { runId: 'run-1', deletedAt: null },
       take: 500,
-      skip: 0,
     }));
+    expect(transcriptFindMany.mock.calls[0]?.[0]?.select).not.toHaveProperty('definitionSnapshot');
     expect(transcriptFindMany).toHaveBeenNthCalledWith(2, expect.objectContaining({
       where: { runId: 'run-1', deletedAt: null },
       take: 500,
-      skip: 500,
+      cursor: { id: 'run-1-transcript-499' },
+      skip: 1,
     }));
     expect(transcriptFindMany).toHaveBeenNthCalledWith(3, expect.objectContaining({
       where: { runId: 'run-2', deletedAt: null },
       take: 500,
-      skip: 0,
     }));
 
     expect(onProgress).toHaveBeenCalledTimes(2);
@@ -143,6 +176,132 @@ describe('buildSnapshotOutput batching', () => {
       completedRuns: 2,
       totalRuns: 2,
       currentRunId: 'run-2',
+    }));
+  });
+
+  it('builds one small decision snapshot per definition and passes it to accumulation', async () => {
+    resolveDefinitionContentMock.mockResolvedValue({ resolvedContent: makeDefinitionContent() });
+    transcriptFindMany.mockResolvedValue([
+      {
+        id: 'run-1-transcript-0',
+        runId: 'run-1',
+        modelId: 'model-1',
+        decisionMetadata: {},
+        deletedAt: null,
+        scenario: {
+          id: 'scenario-1',
+          content: {},
+          orientationFlipped: false,
+          deletedAt: null,
+        },
+      },
+    ]);
+
+    await buildSnapshotOutput({
+      scope: 'ALL_DOMAINS',
+      domain: { id: 'all-domains', name: 'All domains', defaultModelIds: [] },
+      domains: [],
+      definitions: [],
+      latestDefinitions: [{ id: 'definition-1', updatedAt: new Date('2025-01-01T00:00:00.000Z') }],
+      latestDefinitionIds: ['definition-1'],
+      definitionNameById: new Map([['definition-1', 'Definition 1']]),
+      definitionDomainIdById: new Map([['definition-1', 'domain-1']]),
+      resolvedSignatureRuns: {
+        selectedSignature: 'vnewtd',
+        filteredSourceRunIds: ['run-1'],
+        filteredSourceRunDefinitionById: new Map([
+          ['run-1', 'definition-1'],
+        ]),
+        coveredDefinitionIds: new Set(['definition-1']),
+        missingReasonByDefinitionId: new Map(),
+      },
+      selectedSignature: 'vnewtd',
+      configSignature: 'vnewtd',
+      fingerprintRows: [],
+      inputHash: 'hash-1',
+    });
+
+    expect(resolveDefinitionContentMock).toHaveBeenCalledTimes(1);
+    expect(resolveDefinitionContentMock).toHaveBeenCalledWith('definition-1');
+    expect(accumulateTranscriptCellsMock).toHaveBeenCalledWith(expect.objectContaining({
+      decisionSnapshotByDefinitionId: expect.any(Map),
+    }));
+    const [call] = accumulateTranscriptCellsMock.mock.calls;
+    expect(call?.[0]?.decisionSnapshotByDefinitionId?.get('definition-1')).toEqual(expect.objectContaining({
+      components: expect.objectContaining({
+        value_first: expect.objectContaining({
+          token: 'Achievement',
+        }),
+      }),
+    }));
+  });
+
+  it('falls back to one stored transcript snapshot when resolved content lacks components', async () => {
+    resolveDefinitionContentMock.mockResolvedValue({
+      resolvedContent: {
+        template: 'Legacy job choice',
+        dimensions: [
+          { name: 'achievement' },
+          { name: 'security_personal' },
+        ],
+      },
+    });
+    transcriptFindFirst.mockResolvedValue({
+      definitionSnapshot: makeDefinitionContent(),
+    });
+    transcriptFindMany.mockResolvedValue([
+      {
+        id: 'run-1-transcript-0',
+        runId: 'run-1',
+        modelId: 'model-1',
+        decisionMetadata: {},
+        deletedAt: null,
+        scenario: {
+          id: 'scenario-1',
+          content: {},
+          orientationFlipped: false,
+          deletedAt: null,
+        },
+      },
+    ]);
+
+    await buildSnapshotOutput({
+      scope: 'ALL_DOMAINS',
+      domain: { id: 'all-domains', name: 'All domains', defaultModelIds: [] },
+      domains: [],
+      definitions: [],
+      latestDefinitions: [{ id: 'definition-1', updatedAt: new Date('2025-01-01T00:00:00.000Z') }],
+      latestDefinitionIds: ['definition-1'],
+      definitionNameById: new Map([['definition-1', 'Definition 1']]),
+      definitionDomainIdById: new Map([['definition-1', 'domain-1']]),
+      resolvedSignatureRuns: {
+        selectedSignature: 'vnewtd',
+        filteredSourceRunIds: ['run-1'],
+        filteredSourceRunDefinitionById: new Map([
+          ['run-1', 'definition-1'],
+        ]),
+        coveredDefinitionIds: new Set(['definition-1']),
+        missingReasonByDefinitionId: new Map(),
+      },
+      selectedSignature: 'vnewtd',
+      configSignature: 'vnewtd',
+      fingerprintRows: [],
+      inputHash: 'hash-1',
+    });
+
+    expect(transcriptFindFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        runId: 'run-1',
+        deletedAt: null,
+      },
+      select: {
+        definitionSnapshot: true,
+      },
+    }));
+    const [call] = accumulateTranscriptCellsMock.mock.calls;
+    expect(call?.[0]?.decisionSnapshotByDefinitionId?.get('definition-1')).toEqual(expect.objectContaining({
+      template: expect.any(String),
+      components: expect.any(Object),
     }));
   });
 });

--- a/cloud/apps/api/tests/services/analysis/transcript-cell-accumulator.test.ts
+++ b/cloud/apps/api/tests/services/analysis/transcript-cell-accumulator.test.ts
@@ -196,6 +196,34 @@ describe('accumulateTranscriptCells', () => {
     expect(cellMap.size).toBe(0);
   });
 
+  it('reads decisionSnapshot when definitionSnapshot is omitted', () => {
+    const transcript = buildTranscript({
+      runId: 'run-1',
+      definitionSnapshot: undefined,
+      decisionSnapshot: buildDefinitionSnapshot(FIRST_VALUE, SECOND_VALUE),
+    });
+    const cellMap = accumulateTranscriptCells({
+      transcripts: [transcript],
+      filteredSourceRunDefinitionById: new Map([['run-1', 'def1']]),
+    });
+
+    expect(cellMap.size).toBe(2);
+    expect(cellMap.get(encodeCellKey({
+      definitionId: 'def1',
+      modelId: 'm1',
+      valueKey: FIRST_VALUE,
+      ownLevel: 1,
+      opponentLevel: 2,
+    }))).toEqual({ wins: 1, losses: 0, neutrals: 0 });
+    expect(cellMap.get(encodeCellKey({
+      definitionId: 'def1',
+      modelId: 'm1',
+      valueKey: SECOND_VALUE,
+      ownLevel: 2,
+      opponentLevel: 1,
+    }))).toEqual({ wins: 0, losses: 1, neutrals: 0 });
+  });
+
   it('reads dimension_values (snake_case) when dimensionValues is absent — production scenario format', () => {
     const transcript = buildTranscript({
       runId: 'run-1',


### PR DESCRIPTION
## Summary
- Avoid loading full transcript definition snapshots during domain analysis cache builds by resolving compact per-definition decision snapshots once.
- Switch transcript cache pagination from offset-based `skip` paging to cursor paging by transcript id.
- Keep accumulator compatibility with existing per-transcript snapshots and cover the new path with focused tests.

## Validation
- [x] `npm ci`
- [x] `npm run build --workspace @valuerank/shared`
- [x] `npm run build --workspace @valuerank/db`
- [x] `npx vitest run tests/services/analysis/transcript-cell-accumulator.test.ts tests/services/analysis/domain-analysis-snapshot-builder-batching.test.ts tests/services/analysis/domain-analysis-vs-pressure-equivalence.test.ts`
- [x] `npx eslint src/services/analysis/domain-analysis-snapshot-builder.ts src/services/analysis/transcript-cell-accumulator.ts`
- [x] `npx tsc --noEmit -p tsconfig.json --pretty false`
- [x] `npm run lint --workspace @valuerank/shared && npm run lint --workspace @valuerank/db && npm run lint --workspace @valuerank/api && npm run build --workspace @valuerank/api && npm run lint --workspace @valuerank/web && npm run build --workspace @valuerank/web`
- [x] `git diff --check`

Generated with Codex.