### PR TITLE
Fix -Infinity score breaking domain analysis GraphQL response

### DIFF
--- a/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
+++ b/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
@@ -83,7 +83,7 @@ async function enqueueSummarizeTranscriptJob(runId: string, transcriptId: string
   const boss = bossModule.getBoss();
   await boss.send(
     'summarize_transcript',
-    { runId, transcriptId },
+    { runId, transcriptId, enqueuedAt: new Date().toISOString() },
     {
       ...DEFAULT_JOB_OPTIONS['summarize_transcript'],
       singletonKey: transcriptId,

--- a/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
+++ b/cloud/apps/api/src/queue/handlers/run-state-reconcile.ts
@@ -83,7 +83,7 @@ async function enqueueSummarizeTranscriptJob(runId: string, transcriptId: string
   const boss = bossModule.getBoss();
   await boss.send(
     'summarize_transcript',
-    { runId, transcriptId, enqueuedAt: new Date().toISOString() },
+    { runId, transcriptId },
     {
       ...DEFAULT_JOB_OPTIONS['summarize_transcript'],
       singletonKey: transcriptId,

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -140,12 +140,12 @@ function buildDomainAnalysisResultFromSnapshot(params: {
       const losses = counts.deprioritized;
       const excNeutralDenom = wins + losses;
       const winRatePct = model.valueWinRates?.[valueKey];
-      if (winRatePct != null && (winRatePct <= 0 || winRatePct >= 100)) {
-        log.warn({ modelId: model.model, valueKey, winRatePct }, 'Extreme win rate (0% or 100%) produces ±Infinity logit score');
-      }
+      // Extreme win rates (0% or 100%) yield ±Infinity from log-odds, which
+      // GraphQL cannot serialize. Fall back to smoothed log-odds.
+      const isExtreme = winRatePct != null && (winRatePct <= 0 || winRatePct >= 100);
       return {
         valueKey,
-        score: winRatePct != null
+        score: winRatePct != null && !isExtreme
           ? computeLogOddsFromWinRate(winRatePct)
           : computeSmoothedLogOddsScore(wins, losses),
         prioritized: counts.prioritized,


### PR DESCRIPTION
## Summary
The `/models/win-rate` page was failing to load with GraphQL error:

> Float cannot represent non numeric value: -Infinity
> path: [\"domainAnalysis\",\"models\",0,\"values\",4,\"score\"]

When a value's win rate is exactly 0% or 100%, `computeLogOddsFromWinRate` returns ±Infinity. The existing code logged a warning ("Extreme win rate") but passed the Infinity value through to the response, breaking GraphQL serialization.

Fix: when win rate is extreme, fall back to `computeSmoothedLogOddsScore` (which adds +1 to wins and losses) so the score stays finite while still reflecting the directional signal.

## Test plan
- [ ] After deploy: `/models/win-rate?signature=vnewtd` page loads without GraphQL error
- [ ] Models with 0% or 100% on a value still get a (large but finite) score

🤖 Generated with [Claude Code](https://claude.com/claude-code)