### PR TITLE
Support selected domain sets in analysis filters

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/domain/analysis.ts
+++ b/cloud/apps/api/src/graphql/mutations/domain/analysis.ts
@@ -5,12 +5,18 @@ import {
   refreshDomainAnalysisSnapshot,
 } from '../../../services/analysis/domain-analysis-cache.js';
 import { DomainAnalysisRefreshResultRef } from './types.js';
+import {
+  normalizeDomainIds,
+  resolveDomainAnalysisSelection,
+} from '../../../services/analysis/domain-analysis-scope.js';
 
 builder.mutationField('refreshDomainAnalysis', (t) =>
   t.field({
     type: DomainAnalysisRefreshResultRef,
     args: {
-      domainId: t.arg.id({ required: true }),
+      domainId: t.arg.id({ required: false }),
+      domainIds: t.arg.idList({ required: false }),
+      scope: t.arg.string({ required: false }),
       signature: t.arg.string({ required: false }),
     },
     resolve: async (_root, args, ctx) => {
@@ -18,14 +24,21 @@ builder.mutationField('refreshDomainAnalysis', (t) =>
         throw new AuthenticationError('Authentication required');
       }
 
-      const domainId = String(args.domainId);
+      const domainId = args.domainId != null ? String(args.domainId) : null;
+      const domainIds = normalizeDomainIds(args.domainIds?.map(String) ?? null);
+      const selection = resolveDomainAnalysisSelection({
+        scope: args.scope,
+        domainId,
+        domainIds,
+      });
       const signature = typeof args.signature === 'string' && args.signature.trim() !== ''
         ? args.signature.trim()
         : null;
 
       const queued = await queueDomainAnalysisRefresh({
-        scope: 'DOMAIN',
-        domainId,
+        scope: selection.scope,
+        domainId: selection.domainId,
+        domainIds: selection.domainIds,
         signature,
         reason: 'manual-refresh',
       });
@@ -39,8 +52,9 @@ builder.mutationField('refreshDomainAnalysis', (t) =>
       }
 
       await refreshDomainAnalysisSnapshot({
-        scope: 'DOMAIN',
-        domainId,
+        scope: selection.scope,
+        domainId: selection.domainId,
+        domainIds: selection.domainIds,
         requestedSignature: signature,
       });
       return {

--- a/cloud/apps/api/src/graphql/queries/domain/analysis/domain-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/analysis/domain-analysis.ts
@@ -3,28 +3,38 @@ import { builder } from '../../../builder.js';
 import {
   DomainAnalysisResultRef,
 } from '../types.js';
-import { parseDomainAnalysisScope } from '../../../../services/analysis/domain-analysis-scope.js';
+import {
+  normalizeDomainIds,
+  resolveDomainAnalysisSelection,
+} from '../../../../services/analysis/domain-analysis-scope.js';
 
 builder.queryField('domainAnalysis', (t) =>
   t.field({
     type: DomainAnalysisResultRef,
     args: {
-      domainId: t.arg.id({ required: true }),
+      domainId: t.arg.id({ required: false }),
+      domainIds: t.arg.idList({ required: false }),
       scope: t.arg.string({ required: false }),
       signature: t.arg.string({ required: false }),
     },
     resolve: async (_root, args, ctx) => {
-      const domainId = String(args.domainId);
-      const scope = parseDomainAnalysisScope(args.scope);
+      const domainId = args.domainId != null ? String(args.domainId) : null;
+      const domainIds = normalizeDomainIds(args.domainIds?.map(String) ?? null);
+      const selection = resolveDomainAnalysisSelection({
+        scope: args.scope,
+        domainId,
+        domainIds,
+      });
       const requestedSignature = typeof args.signature === 'string' && args.signature.trim() !== ''
         ? args.signature.trim()
         : null;
       if (requestedSignature === null) {
-        ctx.log.warn({ domainId }, 'domainAnalysis called without signature; defaulting to first vnew signature');
+        ctx.log.warn({ domainId: selection.domainId, domainIds: selection.domainIds }, 'domainAnalysis called without signature; defaulting to first vnew signature');
       }
       return getDomainAnalysisResult({
-        scope,
-        domainId,
+        scope: selection.scope,
+        domainId: selection.domainId,
+        domainIds: selection.domainIds,
         requestedSignature,
       });
     },

--- a/cloud/apps/api/src/graphql/queries/domain/planning.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/planning.ts
@@ -13,7 +13,7 @@ import {
 } from './planning-utils.js';
 import { resolveRunAnalysisStatuses } from '../../../services/run/analysis-status.js';
 import { buildDomainEstimate } from './planning-estimate.js';
-import { parseDomainAnalysisScope } from '../../../services/analysis/domain-analysis-scope.js';
+import { normalizeDomainIds, resolveDomainAnalysisSelection } from '../../../services/analysis/domain-analysis-scope.js';
 import { resolveDomainAnalysisScopeDefinitions } from '../../../services/analysis/domain-analysis-scope-loader.js';
 
 builder.queryField('domainTrialsPlan', (t) =>
@@ -204,16 +204,26 @@ builder.queryField('domainAvailableSignatures', (t) =>
   t.field({
     type: [DomainAvailableSignatureRef],
     args: {
-      domainId: t.arg.id({ required: true }),
+      domainId: t.arg.id({ required: false }),
+      domainIds: t.arg.idList({ required: false }),
       scope: t.arg.string({ required: false }),
     },
     resolve: async (_root, args, ctx) => {
       if (!ctx.user) {
         throw new AuthenticationError('Authentication required');
       }
-      const domainId = String(args.domainId);
-      const scope = parseDomainAnalysisScope(args.scope);
-      const scopeData = await resolveDomainAnalysisScopeDefinitions({ scope, domainId });
+      const domainId = args.domainId != null ? String(args.domainId) : null;
+      const domainIds = normalizeDomainIds(args.domainIds?.map(String) ?? null);
+      const selection = resolveDomainAnalysisSelection({
+        scope: args.scope,
+        domainId,
+        domainIds,
+      });
+      const scopeData = await resolveDomainAnalysisScopeDefinitions({
+        scope: selection.scope,
+        domainId: selection.domainId,
+        domainIds: selection.domainIds,
+      });
       if (scopeData.latestDefinitionIds.length === 0) return [];
 
       const runs = await db.run.findMany({

--- a/cloud/apps/api/src/graphql/queries/model-agreement-cluster-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-cluster-analysis.ts
@@ -22,10 +22,13 @@ import {
   queueDomainAnalysisRefresh,
   readModelAgreementSnapshotStateFromSnapshot,
 } from '../../services/analysis/domain-analysis-cache.js';
-import type { DomainAnalysisScope } from '../../services/analysis/domain-analysis-scope.js';
+import {
+  normalizeDomainIds,
+  resolveDomainAnalysisSelection,
+  type DomainAnalysisScope,
+} from '../../services/analysis/domain-analysis-scope.js';
 import type { Context } from '../context.js';
 
-const ALL_DOMAINS_SCOPE_ID = 'all-domains';
 const REFRESH_REASON = 'model-agreement-cluster-analysis-page-load-missing';
 
 function emptyPayload(reason: string): KappaClusterPayload {
@@ -43,12 +46,14 @@ function emptyPayload(reason: string): KappaClusterPayload {
 
 async function resolveScope(params: {
   scope: DomainAnalysisScope;
-  domainId: string | null;
+  domainId: string;
+  domainIds: string[];
   signature: string;
 }): Promise<void> {
   const scopeData = await resolveDomainAnalysisScopeDefinitions({
     scope: params.scope,
-    domainId: params.domainId ?? ALL_DOMAINS_SCOPE_ID,
+    domainId: params.domainId,
+    domainIds: params.domainIds,
   });
   const resolvedSignatureRuns = await resolveSignatureRuns(
     scopeData.latestDefinitionIds,
@@ -62,13 +67,14 @@ async function resolveScope(params: {
 
 async function readAgreementSnapshot(params: {
   scope: DomainAnalysisScope;
-  domainId: string | null;
+  domainId: string;
+  domainIds: string[];
   signature: string;
   ctx: Context;
 }): Promise<Awaited<ReturnType<typeof readModelAgreementSnapshotStateFromSnapshot>>> {
   const snapshotState = await readModelAgreementSnapshotStateFromSnapshot(
     params.scope,
-    params.domainId ?? ALL_DOMAINS_SCOPE_ID,
+    params.domainId,
     params.signature,
   );
   if (snapshotState != null) {
@@ -77,12 +83,13 @@ async function readAgreementSnapshot(params: {
 
   await queueDomainAnalysisRefresh({
     scope: params.scope,
-    domainId: params.domainId ?? ALL_DOMAINS_SCOPE_ID,
+    domainId: params.domainId,
+    domainIds: params.domainIds,
     signature: params.signature,
     reason: REFRESH_REASON,
   });
   params.ctx.log.info(
-    { scope: params.scope, domainId: params.domainId, signature: params.signature },
+    { scope: params.scope, domainId: params.domainId, domainIds: params.domainIds, signature: params.signature },
     'Kappa cluster analysis snapshot not ready — rebuild queued, returning pending',
   );
   return null;
@@ -119,6 +126,7 @@ export async function resolveModelAgreementClusterAnalysis(
   args: {
     modelIds: ReadonlyArray<string | number>;
     domainId?: string | number | null | undefined;
+    domainIds?: ReadonlyArray<string | number> | null;
     scope: string;
     signature: string;
     method: string;
@@ -126,15 +134,20 @@ export async function resolveModelAgreementClusterAnalysis(
   ctx: Context,
 ): Promise<KappaClusterPayload> {
   const scopeValue = String(args.scope);
-  if (scopeValue !== 'DOMAIN' && scopeValue !== 'ALL_DOMAINS') {
+  if (scopeValue !== 'DOMAIN' && scopeValue !== 'ALL_DOMAINS' && scopeValue !== 'DOMAIN_SET') {
     throw new ValidationError(`Unsupported scope: ${scopeValue}`);
   }
-  const scope: DomainAnalysisScope = scopeValue;
-
+  const domainIds = normalizeDomainIds((args.domainIds ?? []).map(String));
   const domainId = args.domainId != null ? String(args.domainId).trim() : null;
-  if (scope === 'DOMAIN' && (domainId == null || domainId.length === 0)) {
+  const selection = resolveDomainAnalysisSelection({
+    scope: scopeValue,
+    domainId,
+    domainIds,
+  });
+  if (scopeValue === 'DOMAIN' && selection.scope !== 'DOMAIN') {
     throw new ValidationError('domainId is required when scope is DOMAIN');
   }
+  const scope: DomainAnalysisScope = selection.scope;
 
   const signature = String(args.signature).trim();
   if (signature.length === 0) {
@@ -157,9 +170,20 @@ export async function resolveModelAgreementClusterAnalysis(
   const selectedModels = buildSelectedModels(selectedModelIds, labelByModelId);
   const selectedModelIdSet = new Set(selectedModels.map((model) => model.modelId));
 
-  await resolveScope({ scope, domainId, signature });
+  await resolveScope({
+    scope,
+    domainId: selection.domainId,
+    domainIds: selection.domainIds,
+    signature,
+  });
 
-  const snapshotState = await readAgreementSnapshot({ scope, domainId, signature, ctx });
+  const snapshotState = await readAgreementSnapshot({
+    scope,
+    domainId: selection.domainId,
+    domainIds: selection.domainIds,
+    signature,
+    ctx,
+  });
   if (snapshotState == null) {
     return emptyPayload('Kappa cluster analysis is rebuilding — try again in a moment.');
   }
@@ -179,7 +203,8 @@ export async function resolveModelAgreementClusterAnalysis(
   // tends to value. Falls back to zeros if a model is missing from the result.
   const domainAnalysis = await getDomainAnalysisResult({
     scope,
-    domainId: domainId ?? ALL_DOMAINS_SCOPE_ID,
+    domainId: selection.domainId,
+    domainIds: selection.domainIds,
     requestedSignature: signature,
   });
   const scoresByModelId = new Map<string, Record<string, number>>();
@@ -229,6 +254,7 @@ builder.queryField('modelAgreementClusterAnalysis', (t) =>
     args: {
       modelIds: t.arg.idList({ required: true }),
       domainId: t.arg.id({ required: false }),
+      domainIds: t.arg.idList({ required: false }),
       scope: t.arg.string({ required: true }),
       signature: t.arg.string({ required: true }),
       method: t.arg.string({ required: true }),

--- a/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
@@ -37,10 +37,13 @@ import {
   queueDomainAnalysisRefresh,
   readModelAgreementSnapshotStateFromSnapshot,
 } from '../../services/analysis/domain-analysis-cache.js';
-import type { DomainAnalysisScope } from '../../services/analysis/domain-analysis-scope.js';
+import {
+  normalizeDomainIds,
+  resolveDomainAnalysisSelection,
+  type DomainAnalysisScope,
+} from '../../services/analysis/domain-analysis-scope.js';
 import type { Context } from '../context.js';
 
-const ALL_DOMAINS_SCOPE_ID = 'all-domains';
 const AGREEMENT_REFRESH_REASON = 'model-agreement-on-tradeoffs-page-load-missing';
 const DRILLDOWN_REFRESH_REASON = 'model-pair-divergence-breakdown-missing';
 const NON_BINARY_CELL_FALLBACK_COUNT = 0;
@@ -49,7 +52,8 @@ const KAPPA_BOOTSTRAP_ITERATIONS = 1000;
 
 async function resolveAgreementScope(params: {
   scope: DomainAnalysisScope;
-  domainId: string | null;
+  domainId: string;
+  domainIds: string[];
   signature: string;
 }): Promise<{
   scopeData: Awaited<ReturnType<typeof resolveDomainAnalysisScopeDefinitions>>;
@@ -57,7 +61,8 @@ async function resolveAgreementScope(params: {
 }> {
   const scopeData = await resolveDomainAnalysisScopeDefinitions({
     scope: params.scope,
-    domainId: params.domainId ?? ALL_DOMAINS_SCOPE_ID,
+    domainId: params.domainId,
+    domainIds: params.domainIds,
   });
   const resolvedSignatureRuns = await resolveSignatureRuns(
     scopeData.latestDefinitionIds,
@@ -74,7 +79,8 @@ async function resolveAgreementScope(params: {
 
 async function readAgreementSnapshot(params: {
   scope: DomainAnalysisScope;
-  domainId: string | null;
+  domainId: string;
+  domainIds: string[];
   signature: string;
   refreshReason: string;
   ctx: Context;
@@ -90,7 +96,7 @@ async function readAgreementSnapshot(params: {
 }> {
   const snapshotState = await readModelAgreementSnapshotStateFromSnapshot(
     params.scope,
-    params.domainId ?? ALL_DOMAINS_SCOPE_ID,
+    params.domainId,
     params.signature,
   );
   if (snapshotState != null) {
@@ -103,18 +109,19 @@ async function readAgreementSnapshot(params: {
 
   const queued = await queueDomainAnalysisRefresh({
     scope: params.scope,
-    domainId: params.domainId ?? ALL_DOMAINS_SCOPE_ID,
+    domainId: params.domainId,
+    domainIds: params.domainIds,
     signature: params.signature,
     reason: params.refreshReason,
   });
   if (queued) {
     params.ctx.log.info(
-      { scope: params.scope, domainId: params.domainId, signature: params.signature },
+      { scope: params.scope, domainId: params.domainId, domainIds: params.domainIds, signature: params.signature },
       'Model agreement snapshot not ready - rebuild queued, returning pending',
     );
   } else {
     params.ctx.log.warn(
-      { scope: params.scope, domainId: params.domainId, signature: params.signature },
+      { scope: params.scope, domainId: params.domainId, domainIds: params.domainIds, signature: params.signature },
       'Model agreement snapshot not ready and rebuild could not be queued',
     );
   }
@@ -126,21 +133,27 @@ export async function resolveModelAgreementOnTradeoffs(
   args: {
     modelIds: ReadonlyArray<string | number>;
     domainId?: string | number | null;
+    domainIds?: ReadonlyArray<string | number> | null;
     scope: string;
     signature: string;
   },
   ctx: Context,
 ): Promise<ModelAgreementResultShape> {
   const scopeValue = String(args.scope);
-  if (scopeValue !== 'DOMAIN' && scopeValue !== 'ALL_DOMAINS') {
+  if (scopeValue !== 'DOMAIN' && scopeValue !== 'ALL_DOMAINS' && scopeValue !== 'DOMAIN_SET') {
     throw new ValidationError(`Unsupported scope: ${scopeValue}`);
   }
-  const scope: DomainAnalysisScope = scopeValue;
-
+  const domainIds = normalizeDomainIds((args.domainIds ?? []).map(String));
   const domainId = args.domainId != null ? String(args.domainId).trim() : null;
-  if (scope === 'DOMAIN' && (domainId == null || domainId.length === 0)) {
+  const selection = resolveDomainAnalysisSelection({
+    scope: scopeValue,
+    domainId,
+    domainIds,
+  });
+  if (scopeValue === 'DOMAIN' && selection.scope !== 'DOMAIN') {
     throw new ValidationError('domainId is required when scope is DOMAIN');
   }
+  const scope: DomainAnalysisScope = selection.scope;
 
   const signature = String(args.signature).trim();
   if (signature.length === 0) {
@@ -159,13 +172,15 @@ export async function resolveModelAgreementOnTradeoffs(
 
   await resolveAgreementScope({
     scope,
-    domainId,
+    domainId: selection.domainId,
+    domainIds: selection.domainIds,
     signature,
   });
 
   const snapshotResult = await readAgreementSnapshot({
     scope,
-    domainId,
+    domainId: selection.domainId,
+    domainIds: selection.domainIds,
     signature,
     refreshReason: AGREEMENT_REFRESH_REASON,
     ctx,
@@ -246,7 +261,8 @@ export async function resolveModelAgreementOnTradeoffs(
   ctx.log.debug(
     {
       scope,
-      domainId,
+      domainId: selection.domainId,
+      domainIds: selection.domainIds,
       signature,
       selectedModelCount: selectedModels.length,
       availableModelCount: availableModels.length,
@@ -273,21 +289,27 @@ export async function resolveModelPairDivergenceBreakdown(
     modelAId: string | number;
     modelBId: string | number;
     domainId?: string | number | null;
+    domainIds?: ReadonlyArray<string | number> | null;
     scope: string;
     signature: string;
   },
   ctx: Context,
 ): Promise<PairDivergenceBreakdownShape> {
   const scopeValue = String(args.scope);
-  if (scopeValue !== 'DOMAIN' && scopeValue !== 'ALL_DOMAINS') {
+  if (scopeValue !== 'DOMAIN' && scopeValue !== 'ALL_DOMAINS' && scopeValue !== 'DOMAIN_SET') {
     throw new ValidationError(`Unsupported scope: ${scopeValue}`);
   }
-  const scope: DomainAnalysisScope = scopeValue;
-
+  const domainIds = normalizeDomainIds((args.domainIds ?? []).map(String));
   const domainId = args.domainId != null ? String(args.domainId).trim() : null;
-  if (scope === 'DOMAIN' && (domainId == null || domainId.length === 0)) {
+  const selection = resolveDomainAnalysisSelection({
+    scope: scopeValue,
+    domainId,
+    domainIds,
+  });
+  if (scopeValue === 'DOMAIN' && selection.scope !== 'DOMAIN') {
     throw new ValidationError('domainId is required when scope is DOMAIN');
   }
+  const scope: DomainAnalysisScope = selection.scope;
 
   const signature = String(args.signature).trim();
   if (signature.length === 0) {
@@ -310,13 +332,15 @@ export async function resolveModelPairDivergenceBreakdown(
 
   await resolveAgreementScope({
     scope,
-    domainId,
+    domainId: selection.domainId,
+    domainIds: selection.domainIds,
     signature,
   });
 
   const snapshotResult = await readAgreementSnapshot({
     scope,
-    domainId,
+    domainId: selection.domainId,
+    domainIds: selection.domainIds,
     signature,
     refreshReason: DRILLDOWN_REFRESH_REASON,
     ctx,
@@ -405,7 +429,8 @@ export async function resolveModelPairDivergenceBreakdown(
   ctx.log.debug(
     {
       scope,
-      domainId,
+      domainId: selection.domainId,
+      domainIds: selection.domainIds,
       signature,
       modelAId,
       modelBId,
@@ -431,6 +456,7 @@ builder.queryField('modelAgreementOnTradeoffs', (t) =>
     args: {
       modelIds: t.arg.idList({ required: true }),
       domainId: t.arg.id({ required: false }),
+      domainIds: t.arg.idList({ required: false }),
       scope: t.arg.string({ required: true }),
       signature: t.arg.string({ required: true }),
     },
@@ -445,6 +471,7 @@ builder.queryField('modelPairDivergenceBreakdown', (t) =>
       modelAId: t.arg.id({ required: true }),
       modelBId: t.arg.id({ required: true }),
       domainId: t.arg.id({ required: false }),
+      domainIds: t.arg.idList({ required: false }),
       scope: t.arg.string({ required: true }),
       signature: t.arg.string({ required: true }),
     },

--- a/cloud/apps/api/src/graphql/queries/models-analysis-snapshot-selection.ts
+++ b/cloud/apps/api/src/graphql/queries/models-analysis-snapshot-selection.ts
@@ -2,15 +2,28 @@ import { isVnewSignature, parseVnewTemperature } from '@valuerank/shared/trial-s
 import { DOMAIN_ANALYSIS_ASSUMPTION_PREFIX } from '../../services/analysis/domain-analysis-cache-types.js';
 
 const ALL_DOMAINS_ASSUMPTION_KEY = `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:all-domains`;
+const DOMAIN_SET_ASSUMPTION_KEY_PREFIX = `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:domain-set:`;
 
 export type ModelsAnalysisSnapshotCandidate = {
   assumptionKey: string;
   configSignature: string;
 };
 
+export type ModelsAnalysisSnapshotSelection = {
+  scope: 'DOMAIN' | 'ALL_DOMAINS' | 'DOMAIN_SET';
+  assumptionKey: string;
+};
+
 function isDomainSnapshot(snapshot: ModelsAnalysisSnapshotCandidate): boolean {
   return snapshot.assumptionKey.startsWith(`${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:`)
     && snapshot.assumptionKey !== ALL_DOMAINS_ASSUMPTION_KEY;
+}
+
+function isSelectedDomainSnapshot(snapshot: ModelsAnalysisSnapshotCandidate, selection: ModelsAnalysisSnapshotSelection): boolean {
+  if (selection.scope === 'ALL_DOMAINS') {
+    return isDomainSnapshot(snapshot) && !snapshot.assumptionKey.startsWith(DOMAIN_SET_ASSUMPTION_KEY_PREFIX);
+  }
+  return snapshot.assumptionKey === selection.assumptionKey;
 }
 
 function getSignaturePreference(signature: string): number {
@@ -32,11 +45,12 @@ function getSignaturePreference(signature: string): number {
 export function selectModelsAnalysisSnapshots<T extends ModelsAnalysisSnapshotCandidate>(
   snapshots: T[],
   requestedSignature: string | null,
+  selection: ModelsAnalysisSnapshotSelection,
 ): T[] {
   const selectedByAssumptionKey = new Map<string, T>();
 
   for (const snapshot of snapshots) {
-    if (!isDomainSnapshot(snapshot)) continue;
+    if (!isSelectedDomainSnapshot(snapshot, selection)) continue;
 
     const current = selectedByAssumptionKey.get(snapshot.assumptionKey);
     if (current == null) {

--- a/cloud/apps/api/src/graphql/queries/models-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/models-analysis.ts
@@ -12,6 +12,11 @@ import {
   type ModelsAnalysisModelResultShape,
   type ModelsAnalysisValueResultShape,
 } from '../types/models-analysis.js';
+import {
+  buildDomainAnalysisDomainSetId,
+  normalizeDomainIds,
+  resolveDomainAnalysisSelection,
+} from '../../services/analysis/domain-analysis-scope.js';
 
 type DomainContribution = ModelsAnalysisDomainBreakdownShape;
 type ModelsAnalysisSnapshotRow = {
@@ -64,6 +69,10 @@ builder.queryField('modelsAnalysis', (t) =>
         required: false,
         description: 'Optional domain ID to scope the matrix to a single domain',
       }),
+      domainIds: t.arg.idList({
+        required: false,
+        description: 'Optional domain IDs to scope the matrix to a selected domain set',
+      }),
       signature: t.arg.string({
         required: false,
         description: 'Optional batch signature to filter snapshots (e.g. vnewtd, vnewt0)',
@@ -71,7 +80,15 @@ builder.queryField('modelsAnalysis', (t) =>
     },
     resolve: async (_root, args, ctx) => {
       const domainId = args.domainId != null ? String(args.domainId) : null;
+      const domainIds = normalizeDomainIds(args.domainIds?.map(String) ?? null);
       const signature = args.signature != null ? String(args.signature) : null;
+      const selection = resolveDomainAnalysisSelection({
+        domainId,
+        domainIds,
+      });
+      const selectionAssumptionKey = selection.scope === 'DOMAIN_SET'
+        ? buildAssumptionKey('DOMAIN_SET', buildDomainAnalysisDomainSetId(selection.domainIds))
+        : buildAssumptionKey('DOMAIN', selection.domainId);
       const activeModels = await getModelsFromDatabase({
         activeOnly: true,
         availableOnly: false,
@@ -79,11 +96,11 @@ builder.queryField('modelsAnalysis', (t) =>
 
       const snapshots = await db.assumptionAnalysisSnapshot.findMany({
         where: {
-          assumptionKey: domainId != null
-            ? buildAssumptionKey('DOMAIN', domainId)
-            : {
+          assumptionKey: selection.scope === 'ALL_DOMAINS'
+            ? {
                 startsWith: `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:`,
-              },
+              }
+            : selectionAssumptionKey,
           analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
           ...(signature != null ? { configSignature: signature } : {}),
           status: 'CURRENT',
@@ -104,6 +121,10 @@ builder.queryField('modelsAnalysis', (t) =>
       const selectedSnapshots = selectModelsAnalysisSnapshots(
         snapshots as ModelsAnalysisSnapshotRow[],
         signature,
+        {
+          scope: selection.scope,
+          assumptionKey: selectionAssumptionKey,
+        },
       );
 
       const activeModelById = new Map(activeModels.map((model) => [model.modelId, model.displayName] as const));

--- a/cloud/apps/api/src/graphql/queries/models-stability.ts
+++ b/cloud/apps/api/src/graphql/queries/models-stability.ts
@@ -5,6 +5,8 @@ import { normalizeAnalysisArtifacts } from '../../services/analysis/normalize-an
 import { builder } from '../builder.js';
 import { ModelsStabilityResultRef, type ModelsStabilityResultShape } from '../types/models-stability.js';
 import { formatRunSignature, runMatchesSignature } from './domain-coverage-gql-types.js';
+import { normalizeDomainIds, resolveDomainAnalysisSelection } from '../../services/analysis/domain-analysis-scope.js';
+import { resolveDomainAnalysisScopeDefinitions } from '../../services/analysis/domain-analysis-scope-loader.js';
 import {
   resolveDimensionKeys,
   buildConditionGroups,
@@ -74,10 +76,18 @@ builder.queryField('modelsWinRateStability', (t) =>
     args: {
       signature: t.arg.string({ required: false }),
       domainId: t.arg.id({ required: false }),
+      domainIds: t.arg.idList({ required: false }),
     },
     resolve: async (_root, args) => {
       const signature = args.signature != null ? String(args.signature) : null;
       const domainId = args.domainId != null ? String(args.domainId) : null;
+      const domainIds = normalizeDomainIds(args.domainIds?.map(String) ?? null);
+      const selection = resolveDomainAnalysisSelection({ domainId, domainIds });
+      const scopeData = await resolveDomainAnalysisScopeDefinitions({
+        scope: selection.scope,
+        domainId: selection.domainId,
+        domainIds: selection.domainIds,
+      });
 
       const activeModels = await getModelsFromDatabase({ activeOnly: true, availableOnly: false });
 
@@ -86,7 +96,7 @@ builder.queryField('modelsWinRateStability', (t) =>
           status: 'COMPLETED',
           deletedAt: null,
           tags: { some: { tag: { name: 'Aggregate' } } },
-          ...(domainId != null ? { definition: { domainId } } : {}),
+          ...(scopeData.domains.length > 0 ? { definition: { domainId: { in: scopeData.domains.map((domain) => domain.id) } } } : {}),
         },
         orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
         select: {

--- a/cloud/apps/api/src/queue/handlers/refresh-domain-analysis-snapshot.ts
+++ b/cloud/apps/api/src/queue/handlers/refresh-domain-analysis-snapshot.ts
@@ -8,11 +8,12 @@ const log = createLogger('queue:refresh-domain-analysis-snapshot');
 export function createRefreshDomainAnalysisSnapshotHandler(): PgBoss.WorkHandler<RefreshDomainAnalysisSnapshotJobData> {
   return async (jobs: PgBoss.Job<RefreshDomainAnalysisSnapshotJobData>[]) => {
     for (const job of jobs) {
-      const { scope, domainId, signature, reason } = job.data;
+      const { scope, domainId, domainIds, signature, reason } = job.data;
       log.info({ jobId: job.id, scope, domainId, signature, reason }, 'Refreshing domain analysis snapshot');
       await refreshDomainAnalysisSnapshot({
         scope,
         domainId,
+        domainIds,
         requestedSignature: signature,
       });
       log.info({ jobId: job.id, scope, domainId, signature, reason }, 'Domain analysis snapshot refreshed');

--- a/cloud/apps/api/src/queue/types.ts
+++ b/cloud/apps/api/src/queue/types.ts
@@ -87,8 +87,9 @@ export type AggregateAnalysisJobData = {
 };
 
 export type RefreshDomainAnalysisSnapshotJobData = {
-  scope: 'DOMAIN' | 'ALL_DOMAINS';
+  scope: 'DOMAIN' | 'ALL_DOMAINS' | 'DOMAIN_SET';
   domainId: string;
+  domainIds?: string[];
   signature: string | null;
   reason: string;
 };

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
@@ -98,6 +98,7 @@ export type AnalysisOutputRow = {
 export type DomainAnalysisPreparedState = {
   scope: DomainAnalysisScope;
   domain: { id: string; name: string; defaultModelIds: string[] };
+  domainIds: string[];
   domains: Array<{ id: string; name: string; defaultModelIds: string[] }>;
   definitions: DefinitionRow[];
   latestDefinitions: DefinitionRow[];

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -291,6 +291,7 @@ function buildDomainAnalysisResultFromSnapshot(params: {
 export async function queueDomainAnalysisRefresh(params: {
   scope: DomainAnalysisScope;
   domainId: string;
+  domainIds?: string[];
   signature: string | null;
   reason: string;
 }): Promise<boolean> {
@@ -306,6 +307,7 @@ export async function queueDomainAnalysisRefresh(params: {
     {
       scope: params.scope,
       domainId: params.domainId,
+      domainIds: params.domainIds,
       signature: params.signature,
       reason: params.reason,
     },
@@ -320,11 +322,13 @@ export async function queueDomainAnalysisRefresh(params: {
 export async function refreshDomainAnalysisSnapshot(params: {
   scope: DomainAnalysisScope;
   domainId: string;
+  domainIds?: string[];
   requestedSignature: string | null;
 }) {
   const state = await prepareDomainAnalysisState({
     scope: params.scope,
     domainId: params.domainId,
+    domainIds: params.domainIds,
     requestedSignature: params.requestedSignature,
   });
   const totalRuns = state.resolvedSignatureRuns.filteredSourceRunIds.length;
@@ -354,6 +358,7 @@ export async function refreshDomainAnalysisSnapshot(params: {
       config: {
         scope: state.scope,
         domainId: state.domain.id,
+        domainIds: state.domainIds,
         signature: state.configSignature,
       },
       output: {
@@ -424,11 +429,13 @@ export async function refreshDomainAnalysisSnapshot(params: {
 export async function getDomainAnalysisResult(params: {
   scope: DomainAnalysisScope;
   domainId: string;
+  domainIds?: string[];
   requestedSignature: string | null;
 }): Promise<DomainAnalysisResult> {
   const state = await prepareDomainAnalysisState({
     scope: params.scope,
     domainId: params.domainId,
+    domainIds: params.domainIds,
     requestedSignature: params.requestedSignature,
   });
   const activeModels = await db.llmModel.findMany({
@@ -464,6 +471,7 @@ export async function getDomainAnalysisResult(params: {
     const queued = await queueDomainAnalysisRefresh({
       scope: state.scope,
       domainId: state.domain.id,
+      domainIds: state.domainIds,
       signature: state.selectedSignature,
       reason: 'page-load-stale',
     });
@@ -509,6 +517,7 @@ export async function getDomainAnalysisResult(params: {
   const refreshed = await refreshDomainAnalysisSnapshot({
     scope: state.scope,
     domainId: state.domain.id,
+    domainIds: state.domainIds,
     requestedSignature: state.selectedSignature,
   });
   const parsedFresh = parseSnapshotOutput(refreshed.snapshot.output);

--- a/cloud/apps/api/src/services/analysis/domain-analysis-scope-loader.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-scope-loader.ts
@@ -5,12 +5,15 @@ import type { AnalysisOutputRow, DomainAnalysisContributionSummary, DomainAnalys
 import {
   type DomainAnalysisScope,
   DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE,
+  buildDomainAnalysisDomainSetId,
+  normalizeDomainIds,
 } from './domain-analysis-scope.js';
 import type { DomainAnalysisValuePair } from '../../graphql/queries/domain-analysis-values.js';
 
 export type DomainAnalysisScopeDefinitionSet = {
   scope: DomainAnalysisScope;
   domain: { id: string; name: string; defaultModelIds: string[] };
+  domainIds: string[];
   domains: Array<{ id: string; name: string; defaultModelIds: string[] }>;
   definitions: Array<{
     id: string;
@@ -182,8 +185,11 @@ export function buildContributionAndExcludedSummary(params: {
 export async function resolveDomainAnalysisScopeDefinitions(params: {
   scope: DomainAnalysisScope;
   domainId: string;
+  domainIds?: string[];
 }): Promise<DomainAnalysisScopeDefinitionSet> {
-  if (params.scope === 'ALL_DOMAINS') {
+  const selectedDomainIds = normalizeDomainIds(params.domainIds);
+
+  if (params.scope === 'ALL_DOMAINS' && selectedDomainIds.length === 0) {
     const allDomains = await db.domain.findMany({
       select: { id: true, name: true, defaultModelIds: true },
       orderBy: [{ name: 'asc' }, { id: 'asc' }],
@@ -262,6 +268,80 @@ export async function resolveDomainAnalysisScopeDefinitions(params: {
     return {
       scope: 'ALL_DOMAINS',
       domain: { id: DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE, name: 'All domains', defaultModelIds: [] },
+      domainIds: domains.map((domain) => domain.id),
+      domains,
+      definitions,
+      latestDefinitions,
+      latestDefinitionIds,
+      definitionNameById,
+      definitionDomainIdById,
+    };
+  }
+
+  if (selectedDomainIds.length >= 2 || params.scope === 'DOMAIN_SET') {
+    const selectedDomains = await db.domain.findMany({
+      where: { id: { in: selectedDomainIds } },
+      select: { id: true, name: true, defaultModelIds: true },
+      orderBy: [{ name: 'asc' }, { id: 'asc' }],
+    });
+
+    const domainsById = new Map(selectedDomains.map((domain) => [domain.id, domain]));
+    const domains = selectedDomainIds
+      .map((domainId) => domainsById.get(domainId))
+      .filter((domain): domain is { id: string; name: string; defaultModelIds: string[] } => domain != null);
+    if (domains.length !== selectedDomainIds.length) {
+      const missingDomainId = selectedDomainIds.find((domainId) => !domainsById.has(domainId)) ?? params.domainId;
+      throw new NotFoundError('Domain', missingDomainId);
+    }
+
+    const definitions = await db.definition.findMany({
+      where: { domainId: { in: domains.map((domain) => domain.id) }, deletedAt: null },
+      select: {
+        id: true,
+        domainId: true,
+        name: true,
+        parentId: true,
+        version: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    const definitionsById = await hydrateDefinitionAncestors(definitions);
+    const latestDefinitions = selectLatestDefinitionPerLineage(definitions, definitionsById).filter((definition) => definition.domainId != null) as Array<{
+      id: string;
+      domainId: string;
+      name: string;
+      parentId: string | null;
+      version: number;
+      createdAt: Date;
+      updatedAt: Date;
+    }>;
+    const latestDefinitionIds = latestDefinitions.map((definition) => definition.id);
+    const definitionNameById = new Map<string, string>(
+      definitions.map((definition) => [definition.id, definition.name ?? definition.id]),
+    );
+    const definitionsWithDomainId = definitions.filter((definition) => definition.domainId != null) as Array<{
+      id: string;
+      domainId: string;
+      name: string;
+      parentId: string | null;
+      version: number;
+      createdAt: Date;
+      updatedAt: Date;
+    }>;
+    const definitionDomainIdById = new Map<string, string>(
+      definitionsWithDomainId.map((definition) => [definition.id, definition.domainId]),
+    );
+
+    return {
+      scope: 'DOMAIN_SET',
+      domain: {
+        id: buildDomainAnalysisDomainSetId(selectedDomainIds),
+        name: 'Selected domains',
+        defaultModelIds: [],
+      },
+      domainIds: selectedDomainIds,
       domains,
       definitions,
       latestDefinitions,
@@ -322,6 +402,7 @@ export async function resolveDomainAnalysisScopeDefinitions(params: {
   return {
     scope: 'DOMAIN',
     domain,
+    domainIds: [domain.id],
     domains: [domain],
     definitions,
     latestDefinitions,

--- a/cloud/apps/api/src/services/analysis/domain-analysis-scope.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-scope.ts
@@ -1,6 +1,85 @@
-export const DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE = 'all-domains' as const;
+import { createHash } from 'node:crypto';
 
-export type DomainAnalysisScope = 'DOMAIN' | 'ALL_DOMAINS';
+export const DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE = 'all-domains' as const;
+export const DOMAIN_ANALYSIS_DOMAIN_SET_SCOPE_PREFIX = 'domain-set' as const;
+
+export type DomainAnalysisScope = 'DOMAIN' | 'ALL_DOMAINS' | 'DOMAIN_SET';
+
+export type DomainAnalysisSelection = {
+  scope: DomainAnalysisScope;
+  domainId: string;
+  domainIds: string[];
+};
+
+export function normalizeDomainIds(domainIds: readonly string[] | null | undefined): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const rawDomainId of domainIds ?? []) {
+    const domainId = String(rawDomainId).trim();
+    if (domainId.length === 0 || seen.has(domainId)) {
+      continue;
+    }
+    seen.add(domainId);
+    normalized.push(domainId);
+  }
+
+  normalized.sort((left, right) => left.localeCompare(right));
+  return normalized;
+}
+
+export function buildDomainAnalysisDomainSetId(domainIds: readonly string[]): string {
+  const normalized = normalizeDomainIds(domainIds);
+  const hash = createHash('sha256').update(normalized.join('\u0000')).digest('hex').slice(0, 16);
+  return `${DOMAIN_ANALYSIS_DOMAIN_SET_SCOPE_PREFIX}:${hash}`;
+}
+
+export function resolveDomainAnalysisSelection(params: {
+  scope?: string | null;
+  domainId?: string | null;
+  domainIds?: readonly string[] | null;
+}): DomainAnalysisSelection {
+  const normalizedDomainIds = normalizeDomainIds(params.domainIds);
+  if (normalizedDomainIds.length >= 2) {
+    return {
+      scope: 'DOMAIN_SET',
+      domainId: buildDomainAnalysisDomainSetId(normalizedDomainIds),
+      domainIds: normalizedDomainIds,
+    };
+  }
+
+  if (normalizedDomainIds.length === 1) {
+    return {
+      scope: 'DOMAIN',
+      domainId: normalizedDomainIds[0]!,
+      domainIds: normalizedDomainIds,
+    };
+  }
+
+  const scopeValue = parseDomainAnalysisScope(params.scope);
+  if (scopeValue === 'ALL_DOMAINS') {
+    return {
+      scope: 'ALL_DOMAINS',
+      domainId: DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE,
+      domainIds: [],
+    };
+  }
+
+  const domainId = params.domainId != null ? String(params.domainId).trim() : '';
+  if (domainId.length === 0) {
+    return {
+      scope: 'ALL_DOMAINS',
+      domainId: DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE,
+      domainIds: [],
+    };
+  }
+
+  return {
+    scope: 'DOMAIN',
+    domainId,
+    domainIds: [domainId],
+  };
+}
 
 export function parseDomainAnalysisScope(value: string | null | undefined): DomainAnalysisScope {
   return value === DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE ? 'ALL_DOMAINS' : 'DOMAIN';

--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
@@ -21,10 +21,10 @@ import { buildPressureSensitivityDecisionSnapshot } from '../pressure-sensitivit
 
 const DEFINITION_SNAPSHOT_RESOLVE_CHUNK_SIZE = 20;
 
-export function buildAssumptionKey(scope: DomainAnalysisScope, domainId: string): string {
+export function buildAssumptionKey(scope: DomainAnalysisScope, scopeId: string): string {
   return scope === 'ALL_DOMAINS'
     ? `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:all-domains`
-    : `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:${domainId}`;
+    : `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:${scopeId}`;
 }
 
 export function normalizeSignature(signature: string | null): string {
@@ -75,11 +75,13 @@ export function computeInputHash(params: {
 export async function prepareDomainAnalysisState(params: {
   scope: DomainAnalysisScope;
   domainId: string;
+  domainIds?: string[];
   requestedSignature: string | null;
 }): Promise<DomainAnalysisPreparedState> {
   const scopeData = await resolveDomainAnalysisScopeDefinitions({
     scope: params.scope,
     domainId: params.domainId,
+    domainIds: params.domainIds,
   });
 
   const defaultModelIds = scopeData.scope === 'ALL_DOMAINS' ? [] : scopeData.domain.defaultModelIds;
@@ -104,7 +106,7 @@ export async function prepareDomainAnalysisState(params: {
 
   const inputHash = computeInputHash({
     scope: scopeData.scope,
-    domainIds: scopeData.domains.map((domain) => domain.id),
+    domainIds: scopeData.domainIds,
     signature: configSignature,
     latestDefinitions: scopeData.latestDefinitions,
     fingerprints: fingerprintRows,
@@ -113,6 +115,7 @@ export async function prepareDomainAnalysisState(params: {
   return {
     scope: scopeData.scope,
     domain: scopeData.domain,
+    domainIds: scopeData.domainIds,
     domains: scopeData.domains,
     definitions: scopeData.definitions,
     latestDefinitions: scopeData.latestDefinitions,

--- a/cloud/apps/api/tests/graphql/queries/models-analysis.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/models-analysis.test.ts
@@ -17,7 +17,10 @@ describe('selectModelsAnalysisSnapshots', () => {
     const selected = selectModelsAnalysisSnapshots([
       snapshot('new-t0', 'domain-analysis:job-choice', 'vnewt0'),
       snapshot('older-default', 'domain-analysis:job-choice', 'vnewtd'),
-    ], null);
+    ], null, {
+      scope: 'ALL_DOMAINS',
+      assumptionKey: 'domain-analysis:all-domains',
+    });
 
     expect(selected).toEqual([
       snapshot('older-default', 'domain-analysis:job-choice', 'vnewtd'),
@@ -28,7 +31,10 @@ describe('selectModelsAnalysisSnapshots', () => {
     const selected = selectModelsAnalysisSnapshots([
       snapshot('new-default', 'domain-analysis:job-choice', 'vnewtd'),
       snapshot('older-default', 'domain-analysis:job-choice', 'vnewtd'),
-    ], 'vnewtd');
+    ], 'vnewtd', {
+      scope: 'ALL_DOMAINS',
+      assumptionKey: 'domain-analysis:all-domains',
+    });
 
     expect(selected).toEqual([
       snapshot('new-default', 'domain-analysis:job-choice', 'vnewtd'),
@@ -39,10 +45,42 @@ describe('selectModelsAnalysisSnapshots', () => {
     const selected = selectModelsAnalysisSnapshots([
       snapshot('all-domains', 'domain-analysis:all-domains', 'vnewt0'),
       snapshot('job-choice', 'domain-analysis:job-choice', 'vnewt0'),
-    ], null);
+    ], null, {
+      scope: 'ALL_DOMAINS',
+      assumptionKey: 'domain-analysis:all-domains',
+    });
 
     expect(selected).toEqual([
       snapshot('job-choice', 'domain-analysis:job-choice', 'vnewt0'),
+    ]);
+  });
+
+  it('does not treat selected-domain-set snapshots as all-domain report columns', () => {
+    const selected = selectModelsAnalysisSnapshots([
+      snapshot('domain-set', 'domain-analysis:domain-set:abc123', 'vnewtd'),
+      snapshot('job-choice', 'domain-analysis:job-choice', 'vnewtd'),
+    ], null, {
+      scope: 'ALL_DOMAINS',
+      assumptionKey: 'domain-analysis:all-domains',
+    });
+
+    expect(selected).toEqual([
+      snapshot('job-choice', 'domain-analysis:job-choice', 'vnewtd'),
+    ]);
+  });
+
+  it('selects exactly the requested selected-domain-set snapshot', () => {
+    const selected = selectModelsAnalysisSnapshots([
+      snapshot('domain-set-a', 'domain-analysis:domain-set:abc123', 'vnewtd'),
+      snapshot('domain-set-b', 'domain-analysis:domain-set:def456', 'vnewtd'),
+      snapshot('job-choice', 'domain-analysis:job-choice', 'vnewtd'),
+    ], null, {
+      scope: 'DOMAIN_SET',
+      assumptionKey: 'domain-analysis:domain-set:abc123',
+    });
+
+    expect(selected).toEqual([
+      snapshot('domain-set-a', 'domain-analysis:domain-set:abc123', 'vnewtd'),
     ]);
   });
 });

--- a/cloud/apps/api/tests/services/analysis/domain-analysis-scope.test.ts
+++ b/cloud/apps/api/tests/services/analysis/domain-analysis-scope.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDomainAnalysisDomainSetId,
+  normalizeDomainIds,
+  resolveDomainAnalysisSelection,
+} from '../../../src/services/analysis/domain-analysis-scope.js';
+
+describe('domain-analysis scope selection', () => {
+  it('normalizes selected domain IDs and builds stable selected-domain-set IDs', () => {
+    const ids = ['domain-b', 'domain-a', 'domain-b', ''];
+
+    expect(normalizeDomainIds(ids)).toEqual(['domain-a', 'domain-b']);
+    expect(buildDomainAnalysisDomainSetId(ids)).toBe(buildDomainAnalysisDomainSetId(['domain-a', 'domain-b']));
+  });
+
+  it('treats multiple selected domains as a selected-domain-set scope', () => {
+    const selection = resolveDomainAnalysisSelection({ domainIds: ['domain-b', 'domain-a'] });
+
+    expect(selection.scope).toBe('DOMAIN_SET');
+    expect(selection.domainIds).toEqual(['domain-a', 'domain-b']);
+    expect(selection.domainId).toMatch(/^domain-set:/);
+  });
+});

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1909,7 +1909,7 @@ type Mutation {
     """The ID of the run to recover"""
     runId: ID!
   ): RecoverRunPayload!
-  refreshDomainAnalysis(domainId: ID!, signature: String): DomainAnalysisRefreshResult!
+  refreshDomainAnalysis(domainId: ID, domainIds: [ID!], scope: String, signature: String): DomainAnalysisRefreshResult!
 
   """
   Manually trigger scenario regeneration for a definition. Queues a new expansion job.
@@ -2123,7 +2123,7 @@ type PairwiseAgreementRow {
 type PairwiseWinRateModel {
   trialCountMatrix: [[Int!]!]!
   valueOrder: [String!]!
-  winRateExcNeutralMatrix: [[Float]!]!
+  winRateExcNeutralMatrix: [[Float]!]
   winRateMatrix: [[Float]!]!
 }
 
@@ -2583,11 +2583,11 @@ type Query {
     withoutDomain: Boolean
   ): [Definition!]!
   domain(id: ID!): Domain
-  domainAnalysis(domainId: ID!, scope: String, signature: String): DomainAnalysisResult!
+  domainAnalysis(domainId: ID, domainIds: [ID!], scope: String, signature: String): DomainAnalysisResult!
   domainAnalysisConditionTranscripts(definitionId: ID!, domainId: ID!, limit: Int, modelId: String!, scenarioId: ID, signature: String, valueKey: String!): [DomainAnalysisConditionTranscript!]!
   domainAnalysisPairDetail(domainId: ID, modelId: String!, signature: String, valueA: String!, valueB: String!): DomainAnalysisPairDetailResult!
   domainAnalysisValueDetail(domainId: ID!, modelId: String!, signature: String, valueKey: String!): DomainAnalysisValueDetailResult!
-  domainAvailableSignatures(domainId: ID!, scope: String): [DomainAvailableSignature!]!
+  domainAvailableSignatures(domainId: ID, domainIds: [ID!], scope: String): [DomainAvailableSignature!]!
   domainConfigSnapshots(domainId: ID!, limit: Int): [DomainConfigSnapshotSummary!]!
   domainContext(id: ID!): DomainContext
   domainContexts(domainId: String): [DomainContext!]!
@@ -2714,9 +2714,9 @@ type Query {
 
   "\n      Get the currently authenticated user.\n      Returns null if not authenticated.\n    "
   me: User
-  modelAgreementClusterAnalysis(domainId: ID, method: String!, modelIds: [ID!]!, scope: String!, signature: String!): KappaClusterPayload!
-  modelAgreementOnTradeoffs(domainId: ID, modelIds: [ID!]!, scope: String!, signature: String!): ModelAgreementResult!
-  modelPairDivergenceBreakdown(domainId: ID, modelAId: ID!, modelBId: ID!, scope: String!, signature: String!): PairDivergenceBreakdown!
+  modelAgreementClusterAnalysis(domainId: ID, domainIds: [ID!], method: String!, modelIds: [ID!]!, scope: String!, signature: String!): KappaClusterPayload!
+  modelAgreementOnTradeoffs(domainId: ID, domainIds: [ID!], modelIds: [ID!]!, scope: String!, signature: String!): ModelAgreementResult!
+  modelPairDivergenceBreakdown(domainId: ID, domainIds: [ID!], modelAId: ID!, modelBId: ID!, scope: String!, signature: String!): PairDivergenceBreakdown!
 
   """
   Get token statistics for specific models. Useful for understanding prediction quality.
@@ -2729,11 +2729,14 @@ type Query {
     """Optional domain ID to scope the matrix to a single domain"""
     domainId: ID
 
+    """Optional domain IDs to scope the matrix to a selected domain set"""
+    domainIds: [ID!]
+
     """Optional batch signature to filter snapshots (e.g. vnewtd, vnewt0)"""
     signature: String
   ): ModelsAnalysisResult!
   modelsConfidence(domainId: ID, signature: String): ModelsConfidenceResult!
-  modelsWinRateStability(domainId: ID, signature: String): ModelsStabilityResult!
+  modelsWinRateStability(domainId: ID, domainIds: [ID!], signature: String): ModelsStabilityResult!
 
   """
   List anomalies that are currently open (resolvedAt IS NULL) across all runs. Optional filters: domainId scopes to anomalies whose run belongs to a definition in that domain; type scopes to a single RunAnomalyType.

--- a/cloud/apps/web/src/api/operations/domainAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/domainAnalysis.graphql
@@ -1,5 +1,5 @@
-query DomainAnalysis($domainId: ID!, $scope: String, $signature: String) {
-  domainAnalysis(domainId: $domainId, scope: $scope, signature: $signature) {
+query DomainAnalysis($domainId: ID, $domainIds: [ID!], $scope: String, $signature: String) {
+  domainAnalysis(domainId: $domainId, domainIds: $domainIds, scope: $scope, signature: $signature) {
     domainId
     domainName
     contributionSummary {
@@ -96,8 +96,8 @@ query DomainAnalysis($domainId: ID!, $scope: String, $signature: String) {
   }
 }
 
-mutation RefreshDomainAnalysis($domainId: ID!, $signature: String) {
-  refreshDomainAnalysis(domainId: $domainId, signature: $signature) {
+mutation RefreshDomainAnalysis($domainId: ID, $domainIds: [ID!], $scope: String, $signature: String) {
+  refreshDomainAnalysis(domainId: $domainId, domainIds: $domainIds, scope: $scope, signature: $signature) {
     success
     mode
     message
@@ -251,8 +251,8 @@ query DomainAnalysisConditionTranscripts(
   }
 }
 
-query DomainAvailableSignatures($domainId: ID!, $scope: String) {
-  domainAvailableSignatures(domainId: $domainId, scope: $scope) {
+query DomainAvailableSignatures($domainId: ID, $domainIds: [ID!], $scope: String) {
+  domainAvailableSignatures(domainId: $domainId, domainIds: $domainIds, scope: $scope) {
     signature
     label
     isVirtual

--- a/cloud/apps/web/src/api/operations/modelAgreementClusterAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/modelAgreementClusterAnalysis.graphql
@@ -1,6 +1,7 @@
 query ModelAgreementClusterAnalysis(
   $modelIds: [ID!]!
   $domainId: ID
+  $domainIds: [ID!]
   $scope: String!
   $signature: String!
   $method: String!
@@ -8,6 +9,7 @@ query ModelAgreementClusterAnalysis(
   modelAgreementClusterAnalysis(
     modelIds: $modelIds
     domainId: $domainId
+    domainIds: $domainIds
     scope: $scope
     signature: $signature
     method: $method

--- a/cloud/apps/web/src/api/operations/modelAgreementOnTradeoffs.graphql
+++ b/cloud/apps/web/src/api/operations/modelAgreementOnTradeoffs.graphql
@@ -1,12 +1,14 @@
 query ModelAgreementOnTradeoffs(
   $modelIds: [ID!]!
   $domainId: ID
+  $domainIds: [ID!]
   $scope: String!
   $signature: String!
 ) {
   modelAgreementOnTradeoffs(
     modelIds: $modelIds
     domainId: $domainId
+    domainIds: $domainIds
     scope: $scope
     signature: $signature
   ) {
@@ -56,6 +58,7 @@ query ModelPairDivergenceBreakdown(
   $modelAId: ID!
   $modelBId: ID!
   $domainId: ID
+  $domainIds: [ID!]
   $scope: String!
   $signature: String!
 ) {
@@ -63,6 +66,7 @@ query ModelPairDivergenceBreakdown(
     modelAId: $modelAId
     modelBId: $modelBId
     domainId: $domainId
+    domainIds: $domainIds
     scope: $scope
     signature: $signature
   ) {

--- a/cloud/apps/web/src/api/operations/modelsAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/modelsAnalysis.graphql
@@ -1,17 +1,19 @@
-query ModelsAnalysis($domainId: ID, $signature: String) {
-  modelsAnalysis(domainId: $domainId, signature: $signature) {
+query ModelsAnalysis($domainId: ID, $domainIds: [ID!], $signature: String) {
+  modelsAnalysis(domainId: $domainId, domainIds: $domainIds, signature: $signature) {
     models {
       modelId
       label
       values {
         valueKey
         pooledWinRate
+        pooledWinRateExcNeutral
         stabilityScore
         eligibleDomainCount
         domains {
           domainId
           domainName
           winRate
+          winRateExcNeutral
           evidenceWeight
         }
       }

--- a/cloud/apps/web/src/api/operations/modelsStability.graphql
+++ b/cloud/apps/web/src/api/operations/modelsStability.graphql
@@ -1,5 +1,5 @@
-query ModelsWinRateStability($signature: String, $domainId: ID) {
-  modelsWinRateStability(signature: $signature, domainId: $domainId) {
+query ModelsWinRateStability($signature: String, $domainId: ID, $domainIds: [ID!]) {
+  modelsWinRateStability(signature: $signature, domainId: $domainId, domainIds: $domainIds) {
     models {
       modelId
       label

--- a/cloud/apps/web/src/components/models/ModelAgreementSection.tsx
+++ b/cloud/apps/web/src/components/models/ModelAgreementSection.tsx
@@ -13,8 +13,9 @@ type PairwiseAgreementRow = ModelAgreementOnTradeoffsQuery['modelAgreementOnTrad
 
 type Props = {
   modelIds: string[];
-  scope: 'DOMAIN' | 'ALL_DOMAINS';
+  scope: 'DOMAIN' | 'ALL_DOMAINS' | 'DOMAIN_SET';
   domainId: string | null;
+  domainIds?: string[] | null;
   signature: string;
 };
 
@@ -155,11 +156,12 @@ function BuildStatusCard({
   );
 }
 
-export function ModelAgreementSection({ modelIds, scope, domainId, signature }: Props): JSX.Element {
+export function ModelAgreementSection({ modelIds, scope, domainId, domainIds, signature }: Props): JSX.Element {
   const [{ data, fetching, error }, reexecuteQuery] = useModelAgreementOnTradeoffsQuery({
     variables: {
       modelIds,
       domainId: domainId ?? undefined,
+      domainIds: domainIds ?? undefined,
       scope,
       signature,
     },
@@ -377,6 +379,7 @@ export function ModelAgreementSection({ modelIds, scope, domainId, signature }: 
         selectedPair={selectedPair}
         scope={scope}
         domainId={domainId}
+        domainIds={domainIds}
         signature={signature}
       />
     </section>

--- a/cloud/apps/web/src/components/models/PairwiseDivergenceDrilldownReport.tsx
+++ b/cloud/apps/web/src/components/models/PairwiseDivergenceDrilldownReport.tsx
@@ -15,8 +15,9 @@ const DRILLDOWN_POLL_INTERVAL_MS = 5000;
 
 type Props = {
   selectedPair: SelectedPair | null;
-  scope: 'DOMAIN' | 'ALL_DOMAINS';
+  scope: 'DOMAIN' | 'ALL_DOMAINS' | 'DOMAIN_SET';
   domainId: string | null;
+  domainIds?: string[] | null;
   signature: string;
 };
 
@@ -65,12 +66,13 @@ function getProgressPercent(progress: {
   return Math.min(100, Math.round((Math.min(progress.completedRuns, progress.totalRuns) / progress.totalRuns) * 100));
 }
 
-export function PairwiseDivergenceDrilldownReport({ selectedPair, scope, domainId, signature }: Props) {
+export function PairwiseDivergenceDrilldownReport({ selectedPair, scope, domainId, domainIds, signature }: Props) {
   const [{ data, fetching, error }, reexecuteQuery] = useModelPairDivergenceBreakdownQuery({
     variables: {
       modelAId: selectedPair?.modelAId ?? '',
       modelBId: selectedPair?.modelBId ?? '',
       domainId: domainId ?? undefined,
+      domainIds: domainIds ?? undefined,
       scope,
       signature,
     },

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -2172,7 +2172,9 @@ export type MutationRecoverRunArgs = {
 
 
 export type MutationRefreshDomainAnalysisArgs = {
-  domainId: Scalars['ID']['input'];
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+  scope?: InputMaybe<Scalars['String']['input']>;
   signature?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -2425,7 +2427,7 @@ export type PairwiseWinRateModel = {
   __typename?: 'PairwiseWinRateModel';
   trialCountMatrix: Array<Array<Scalars['Int']['output']>>;
   valueOrder: Array<Scalars['String']['output']>;
-  winRateExcNeutralMatrix: Array<Array<Maybe<Scalars['Float']['output']>>>;
+  winRateExcNeutralMatrix?: Maybe<Array<Array<Maybe<Scalars['Float']['output']>>>>;
   winRateMatrix: Array<Array<Maybe<Scalars['Float']['output']>>>;
 };
 
@@ -3041,7 +3043,8 @@ export type QueryDomainArgs = {
 
 
 export type QueryDomainAnalysisArgs = {
-  domainId: Scalars['ID']['input'];
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   scope?: InputMaybe<Scalars['String']['input']>;
   signature?: InputMaybe<Scalars['String']['input']>;
 };
@@ -3076,7 +3079,8 @@ export type QueryDomainAnalysisValueDetailArgs = {
 
 
 export type QueryDomainAvailableSignaturesArgs = {
-  domainId: Scalars['ID']['input'];
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   scope?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3234,6 +3238,7 @@ export type QueryLlmProvidersArgs = {
 
 export type QueryModelAgreementClusterAnalysisArgs = {
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   method: Scalars['String']['input'];
   modelIds: Array<Scalars['ID']['input']>;
   scope: Scalars['String']['input'];
@@ -3243,6 +3248,7 @@ export type QueryModelAgreementClusterAnalysisArgs = {
 
 export type QueryModelAgreementOnTradeoffsArgs = {
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   modelIds: Array<Scalars['ID']['input']>;
   scope: Scalars['String']['input'];
   signature: Scalars['String']['input'];
@@ -3251,6 +3257,7 @@ export type QueryModelAgreementOnTradeoffsArgs = {
 
 export type QueryModelPairDivergenceBreakdownArgs = {
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   modelAId: Scalars['ID']['input'];
   modelBId: Scalars['ID']['input'];
   scope: Scalars['String']['input'];
@@ -3265,6 +3272,7 @@ export type QueryModelTokenStatsArgs = {
 
 export type QueryModelsAnalysisArgs = {
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   signature?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3277,6 +3285,7 @@ export type QueryModelsConfidenceArgs = {
 
 export type QueryModelsWinRateStabilityArgs = {
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']>>;
   signature?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -4454,16 +4463,19 @@ export type DeleteDomainContextMutationVariables = Exact<{
 export type DeleteDomainContextMutation = { __typename?: 'Mutation', deleteDomainContext: boolean };
 
 export type DomainAnalysisQueryVariables = Exact<{
-  domainId: Scalars['ID']['input'];
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
   scope?: InputMaybe<Scalars['String']['input']>;
   signature?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type DomainAnalysisQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, definitionsWithAnalysis: number, cacheStatus: string, generatedAt: string, clusterAnalysisByMethod: unknown, contributionSummary: Array<{ __typename?: 'DomainAnalysisContributionSummary', domainId: string, domainName: string, rawTrialCount: number, share: number }>, excludedDataSummary: Array<{ __typename?: 'DomainAnalysisExcludedDataSummary', domainId: string, domainName: string, reasonCode: string, count: number }>, missingDefinitions: Array<{ __typename?: 'DomainAnalysisMissingDefinition', definitionId: string, definitionName: string, reasonCode: string, reasonLabel: string, missingAllModels: boolean, missingModelIds: Array<string>, missingModelLabels: Array<string> }>, refreshProgress?: { __typename?: 'DomainAnalysisRefreshProgress', completedRuns: number, totalRuns: number } | null, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number, winRateExcNeutral?: number | null }>, rankingShape: { __typename?: 'RankingShape', topStructure: string, bottomStructure: string, topGap: number, bottomGap: number, spread: number, steepness: number, dominanceZScore?: number | null }, pairwiseWinRateModel?: { __typename?: 'PairwiseWinRateModel', valueOrder: Array<string>, winRateMatrix: Array<Array<number | null>>, winRateExcNeutralMatrix: Array<Array<number | null>>, trialCountMatrix: Array<Array<number>> } | null }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }>, rankingShapeBenchmarks: { __typename?: 'RankingShapeBenchmarks', domainMeanTopGap: number, domainStdTopGap?: number | null, medianSpread: number }, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } } };
+export type DomainAnalysisQuery = { __typename?: 'Query', domainAnalysis: { __typename?: 'DomainAnalysisResult', domainId: string, domainName: string, totalDefinitions: number, targetedDefinitions: number, coveredDefinitions: number, missingDefinitionIds: Array<string>, definitionsWithAnalysis: number, cacheStatus: string, generatedAt: string, clusterAnalysisByMethod: unknown, contributionSummary: Array<{ __typename?: 'DomainAnalysisContributionSummary', domainId: string, domainName: string, rawTrialCount: number, share: number }>, excludedDataSummary: Array<{ __typename?: 'DomainAnalysisExcludedDataSummary', domainId: string, domainName: string, reasonCode: string, count: number }>, missingDefinitions: Array<{ __typename?: 'DomainAnalysisMissingDefinition', definitionId: string, definitionName: string, reasonCode: string, reasonLabel: string, missingAllModels: boolean, missingModelIds: Array<string>, missingModelLabels: Array<string> }>, refreshProgress?: { __typename?: 'DomainAnalysisRefreshProgress', completedRuns: number, totalRuns: number } | null, models: Array<{ __typename?: 'DomainAnalysisModel', model: string, label: string, values: Array<{ __typename?: 'DomainAnalysisValueScore', valueKey: string, score: number, prioritized: number, deprioritized: number, neutral: number, totalComparisons: number, winRateExcNeutral?: number | null }>, rankingShape: { __typename?: 'RankingShape', topStructure: string, bottomStructure: string, topGap: number, bottomGap: number, spread: number, steepness: number, dominanceZScore?: number | null }, pairwiseWinRateModel?: { __typename?: 'PairwiseWinRateModel', valueOrder: Array<string>, winRateMatrix: Array<Array<number | null>>, winRateExcNeutralMatrix?: Array<Array<number | null>> | null, trialCountMatrix: Array<Array<number>> } | null }>, unavailableModels: Array<{ __typename?: 'DomainAnalysisUnavailableModel', model: string, label: string, reason: string }>, rankingShapeBenchmarks: { __typename?: 'RankingShapeBenchmarks', domainMeanTopGap: number, domainStdTopGap?: number | null, medianSpread: number }, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }> } } };
 
 export type RefreshDomainAnalysisMutationVariables = Exact<{
-  domainId: Scalars['ID']['input'];
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
+  scope?: InputMaybe<Scalars['String']['input']>;
   signature?: InputMaybe<Scalars['String']['input']>;
 }>;
 
@@ -4512,7 +4524,8 @@ export type DomainAnalysisConditionTranscriptsQueryVariables = Exact<{
 export type DomainAnalysisConditionTranscriptsQuery = { __typename?: 'Query', domainAnalysisConditionTranscripts: Array<{ __typename?: 'DomainAnalysisConditionTranscript', id: string, runId: string, scenarioId?: string | null, modelId: string, decisionModelV2?: unknown | null, turnCount: number, tokenCount: number, durationMs: number, createdAt: string, content: unknown }> };
 
 export type DomainAvailableSignaturesQueryVariables = Exact<{
-  domainId: Scalars['ID']['input'];
+  domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
   scope?: InputMaybe<Scalars['String']['input']>;
 }>;
 
@@ -4856,6 +4869,7 @@ export type SetProviderBalanceMutation = { __typename?: 'Mutation', setProviderB
 export type ModelAgreementClusterAnalysisQueryVariables = Exact<{
   modelIds: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
   scope: Scalars['String']['input'];
   signature: Scalars['String']['input'];
   method: Scalars['String']['input'];
@@ -4867,6 +4881,7 @@ export type ModelAgreementClusterAnalysisQuery = { __typename?: 'Query', modelAg
 export type ModelAgreementOnTradeoffsQueryVariables = Exact<{
   modelIds: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
   scope: Scalars['String']['input'];
   signature: Scalars['String']['input'];
 }>;
@@ -4878,6 +4893,7 @@ export type ModelPairDivergenceBreakdownQueryVariables = Exact<{
   modelAId: Scalars['ID']['input'];
   modelBId: Scalars['ID']['input'];
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
   scope: Scalars['String']['input'];
   signature: Scalars['String']['input'];
 }>;
@@ -4892,11 +4908,12 @@ export type AvailableModelsQuery = { __typename?: 'Query', availableModels: Arra
 
 export type ModelsAnalysisQueryVariables = Exact<{
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
   signature?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type ModelsAnalysisQuery = { __typename?: 'Query', modelsAnalysis: { __typename?: 'ModelsAnalysisResult', models: Array<{ __typename?: 'ModelsAnalysisModelResult', modelId: string, label: string, values: Array<{ __typename?: 'ModelsAnalysisValueResult', valueKey: string, pooledWinRate?: number | null, stabilityScore?: number | null, eligibleDomainCount: number, domains: Array<{ __typename?: 'ModelsAnalysisDomainBreakdown', domainId: string, domainName: string, winRate: number, evidenceWeight?: number | null }> }> }> } };
+export type ModelsAnalysisQuery = { __typename?: 'Query', modelsAnalysis: { __typename?: 'ModelsAnalysisResult', models: Array<{ __typename?: 'ModelsAnalysisModelResult', modelId: string, label: string, values: Array<{ __typename?: 'ModelsAnalysisValueResult', valueKey: string, pooledWinRate?: number | null, pooledWinRateExcNeutral?: number | null, stabilityScore?: number | null, eligibleDomainCount: number, domains: Array<{ __typename?: 'ModelsAnalysisDomainBreakdown', domainId: string, domainName: string, winRate: number, winRateExcNeutral?: number | null, evidenceWeight?: number | null }> }> }> } };
 
 export type ModelsConfidenceQueryVariables = Exact<{
   signature?: InputMaybe<Scalars['String']['input']>;
@@ -4909,6 +4926,7 @@ export type ModelsConfidenceQuery = { __typename?: 'Query', modelsConfidence: { 
 export type ModelsWinRateStabilityQueryVariables = Exact<{
   signature?: InputMaybe<Scalars['String']['input']>;
   domainId?: InputMaybe<Scalars['ID']['input']>;
+  domainIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
 }>;
 
 
@@ -6225,8 +6243,13 @@ export function useDeleteDomainContextMutation() {
   return Urql.useMutation<DeleteDomainContextMutation, DeleteDomainContextMutationVariables>(DeleteDomainContextDocument);
 };
 export const DomainAnalysisDocument = gql`
-    query DomainAnalysis($domainId: ID!, $scope: String, $signature: String) {
-  domainAnalysis(domainId: $domainId, scope: $scope, signature: $signature) {
+    query DomainAnalysis($domainId: ID, $domainIds: [ID!], $scope: String, $signature: String) {
+  domainAnalysis(
+    domainId: $domainId
+    domainIds: $domainIds
+    scope: $scope
+    signature: $signature
+  ) {
     domainId
     domainName
     contributionSummary {
@@ -6324,12 +6347,17 @@ export const DomainAnalysisDocument = gql`
 }
     `;
 
-export function useDomainAnalysisQuery(options: Omit<Urql.UseQueryArgs<DomainAnalysisQueryVariables>, 'query'>) {
+export function useDomainAnalysisQuery(options?: Omit<Urql.UseQueryArgs<DomainAnalysisQueryVariables>, 'query'>) {
   return Urql.useQuery<DomainAnalysisQuery, DomainAnalysisQueryVariables>({ query: DomainAnalysisDocument, ...options });
 };
 export const RefreshDomainAnalysisDocument = gql`
-    mutation RefreshDomainAnalysis($domainId: ID!, $signature: String) {
-  refreshDomainAnalysis(domainId: $domainId, signature: $signature) {
+    mutation RefreshDomainAnalysis($domainId: ID, $domainIds: [ID!], $scope: String, $signature: String) {
+  refreshDomainAnalysis(
+    domainId: $domainId
+    domainIds: $domainIds
+    scope: $scope
+    signature: $signature
+  ) {
     success
     mode
     message
@@ -6499,8 +6527,12 @@ export function useDomainAnalysisConditionTranscriptsQuery(options: Omit<Urql.Us
   return Urql.useQuery<DomainAnalysisConditionTranscriptsQuery, DomainAnalysisConditionTranscriptsQueryVariables>({ query: DomainAnalysisConditionTranscriptsDocument, ...options });
 };
 export const DomainAvailableSignaturesDocument = gql`
-    query DomainAvailableSignatures($domainId: ID!, $scope: String) {
-  domainAvailableSignatures(domainId: $domainId, scope: $scope) {
+    query DomainAvailableSignatures($domainId: ID, $domainIds: [ID!], $scope: String) {
+  domainAvailableSignatures(
+    domainId: $domainId
+    domainIds: $domainIds
+    scope: $scope
+  ) {
     signature
     label
     isVirtual
@@ -6509,7 +6541,7 @@ export const DomainAvailableSignaturesDocument = gql`
 }
     `;
 
-export function useDomainAvailableSignaturesQuery(options: Omit<Urql.UseQueryArgs<DomainAvailableSignaturesQueryVariables>, 'query'>) {
+export function useDomainAvailableSignaturesQuery(options?: Omit<Urql.UseQueryArgs<DomainAvailableSignaturesQueryVariables>, 'query'>) {
   return Urql.useQuery<DomainAvailableSignaturesQuery, DomainAvailableSignaturesQueryVariables>({ query: DomainAvailableSignaturesDocument, ...options });
 };
 export const DomainFindingsEligibilityDocument = gql`
@@ -7379,10 +7411,11 @@ export function useSetProviderBalanceMutation() {
   return Urql.useMutation<SetProviderBalanceMutation, SetProviderBalanceMutationVariables>(SetProviderBalanceDocument);
 };
 export const ModelAgreementClusterAnalysisDocument = gql`
-    query ModelAgreementClusterAnalysis($modelIds: [ID!]!, $domainId: ID, $scope: String!, $signature: String!, $method: String!) {
+    query ModelAgreementClusterAnalysis($modelIds: [ID!]!, $domainId: ID, $domainIds: [ID!], $scope: String!, $signature: String!, $method: String!) {
   modelAgreementClusterAnalysis(
     modelIds: $modelIds
     domainId: $domainId
+    domainIds: $domainIds
     scope: $scope
     signature: $signature
     method: $method
@@ -7422,10 +7455,11 @@ export function useModelAgreementClusterAnalysisQuery(options: Omit<Urql.UseQuer
   return Urql.useQuery<ModelAgreementClusterAnalysisQuery, ModelAgreementClusterAnalysisQueryVariables>({ query: ModelAgreementClusterAnalysisDocument, ...options });
 };
 export const ModelAgreementOnTradeoffsDocument = gql`
-    query ModelAgreementOnTradeoffs($modelIds: [ID!]!, $domainId: ID, $scope: String!, $signature: String!) {
+    query ModelAgreementOnTradeoffs($modelIds: [ID!]!, $domainId: ID, $domainIds: [ID!], $scope: String!, $signature: String!) {
   modelAgreementOnTradeoffs(
     modelIds: $modelIds
     domainId: $domainId
+    domainIds: $domainIds
     scope: $scope
     signature: $signature
   ) {
@@ -7476,11 +7510,12 @@ export function useModelAgreementOnTradeoffsQuery(options: Omit<Urql.UseQueryArg
   return Urql.useQuery<ModelAgreementOnTradeoffsQuery, ModelAgreementOnTradeoffsQueryVariables>({ query: ModelAgreementOnTradeoffsDocument, ...options });
 };
 export const ModelPairDivergenceBreakdownDocument = gql`
-    query ModelPairDivergenceBreakdown($modelAId: ID!, $modelBId: ID!, $domainId: ID, $scope: String!, $signature: String!) {
+    query ModelPairDivergenceBreakdown($modelAId: ID!, $modelBId: ID!, $domainId: ID, $domainIds: [ID!], $scope: String!, $signature: String!) {
   modelPairDivergenceBreakdown(
     modelAId: $modelAId
     modelBId: $modelBId
     domainId: $domainId
+    domainIds: $domainIds
     scope: $scope
     signature: $signature
   ) {
@@ -7528,20 +7563,26 @@ export function useAvailableModelsQuery(options?: Omit<Urql.UseQueryArgs<Availab
   return Urql.useQuery<AvailableModelsQuery, AvailableModelsQueryVariables>({ query: AvailableModelsDocument, ...options });
 };
 export const ModelsAnalysisDocument = gql`
-    query ModelsAnalysis($domainId: ID, $signature: String) {
-  modelsAnalysis(domainId: $domainId, signature: $signature) {
+    query ModelsAnalysis($domainId: ID, $domainIds: [ID!], $signature: String) {
+  modelsAnalysis(
+    domainId: $domainId
+    domainIds: $domainIds
+    signature: $signature
+  ) {
     models {
       modelId
       label
       values {
         valueKey
         pooledWinRate
+        pooledWinRateExcNeutral
         stabilityScore
         eligibleDomainCount
         domains {
           domainId
           domainName
           winRate
+          winRateExcNeutral
           evidenceWeight
         }
       }
@@ -7577,8 +7618,12 @@ export function useModelsConfidenceQuery(options?: Omit<Urql.UseQueryArgs<Models
   return Urql.useQuery<ModelsConfidenceQuery, ModelsConfidenceQueryVariables>({ query: ModelsConfidenceDocument, ...options });
 };
 export const ModelsWinRateStabilityDocument = gql`
-    query ModelsWinRateStability($signature: String, $domainId: ID) {
-  modelsWinRateStability(signature: $signature, domainId: $domainId) {
+    query ModelsWinRateStability($signature: String, $domainId: ID, $domainIds: [ID!]) {
+  modelsWinRateStability(
+    signature: $signature
+    domainId: $domainId
+    domainIds: $domainIds
+  ) {
     models {
       modelId
       label

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -52,6 +52,20 @@ import {
 import { formatQueryError } from '../utils/urqlError';
 
 const ALL_DOMAINS_SCOPE = 'all-domains';
+type DomainSelectionScope = 'DOMAIN' | 'ALL_DOMAINS' | 'DOMAIN_SET';
+
+function normalizeDomainIds(domainIds: readonly string[]): string[] {
+  return Array.from(new Set(domainIds.map((id) => id.trim()).filter((id) => id !== ''))).sort((a, b) => a.localeCompare(b));
+}
+
+function getDomainSelectionScope(domainIds: readonly string[]): DomainSelectionScope {
+  if (domainIds.length === 0) return 'ALL_DOMAINS';
+  return domainIds.length === 1 ? 'DOMAIN' : 'DOMAIN_SET';
+}
+
+function getDomainAnalysisScopeParam(scope: DomainSelectionScope): string | undefined {
+  return scope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined;
+}
 
 export function filterSelectedModels<T>(
   models: T[],
@@ -87,9 +101,10 @@ export function DomainAnalysis() {
   const initializedModelSelection = useRef(false);
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
 
-  const effectiveDomainId = selectedDomainIds.length === 1 ? (selectedDomainIds[0] ?? '') : '';
-  const isAllDomains = selectedDomainIds.length !== 1;
-  const queryDomainId = effectiveDomainId !== '' ? effectiveDomainId : (domains[0]?.id ?? '');
+  const normalizedSelectedDomainIds = useMemo(() => normalizeDomainIds(selectedDomainIds), [selectedDomainIds]);
+  const selectionScope = useMemo(() => getDomainSelectionScope(normalizedSelectedDomainIds), [normalizedSelectedDomainIds]);
+  const effectiveDomainId = normalizedSelectedDomainIds.length === 1 ? (normalizedSelectedDomainIds[0] ?? '') : '';
+  const isDomainSet = selectionScope === 'DOMAIN_SET';
   const [exportLoading, setExportLoading] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [refreshNotice, setRefreshNotice] = useState<string | null>(null);
@@ -102,10 +117,11 @@ export function DomainAnalysis() {
   >({
     query: DOMAIN_AVAILABLE_SIGNATURES_QUERY,
     variables: {
-      domainId: queryDomainId,
-      scope: isAllDomains ? ALL_DOMAINS_SCOPE : undefined,
+      domainId: effectiveDomainId !== '' ? effectiveDomainId : undefined,
+      domainIds: isDomainSet ? normalizedSelectedDomainIds : undefined,
+      scope: getDomainAnalysisScopeParam(selectionScope),
     },
-    pause: queryDomainId === '',
+    pause: domainsLoading,
     requestPolicy: 'cache-and-network',
   });
 
@@ -121,13 +137,13 @@ export function DomainAnalysis() {
   }, [signatureData]);
 
   useEffect(() => {
-    if (domains.length === 0 || selectedDomainIds.length === 0) return;
+    if (domains.length === 0 || normalizedSelectedDomainIds.length === 0) return;
     const validIds = new Set(domains.map((d) => d.id));
-    const next = selectedDomainIds.filter((id) => validIds.has(id));
-    if (next.length !== selectedDomainIds.length) {
+    const next = normalizedSelectedDomainIds.filter((id) => validIds.has(id));
+    if (next.length !== normalizedSelectedDomainIds.length) {
       setSelectedDomainIds(next);
     }
-  }, [domains, selectedDomainIds]);
+  }, [domains, normalizedSelectedDomainIds]);
 
   useEffect(() => {
     if (signatureOptions.length === 0) { setSelectedSignature(''); return; }
@@ -144,16 +160,16 @@ export function DomainAnalysis() {
 
   useEffect(() => {
     const next = new URLSearchParams(searchParams);
-    if (selectedDomainIds.length === 0) {
+    if (normalizedSelectedDomainIds.length === 0) {
       next.delete('domainId');
       next.delete('domainIds');
       next.delete('scope');
-    } else if (selectedDomainIds.length === 1) {
-      next.set('domainId', selectedDomainIds[0]!);
+    } else if (normalizedSelectedDomainIds.length === 1) {
+      next.set('domainId', normalizedSelectedDomainIds[0]!);
       next.delete('domainIds');
       next.delete('scope');
     } else {
-      next.set('domainIds', selectedDomainIds.join(','));
+      next.set('domainIds', normalizedSelectedDomainIds.join(','));
       next.delete('domainId');
       next.delete('scope');
     }
@@ -161,20 +177,21 @@ export function DomainAnalysis() {
     else next.set('signature', selectedSignature);
     if (next.toString() === searchParams.toString()) return;
     setSearchParams(next, { replace: true });
-  }, [selectedDomainIds, selectedSignature, searchParams, setSearchParams]);
+  }, [normalizedSelectedDomainIds, selectedSignature, searchParams, setSearchParams]);
 
-  const activeUseLegacyQuery = useLegacyQuery && !isAllDomains;
+  const activeUseLegacyQuery = useLegacyQuery && effectiveDomainId !== '';
   const [
     { data: scoredData, fetching: scoredFetching, error: scoredError },
     reexecuteScoredQuery,
   ] = useQuery<DomainAnalysisQueryResult, DomainAnalysisQueryVariables>({
     query: DOMAIN_ANALYSIS_QUERY,
     variables: {
-      domainId: queryDomainId,
-      scope: isAllDomains ? ALL_DOMAINS_SCOPE : undefined,
+      domainId: effectiveDomainId !== '' ? effectiveDomainId : undefined,
+      domainIds: isDomainSet ? normalizedSelectedDomainIds : undefined,
+      scope: getDomainAnalysisScopeParam(selectionScope),
       signature: selectedSignature === '' ? undefined : selectedSignature,
     },
-    pause: queryDomainId === '' || activeUseLegacyQuery,
+    pause: domainsLoading || activeUseLegacyQuery,
     requestPolicy: 'cache-and-network',
   });
   const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<DomainAnalysisQueryResult, { domainId: string }>({
@@ -190,9 +207,10 @@ export function DomainAnalysis() {
     query: MODELS_ANALYSIS_QUERY,
     variables: {
       ...(effectiveDomainId !== '' ? { domainId: effectiveDomainId } : {}),
+      ...(isDomainSet ? { domainIds: normalizedSelectedDomainIds } : {}),
       ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
     },
-    pause: !isAllDomains && effectiveDomainId === '',
+    pause: domainsLoading,
     requestPolicy: 'cache-and-network',
   });
   const [{ data: llmModelsData }] = useQuery<LlmModelsQueryResult>({
@@ -207,9 +225,10 @@ export function DomainAnalysis() {
     query: MODELS_STABILITY_QUERY,
     variables: {
       ...(effectiveDomainId !== '' ? { domainId: effectiveDomainId } : {}),
+      ...(isDomainSet ? { domainIds: normalizedSelectedDomainIds } : {}),
       ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
     },
-    pause: !isAllDomains && effectiveDomainId === '',
+    pause: domainsLoading,
     requestPolicy: 'cache-and-network',
   });
   const [{ fetching: refreshFetching }, refreshDomainAnalysis] = useMutation<
@@ -222,8 +241,8 @@ export function DomainAnalysis() {
     const isFieldError = message.includes('Unknown argument "signature"')
       || message.includes('Cannot query field')
       || message.includes('Unknown field');
-    if (isFieldError && !useLegacyQuery && !isAllDomains) setUseLegacyQuery(true);
-  }, [scoredError, isAllDomains, useLegacyQuery]);
+    if (isFieldError && !useLegacyQuery && effectiveDomainId !== '') setUseLegacyQuery(true);
+  }, [effectiveDomainId, scoredError, useLegacyQuery]);
 
   const data = activeUseLegacyQuery ? legacyData : scoredData;
   const fetching = activeUseLegacyQuery ? legacyFetching : scoredFetching;
@@ -248,7 +267,7 @@ export function DomainAnalysis() {
     const id = setInterval(() => { reexecuteScoredQuery({ requestPolicy: 'network-only' }); }, 20_000);
     return () => { clearInterval(id); };
   }, [isUpdating, reexecuteScoredQuery]);
-  const showPageLoader = domainsLoading || (queryDomainId !== '' && data?.domainAnalysis == null && fetching);
+  const showPageLoader = domainsLoading || (data?.domainAnalysis == null && fetching);
 
   const models = useMemo<ModelEntry[]>(() => {
     const sourceModels = data?.domainAnalysis.models ?? [];
@@ -361,15 +380,15 @@ export function DomainAnalysis() {
   );
 
   const domainSummary = useMemo(() => {
-    if (selectedDomainIds.length === 0 || selectedDomainIds.length === domains.length) {
+    if (normalizedSelectedDomainIds.length === 0 || normalizedSelectedDomainIds.length === domains.length) {
       return 'All Domains';
     }
-    if (selectedDomainIds.length === 1) {
-      const found = domains.find((d) => d.id === selectedDomainIds[0]);
-      return found?.name ?? selectedDomainIds[0] ?? 'Unknown';
+    if (normalizedSelectedDomainIds.length === 1) {
+      const found = domains.find((d) => d.id === normalizedSelectedDomainIds[0]);
+      return found?.name ?? normalizedSelectedDomainIds[0] ?? 'Unknown';
     }
-    return `${selectedDomainIds.length} of ${domains.length} domains`;
-  }, [selectedDomainIds, domains]);
+    return `${normalizedSelectedDomainIds.length} of ${domains.length} domains`;
+  }, [normalizedSelectedDomainIds, domains]);
   const selectedModelId = selectedModelIds.length === 1 ? (selectedModelIds[0] ?? null) : null;
   const selectedDomainIdForDrawer = effectiveDomainId !== '' ? effectiveDomainId : null;
   const selectedSignatureForDrawer = selectedSignature !== '' ? selectedSignature : null;
@@ -452,16 +471,16 @@ export function DomainAnalysis() {
           label: 'Domain',
           multi: true,
           summary: domainSummary,
-          selectedIds: selectedDomainIds,
+          selectedIds: normalizedSelectedDomainIds,
           options: domains.map((d) => ({ value: d.id, label: d.name })),
           actions: [
             {
               label: 'All Domains',
-              isActive: selectedDomainIds.length === 0 || selectedDomainIds.length === domains.length,
+              isActive: normalizedSelectedDomainIds.length === 0 || normalizedSelectedDomainIds.length === domains.length,
               onClick: () => setSelectedDomainIds([]),
             },
           ],
-          onChange: setSelectedDomainIds,
+          onChange: (ids) => setSelectedDomainIds(normalizeDomainIds(ids)),
           disabled: domainsLoading,
         }}
         signature={{
@@ -573,7 +592,7 @@ export function DomainAnalysis() {
             models={selectedModels}
             selectedDomainId={effectiveDomainId}
             selectedSignature={selectedSignature === '' ? null : selectedSignature}
-            isReadOnly={isAllDomains}
+            isReadOnly={effectiveDomainId === ''}
             showStabilityDots
             winRateMode={winRateMode}
           />

--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -45,6 +45,20 @@ import {
 } from '../utils/domainAnalysisUtils';
 
 const ALL_DOMAINS_SCOPE = 'all-domains';
+type DomainSelectionScope = 'DOMAIN' | 'ALL_DOMAINS' | 'DOMAIN_SET';
+
+function normalizeDomainIds(domainIds: readonly string[]): string[] {
+  return Array.from(new Set(domainIds.map((id) => id.trim()).filter((id) => id !== ''))).sort((a, b) => a.localeCompare(b));
+}
+
+function getDomainSelectionScope(domainIds: readonly string[]): DomainSelectionScope {
+  if (domainIds.length === 0) return 'ALL_DOMAINS';
+  return domainIds.length === 1 ? 'DOMAIN' : 'DOMAIN_SET';
+}
+
+function getDomainAnalysisScopeParam(scope: DomainSelectionScope): string | undefined {
+  return scope === 'ALL_DOMAINS' ? ALL_DOMAINS_SCOPE : undefined;
+}
 
 function buildModelEntries(
   models: DomainAnalysisModel[],
@@ -107,10 +121,11 @@ export function ModelsGroups() {
   });
   const [selectedSignature, setSelectedSignature] = useState<string>(searchParams.get('signature') ?? '');
 
-  const effectiveDomainId = selectedDomainIds.length === 1 ? (selectedDomainIds[0] ?? '') : '';
-  const isAllDomains = selectedDomainIds.length !== 1;
-  const effectiveScope: 'DOMAIN' | 'ALL_DOMAINS' = isAllDomains ? 'ALL_DOMAINS' : 'DOMAIN';
-  const queryDomainId = effectiveDomainId !== '' ? effectiveDomainId : (domains[0]?.id ?? '');
+  const normalizedSelectedDomainIds = useMemo(() => normalizeDomainIds(selectedDomainIds), [selectedDomainIds]);
+  const effectiveScope = useMemo(() => getDomainSelectionScope(normalizedSelectedDomainIds), [normalizedSelectedDomainIds]);
+  const effectiveDomainId = normalizedSelectedDomainIds.length === 1 ? (normalizedSelectedDomainIds[0] ?? '') : '';
+  const isAllDomains = effectiveScope === 'ALL_DOMAINS';
+  const isDomainSet = effectiveScope === 'DOMAIN_SET';
   const [selectedModelIds, setSelectedModelIds] = useState<string[] | null>(null);
   const [useLegacyQuery, setUseLegacyQuery] = useState(false);
   const [clusteringMethod, setClusteringMethod] = useState<'upgma' | 'ward'>('ward');
@@ -127,10 +142,11 @@ export function ModelsGroups() {
   >({
     query: DOMAIN_AVAILABLE_SIGNATURES_QUERY,
     variables: {
-      domainId: queryDomainId,
-      scope: isAllDomains ? ALL_DOMAINS_SCOPE : undefined,
+      domainId: effectiveDomainId !== '' ? effectiveDomainId : undefined,
+      domainIds: isDomainSet ? normalizedSelectedDomainIds : undefined,
+      scope: getDomainAnalysisScopeParam(effectiveScope),
     },
-    pause: queryDomainId === '',
+    pause: domainsLoading,
     requestPolicy: 'network-only',
   });
 
@@ -146,11 +162,12 @@ export function ModelsGroups() {
   }, [signatureData]);
 
   useEffect(() => {
-    if (domains.length === 0 || selectedDomainIds.length === 0) return;
-    const validIds = selectedDomainIds.filter((id) => domains.some((d) => d.id === id));
-    if (validIds.length === selectedDomainIds.length) return;
+    if (domains.length === 0 || normalizedSelectedDomainIds.length === 0) return;
+    const domainIdSet = new Set(domains.map((domain) => domain.id));
+    const validIds = normalizedSelectedDomainIds.filter((id) => domainIdSet.has(id));
+    if (validIds.length === normalizedSelectedDomainIds.length) return;
     setSelectedDomainIds(validIds);
-  }, [domains, selectedDomainIds]);
+  }, [domains, normalizedSelectedDomainIds]);
 
   useEffect(() => {
     if (signatureOptions.length === 0) {
@@ -163,14 +180,14 @@ export function ModelsGroups() {
 
   useEffect(() => {
     const next = new URLSearchParams(searchParams);
-    if (selectedDomainIds.length === 0) {
+    if (normalizedSelectedDomainIds.length === 0) {
       next.delete('domainId');
       next.delete('domainIds');
-    } else if (selectedDomainIds.length === 1) {
-      next.set('domainId', selectedDomainIds[0]!);
+    } else if (normalizedSelectedDomainIds.length === 1) {
+      next.set('domainId', normalizedSelectedDomainIds[0]!);
       next.delete('domainIds');
     } else {
-      next.set('domainIds', selectedDomainIds.join(','));
+      next.set('domainIds', normalizedSelectedDomainIds.join(','));
       next.delete('domainId');
     }
     next.delete('scope');
@@ -179,17 +196,18 @@ export function ModelsGroups() {
     if (next.toString() !== searchParams.toString()) {
       setSearchParams(next, { replace: true });
     }
-  }, [searchParams, selectedDomainIds, selectedSignature, setSearchParams]);
+  }, [searchParams, normalizedSelectedDomainIds, selectedSignature, setSearchParams]);
 
-  const activeUseLegacyQuery = useLegacyQuery && !isAllDomains;
+  const activeUseLegacyQuery = useLegacyQuery && effectiveDomainId !== '';
   const [{ data: scoredData, fetching: scoredFetching, error: scoredError }, reexecuteScoredQuery] = useQuery<DomainAnalysisQueryResult, DomainAnalysisQueryVariables>({
     query: DOMAIN_ANALYSIS_QUERY,
     variables: {
-      domainId: queryDomainId,
-      scope: isAllDomains ? ALL_DOMAINS_SCOPE : undefined,
+      domainId: effectiveDomainId !== '' ? effectiveDomainId : undefined,
+      domainIds: isDomainSet ? normalizedSelectedDomainIds : undefined,
+      scope: getDomainAnalysisScopeParam(effectiveScope),
       signature: selectedSignature === '' ? undefined : selectedSignature,
     },
-    pause: queryDomainId === '' || activeUseLegacyQuery,
+    pause: domainsLoading || activeUseLegacyQuery,
     requestPolicy: 'network-only',
   });
   const [{ data: modelsAnalysisData, fetching: modelsAnalysisFetching, error: modelsAnalysisError }] = useQuery<
@@ -198,10 +216,11 @@ export function ModelsGroups() {
   >({
     query: MODELS_ANALYSIS_QUERY,
     variables: {
-      ...(!isAllDomains && effectiveDomainId !== '' ? { domainId: effectiveDomainId } : {}),
+      ...(effectiveDomainId !== '' ? { domainId: effectiveDomainId } : {}),
+      ...(isDomainSet ? { domainIds: normalizedSelectedDomainIds } : {}),
       ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
     },
-    pause: !isAllDomains && effectiveDomainId === '',
+    pause: domainsLoading,
     requestPolicy: 'network-only',
   });
   const [{ data: llmModelsData, error: llmModelsError }] = useQuery<LlmModelsQueryResult>({
@@ -221,8 +240,8 @@ export function ModelsGroups() {
     const isFieldError = message.includes('Unknown argument "signature"')
       || message.includes('Cannot query field')
       || message.includes('Unknown field');
-    if (isFieldError && !useLegacyQuery && !isAllDomains) setUseLegacyQuery(true);
-  }, [scoredError, isAllDomains, useLegacyQuery]);
+    if (isFieldError && !useLegacyQuery && effectiveDomainId !== '') setUseLegacyQuery(true);
+  }, [effectiveDomainId, scoredError, useLegacyQuery]);
 
   // Auto-default similarity method to 'kappa' when switching to kappa-agreement data source,
   // unless the user has already made an explicit choice.
@@ -258,7 +277,8 @@ export function ModelsGroups() {
     query: ModelAgreementClusterAnalysisDocument,
     variables: {
       modelIds: visibleModelIds,
-      ...(!isAllDomains && effectiveDomainId !== '' ? { domainId: effectiveDomainId } : {}),
+      ...(effectiveDomainId !== '' ? { domainId: effectiveDomainId } : {}),
+      ...(isDomainSet ? { domainIds: normalizedSelectedDomainIds } : {}),
       scope: effectiveScope,
       signature: selectedSignature,
       method: clusteringMethod,
@@ -267,7 +287,7 @@ export function ModelsGroups() {
       !isKappaClusterMode
       || selectedSignature === ''
       || visibleModelIds.length < 3
-      || (!isAllDomains && effectiveDomainId === '')
+      || domainsLoading
       || llmModelsData == null,
     requestPolicy: 'cache-and-network',
   });
@@ -321,16 +341,16 @@ export function ModelsGroups() {
   }, [isUpdating, reexecuteScoredQuery]);
   const domainSummary = useMemo(() => {
     if (isAllDomains) return 'All Domains';
-    if (selectedDomainIds.length === 1) {
-      const id = selectedDomainIds[0];
+    if (normalizedSelectedDomainIds.length === 1) {
+      const id = normalizedSelectedDomainIds[0];
       return domains.find((d) => d.id === id)?.name ?? id ?? 'Unknown';
     }
-    return `${selectedDomainIds.length} domains`;
-  }, [domains, isAllDomains, selectedDomainIds]);
+    return `${normalizedSelectedDomainIds.length} domains`;
+  }, [domains, isAllDomains, normalizedSelectedDomainIds]);
 
   const showPageLoader = domainsLoading
-    || (queryDomainId !== '' && data?.domainAnalysis == null && fetching && error == null)
-    || (queryDomainId !== '' && modelsAnalysisData == null && modelsAnalysisFetching && modelsAnalysisError == null)
+    || (data?.domainAnalysis == null && fetching && error == null)
+    || (modelsAnalysisData == null && modelsAnalysisFetching && modelsAnalysisError == null)
     || (signatureData == null && signaturesLoading && signaturesError == null)
     || (llmModelsData == null && llmModelsError == null);
   const models = useMemo(
@@ -358,11 +378,11 @@ export function ModelsGroups() {
   const pageErrorMessage = domainsError != null
     ? formatQueryError('Model Groups domains query', domainsError, {
       scope: effectiveScope,
-      domainId: queryDomainId === '' ? '(auto)' : queryDomainId,
+      domainId: effectiveDomainId === '' ? '(none)' : effectiveDomainId,
     })
     : signaturesError != null
       ? formatQueryError('Model Groups available signatures query', signaturesError, {
-        domainId: queryDomainId,
+        domainId: effectiveDomainId === '' ? '(none)' : effectiveDomainId,
         scope: effectiveScope,
       })
       : error != null
@@ -370,14 +390,14 @@ export function ModelsGroups() {
           activeUseLegacyQuery ? 'Model Groups legacy domain analysis query' : 'Model Groups domain analysis query',
           error,
           {
-            domainId: queryDomainId === '' ? '(auto)' : queryDomainId,
+            domainId: effectiveDomainId === '' ? '(none)' : effectiveDomainId,
             scope: effectiveScope,
             signature: selectedSignature === '' ? '(none)' : selectedSignature,
           },
         )
         : modelsAnalysisError != null
           ? formatQueryError('Model Groups models analysis query', modelsAnalysisError, {
-            domainId: !isAllDomains && effectiveDomainId !== '' ? effectiveDomainId : ALL_DOMAINS_SCOPE,
+            domainId: effectiveDomainId !== '' ? effectiveDomainId : ALL_DOMAINS_SCOPE,
             signature: selectedSignature === '' ? '(none)' : selectedSignature,
           })
           : llmModelsError != null
@@ -388,7 +408,7 @@ export function ModelsGroups() {
   const showAgreementSection =
     selectedSignature !== ''
     && visibleModelIds.length >= 2
-    && !(!isAllDomains && effectiveDomainId === '')
+    && !domainsLoading
     && llmModelsData != null;
 
   // Fire the agreement query here too so we can extract the kappa matrix for
@@ -397,7 +417,8 @@ export function ModelsGroups() {
   const [{ data: agreementData }] = useModelAgreementOnTradeoffsQuery({
     variables: {
       modelIds: visibleModelIds,
-      domainId: !isAllDomains && effectiveDomainId !== '' ? effectiveDomainId : undefined,
+      domainId: effectiveDomainId !== '' ? effectiveDomainId : undefined,
+      domainIds: isDomainSet ? normalizedSelectedDomainIds : undefined,
       scope: effectiveScope,
       signature: selectedSignature,
     },
@@ -442,7 +463,7 @@ export function ModelsGroups() {
           label: 'Domain',
           multi: true,
           summary: domainSummary,
-          selectedIds: selectedDomainIds,
+          selectedIds: normalizedSelectedDomainIds,
           options: domains.map((d) => ({ value: d.id, label: d.name })),
           actions: [
             {
@@ -451,7 +472,7 @@ export function ModelsGroups() {
               onClick: () => setSelectedDomainIds([]),
             },
           ],
-          onChange: (ids) => { setSelectedDomainIds(ids); },
+          onChange: (ids) => { setSelectedDomainIds(normalizeDomainIds(ids)); },
           disabled: domainsLoading || domains.length === 0,
         }}
         signature={{
@@ -527,7 +548,8 @@ export function ModelsGroups() {
             <ModelAgreementSection
               modelIds={visibleModelIds}
               scope={effectiveScope}
-              domainId={!isAllDomains && effectiveDomainId !== '' ? effectiveDomainId : null}
+              domainId={effectiveDomainId !== '' ? effectiveDomainId : null}
+              domainIds={isDomainSet ? normalizedSelectedDomainIds : null}
               signature={selectedSignature}
             />
           ) : null}

--- a/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
+++ b/cloud/apps/web/tests/pages/DomainAnalysis.test.tsx
@@ -252,8 +252,10 @@ describe('DomainAnalysis', () => {
     await waitFor(() => {
       expect(useQueryMock).toHaveBeenCalledWith(
         expect.objectContaining({
+          query: DOMAIN_ANALYSIS_QUERY,
           variables: expect.objectContaining({
-            domainId: 'domain-a',
+            domainId: undefined,
+            domainIds: undefined,
             scope: 'all-domains',
             signature: 'vnewtd',
           }),


### PR DESCRIPTION
## Summary
- Add a DOMAIN_SET analysis scope with stable cache keys and normalized selected domain IDs.
- Thread multi-domain selections through Domain Analysis, Models Analysis, stability, and model agreement queries.
- Keep all-domains model reports from consuming selected-domain-set snapshots.

## Validation
- npm test -- --run tests/services/analysis/domain-analysis-scope.test.ts tests/graphql/queries/models-analysis.test.ts
- npm test -- --run tests/graphql/queries/domain-analysis.test.ts tests/graphql/queries/model-agreement-on-tradeoffs.test.ts tests/services/analysis/domain-analysis-snapshot-builder-batching.test.ts
- npm test -- --run src/components/models/ModelAgreementSection.test.tsx src/components/models/PairwiseDivergenceDrilldownReport.test.tsx
- npm run typecheck --workspace @valuerank/api
- npm run typecheck --workspace @valuerank/web
- npm run lint --workspace @valuerank/shared && npm run lint --workspace @valuerank/db && npm run lint --workspace @valuerank/api && npm run build --workspace @valuerank/api && npm run lint --workspace @valuerank/web && npm run build --workspace @valuerank/web