### PR TITLE
fix(pressure-sensitivity): raise transcript scan limit from 500k to 1M

### DIFF
--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-builder.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-builder.ts
@@ -12,7 +12,7 @@ import {
   PRESSURE_SENSITIVITY_ASSUMPTION_PREFIX,
 } from './snapshot-types.js';
 
-const TRANSCRIPT_FETCH_LIMIT = 500_000;
+const TRANSCRIPT_FETCH_LIMIT = 1_000_000;
 
 export const PAIR_KEY_COMPANION_COLLISION = 'pair_key_companion_collision';
 export const PAIR_KEY_COMPANION_MIRROR_FAILURE = 'pair_key_companion_mirror_failure';

--- a/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.test.tsx
@@ -318,7 +318,7 @@ describe('PressureSensitivity page', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText(/Coverage warning: this report scanned the maximum 500,000 transcripts/)).toBeDefined();
+    expect(screen.getByText(/Coverage warning: this report scanned the maximum 1,000,000 transcripts/)).toBeDefined();
   });
 
   it('hides the transcript cap banner when the backend does not flag it', () => {
@@ -331,7 +331,7 @@ describe('PressureSensitivity page', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.queryByText(/Coverage warning: this report scanned the maximum 500,000 transcripts/)).toBeNull();
+    expect(screen.queryByText(/Coverage warning: this report scanned the maximum 1,000,000 transcripts/)).toBeNull();
   });
 
   it('renders the exclusion warning when pressureConditionExcludedCount is nonzero', () => {

--- a/cloud/apps/web/src/pages/PressureSensitivity.tsx
+++ b/cloud/apps/web/src/pages/PressureSensitivity.tsx
@@ -329,7 +329,7 @@ export function PressureSensitivity() {
 
       {transcriptCapHit && (
         <section className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
-          Coverage warning: this report scanned the maximum 500,000 transcripts and stopped before reaching the end of the data. Win rates and CIs may be biased toward earlier transcripts in the corpus.
+          Coverage warning: this report scanned the maximum 1,000,000 transcripts and stopped before reaching the end of the data. Win rates and CIs may be biased toward earlier transcripts in the corpus.
           {pressureConditionExcludedCount > 0 && (
             <>{' '}Together with the {pressureConditionExcludedCount} excluded pressure condition{pressureConditionExcludedCount === 1 ? '' : 's'}, these limits are a lower bound on pressure sensitivity — the true effect could be larger.</>
           )}


### PR DESCRIPTION
## Summary
- Raises `TRANSCRIPT_FETCH_LIMIT` in `snapshot-builder.ts` from 500,000 to 1,000,000
- Updates the coverage warning message in `PressureSensitivity.tsx` to reflect the new limit

The pressure sensitivity page was showing a coverage warning because the corpus exceeded 500k transcripts. This change doubles the scan cap so analyses cover more of the data before hitting the limit.

## Test plan
- [ ] Preflight passed (lint + build)
- [ ] Coverage warning no longer appears for current corpus size (or shows updated 1M figure if corpus still exceeds the new limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)