### PR TITLE
fix(launch): serialize batch run launches and surface pgboss insert errors

### DIFF
--- a/cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts
+++ b/cloud/apps/api/src/graphql/mutations/domain/launch/execute-runs.ts
@@ -110,6 +110,7 @@ export async function executeLaunchRuns(params: {
   let startedRuns = 0;
   let failedDefinitions = 0;
   const runs: DomainTrialRunEntry[] = [];
+  type StartRunResult = Awaited<ReturnType<typeof startRunService>>;
 
   for (let offset = 0; offset < launchSlots.length; offset += 25) {
     const batch = launchSlots.slice(offset, offset + 25);
@@ -138,9 +139,11 @@ export async function executeLaunchRuns(params: {
       break;
     }
 
-    const runResults = await Promise.allSettled(
-      batch.map(async (slot) => {
-        return startRunService({
+    const runResults: Array<{ slot: LaunchSlot; result: PromiseSettledResult<StartRunResult> }> = [];
+    for (let i = 0; i < batch.length; i += 1) {
+      const slot = batch[i]!;
+      try {
+        const value = await startRunService({
           definitionId: slot.definition.id,
           models: selectedModels,
           samplePercentage,
@@ -150,10 +153,17 @@ export async function executeLaunchRuns(params: {
           runCategory: scopeCategory,
           userId,
         });
-      })
-    );
+        runResults.push({ slot, result: { status: 'fulfilled', value } });
+      } catch (reason) {
+        runResults.push({ slot, result: { status: 'rejected', reason } });
+      }
 
-    runResults.forEach((result, index) => {
+      if (i < batch.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    runResults.forEach(({ slot, result }) => {
       if (result.status === 'fulfilled') {
         startedRuns += 1;
         runs.push({
@@ -164,11 +174,10 @@ export async function executeLaunchRuns(params: {
         return;
       }
       failedDefinitions += 1;
-      const failedSlot = batch[index];
       log.error(
         {
           domainId,
-          definitionId: failedSlot?.definition.id ?? null,
+          definitionId: slot.definition.id,
           error: result.reason instanceof Error ? result.reason.message : String(result.reason),
           scopeCategory,
         },
@@ -250,9 +259,15 @@ export async function executeBackfillRuns(params: {
       continue;
     }
 
-    const runResults = await Promise.allSettled(
-      group.definitions.map(async (definition) => {
-        return startRunService({
+    type StartRunResult = Awaited<ReturnType<typeof startRunService>>;
+    const runResults: Array<{
+      definition: BackfillLaunchGroupRepetition['definitions'][number];
+      result: PromiseSettledResult<StartRunResult>;
+    }> = [];
+    for (let i = 0; i < group.definitions.length; i += 1) {
+      const definition = group.definitions[i]!;
+      try {
+        const value = await startRunService({
           definitionId: definition.id,
           models: [group.modelId],
           samplePercentage: snapshot.samplePercentage,
@@ -262,10 +277,17 @@ export async function executeBackfillRuns(params: {
           runCategory: scopeCategory,
           userId,
         });
-      }),
-    );
+        runResults.push({ definition, result: { status: 'fulfilled', value } });
+      } catch (reason) {
+        runResults.push({ definition, result: { status: 'rejected', reason } });
+      }
 
-    runResults.forEach((result, index) => {
+      if (i < group.definitions.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    runResults.forEach(({ definition, result }) => {
       if (result.status === 'fulfilled') {
         startedRuns += 1;
         runs.push({
@@ -277,11 +299,10 @@ export async function executeBackfillRuns(params: {
       }
 
       failedDefinitions += 1;
-      const failedDefinition = group.definitions[index];
       log.error(
         {
           domainEvaluationId,
-          definitionId: failedDefinition?.id ?? null,
+          definitionId: definition.id,
           modelId: group.modelId,
           error: result.reason instanceof Error ? result.reason.message : String(result.reason),
         },

--- a/cloud/apps/api/src/services/run/start-helpers.ts
+++ b/cloud/apps/api/src/services/run/start-helpers.ts
@@ -111,6 +111,10 @@ export async function bulkEnqueueJobs(
     try {
       const ids = await boss.insert(queueName, insertPayloads);
       if (ids === null || ids.length === 0) {
+        log.error(
+          { queueName, jobCount: queueJobs.length },
+          'boss.insert returned null or empty — no jobs queued',
+        );
         failures.push(
           ...queueJobs.map((job) => ({ job, error: 'bulk insert returned no ids' })),
         );
@@ -130,10 +134,16 @@ export async function bulkEnqueueJobs(
         }
       }
     } catch (err) {
+      const errMessage = err instanceof Error ? err.message : String(err);
+      const errStack = err instanceof Error ? err.stack : undefined;
+      log.error(
+        { queueName, jobCount: queueJobs.length, err: errMessage, stack: errStack },
+        'boss.insert threw',
+      );
       failures.push(
         ...queueJobs.map((job) => ({
           job,
-          error: err instanceof Error ? err.message : String(err),
+          error: errMessage,
         })),
       );
     }


### PR DESCRIPTION
## Summary

Two related reliability fixes for the domain-evaluation launch pipeline, both rooted in the same incident analysis:

1. **Serialize per-batch run launches.** `executeLaunchRuns` and `executeBackfillRuns` were calling `Promise.allSettled(batch.map(startRunService))` — 25 simultaneous run starts, which translates to ~200 simultaneous `boss.insert()` calls hitting `pgboss.job`. That contention is what caused 21/25 runs in batch 1 of a recent Partner Choice Male evaluation to die with `RUN_INIT_FAILED`. Replaced with a sequential loop and a 1s delay between launches.

2. **Surface the actual pgboss error.** `bulkEnqueueJobs` previously recorded "bulk insert returned no ids" with no queue name, no error stack, no context. Now it emits an ERROR-level structured log with `queueName`, `jobCount`, and (for thrown errors) the message + stack. Triage of the next incident becomes a 30-second look at logs instead of an hour of code-spelunking.

## Why both in one PR

Both are small, both touch the same launch pipeline, and #2 is what makes #1's residual failures (if any) diagnosable. Splitting just adds review burden.

## Companion to #1056

#1056 (already merged) adds a single retry of `enqueueRunJobs` on `RUN_INIT_FAILED` — second line of defense. This PR is the actual root-cause fix.

## Behavior change

| Before | After |
|---|---|
| `Promise.allSettled(25 startRun calls)` per batch | `for` loop with 1s delay between each |
| Launch wall-clock per 25-run batch: ~2s | ~25s |
| Concurrent `boss.insert` calls per batch: ~200 | ~8 (1 run × 8 queues at a time) |
| pgboss write contention | Eliminated |

Domain launches will take noticeably longer end-to-end (25s × N/25 batches ≈ N seconds added), but that was already swamped by the backpressure-wait time between batches.

## Test plan

- [x] Preflight: `npm run lint --workspace @valuerank/shared` → 0 errors
- [x] Preflight: `npm run lint --workspace @valuerank/db` → 0 errors
- [x] Preflight: `npm run lint --workspace @valuerank/api` → 0 errors
- [x] Preflight: `npm run build --workspace @valuerank/api` → clean
- [ ] Manual smoke: next domain evaluation should complete cleanly with no `RUN_INIT_FAILED` (or, if any, the log lines now identify the queue + error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)