### PR TITLE
fix(scoring): compute logit score from hierarchical win rate

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/domain-analysis-scoring.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/domain-analysis-scoring.ts
@@ -1,3 +1,8 @@
 export function computeSmoothedLogOddsScore(wins: number, losses: number): number {
   return Math.log((wins + 1) / (losses + 1));
 }
+
+export function computeLogOddsFromWinRate(winRatePct: number): number {
+  const p = winRatePct / 100;
+  return Math.log(p / (1 - p));
+}

--- a/cloud/apps/api/src/graphql/queries/domain/shared.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/shared.ts
@@ -31,7 +31,7 @@ export type {
 
 export { formatVnewLabel, formatVnewSignature };
 export { aggregateValueCountsFromTranscripts, incrementPairwiseWin, isDomainAnalysisValueKey } from './domain-analysis-aggregation.js';
-export { computeSmoothedLogOddsScore } from './domain-analysis-scoring.js';
+export { computeSmoothedLogOddsScore, computeLogOddsFromWinRate } from './domain-analysis-scoring.js';
 export type {
   DomainAnalysisConditionDetail,
   DomainAnalysisConditionTranscript,

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -201,10 +201,7 @@ function buildDomainAnalysisResultFromSnapshot(params: {
       const excNeutralDenom = wins + losses;
       const winRatePct = model.valueWinRates?.[valueKey];
       if (winRatePct != null && (winRatePct <= 0 || winRatePct >= 100)) {
-        log.warn(
-          { modelId: model.model, valueKey, winRatePct },
-          'Extreme win rate (0% or 100%) produces ±Infinity logit score',
-        );
+        log.warn({ modelId: model.model, valueKey, winRatePct }, 'Extreme win rate (0% or 100%) produces ±Infinity logit score');
       }
       return {
         valueKey,

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -7,6 +7,7 @@ import {
 } from '../../graphql/queries/domain-analysis-values.js';
 import {
   computeSmoothedLogOddsScore,
+  computeLogOddsFromWinRate,
 } from '../../graphql/queries/domain/shared.js';
 import { computeRankingShapes } from '../../graphql/queries/domain-shape.js';
 import { computeClusterAnalysis, computeAllClusterAnalyses } from '../../graphql/queries/domain-clustering.js';
@@ -198,9 +199,18 @@ function buildDomainAnalysisResultFromSnapshot(params: {
       const wins = counts.prioritized;
       const losses = counts.deprioritized;
       const excNeutralDenom = wins + losses;
+      const winRatePct = model.valueWinRates?.[valueKey];
+      if (winRatePct != null && (winRatePct <= 0 || winRatePct >= 100)) {
+        log.warn(
+          { modelId: model.model, valueKey, winRatePct },
+          'Extreme win rate (0% or 100%) produces ±Infinity logit score',
+        );
+      }
       return {
         valueKey,
-        score: computeSmoothedLogOddsScore(wins, losses),
+        score: winRatePct != null
+          ? computeLogOddsFromWinRate(winRatePct)
+          : computeSmoothedLogOddsScore(wins, losses),
         prioritized: counts.prioritized,
         deprioritized: counts.deprioritized,
         neutral: counts.neutral,

--- a/cloud/apps/api/tests/graphql/queries/domain-analysis-scoring.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/domain-analysis-scoring.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure unit tests for domain-analysis-scoring.ts.
+ * No database access. No server setup required.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeSmoothedLogOddsScore,
+  computeLogOddsFromWinRate,
+} from '../../../src/graphql/queries/domain/domain-analysis-scoring.js';
+
+describe('computeSmoothedLogOddsScore', () => {
+  it('returns 0 for equal wins and losses', () => {
+    expect(computeSmoothedLogOddsScore(10, 10)).toBe(0);
+  });
+
+  it('returns a positive score when wins exceed losses', () => {
+    expect(computeSmoothedLogOddsScore(80, 20)).toBeGreaterThan(0);
+  });
+
+  it('returns a negative score when losses exceed wins', () => {
+    expect(computeSmoothedLogOddsScore(20, 80)).toBeLessThan(0);
+  });
+
+  it('handles zero wins and losses via +1 smoothing', () => {
+    expect(computeSmoothedLogOddsScore(0, 0)).toBe(0);
+  });
+});
+
+describe('computeLogOddsFromWinRate', () => {
+  it('returns 0 for 50% win rate', () => {
+    expect(computeLogOddsFromWinRate(50)).toBeCloseTo(0);
+  });
+
+  it('returns a positive score for win rates above 50%', () => {
+    expect(computeLogOddsFromWinRate(75)).toBeGreaterThan(0);
+  });
+
+  it('returns a negative score for win rates below 50%', () => {
+    expect(computeLogOddsFromWinRate(25)).toBeLessThan(0);
+  });
+
+  it('is symmetric: logit(p) === -logit(1-p)', () => {
+    expect(computeLogOddsFromWinRate(70)).toBeCloseTo(-computeLogOddsFromWinRate(30));
+  });
+
+  it('returns +Infinity for 100% win rate', () => {
+    expect(computeLogOddsFromWinRate(100)).toBe(Infinity);
+  });
+
+  it('returns -Infinity for 0% win rate', () => {
+    expect(computeLogOddsFromWinRate(0)).toBe(-Infinity);
+  });
+
+  it('accepts win rate on 0–100 scale (not 0–1)', () => {
+    // logit(0.77) ≈ 1.208
+    expect(computeLogOddsFromWinRate(77)).toBeCloseTo(Math.log(0.77 / 0.23), 5);
+  });
+});


### PR DESCRIPTION
## Summary

- The logit score was computed from flat cumulative counts (`wins + losses` across all domains), which over-weighted high-trial domains
- Win rate uses a hierarchical mean (vignette → pair → domain → pooled), giving every domain equal weight
- This PR makes logit consistent with win rate by converting the already-computed hierarchical win rate (`valueWinRates` on the snapshot) to log-odds instead of computing from raw counts
- Adds a `log.warn` when a 0% or 100% win rate is encountered (would produce `±Infinity`)
- Falls back to the old smoothed log-odds for snapshots that pre-date `valueWinRates`

## Affected surfaces (all move together)

- Logit column in Win Rate by Values by Model table
- Ranking shapes (computed server-side from sorted scores)
- Cluster analysis (uses scores record)
- Dominance section
- Domain Value Shift heatmap and Models Confidence heatmap

Not affected: pairwise win rate matrix, value detail drill-down (has its own independent score computation).

## Validation

- `npm run lint --workspace @valuerank/api` — 0 errors
- `npm run test --workspace @valuerank/api` — 216/216 pass (2455 tests)
- `npm run build --workspace @valuerank/api` — clean

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>