### PR TITLE
fix(analysis): always return UPDATING for multi-domain scopes, never sync refresh

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -33,7 +33,7 @@ import {
   buildSnapshotOutput,
 } from './domain-analysis-snapshot-builder.js';
 import type { DomainAnalysisScope } from './domain-analysis-scope.js';
-import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE } from './domain-analysis-scope.js';
+import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE, buildDomainAnalysisDomainSetId, normalizeDomainIds } from './domain-analysis-scope.js';
 
 const log = createLogger('analysis:domain-cache');
 

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -590,26 +590,27 @@ export async function getDomainAnalysisResult(params: {
   // queue async and return UPDATING immediately so the client can poll and show
   // X/Y progress. A synchronous rebuild here would block the HTTP response for
   // the full rebuild duration (can be minutes for large sets).
+  // Crucially: even if queueing fails (job already in flight), still return
+  // UPDATING — never fall through to synchronous refreshDomainAnalysisSnapshot
+  // for multi-domain scopes.
   if (params.scope !== 'DOMAIN') {
     const totalRuns = state.resolvedSignatureRuns.filteredSourceRunIds.length;
-    const queued = await queueDomainAnalysisRefresh({
+    await queueDomainAnalysisRefresh({
       scope: state.scope,
       domainId: state.domain.id,
       domainIds: state.scope === 'ALL_DOMAINS' ? undefined : state.domainIds,
       signature: state.selectedSignature,
       reason: 'cache-miss',
     });
-    if (queued) {
-      return buildEmptyDomainAnalysisResult({
-        domainId: state.domain.id,
-        domainName: state.domain.name,
-        activeModels,
-        generatedAt: new Date(),
-        cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.UPDATING,
-        unavailableReason: 'Building analysis for this domain combination. Refresh in a moment.',
-        refreshProgress: { completedRuns: 0, totalRuns },
-      });
-    }
+    return buildEmptyDomainAnalysisResult({
+      domainId: state.domain.id,
+      domainName: state.domain.name,
+      activeModels,
+      generatedAt: new Date(),
+      cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.UPDATING,
+      unavailableReason: 'Building analysis for this domain combination. Refresh in a moment.',
+      refreshProgress: { completedRuns: 0, totalRuns },
+    });
   }
 
   const refreshed = await refreshDomainAnalysisSnapshot({

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -33,7 +33,7 @@ import {
   buildSnapshotOutput,
 } from './domain-analysis-snapshot-builder.js';
 import type { DomainAnalysisScope } from './domain-analysis-scope.js';
-import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE, buildDomainAnalysisDomainSetId, normalizeDomainIds } from './domain-analysis-scope.js';
+import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE } from './domain-analysis-scope.js';
 
 const log = createLogger('analysis:domain-cache');
 


### PR DESCRIPTION
## Summary
- When an ALL_DOMAINS/DOMAIN_SET progress snapshot goes stale (>5 min), `getDomainAnalysisResult` fell through to synchronous `refreshDomainAnalysisSnapshot`
- If a rebuild job was already in flight (queued by startup warming), `queueDomainAnalysisRefresh` returned `false` — and execution continued to the synchronous rebuild path
- For ALL_DOMAINS, that synchronous rebuild blocks the HTTP request for minutes and times out → `INTERNAL_SERVER_ERROR`
- This was exposed by #1076 which caused all snapshots to be rebuilt from scratch on deploy

## Root cause
The multi-domain guard at the bottom of `getDomainAnalysisResult` only returned `UPDATING` when `queued = true`. When `queued = false` (job already in flight), it silently fell through to `refreshDomainAnalysisSnapshot`. For non-DOMAIN scopes that function can take many minutes.

## Fix
Remove the `if (queued)` check — for any non-DOMAIN scope, always return `UPDATING` after attempting to queue. The synchronous refresh at line 615 is only appropriate for single-domain rebuilds that complete in seconds.

## Validation
- `npm run lint --workspace @valuerank/api` — 0 errors ✓
- `npm run build --workspace @valuerank/api` — clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)