### PR TITLE
fix(launch): retry RUN_INIT_FAILED once before marking run failed

### DIFF
--- a/cloud/apps/api/src/services/run/start.ts
+++ b/cloud/apps/api/src/services/run/start.ts
@@ -324,26 +324,37 @@ export async function startRun(input: StartRunInput): Promise<StartRunResult> {
   log.info({ runId: run.id, totalJobs }, 'Run created, queuing jobs');
 
   let jobIds: string[];
+  const enqueueArgs = {
+    runId: run.id,
+    jobPlan,
+    priority,
+    temperature,
+    totalJobs,
+  };
+
   try {
-    jobIds = await enqueueRunJobs({
-      runId: run.id,
-      jobPlan,
-      priority,
-      temperature,
-      totalJobs,
-    });
+    jobIds = await enqueueRunJobs(enqueueArgs);
   } catch (error) {
     if (error instanceof AppError && error.code === 'RUN_INIT_FAILED') {
-      await db.run.update({
-        where: { id: run.id },
-        data: {
-          status: 'FAILED',
-          completedAt: new Date(),
-          stalledModels: [],
-        },
-      });
+      await new Promise((r) => setTimeout(r, 2000));
+
+      try {
+        jobIds = await enqueueRunJobs(enqueueArgs);
+        log.warn({ runId: run.id }, 'Recovered from RUN_INIT_FAILED on retry');
+      } catch (retryError) {
+        await db.run.update({
+          where: { id: run.id },
+          data: {
+            status: 'FAILED',
+            completedAt: new Date(),
+            stalledModels: [],
+          },
+        });
+        throw retryError;
+      }
+    } else {
+      throw error;
     }
-    throw error;
   }
 
   log.info(

--- a/cloud/apps/api/tests/services/run/start.test.ts
+++ b/cloud/apps/api/tests/services/run/start.test.ts
@@ -636,9 +636,11 @@ describe('startRun service', () => {
         createdRunIds.push(failedRun.id);
       }
       expect(failedRun?.status).toBe('FAILED');
-      // insert called once (bulk), send called once per job (2 jobs) in retry.
-      expect(mockBoss.insert).toHaveBeenCalledTimes(1);
-      expect(mockBoss.send).toHaveBeenCalledTimes(2);
+      // startRun retries enqueueRunJobs once on RUN_INIT_FAILED.
+      // Each attempt = 1 bulk insert + 1 send per job (2 jobs).
+      // So both attempts total: insert ×2, send ×4.
+      expect(mockBoss.insert).toHaveBeenCalledTimes(2);
+      expect(mockBoss.send).toHaveBeenCalledTimes(4);
     });
   });
 


### PR DESCRIPTION
## Summary

Add a single automatic retry of `enqueueRunJobs` (with a 2s delay) when it throws `RUN_INIT_FAILED`, before marking the run as `FAILED`.

The pgboss bulk-insert failures that produce this error are usually transient — write contention, brief deadlock, or a connection-pool blip. One retry would have recovered most of the 21 runs that failed during a recent Partner Choice Male domain evaluation without any operator intervention.

## Why

When `executeLaunchRuns` launches 25 runs concurrently via `Promise.allSettled`, each `startRun` triggers 8 simultaneous `boss.insert()` calls. With 25 runs × 8 queues = 200 concurrent pgboss writes, some return null/empty or throw under contention. The current code maps any single one of those to a permanent run failure with no recovery.

Companion PR addresses the root cause by serializing the per-batch launches; this PR is the second line of defense.

## Behavior

| Outcome | Today | After this PR |
|---|---|---|
| First call succeeds | Run proceeds | Run proceeds (unchanged) |
| First call throws RUN_INIT_FAILED, retry succeeds | Run marked FAILED | Run proceeds; WARN log "Recovered from RUN_INIT_FAILED on retry" |
| Both calls throw RUN_INIT_FAILED | Run marked FAILED | Run marked FAILED (unchanged) |
| Any non-RUN_INIT_FAILED error | Rethrown immediately | Rethrown immediately (unchanged) |

No retry knob — single retry, fixed 2s delay.

## Test plan

- [x] Preflight: \`npm run lint --workspace @valuerank/api\` → 0 errors
- [x] Preflight: \`npm run build --workspace @valuerank/api\` → clean
- [ ] Manual smoke: next domain evaluation should show fewer RUN_INIT_FAILED final failures in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)