### PR TITLE
fix(api): use correct singleton_key column in pgboss in-flight check

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -259,7 +259,7 @@ export async function queueDomainAnalysisRefresh(params: {
   const inFlight = await db.$queryRaw<Array<{ id: string }>>`
     SELECT id FROM pgboss.job
     WHERE name = 'refresh_domain_analysis_snapshot'
-      AND singletonkey = ${singletonKey}
+      AND singleton_key = ${singletonKey}
       AND state IN ('created', 'active', 'retry')
     LIMIT 1
   `;


### PR DESCRIPTION
## Summary

- All Domains / Domain Set page loads were throwing `INTERNAL_SERVER_ERROR` (errorId `vr-f2babae1`) whenever no fresh snapshot existed.
- Root cause: the thundering-herd defense added in #1067 queries `pgboss.job` using column `singletonkey`, but pg-boss v12's actual column is `singleton_key`. Postgres returns SQLSTATE `42703` (column does not exist), the error bubbles up unhandled, and the page fails to load.
- Fix: one-character SQL change — `singletonkey` → `singleton_key` in `cloud/apps/api/src/services/analysis/domain-analysis-cache.ts:262`.

## Why it surfaced now

The bad SQL has been on `main` since #1067, but it only runs on the cache-miss path for `ALL_DOMAINS` / `DOMAIN_SET` scopes. Recent invalidations pushed the All Domains snapshot into that path on every page load, exposing the typo.

## Validation

Ran from `cloud/`:
- `npx turbo lint --filter=@valuerank/api` — 0 errors (37 pre-existing warnings)
- `npx turbo build --filter=@valuerank/api` — pass
- `npx turbo test --filter=@valuerank/api` — 2455 passed, 4 skipped, 0 failed

## Test plan

- [ ] After deploy, load All Domains view in prod and confirm it renders without `vr-*` errorId
- [ ] Tail Railway logs for ~10 min for any new `42703` or `column ... does not exist` errors
- [ ] Optional follow-up: add an integration test that exercises `queueDomainAnalysisRefresh` against the real pg-boss schema so a future column rename is caught at CI time

Generated with Claude Code (https://claude.com/claude-code)