### PR TITLE
Show rebuild spinner and status banner when domain combination is loading

### DIFF
--- a/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
+++ b/cloud/apps/web/src/components/analysis/AnalysisContextBar.tsx
@@ -33,6 +33,7 @@ type DomainMultiProp = {
   actions?: ChipPickerAction[];
   disabled?: boolean;
   singleSelect?: boolean;
+  loading?: boolean;
 };
 
 function isMultiDomain(domain: DomainSingleProp | DomainMultiProp): domain is DomainMultiProp {
@@ -119,6 +120,7 @@ export function AnalysisContextBar({
               actions={domain.actions}
               disabled={domain.disabled}
               singleSelect={domain.singleSelect}
+              loading={domain.loading}
               emptyMessage="No domains available."
             />
           ) : (

--- a/cloud/apps/web/src/components/ui/ChipPicker.tsx
+++ b/cloud/apps/web/src/components/ui/ChipPicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Loader2 } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { Button } from './Button';
 import { selectTriggerVariants } from './Select';
@@ -28,6 +28,7 @@ type ChipPickerProps = {
   emptyMessage?: string;
   /** When true, clicking a chip selects only that item; clicking the active chip does nothing. */
   singleSelect?: boolean;
+  loading?: boolean;
 };
 
 export function ChipPicker({
@@ -40,6 +41,7 @@ export function ChipPicker({
   ariaLabel,
   emptyMessage = 'No options available.',
   singleSelect = false,
+  loading = false,
 }: ChipPickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLDivElement>(null);
@@ -95,7 +97,10 @@ export function ChipPicker({
         )}
       >
         <span className="min-w-0 flex-1 truncate">{summary}</span>
-        <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 text-gray-400 transition-transform', isOpen && 'rotate-180')} />
+        {loading
+          ? <Loader2 className="ml-2 h-4 w-4 shrink-0 animate-spin text-gray-400" aria-hidden="true" />
+          : <ChevronDown className={cn('ml-2 h-4 w-4 shrink-0 text-gray-400 transition-transform', isOpen && 'rotate-180')} />
+        }
       </Button>
 
       {isOpen && (

--- a/cloud/apps/web/src/pages/DomainAnalysis.tsx
+++ b/cloud/apps/web/src/pages/DomainAnalysis.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery } from 'urql';
+import { Loader2 } from 'lucide-react';
 import { ErrorMessage } from '../components/ui/ErrorMessage';
 import { Loading } from '../components/ui/Loading';
 import { AnalysisContextBar } from '../components/analysis/AnalysisContextBar';
@@ -482,6 +483,7 @@ export function DomainAnalysis() {
           ],
           onChange: (ids) => setSelectedDomainIds(normalizeDomainIds(ids)),
           disabled: domainsLoading,
+          loading: fetching,
         }}
         signature={{
           label: 'Signature',
@@ -505,6 +507,21 @@ export function DomainAnalysis() {
         }}
         winRateMode={{ value: winRateMode, onChange: setWinRateMode }}
       />
+
+      {!showPageLoader && ((fetching && data?.domainAnalysis != null) || isUpdating) && (
+        <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-800">
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden="true" />
+          <span>
+            {'Rebuilding report'}
+            {data?.domainAnalysis.refreshProgress != null && (
+              <> — {data.domainAnalysis.refreshProgress.completedRuns} of {data.domainAnalysis.refreshProgress.totalRuns} processed</>
+            )}
+            {(data?.domainAnalysis.contributionSummary.length ?? 0) > 0 && (
+              <> — showing {data?.domainAnalysis.contributionSummary.length} domain{data?.domainAnalysis.contributionSummary.length === 1 ? '' : 's'} until it&apos;s complete</>
+            )}
+          </span>
+        </div>
+      )}
 
       <div className="space-y-2">
         <h1 className="text-2xl font-serif font-medium text-[#1A1A1A]">Win Rate</h1>


### PR DESCRIPTION
## Summary
- Adds a small spinner to the domain picker's trigger button (replaces the chevron while loading)
- Adds an amber banner strip between the filter bar and report content when a rebuild is in progress
- Banner text: "Rebuilding report — X of Y processed — showing N domain(s) until it's complete" — run counts come from `refreshProgress` on the API response, which is populated when the server is computing an uncached domain combination

## Test plan
- [ ] Preflight passed (lint + build)
- [ ] Select a multi-domain combination that isn't cached — confirm banner appears with run counts
- [ ] Select a cached combination — confirm spinner appears briefly then disappears with no banner
- [ ] Single-domain / All-domains selections unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)