### PR TITLE
feat(domains): add partner-choice-female domain

### DIFF
--- a/cloud/packages/shared/src/value-statements.ts
+++ b/cloud/packages/shared/src/value-statements.ts
@@ -714,3 +714,58 @@ export { PARTNER_CHOICE_VALUE_STATEMENTS };
 export function getPartnerChoiceValueStatementBody(token: string): string | undefined {
   return PARTNER_CHOICE_VALUE_STATEMENT_MAP.get(token);
 }
+
+// ---------------------------------------------------------------------------
+
+const PARTNER_CHOICE_FEMALE_VALUE_STATEMENTS = [
+  {
+    token: 'self_direction_action',
+    body: 'freedom in pursuing her own goals because of how they relate to independent choice in goals and actions',
+  },
+  {
+    token: 'power_dominance',
+    body: "power over how she's perceived and treated by the people around her because of how they relate to control over people and the decisions that affect them",
+  },
+  {
+    token: 'security_personal',
+    body: 'steadiness and reassurance in her life because of how they relate to stability, safety, and predictability',
+  },
+  {
+    token: 'conformity_interpersonal',
+    body: 'harmony with her family and the people close to her because of how they relate to maintaining smooth interactions with the people around them',
+  },
+  {
+    token: 'tradition',
+    body: 'connection to her heritage and the ways of life passed down to her because of how they relate to long-standing customs and inherited ways of doing things',
+  },
+  {
+    token: 'stimulation',
+    body: 'excitement and novelty in her life because of how they relate to change, challenge, and unpredictability',
+  },
+  {
+    token: 'benevolence_dependability',
+    body: 'support in keeping her commitments to the people who rely on her because of how they relate to being someone others can rely on to carry through on shared responsibilities',
+  },
+  {
+    token: 'universalism_nature',
+    body: 'connection to the natural world in her life because of how they relate to care for nature and the environment',
+  },
+  {
+    token: 'achievement',
+    body: 'recognition of her drive and accomplishments because of how they relate to success through strong performance',
+  },
+  {
+    token: 'hedonism',
+    body: 'fun and ease in her daily life because of how they relate to pleasure and comfort in everyday life',
+  },
+] as const;
+
+const PARTNER_CHOICE_FEMALE_VALUE_STATEMENT_MAP = new Map<string, string>(
+  PARTNER_CHOICE_FEMALE_VALUE_STATEMENTS.map(({ token, body }) => [token, body]),
+);
+
+export { PARTNER_CHOICE_FEMALE_VALUE_STATEMENTS };
+
+export function getPartnerChoiceFemaleValueStatementBody(token: string): string | undefined {
+  return PARTNER_CHOICE_FEMALE_VALUE_STATEMENT_MAP.get(token);
+}

--- a/cloud/scripts/seed-domain.ts
+++ b/cloud/scripts/seed-domain.ts
@@ -30,6 +30,7 @@ import {
   NATIONAL_PRIORITIES_VALUE_STATEMENTS,
   NEIGHBORHOOD_VALUE_STATEMENTS,
   PARENTING_ACTIVITY_VALUE_STATEMENTS,
+  PARTNER_CHOICE_FEMALE_VALUE_STATEMENTS,
   PARTNER_CHOICE_VALUE_STATEMENTS,
   PRODUCT_CHOICE_VALUE_STATEMENTS,
   RETIREMENT_ACTIVITY_VALUE_STATEMENTS,
@@ -55,6 +56,15 @@ type DomainConfig = {
 };
 
 const DOMAIN_REGISTRY: Record<string, DomainConfig> = {
+  'partner-choice-female': {
+    name: 'Partner Choice (Female)',
+    normalizedName: 'partner-choice-female',
+    sentencePrefix: 'One partner offers [level]',
+    labelPrefix: 'the partner that offers',
+    contextText:
+      'You are a matchmaker advising a woman choosing between two potential partners. Both are equally attracted to her and available for a relationship, but the experiences they offer her differ.',
+    valueStatements: PARTNER_CHOICE_FEMALE_VALUE_STATEMENTS,
+  },
   'partner-choice-male': {
     name: 'Partner Choice (Male)',
     normalizedName: 'partner-choice-male',


### PR DESCRIPTION
## Summary
- Adds `PARTNER_CHOICE_FEMALE_VALUE_STATEMENTS` to `value-statements.ts` — 10 Schwartz tokens with female voice (her/she)
- Registers `partner-choice-female` in `seed-domain.ts` domain registry
- Female-voice counterpart to `partner-choice-male` (merged in #1054); identical structure, pronouns swapped

## Test plan
- [ ] Preflight passed (lint + build)
- [ ] Seed against prod: `DATABASE_URL="..." npx tsx scripts/seed-domain.ts --domain partner-choice-female`

🤖 Generated with [Claude Code](https://claude.com/claude-code)