### PR TITLE
fix(domain-analysis): multiply winRateExcNeutral by 100 to match pooledWinRate scale

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -205,7 +205,7 @@ function buildDomainAnalysisResultFromSnapshot(params: {
         deprioritized: counts.deprioritized,
         neutral: counts.neutral,
         totalComparisons: wins + losses + counts.neutral,
-        winRateExcNeutral: excNeutralDenom > 0 ? wins / excNeutralDenom : null,
+        winRateExcNeutral: excNeutralDenom > 0 ? (wins / excNeutralDenom) * 100 : null,
       };
     });
 


### PR DESCRIPTION
## Summary
- `DomainAnalysisValueScore.winRateExcNeutral` was computed as `wins / (wins + losses)` — a fraction (0–1)
- `pooledWinRate` (the standard win rate) is stored in snapshots as `crossDomainRate * 100` — a percentage (0–100)
- Switching to Exc. neutral replaced e.g. `73.1` with `0.731`, which formatted as `0.7%` instead of `73.1%`
- Fix: multiply by 100 in `domain-analysis-cache.ts` so both fields use the same scale

## Test plan
- [ ] Preflight passed (lint + build)
- [ ] Manually toggle Exc. neutral on the Win Rate page — values should shift slightly upward (neutrals excluded from denominator), not drop dramatically
- [ ] Pairwise matrix is unaffected (both `winRateMatrix` and `winRateExcNeutralMatrix` are fractions, handled consistently by the component)

## Validation
- `npm run lint --workspace @valuerank/api` — ✅ 0 errors
- `npm run build --workspace @valuerank/api` — ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)