### PR TITLE
Replace Vignettes (N) with Transcripts (N) in Response Consistency table

### DIFF
--- a/cloud/apps/api/src/graphql/queries/models-stability-math.ts
+++ b/cloud/apps/api/src/graphql/queries/models-stability-math.ts
@@ -157,6 +157,7 @@ export function aggregateConditionStats(
 
 export type VignetteStabilityStats = {
   classifiedCount: number;
+  totalTranscriptCount: number;
   stableShare: number;
   softLeanShare: number;
   tornShare: number;
@@ -173,6 +174,7 @@ export function computeVignetteStability(
   let softLean = 0;
   let torn = 0;
   let unstable = 0;
+  let totalTranscriptCount = 0;
   const agreementValues: Array<{ value: number; weight: number }> = [];
   const exactValues: Array<{ sampleCount: number; value: number }> = [];
 
@@ -194,6 +196,7 @@ export function computeVignetteStability(
     else if (pattern === 'torn') torn++;
     else if (pattern === 'noisy') unstable++;
 
+    totalTranscriptCount += stats.totalSamples;
     agreementValues.push({ value: stats.directionalAgreement, weight: stats.totalSamples });
     if (stats.exactAgreement != null) {
       exactValues.push({ sampleCount: stats.totalSamples, value: stats.exactAgreement });
@@ -210,6 +213,7 @@ export function computeVignetteStability(
 
   return {
     classifiedCount,
+    totalTranscriptCount,
     stableShare: stable / classifiedCount,
     softLeanShare: softLean / classifiedCount,
     tornShare: torn / classifiedCount,

--- a/cloud/apps/api/src/graphql/queries/models-stability.ts
+++ b/cloud/apps/api/src/graphql/queries/models-stability.ts
@@ -213,6 +213,7 @@ builder.queryField('modelsWinRateStability', (t) =>
           modelId: model.modelId,
           label: model.displayName,
           qualifyingVignetteCount: entries.length,
+          totalTranscriptCount: entries.reduce((sum, e) => sum + e.stats.totalTranscriptCount, 0),
           avgDirectionalAgreement: avg?.avgDirectionalAgreement ?? null,
           avgExactAgreement: avg?.avgExactAgreement ?? null,
           stableShare: avg?.stableShare ?? null,

--- a/cloud/apps/api/src/graphql/types/models-stability.ts
+++ b/cloud/apps/api/src/graphql/types/models-stability.ts
@@ -22,6 +22,7 @@ export type ModelsStabilityModelResultShape = {
   modelId: string;
   label: string;
   qualifyingVignetteCount: number;
+  totalTranscriptCount: number;
   avgDirectionalAgreement: number | null;
   avgExactAgreement: number | null;
   stableShare: number | null;
@@ -68,6 +69,7 @@ builder.objectType(ModelsStabilityModelResultRef, {
     modelId: t.exposeString('modelId'),
     label: t.exposeString('label'),
     qualifyingVignetteCount: t.exposeInt('qualifyingVignetteCount'),
+    totalTranscriptCount: t.exposeInt('totalTranscriptCount'),
     avgDirectionalAgreement: t.exposeFloat('avgDirectionalAgreement', { nullable: true }),
     avgExactAgreement: t.exposeFloat('avgExactAgreement', { nullable: true }),
     stableShare: t.exposeFloat('stableShare', { nullable: true }),

--- a/cloud/apps/api/tests/graphql/queries/models-stability-math.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/models-stability-math.test.ts
@@ -426,6 +426,7 @@ describe('averageVignetteStability', () => {
       averageVignetteStability([
         {
           classifiedCount: 10,
+          totalTranscriptCount: 50,
           stableShare: 1,
           softLeanShare: 0,
           tornShare: 0,
@@ -435,6 +436,7 @@ describe('averageVignetteStability', () => {
         },
         {
           classifiedCount: 2,
+          totalTranscriptCount: 10,
           stableShare: 0,
           softLeanShare: 1,
           tornShare: 0,
@@ -458,6 +460,7 @@ describe('averageVignetteStability', () => {
       averageVignetteStability([
         {
           classifiedCount: 10,
+          totalTranscriptCount: 50,
           stableShare: 1,
           softLeanShare: 0,
           tornShare: 0,
@@ -467,6 +470,7 @@ describe('averageVignetteStability', () => {
         },
         {
           classifiedCount: 2,
+          totalTranscriptCount: 10,
           stableShare: 0,
           softLeanShare: 1,
           tornShare: 0,

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1722,6 +1722,7 @@ type ModelsStabilityModelResult {
   label: String!
   modelId: String!
   qualifyingVignetteCount: Int!
+  totalTranscriptCount: Int!
   softLeanShare: Float
   stableShare: Float
   tornShare: Float

--- a/cloud/apps/web/src/api/operations/modelsStability.graphql
+++ b/cloud/apps/web/src/api/operations/modelsStability.graphql
@@ -3,7 +3,7 @@ query ModelsWinRateStability($signature: String, $domainId: ID, $domainIds: [ID!
     models {
       modelId
       label
-      qualifyingVignetteCount
+      totalTranscriptCount
       avgDirectionalAgreement
       avgExactAgreement
     }

--- a/cloud/apps/web/src/components/models/WinRateStabilitySection.test.tsx
+++ b/cloud/apps/web/src/components/models/WinRateStabilitySection.test.tsx
@@ -6,21 +6,21 @@ import type { ModelsStabilityModelResult, ModelsStabilitySkippedVignette } from 
 
 function makeModel(overrides: Partial<ModelsStabilityModelResult> & { modelId: string; label: string }): ModelsStabilityModelResult {
   return {
-    qualifyingVignetteCount: 10,
+    totalTranscriptCount: 40,
     avgDirectionalAgreement: 0.75,
     avgExactAgreement: 0.60,
     ...overrides,
   };
 }
 
-const MODEL_A = makeModel({ modelId: 'model-a', label: 'Model A', avgDirectionalAgreement: 0.8, qualifyingVignetteCount: 10 });
-const MODEL_B = makeModel({ modelId: 'model-b', label: 'Model B', avgDirectionalAgreement: 0.3, qualifyingVignetteCount: 6 });
+const MODEL_A = makeModel({ modelId: 'model-a', label: 'Model A', avgDirectionalAgreement: 0.8, totalTranscriptCount: 40 });
+const MODEL_B = makeModel({ modelId: 'model-b', label: 'Model B', avgDirectionalAgreement: 0.3, totalTranscriptCount: 24 });
 const MODEL_C = makeModel({
   modelId: 'model-c',
   label: 'Model C',
   avgDirectionalAgreement: null,
   avgExactAgreement: null,
-  qualifyingVignetteCount: 0,
+  totalTranscriptCount: 0,
 });
 
 describe('WinRateStabilitySection', () => {
@@ -35,7 +35,7 @@ describe('WinRateStabilitySection', () => {
     );
 
     expect(screen.getByRole('heading', { name: /response consistency by model/i })).toBeTruthy();
-    expect(screen.getAllByText(/vignettes \(n\)/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/transcripts \(n\)/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/direction agree/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/exact agree/i).length).toBeGreaterThan(0);
   });
@@ -74,32 +74,6 @@ describe('WinRateStabilitySection', () => {
       />,
     );
     expect(screen.getByText(/something went wrong/i)).toBeTruthy();
-  });
-
-  it('shows Low N badge for models with fewer than 5 qualifying vignettes', () => {
-    const lowNModel = makeModel({ modelId: 'low', label: 'Low N Model', qualifyingVignetteCount: 3 });
-    render(
-      <WinRateStabilitySection
-        models={[lowNModel, MODEL_A]}
-        skippedVignettes={[]}
-        fetching={false}
-        errorMessage={null}
-      />,
-    );
-    expect(screen.getByText('Low N')).toBeTruthy();
-    expect(screen.queryAllByText('Low N').length).toBe(1);
-  });
-
-  it('does not show Low N badge for models with 0 qualifying vignettes', () => {
-    render(
-      <WinRateStabilitySection
-        models={[MODEL_C]}
-        skippedVignettes={[]}
-        fetching={false}
-        errorMessage={null}
-      />,
-    );
-    expect(screen.queryByText('Low N')).toBeNull();
   });
 
   it('renders skipped vignettes warning block when skips are present', () => {

--- a/cloud/apps/web/src/components/models/WinRateStabilitySection.tsx
+++ b/cloud/apps/web/src/components/models/WinRateStabilitySection.tsx
@@ -6,7 +6,7 @@ import { Loading } from '../ui/Loading';
 
 type SortKey =
   | 'label'
-  | 'qualifyingVignetteCount'
+  | 'totalTranscriptCount'
   | 'avgDirectionalAgreement'
   | 'avgExactAgreement';
 type SortDir = 'asc' | 'desc';
@@ -30,7 +30,7 @@ function pct(value: number | null | undefined): string {
 function getSortValue(model: ModelsStabilityModelResult, key: SortKey): string | number | null {
   switch (key) {
     case 'label': return model.label;
-    case 'qualifyingVignetteCount': return model.qualifyingVignetteCount;
+    case 'totalTranscriptCount': return model.totalTranscriptCount;
     case 'avgDirectionalAgreement': return model.avgDirectionalAgreement ?? null;
     case 'avgExactAgreement': return model.avgExactAgreement ?? null;
   }
@@ -164,41 +164,29 @@ export function WinRateStabilitySection({
                 onSort={setSort}
               />
               <ColHeader
-                label="Vignettes (N)"
-                tooltip="Number of qualifying vignettes with sufficient repeat data"
-                sortKey="qualifyingVignetteCount"
+                label="Transcripts (N)"
+                tooltip="Total transcripts analyzed across qualifying conditions"
+                sortKey="totalTranscriptCount"
                 sort={sort}
                 onSort={setSort}
               />
             </tr>
           </thead>
           <tbody>
-            {sorted.map((model) => {
-              const hasData = model.qualifyingVignetteCount > 0;
-              const isLowN = hasData && model.qualifyingVignetteCount < 5;
-              return (
-                <tr key={model.modelId} className="border-b border-gray-100 hover:bg-gray-50">
-                  <td className="whitespace-nowrap px-2 py-2 font-medium text-gray-900">{model.label}</td>
-                  <td className="px-2 py-2 text-right font-mono text-gray-700">
-                    {pct(model.avgDirectionalAgreement)}
-                  </td>
-                  <td className="px-2 py-2 text-right font-mono text-gray-700">
-                    {pct(model.avgExactAgreement)}
-                  </td>
-                  <td className="px-2 py-2 text-right font-mono text-gray-700">
-                    {model.qualifyingVignetteCount}
-                    {isLowN && (
-                      <span
-                        className="ml-1.5 rounded bg-amber-100 px-1 py-0.5 text-[10px] font-sans text-amber-800"
-                        title="Low vignette count — results may be unreliable"
-                      >
-                        Low N
-                      </span>
-                    )}
-                  </td>
-                </tr>
-              );
-            })}
+            {sorted.map((model) => (
+              <tr key={model.modelId} className="border-b border-gray-100 hover:bg-gray-50">
+                <td className="whitespace-nowrap px-2 py-2 font-medium text-gray-900">{model.label}</td>
+                <td className="px-2 py-2 text-right font-mono text-gray-700">
+                  {pct(model.avgDirectionalAgreement)}
+                </td>
+                <td className="px-2 py-2 text-right font-mono text-gray-700">
+                  {pct(model.avgExactAgreement)}
+                </td>
+                <td className="px-2 py-2 text-right font-mono text-gray-700">
+                  {model.totalTranscriptCount}
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1630,6 +1630,7 @@ export type ModelsStabilityModelResult = {
   label: Scalars['String']['output'];
   modelId: Scalars['String']['output'];
   qualifyingVignetteCount: Scalars['Int']['output'];
+  totalTranscriptCount: Scalars['Int']['output'];
   softLeanShare?: Maybe<Scalars['Float']['output']>;
   stableShare?: Maybe<Scalars['Float']['output']>;
   tornShare?: Maybe<Scalars['Float']['output']>;
@@ -4933,7 +4934,7 @@ export type ModelsWinRateStabilityQueryVariables = Exact<{
 }>;
 
 
-export type ModelsWinRateStabilityQuery = { __typename?: 'Query', modelsWinRateStability: { __typename?: 'ModelsStabilityResult', models: Array<{ __typename?: 'ModelsStabilityModelResult', modelId: string, label: string, qualifyingVignetteCount: number, avgDirectionalAgreement?: number | null, avgExactAgreement?: number | null }>, skippedVignettes: Array<{ __typename?: 'ModelsStabilitySkippedVignette', definitionId: string, vignetteName: string, reason: string }> } };
+export type ModelsWinRateStabilityQuery = { __typename?: 'Query', modelsWinRateStability: { __typename?: 'ModelsStabilityResult', models: Array<{ __typename?: 'ModelsStabilityModelResult', modelId: string, label: string, totalTranscriptCount: number, avgDirectionalAgreement?: number | null, avgExactAgreement?: number | null }>, skippedVignettes: Array<{ __typename?: 'ModelsStabilitySkippedVignette', definitionId: string, vignetteName: string, reason: string }> } };
 
 export type CreatePairedVignetteMutationVariables = Exact<{
   input: CreatePairedVignetteInput;
@@ -7630,7 +7631,7 @@ export const ModelsWinRateStabilityDocument = gql`
     models {
       modelId
       label
-      qualifyingVignetteCount
+      totalTranscriptCount
       avgDirectionalAgreement
       avgExactAgreement
     }


### PR DESCRIPTION
## Summary
- Adds \`totalTranscriptCount\` field to the stability pipeline: counts transcripts (sum of \`sampleCount\`) across all classified conditions per model per vignette, then summed across vignettes
- Replaces the \`Vignettes (N)\` column in the Response Consistency by Model table with \`Transcripts (N)\`
- Removes the Low N badge (vignette-based threshold doesn't translate to transcript counts)
- Updates schema, generated types, GraphQL query, and all tests

## Test plan
- [ ] API build passes
- [ ] Web build passes
- [ ] All API tests pass

## Validation
```
npm run build --workspace @valuerank/api  ✓
npm run build --workspace @valuerank/web  ✓
npm run test --workspace @valuerank/api   ✓ 2442 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)