### PR TITLE
Fix thundering-herd early-exit returning unparseable snapshot

### DIFF
--- a/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
+++ b/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
@@ -83,7 +83,7 @@ async function enqueueSummarizeTranscriptJob(runId: string, transcriptId: string
   const boss = bossModule.getBoss();
   await boss.send(
     'summarize_transcript',
-    { runId, transcriptId },
+    { runId, transcriptId, enqueuedAt: new Date().toISOString() },
     {
       ...DEFAULT_JOB_OPTIONS['summarize_transcript'],
       singletonKey: transcriptId,

--- a/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
+++ b/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
@@ -83,7 +83,7 @@ async function enqueueSummarizeTranscriptJob(runId: string, transcriptId: string
   const boss = bossModule.getBoss();
   await boss.send(
     'summarize_transcript',
-    { runId, transcriptId, enqueuedAt: new Date().toISOString() },
+    { runId, transcriptId },
     {
       ...DEFAULT_JOB_OPTIONS['summarize_transcript'],
       singletonKey: transcriptId,

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -323,11 +323,15 @@ export async function refreshDomainAnalysisSnapshot(params: {
   }, 'refreshDomainAnalysisSnapshot: prepare complete');
 
   // Thundering-herd defense: if the CURRENT snapshot already has the same
-  // inputHash as what we just computed, the snapshot is already fresh — skip
-  // the expensive rebuild entirely. This covers the case where multiple jobs
-  // were queued, the first one wrote a fresh snapshot, and now subsequent
-  // jobs would just re-do the same work and supersede that snapshot for no
-  // reason.
+  // inputHash as what we just computed AND has a fully-built output (not just
+  // buildProgress), skip the expensive rebuild entirely. This covers the case
+  // where multiple jobs were queued, the first one wrote a fresh snapshot,
+  // and now subsequent jobs would just re-do the same work.
+  //
+  // IMPORTANT: we only return early if `parseSnapshotOutput` succeeds — a
+  // snapshot whose output is still `{ buildProgress: ... }` (i.e., another
+  // rebuild is mid-flight) is NOT useable by the caller and would surface as
+  // "snapshot could not be parsed after refresh".
   const existingFresh = await db.assumptionAnalysisSnapshot.findFirst({
     where: {
       assumptionKey: buildAssumptionKey(state.scope, state.domain.id),
@@ -338,7 +342,7 @@ export async function refreshDomainAnalysisSnapshot(params: {
       inputHash: state.inputHash,
     },
   });
-  if (existingFresh != null) {
+  if (existingFresh != null && parseSnapshotOutput(existingFresh.output) != null) {
     log.info({
       scope: params.scope,
       domainId: params.domainId,


### PR DESCRIPTION
## Summary
The thundering-herd early-exit added in #1067 returned the existing CURRENT snapshot when its `(configSignature, inputHash)` matched, but didn't check that the snapshot's `output` was a fully-built result. If a previous rebuild left a snapshot with just `{ buildProgress: ... }` in its output (mid-flight or aborted), the caller would try `parseSnapshotOutput` on it, get null, and throw "Domain analysis snapshot could not be parsed after refresh".

Fix: guard the early-exit with `parseSnapshotOutput(existingFresh.output) != null` so we only short-circuit on snapshots that actually have usable output.

## Test plan
- [ ] Load `/models/win-rate?signature=vnewtd` → no ValidationError

🤖 Generated with [Claude Code](https://claude.com/claude-code)