### PR TITLE
fix(status): resolve broken view-transcript links for stranded transcript anomalies

### DIFF
--- a/cloud/apps/web/src/components/status/AnomalyRow.tsx
+++ b/cloud/apps/web/src/components/status/AnomalyRow.tsx
@@ -41,6 +41,14 @@ function extractTranscriptId(details: unknown): string | null {
   return typeof transcriptId === 'string' && transcriptId.trim() !== '' ? transcriptId : null;
 }
 
+function extractFirstTranscriptId(details: unknown): string | null {
+  if (!isRecord(details)) return null;
+  const ids = details.transcriptIds;
+  if (!Array.isArray(ids) || ids.length === 0) return null;
+  const first = ids[0];
+  return typeof first === 'string' && first.trim() !== '' ? first : null;
+}
+
 function formatStrengthLevel(value: string): string {
   const lower = value.toLowerCase();
   const num = LEVEL_WORD_TO_NUMBER[lower];
@@ -96,7 +104,10 @@ export function AnomalyRow({ anomaly, tone, onViewTranscript }: AnomalyRowProps)
       // where details.transcriptId still points to the original transcript.
       return anomaly.activeTranscriptId ?? extractTranscriptId(anomaly.details);
     }
-    if (anomaly.type === 'STRANDED_TRANSCRIPT' || anomaly.type === 'ORPHAN_TRANSCRIPT') {
+    if (anomaly.type === 'STRANDED_TRANSCRIPT') {
+      return extractFirstTranscriptId(anomaly.details) ?? anomaly.subject;
+    }
+    if (anomaly.type === 'ORPHAN_TRANSCRIPT') {
       return anomaly.subject;
     }
     return null;


### PR DESCRIPTION
## Summary
- The "View transcript" button on STRANDED_TRANSCRIPT anomaly rows was always broken — clicking it opened a modal that said "Transcript not found for this anomaly."
- Root cause: detection stores transcript IDs in `details.transcriptIds` (an array) but the UI was reading `anomaly.subject`, which is always `''` for this type.
- Fix: added `extractFirstTranscriptId` helper that reads `details.transcriptIds[0]`, and uses it for `STRANDED_TRANSCRIPT` rows instead of `anomaly.subject`.
- Limitation (known, intentional): each anomaly bundles all stranded transcripts for a run into one row. This fix surfaces the first (oldest) one. Others remain invisible from this UI — that's a separate, larger change.

## Test plan
- [ ] Preflight passed (lint + build)
- [ ] View transcript button on a STRANDED_TRANSCRIPT row now opens the modal and shows the transcript content

🤖 Generated with [Claude Code](https://claude.com/claude-code)