### PR TITLE
fix(queue): reduce zombie watchdog threshold 30m → 7m

### DIFF
--- a/cloud/apps/api/src/services/run/recovery.ts
+++ b/cloud/apps/api/src/services/run/recovery.ts
@@ -308,11 +308,12 @@ export async function runStartupRecovery(): Promise<RecoveryResult> {
  * This is a failsafe for when PgBoss expiration mechanisms fail or job handlers crash silently.
  */
 export async function detectAndRecoverStuckJobs(): Promise<{ recovered: number; errors: number }> {
-  // Active-execution timeout. Slow models (Grok, DeepSeek Reasoner, Gemini Flash) with
-  // long outputs can legitimately take >5m, so the previous 5m threshold killed many
-  // probes that would have completed. 30m is generous enough for any single LLM call
-  // and still catches truly hung handlers.
-  const ZOMBIE_THRESHOLD_MINUTES = 30;
+  // Active-execution timeout. The Python process timeout is 300s (5m), so no legitimate
+  // probe can run longer than that. We add a 2-minute buffer (for SIGTERM cleanup and
+  // pgboss write) to arrive at 7m. This is a 4x improvement over the previous 30m
+  // threshold while still giving the longest real calls (deepseek-reasoner p99 ~51s,
+  // max ~299s) room to complete before the watchdog fires.
+  const ZOMBIE_THRESHOLD_MINUTES = 7;
 
   const stuckJobs = await db.$queryRaw<Array<{ id: string; name: string; run_id: string }>>`
     SELECT id, name, data->>'runId' as run_id


### PR DESCRIPTION
## Summary
- Reduces `ZOMBIE_THRESHOLD_MINUTES` from 30 to 7 in `detectAndRecoverStuckJobs()`
- After a container restart, orphaned probe worker slots are now reclaimed in 7 minutes instead of 30 — a 4× improvement
- Zero risk of killing legitimate probes: production data shows the longest real probe is ~299s (deepseek-reasoner hitting the 300s Python timeout); 7 minutes = 300s execution + 120s cleanup buffer

## Why 7 and not 5
The previous 5-minute threshold was removed because it killed legitimate long-running probes. Current p99 durations by model:
- mistral-large-2512: **185s** (max 222s)
- deepseek-reasoner: **51s** (max 299s — right at the Python timeout)
- grok-4-1-fast-reasoning: **33s**

5 minutes (300s) creates a race with deepseek-reasoner's max of 299s. 7 minutes eliminates that entirely.

## Validation
- `npm run lint --workspace @valuerank/api` — 0 errors ✓
- No schema or query changes — build not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)