### PR TITLE
perf(analysis): batch snapshot transcript reads across runs

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
@@ -240,22 +240,35 @@ export async function buildSnapshotOutput(
     }
   }
 
-  const TRANSCRIPT_BATCH_SIZE = 500;
+  const TRANSCRIPT_BATCH_SIZE = 1000;
+  const RUN_ID_CHUNK_SIZE = 200;
   const cellMap = new Map<string, CellCounts>();
   const totalRuns = state.resolvedSignatureRuns.filteredSourceRunIds.length;
-  let completedRuns = 0;
+  // completedRuns is a soft estimate: a runId is counted as soon as we see any
+  // transcript for it in a cross-run batch, not when all its transcripts are done.
+  const seenRunIds = new Set<string>();
 
   if (state.resolvedSignatureRuns.filteredSourceRunIds.length > 0) {
-    // Keep each transcript read bounded so large domains do not exhaust memory
-    // or the Prisma bridge. Aggregate each batch into the shared cell map.
-    for (const runId of state.resolvedSignatureRuns.filteredSourceRunIds) {
+    // Batch transcript reads across multiple runs per query so that a domain
+    // with thousands of small runs does not pay one round-trip per run. Each
+    // chunk of run IDs is cursor-paginated to keep memory bounded.
+    for (
+      let chunkStart = 0;
+      chunkStart < state.resolvedSignatureRuns.filteredSourceRunIds.length;
+      chunkStart += RUN_ID_CHUNK_SIZE
+    ) {
+      const runIdChunk = state.resolvedSignatureRuns.filteredSourceRunIds.slice(
+        chunkStart,
+        chunkStart + RUN_ID_CHUNK_SIZE,
+      );
+
       let cursorTranscriptId: string | null = null;
       let hasMore = true;
 
       while (hasMore) {
         const batch = (await db.transcript.findMany({
           where: {
-            runId,
+            runId: { in: runIdChunk },
             deletedAt: null,
           },
           select: {
@@ -299,20 +312,24 @@ export async function buildSnapshotOutput(
           cellMap.set(key, existing);
         }
 
-        cursorTranscriptId = batch[batch.length - 1]?.id ?? null;
+        for (const transcript of batch) {
+          seenRunIds.add(transcript.runId);
+        }
+
+        const lastRow = batch[batch.length - 1];
+        cursorTranscriptId = lastRow?.id ?? null;
         if (batch.length < TRANSCRIPT_BATCH_SIZE) {
           hasMore = false;
         }
-      }
 
-      completedRuns += 1;
-      if (options?.onProgress != null) {
-        await options.onProgress({
-          completedRuns,
-          totalRuns,
-          currentRunId: runId,
-          updatedAt: new Date().toISOString(),
-        });
+        if (options?.onProgress != null) {
+          await options.onProgress({
+            completedRuns: seenRunIds.size,
+            totalRuns,
+            currentRunId: lastRow?.runId ?? runIdChunk[runIdChunk.length - 1] ?? '',
+            updatedAt: new Date().toISOString(),
+          });
+        }
       }
     }
   }

--- a/cloud/apps/api/tests/services/analysis/domain-analysis-snapshot-builder-batching.test.ts
+++ b/cloud/apps/api/tests/services/analysis/domain-analysis-snapshot-builder-batching.test.ts
@@ -102,19 +102,20 @@ describe('buildSnapshotOutput batching', () => {
     });
   });
 
-  it('pages transcripts in bounded batches per run', async () => {
-    transcriptFindMany.mockImplementation(async (args: { where?: { runId?: string }; cursor?: { id?: string | null }; skip?: number }) => {
-      const runId = args.where?.runId;
+  it('paginates transcripts in bounded batches across chunked runs', async () => {
+    // With TRANSCRIPT_BATCH_SIZE=1000 and RUN_ID_CHUNK_SIZE=200, both runs
+    // share a single chunked query. 1100 total transcripts (600 in run-1,
+    // 500 in run-2) require two cursor-paginated pages within that chunk.
+    transcriptFindMany.mockImplementation(async (args: { where?: { runId?: { in?: string[] } | string }; cursor?: { id?: string | null }; skip?: number; take?: number }) => {
       const cursorId = args.cursor?.id;
-
-      if (runId === 'run-1' && cursorId == null) {
-        return Array.from({ length: 500 }, (_, index) => makeTranscript(runId, index));
+      if (cursorId == null) {
+        return [
+          ...Array.from({ length: 600 }, (_, index) => makeTranscript('run-1', index)),
+          ...Array.from({ length: 400 }, (_, index) => makeTranscript('run-2', index)),
+        ];
       }
-      if (runId === 'run-1' && cursorId === 'run-1-transcript-499') {
-        return [makeTranscript(runId, 500)];
-      }
-      if (runId === 'run-2' && cursorId == null) {
-        return [makeTranscript(runId, 0)];
+      if (cursorId === 'run-2-transcript-399') {
+        return Array.from({ length: 100 }, (_, index) => makeTranscript('run-2', 400 + index));
       }
       return [];
     });
@@ -149,28 +150,26 @@ describe('buildSnapshotOutput batching', () => {
 
     expect(output).toBeDefined();
 
-    expect(transcriptFindMany).toHaveBeenCalledTimes(3);
+    expect(transcriptFindMany).toHaveBeenCalledTimes(2);
     expect(transcriptFindMany).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      where: { runId: 'run-1', deletedAt: null },
-      take: 500,
+      where: { runId: { in: ['run-1', 'run-2'] }, deletedAt: null },
+      take: 1000,
     }));
     expect(transcriptFindMany.mock.calls[0]?.[0]?.select).not.toHaveProperty('definitionSnapshot');
     expect(transcriptFindMany).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      where: { runId: 'run-1', deletedAt: null },
-      take: 500,
-      cursor: { id: 'run-1-transcript-499' },
+      where: { runId: { in: ['run-1', 'run-2'] }, deletedAt: null },
+      take: 1000,
+      cursor: { id: 'run-2-transcript-399' },
       skip: 1,
     }));
-    expect(transcriptFindMany).toHaveBeenNthCalledWith(3, expect.objectContaining({
-      where: { runId: 'run-2', deletedAt: null },
-      take: 500,
-    }));
 
+    // Progress fires once per page now (was once per run). completedRuns is
+    // a soft estimate based on distinct runIds seen so far across batches.
     expect(onProgress).toHaveBeenCalledTimes(2);
     expect(onProgress).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      completedRuns: 1,
+      completedRuns: 2,
       totalRuns: 2,
-      currentRunId: 'run-1',
+      currentRunId: 'run-2',
     }));
     expect(onProgress).toHaveBeenNthCalledWith(2, expect.objectContaining({
       completedRuns: 2,


### PR DESCRIPTION
## Summary

Replaces the per-run pagination loop in `domain-analysis-snapshot-builder.ts` with a chunked-runs + cursor-paginated query. Cuts the cold rebuild's transcript-read round-trips from ~3,700 to ~750 in production (~3,633 completed runs × ~200 transcripts/run = ~726K rows aggregated).

### Before
```
for (const runId of filteredSourceRunIds) {
  // paginated findMany with where: { runId, deletedAt: null }
  // → 1+ round-trip per run
}
```

### After
- `RUN_ID_CHUNK_SIZE = 200` runs per query via `runId IN (chunk)`
- `TRANSCRIPT_BATCH_SIZE = 1000` per cursor page (raised from 500)
- `seenRunIds: Set<string>` drives `completedRuns` (soft estimate — counted as soon as any transcript for the runId appears, not when fully drained)

The accumulator already accepts mixed-run batches (it looks up `definitionId` per transcript via `filteredSourceRunDefinitionById`), so the cell-key math is unchanged.

Part of a small set of perf PRs targeting the win-rate page. Pairs with the new `Transcript(runId, deletedAt, id)` composite index (#1079).

## Test plan

- [x] `npm run lint --workspace @valuerank/api` (passes — pre-existing warnings only)
- [x] `npm run build --workspace @valuerank/api` (passes)
- [ ] CI api tests pass (snapshot builder + accumulator)
- [ ] Post-deploy: trigger a fresh snapshot rebuild for `ALL_DOMAINS` and verify it produces the same `excNeutralValueWinRatesByModel` as before
- [ ] Post-deploy: verify rebuild duration drops materially (compare logs from `analysis:snapshot-builder`)

## Validation

```
npm run lint --workspace @valuerank/api  ✓
npm run build --workspace @valuerank/api ✓
```

## Notes

- `onProgress` now fires once per page (rather than once per run). This is fine for the live status indicator and gives more frequent progress signal on large rebuilds.
- The snapshot output shape, cell key encoding, and `accumulateTranscriptCells` behavior are unchanged. Only the read pattern differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)