### PR TITLE
fix(probe): increase transaction timeout from 5s to 30s

### DIFF
--- a/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
+++ b/cloud/apps/api/src/queue/handlers/probe-scenario/handler.ts
@@ -457,7 +457,7 @@ async function processProbeJob(job: PgBoss.Job<ProbeScenarioJobData>): Promise<v
         definitionSnapshot: scenario.definition.content as Prisma.InputJsonValue,
         costSnapshot,
       }, tx);
-    });
+    }, { timeout: 30000 });
 
     // Record probe success in results table
     // Calculate duration from timestamps


### PR DESCRIPTION
## Summary

- Under high probe concurrency, multiple jobs finishing simultaneously queue up waiting for `pg_advisory_xact_lock`
- The default 5s Prisma interactive transaction timeout fires before the lock clears, causing spurious retries
- Increases the timeout on that specific `$transaction` call to 30s

Observed in production logs: transactions timing out at 6–7s across all providers (openai, anthropic, google, deepseek, xai) during the Partner Choice domain run batch.

## Validation

- `npx turbo lint --filter=@valuerank/api` — 0 errors
- `npx turbo build --filter=@valuerank/api` — clean
- `npx turbo test --filter=@valuerank/api` — 2442 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)