### PR TITLE
Add instrumentation to diagnose ALL_DOMAINS rebuild failures

### DIFF
--- a/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
+++ b/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
@@ -83,7 +83,7 @@ async function enqueueSummarizeTranscriptJob(runId: string, transcriptId: string
   const boss = bossModule.getBoss();
   await boss.send(
     'summarize_transcript',
-    { runId, transcriptId },
+    { runId, transcriptId, enqueuedAt: new Date().toISOString() },
     {
       ...DEFAULT_JOB_OPTIONS['summarize_transcript'],
       singletonKey: transcriptId,

--- a/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
+++ b/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
@@ -83,7 +83,7 @@ async function enqueueSummarizeTranscriptJob(runId: string, transcriptId: string
   const boss = bossModule.getBoss();
   await boss.send(
     'summarize_transcript',
-    { runId, transcriptId, enqueuedAt: new Date().toISOString() },
+    { runId, transcriptId },
     {
       ...DEFAULT_JOB_OPTIONS['summarize_transcript'],
       singletonKey: transcriptId,

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -325,14 +325,29 @@ export async function refreshDomainAnalysisSnapshot(params: {
   domainIds?: string[];
   requestedSignature: string | null;
 }) {
+  const refreshStartedAt = Date.now();
+  log.info({ scope: params.scope, domainId: params.domainId, requestedSignature: params.requestedSignature }, 'refreshDomainAnalysisSnapshot: start');
+
+  const prepareStartedAt = Date.now();
   const state = await prepareDomainAnalysisState({
     scope: params.scope,
     domainId: params.domainId,
     domainIds: params.domainIds,
     requestedSignature: params.requestedSignature,
   });
+  const prepareDurationMs = Date.now() - prepareStartedAt;
+  log.info({
+    scope: params.scope,
+    domainId: params.domainId,
+    prepareDurationMs,
+    configSignature: state.configSignature,
+    inputHash: state.inputHash,
+    totalSourceRuns: state.resolvedSignatureRuns.filteredSourceRunIds.length,
+  }, 'refreshDomainAnalysisSnapshot: prepare complete');
+
   const totalRuns = state.resolvedSignatureRuns.filteredSourceRunIds.length;
-  await db.assumptionAnalysisSnapshot.updateMany({
+  const supersedeStartedAt = Date.now();
+  const supersedeResult = await db.assumptionAnalysisSnapshot.updateMany({
     where: {
       assumptionKey: buildAssumptionKey(state.scope, state.domain.id),
       analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
@@ -347,6 +362,12 @@ export async function refreshDomainAnalysisSnapshot(params: {
       status: 'SUPERSEDED',
     },
   });
+  log.info({
+    scope: params.scope,
+    domainId: params.domainId,
+    durationMs: Date.now() - supersedeStartedAt,
+    supersededCount: supersedeResult.count,
+  }, 'refreshDomainAnalysisSnapshot: supersede done');
 
   const progressSnapshot = await db.assumptionAnalysisSnapshot.create({
     data: {
@@ -372,8 +393,14 @@ export async function refreshDomainAnalysisSnapshot(params: {
       status: 'CURRENT',
     },
   });
+  log.info({
+    scope: params.scope,
+    domainId: params.domainId,
+    progressSnapshotId: progressSnapshot.id,
+  }, 'refreshDomainAnalysisSnapshot: progress snapshot created');
 
   try {
+    const buildStartedAt = Date.now();
     const { output, excNeutralValueWinRatesByModel } = await buildSnapshotOutput(state, {
       onProgress: async (buildProgress) => {
         await db.assumptionAnalysisSnapshot.update({
@@ -386,6 +413,27 @@ export async function refreshDomainAnalysisSnapshot(params: {
         });
       },
     });
+    const buildDurationMs = Date.now() - buildStartedAt;
+    log.info({
+      scope: params.scope,
+      domainId: params.domainId,
+      progressSnapshotId: progressSnapshot.id,
+      buildDurationMs,
+    }, 'refreshDomainAnalysisSnapshot: buildSnapshotOutput complete');
+
+    // Check if we got superseded during build (thundering herd detection)
+    const preWriteCheck = await db.assumptionAnalysisSnapshot.findUnique({
+      where: { id: progressSnapshot.id },
+      select: { status: true },
+    });
+    if (preWriteCheck?.status !== 'CURRENT') {
+      log.warn({
+        scope: params.scope,
+        domainId: params.domainId,
+        progressSnapshotId: progressSnapshot.id,
+        actualStatus: preWriteCheck?.status,
+      }, 'refreshDomainAnalysisSnapshot: progress snapshot was superseded during build (thundering herd)');
+    }
 
     const snapshot = await db.assumptionAnalysisSnapshot.update({
       where: { id: progressSnapshot.id },
@@ -406,7 +454,19 @@ export async function refreshDomainAnalysisSnapshot(params: {
       data: { output: mergedOutput },
     });
     if (phase2Result.count === 0) {
-      log.info({ snapshotId: progressSnapshot.id }, 'Phase 2 exc-neutral write skipped — snapshot superseded');
+      log.warn({
+        scope: params.scope,
+        domainId: params.domainId,
+        snapshotId: progressSnapshot.id,
+        totalRefreshDurationMs: Date.now() - refreshStartedAt,
+      }, 'Phase 2 exc-neutral write skipped — snapshot superseded');
+    } else {
+      log.info({
+        scope: params.scope,
+        domainId: params.domainId,
+        snapshotId: progressSnapshot.id,
+        totalRefreshDurationMs: Date.now() - refreshStartedAt,
+      }, 'refreshDomainAnalysisSnapshot: phase 2 write succeeded');
     }
     const finalSnapshot = phase2Result.count > 0 ? { ...snapshot, output: mergedOutput } : snapshot;
 

--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
@@ -1,7 +1,10 @@
 import { db, resolveDefinitionContent } from '@valuerank/db';
+import { createLogger } from '@valuerank/shared';
 import { getMissingReasonLabel, resolveSignatureRuns } from '../../graphql/queries/domain/shared.js';
 import { extractValuePair, type DomainAnalysisValuePair } from '../../graphql/queries/domain-analysis-values.js';
 import { computeAggregateFingerprint } from './aggregate/aggregate-helpers.js';
+
+const log = createLogger('analysis:snapshot-builder');
 import {
   DOMAIN_ANALYSIS_ASSUMPTION_PREFIX,
   DOMAIN_ANALYSIS_NONE_SIGNATURE,
@@ -78,17 +81,38 @@ export async function prepareDomainAnalysisState(params: {
   domainIds?: string[];
   requestedSignature: string | null;
 }): Promise<DomainAnalysisPreparedState> {
+  const prepareStartedAt = Date.now();
+  log.info({ scope: params.scope, domainId: params.domainId, requestedSignature: params.requestedSignature }, 'prepareDomainAnalysisState: start');
+
+  const scopeStartedAt = Date.now();
   const scopeData = await resolveDomainAnalysisScopeDefinitions({
     scope: params.scope,
     domainId: params.domainId,
     domainIds: params.domainIds,
   });
+  log.info({
+    scope: params.scope,
+    domainId: params.domainId,
+    durationMs: Date.now() - scopeStartedAt,
+    definitionCount: scopeData.latestDefinitionIds.length,
+  }, 'prepareDomainAnalysisState: resolveDomainAnalysisScopeDefinitions done');
 
   const defaultModelIds = scopeData.scope === 'ALL_DOMAINS' ? [] : scopeData.domain.defaultModelIds;
+
+  const sigRunsStartedAt = Date.now();
   const resolvedSignatureRuns = await resolveSignatureRuns(scopeData.latestDefinitionIds, params.requestedSignature, defaultModelIds);
+  log.info({
+    scope: params.scope,
+    domainId: params.domainId,
+    durationMs: Date.now() - sigRunsStartedAt,
+    filteredSourceRunCount: resolvedSignatureRuns.filteredSourceRunIds.length,
+    selectedSignature: resolvedSignatureRuns.selectedSignature,
+  }, 'prepareDomainAnalysisState: resolveSignatureRuns done');
+
   const selectedSignature = resolvedSignatureRuns.selectedSignature;
   const configSignature = normalizeSignature(selectedSignature);
 
+  const fingerprintStartedAt = Date.now();
   const fingerprintRows = resolvedSignatureRuns.filteredSourceRunIds.length === 0
     ? []
     : await db.analysisResult.findMany({
@@ -103,7 +127,14 @@ export async function prepareDomainAnalysisState(params: {
           inputHash: true,
         },
       });
+  log.info({
+    scope: params.scope,
+    domainId: params.domainId,
+    durationMs: Date.now() - fingerprintStartedAt,
+    fingerprintRowCount: fingerprintRows.length,
+  }, 'prepareDomainAnalysisState: analysisResult.findMany done');
 
+  const hashStartedAt = Date.now();
   const inputHash = computeInputHash({
     scope: scopeData.scope,
     domainIds: scopeData.domainIds,
@@ -111,6 +142,13 @@ export async function prepareDomainAnalysisState(params: {
     latestDefinitions: scopeData.latestDefinitions,
     fingerprints: fingerprintRows,
   });
+  log.info({
+    scope: params.scope,
+    domainId: params.domainId,
+    durationMs: Date.now() - hashStartedAt,
+    inputHash,
+    totalPrepareDurationMs: Date.now() - prepareStartedAt,
+  }, 'prepareDomainAnalysisState: complete');
 
   return {
     scope: scopeData.scope,


### PR DESCRIPTION
## Summary
- Adds timing logs to `prepareDomainAnalysisState` (scope resolution, signature runs, analysis fingerprint findMany, hash compute)
- Adds end-to-end timing + mid-build supersede detection to `refreshDomainAnalysisSnapshot`
- These logs will let us confirm whether the ALL_DOMAINS rebuild is failing due to slow prepare-state, thundering-herd supersedes, or both

## Test plan
- [ ] Preflight passed (lint + build)
- [ ] After deploy: trigger an ALL_DOMAINS refresh and inspect logs for which step dominates

🤖 Generated with [Claude Code](https://claude.com/claude-code)