### PR TITLE
fix(pressure-sensitivity): bump snapshot version to clear stale cap-hit cache

### DIFF
--- a/cloud/apps/api/src/services/pressure-sensitivity/snapshot-types.ts
+++ b/cloud/apps/api/src/services/pressure-sensitivity/snapshot-types.ts
@@ -1,3 +1,3 @@
 export const PRESSURE_SENSITIVITY_SNAPSHOT_TYPE = 'pressure_sensitivity';
-export const PRESSURE_SENSITIVITY_SNAPSHOT_CODE_VERSION = '1.4.0';
+export const PRESSURE_SENSITIVITY_SNAPSHOT_CODE_VERSION = '1.4.1';
 export const PRESSURE_SENSITIVITY_ASSUMPTION_PREFIX = 'pressure-sensitivity';


### PR DESCRIPTION
## Summary
- Bumps `PRESSURE_SENSITIVITY_SNAPSHOT_CODE_VERSION` from `1.4.0` to `1.4.1`

**Root cause:** The snapshot was computed when the transcript limit was 500k and had `transcriptCapHit: true` persisted to the DB. Raising the limit to 1M in #1071 didn't help because the old snapshot was still being served from cache. The code version is part of the `inputHash` fingerprint, so bumping it causes a cache miss and forces a fresh recompute — which will produce `transcriptCapHit: false` since the corpus is under 1M.

## Test plan
- [ ] CI green
- [ ] After deploy: coverage warning no longer appears on the pressure sensitivity page

🤖 Generated with [Claude Code](https://claude.com/claude-code)