### PR TITLE
perf(db): add Transcript(runId, deletedAt, id) composite index

### DIFF
--- a/cloud/packages/db/prisma/migrations/20260513140000_add_transcript_runid_deletedat_id_index/migration.sql
+++ b/cloud/packages/db/prisma/migrations/20260513140000_add_transcript_runid_deletedat_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "transcripts_run_id_deleted_at_id_idx" ON "transcripts"("run_id", "deleted_at", "id");

--- a/cloud/packages/db/prisma/schema.prisma
+++ b/cloud/packages/db/prisma/schema.prisma
@@ -553,6 +553,7 @@ model Transcript {
   @@index([deletedAt])
   @@index([sampleIndex])
   @@index([runId, summarizedAt])
+  @@index([runId, deletedAt, id])
   // NOTE: This table also has a partial unique index that is not declared
   // here because Prisma 5.7 does not support partial unique indexes in
   // schema.prisma syntax (no WHERE clause on @@unique). The index lives in:


### PR DESCRIPTION
## Summary

Adds a composite index on `transcripts(run_id, deleted_at, id)` to speed up the win-rate page's `AssumptionAnalysisSnapshot` rebuild path.

The rebuild paginates transcripts via `WHERE run_id = $1 AND deleted_at IS NULL ORDER BY id ASC LIMIT N`. Existing single-column indexes (`runId`, `deletedAt`) don't cover this access pattern, so Postgres falls back to a heap scan + sort. The new composite supports an index-only scan that matches both the predicate and the cursor order.

Part of a small set of perf PRs targeting the win-rate page (3,633 runs × ~200 transcripts/run = ~726K rows aggregated per cold rebuild).

## Test plan

- [x] `npm run lint --workspace @valuerank/db` (passes — 1 pre-existing warning, 0 errors)
- [x] `npm run build --workspace @valuerank/db` (passes — Prisma client regenerated)
- [x] `npm run lint --workspace @valuerank/api` (passes — 37 pre-existing warnings, 0 errors)
- [x] `npm run build --workspace @valuerank/api` (passes — TypeScript compiles)
- [ ] Migration applies cleanly in CI
- [ ] Post-deploy: confirm `transcripts_run_id_deleted_at_id_idx` exists in prod via `\\d transcripts`

## Validation

Run from `cloud/`:
```
npm run lint --workspace @valuerank/db   ✓
npm run build --workspace @valuerank/db  ✓
npm run lint --workspace @valuerank/api  ✓
npm run build --workspace @valuerank/api ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)