### PR TITLE
Raise domain evaluation backpressure threshold from 300 to 2000

### DIFF
--- a/cloud/apps/api/src/queue/handlers/start-domain-launch-snapshot.ts
+++ b/cloud/apps/api/src/queue/handlers/start-domain-launch-snapshot.ts
@@ -1,6 +1,6 @@
 import { type Prisma, type RunCategory } from '@valuerank/db';
 
-export const BACKPRESSURE_THRESHOLD = 300;
+export const BACKPRESSURE_THRESHOLD = 2000;
 export const BACKPRESSURE_POLL_MS = 5_000;
 export const INTER_LAUNCH_DELAY_MS = 1_000;
 export const FLUSH_EVERY = 5;


### PR DESCRIPTION
## Summary
- Raises `BACKPRESSURE_THRESHOLD` in `start-domain-launch-snapshot.ts` from 300 → 2000
- At the old threshold, workers were sitting idle for 3–5 minutes between vignette releases: peak throughput ~400 jobs/min drains 300 jobs in under a minute, then the orchestrator stalls
- 2000 keeps all provider queues continuously fed; can tune further after observing behaviour

## Validation
- `npm run lint --workspace @valuerank/shared` — ✅ pass (warnings only)
- `npm run lint --workspace @valuerank/db` — ✅ pass (warnings only)
- `npm run lint --workspace @valuerank/api` — ✅ pass (warnings only)
- `npm run build --workspace @valuerank/api` — ✅ pass
- `npm run lint --workspace @valuerank/web` — ✅ pass (warnings only)
- `npm run build --workspace @valuerank/web` — ✅ pass
- Tests skipped (require live DB)

## Production smoke test
N/A — constant change only, no data resolver or aggregation logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)