### PR TITLE
fix(analysis): bump snapshot version to force exc-neutral rebuild

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache-types.ts
@@ -17,7 +17,7 @@ export type DomainAnalysisCacheStatus =
   (typeof DOMAIN_ANALYSIS_CACHE_STATUS)[keyof typeof DOMAIN_ANALYSIS_CACHE_STATUS];
 
 export const DOMAIN_ANALYSIS_SNAPSHOT_TYPE = 'domain_overview';
-export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.12.0';
+export const DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION = '1.13.0';
 export const DOMAIN_ANALYSIS_ASSUMPTION_PREFIX = 'domain-analysis';
 export const DOMAIN_ANALYSIS_NONE_SIGNATURE = '__none__';
 

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -33,7 +33,7 @@ import {
   buildSnapshotOutput,
 } from './domain-analysis-snapshot-builder.js';
 import type { DomainAnalysisScope } from './domain-analysis-scope.js';
-import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE } from './domain-analysis-scope.js';
+import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE, buildDomainAnalysisDomainSetId, normalizeDomainIds } from './domain-analysis-scope.js';
 
 const log = createLogger('analysis:domain-cache');
 
@@ -630,7 +630,6 @@ export async function getDomainAnalysisResult(params: {
     cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.FRESH,
   });
 }
-
 
 
 /**

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -33,7 +33,7 @@ import {
   buildSnapshotOutput,
 } from './domain-analysis-snapshot-builder.js';
 import type { DomainAnalysisScope } from './domain-analysis-scope.js';
-import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE, buildDomainAnalysisDomainSetId, normalizeDomainIds } from './domain-analysis-scope.js';
+import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE } from './domain-analysis-scope.js';
 
 const log = createLogger('analysis:domain-cache');
 


### PR DESCRIPTION
## Summary
- PR #1039 added `valueWinRatesExcNeutral` (Phase 2 write) to domain analysis snapshots but never bumped `DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION`
- `DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION` is included in the `inputHash` computation — so existing snapshots looked fresh by hash and were never rebuilt
- All individual domain snapshots built before May 11 lack `valueWinRatesExcNeutral`, meaning ALL_DOMAINS exc-neutral was only pooling ~6/14 domains
- This made "All Domains" and "All minus Motivation for Invasion" show nearly identical exc-neutral win rates

## Root cause
`computeInputHash` hashes `DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION` into the snapshot fingerprint. When #1039 added the Phase 2 exc-neutral write without bumping the version, all pre-existing snapshots satisfied `inputHash === state.inputHash` and were served as-is indefinitely.

## Fix
Bump `DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION` `1.12.0` → `1.13.0`. This invalidates all existing snapshot hashes, triggering rebuilds. After rebuild, all 14 individual domain snapshots will have `valueWinRatesExcNeutral` written by Phase 2, and ALL_DOMAINS exc-neutral will pool across all 14 domains — diverging meaningfully from the 13-domain exc-neutral.

## Validation
- `npm run lint --workspace @valuerank/api` — 0 errors ✓
- `npm run build --workspace @valuerank/api` — clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)