### PR TITLE
perf(analysis): warm ALL_DOMAINS snapshot via hourly cron

### DIFF
--- a/cloud/apps/api/src/services/run/scheduler.ts
+++ b/cloud/apps/api/src/services/run/scheduler.ts
@@ -386,6 +386,39 @@ async function registerAnalysisResultJanitorSchedule(): Promise<void> {
   }
 }
 
+async function registerDomainAnalysisWarmingSchedule(): Promise<void> {
+  try {
+    const boss = getBoss();
+    // pg-boss disambiguates multiple schedules of the same job name via the
+    // ScheduleOptions `key`. Use it for both unschedule and schedule so a
+    // re-deploy replaces the existing entry rather than stacking duplicates.
+    await boss
+      .unschedule('refresh_domain_analysis_snapshot', 'warm_all_domains')
+      .catch(() => undefined);
+    // Hourly warm of the all-domains snapshot so users never trigger a cold rebuild.
+    // Payload shape matches queueDomainAnalysisRefresh() for the ALL_DOMAINS scope:
+    // domainIds is omitted (the scope resolver routes that case to ALL_DOMAINS;
+    // passing >=2 domainIds would silently land in the DOMAIN_SET branch).
+    await boss.schedule(
+      'refresh_domain_analysis_snapshot',
+      '15 * * * *',
+      {
+        scope: 'ALL_DOMAINS',
+        domainId: 'all-domains',
+        signature: null,
+        reason: 'scheduled_warm',
+      },
+      { key: 'warm_all_domains', singletonKey: 'warm_all_domains' },
+    );
+    log.info(
+      { jobType: 'refresh_domain_analysis_snapshot', cron: '15 * * * *', scope: 'ALL_DOMAINS' },
+      'Registered domain-analysis warming schedule',
+    );
+  } catch (error) {
+    log.error({ error }, 'Failed to register domain-analysis warming schedule');
+  }
+}
+
 /**
  * Stops only the recovery interval (not the activity tracking).
  */
@@ -441,6 +474,7 @@ export async function startRecoveryScheduler(): Promise<void> {
 
   await registerRunStateAuditSchedule();
   await registerAnalysisResultJanitorSchedule();
+  await registerDomainAnalysisWarmingSchedule();
 
   // Run startup recovery first
   let hasActiveRuns = false;

--- a/cloud/apps/api/tests/services/run/scheduler.test.ts
+++ b/cloud/apps/api/tests/services/run/scheduler.test.ts
@@ -119,17 +119,29 @@ describe('getReconcileWindowDays', () => {
     expect(mockLogWarn).not.toHaveBeenCalled();
   });
 
-  it('registers the daily audit and janitor schedules on startup', async () => {
+  it('registers the daily audit, janitor, and domain-analysis warming schedules on startup', async () => {
     const { startRecoveryScheduler } = await loadScheduler();
 
     await startRecoveryScheduler();
 
-    expect(mockBossUnschedule).toHaveBeenCalledTimes(2);
+    expect(mockBossUnschedule).toHaveBeenCalledTimes(3);
     expect(mockBossUnschedule).toHaveBeenCalledWith('analysis_result_janitor');
     expect(mockBossUnschedule).toHaveBeenCalledWith('run_state_audit');
-    expect(mockBossSchedule).toHaveBeenCalledTimes(2);
+    expect(mockBossUnschedule).toHaveBeenCalledWith('refresh_domain_analysis_snapshot', 'warm_all_domains');
+    expect(mockBossSchedule).toHaveBeenCalledTimes(3);
     expect(mockBossSchedule).toHaveBeenCalledWith('run_state_audit', '0 9 * * *', {});
     expect(mockBossSchedule).toHaveBeenCalledWith('analysis_result_janitor', '0 10 * * *', {});
+    expect(mockBossSchedule).toHaveBeenCalledWith(
+      'refresh_domain_analysis_snapshot',
+      '15 * * * *',
+      {
+        scope: 'ALL_DOMAINS',
+        domainId: 'all-domains',
+        signature: null,
+        reason: 'scheduled_warm',
+      },
+      { key: 'warm_all_domains', singletonKey: 'warm_all_domains' },
+    );
     expect(mockLogInfo).toHaveBeenCalledWith(
       expect.objectContaining({
         jobType: 'run_state_audit',
@@ -143,6 +155,14 @@ describe('getReconcileWindowDays', () => {
         cron: '0 10 * * *',
       }),
       'Registered analysis_result_janitor schedule'
+    );
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobType: 'refresh_domain_analysis_snapshot',
+        cron: '15 * * * *',
+        scope: 'ALL_DOMAINS',
+      }),
+      'Registered domain-analysis warming schedule'
     );
   });
 


### PR DESCRIPTION
## Summary

Adds a recurring pgBoss schedule (minute 15 of every hour) that warms the `AssumptionAnalysisSnapshot` for the `ALL_DOMAINS` scope. Today, when the snapshot's `inputHash` becomes stale, the next user to load the win-rate page triggers a multi-minute rebuild. With this in place, the warmer absorbs that cost so users always read a current snapshot.

Reuses the existing `refresh_domain_analysis_snapshot` job. Payload mirrors what `queueDomainAnalysisRefresh()` produces for the `ALL_DOMAINS` scope.

Part of a small set of perf PRs targeting the win-rate page.

## Test plan

- [x] `npm run lint --workspace @valuerank/api` (passes — pre-existing warnings only)
- [x] `npm run build --workspace @valuerank/api` (passes)
- [ ] Post-deploy: confirm the schedule appears in pgBoss (`SELECT name, key, cron FROM pgboss.schedule`)
- [ ] Post-deploy: confirm the warmer fires hourly and the snapshot's `updatedAt` advances without user requests

## Validation

```
npm run lint --workspace @valuerank/api  ✓
npm run build --workspace @valuerank/api ✓
```

## Notes

- `key: 'warm_all_domains'` is set on the schedule so a redeploy replaces the entry rather than stacking duplicates.
- Cron uses minute 15 (rather than 0) to avoid colliding with other top-of-hour jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)