### PR TITLE
feat(win-rate): note that consistency metrics are unaffected by exc-neutral mode

### DIFF
--- a/cloud/apps/web/src/components/models/WinRateStabilitySection.tsx
+++ b/cloud/apps/web/src/components/models/WinRateStabilitySection.tsx
@@ -22,6 +22,7 @@ type WinRateStabilitySectionProps = {
   skippedVignettes: ModelsStabilitySkippedVignette[];
   fetching: boolean;
   errorMessage: string | null;
+  winRateMode?: 'all' | 'exc-neutral';
 };
 
 function pct(value: number | null | undefined): string {
@@ -129,6 +130,7 @@ export function WinRateStabilitySection({
   skippedVignettes,
   fetching,
   errorMessage,
+  winRateMode,
 }: WinRateStabilitySectionProps) {
   const [sort, setSort] = useState<Sort>(DEFAULT_SORT);
   const sorted = useMemo(() => sortModels(models, sort), [models, sort]);
@@ -154,6 +156,11 @@ export function WinRateStabilitySection({
           agreement; Soft Lean = moderate agreement with a clear lean; Torn = mixed or near-neutral; Unstable = wide
           swing across conditions.
         </p>
+        {winRateMode === 'exc-neutral' && (
+          <p className="text-sm text-amber-700">
+            Consistency metrics include neutral outcomes and are not affected by the Exc. neutral mode.
+          </p>
+        )}
       </div>
 
       {skippedVignettes.length > 0 && (

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -632,6 +632,7 @@ export function DomainAnalysis() {
                 signature: selectedSignature === '' ? '(none)' : selectedSignature,
               })
               : null}
+            winRateMode={winRateMode}
           />
         </>
       )}


### PR DESCRIPTION
## Summary
- Passes `winRateMode` prop down to `WinRateStabilitySection` from `DomainAnalysis`
- When toggle is set to Exc. neutral, shows an amber note: "Consistency metrics include neutral outcomes and are not affected by the Exc. neutral mode."
- No backend changes — consistency/stability metrics (directional agreement, stable/torn/unstable shares) inherently include neutral outcomes and don't have an exc-neutral variant

## Test plan
- [ ] Toggle to Exc. neutral on the Win Rate page — amber note appears in Response Consistency section
- [ ] Toggle back to All responses — note disappears
- [ ] Preflight passed

## Validation
- `npm run lint --workspace @valuerank/web` — ✅ 0 errors
- `npm run build --workspace @valuerank/web` — ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)