### PR TITLE
perf(api): scope pairwiseWinRates runs query in SQL

### DIFF
--- a/cloud/apps/api/src/services/circumplex/aggregation.ts
+++ b/cloud/apps/api/src/services/circumplex/aggregation.ts
@@ -16,9 +16,6 @@ export type CircumplexPairMatrix = CircumplexPairCell[][];
 type RunRow = {
   id: string;
   config: unknown;
-  status: string;
-  deletedAt: Date | null;
-  definitionId: string;
 };
 
 type TranscriptRow = {
@@ -139,22 +136,23 @@ export async function aggregatePairwiseWinRates(args: {
     where: {
       status: 'COMPLETED',
       deletedAt: null,
+      // Scope to the domain's definitions in SQL when provided, instead of
+      // loading every completed run's config JSONB and filtering in JS. Uses
+      // the Run.definitionId index.
+      ...(args.domainDefinitionIds != null
+        ? { definitionId: { in: [...args.domainDefinitionIds] } }
+        : {}),
     },
     select: {
       id: true,
       config: true,
-      status: true,
-      deletedAt: true,
-      definitionId: true,
     },
   })) as RunRow[];
 
   const scopedRunIds = runs
     .filter((run) => {
-      if (run.status !== 'COMPLETED' || run.deletedAt != null) return false;
       const config = run.config as { isAggregate?: boolean } | null;
       if (config?.isAggregate === true) return false;
-      if (args.domainDefinitionIds != null && !args.domainDefinitionIds.has(run.definitionId)) return false;
       return runMatchesSignature(run.config, args.signature);
     })
     .map((run) => run.id);

--- a/cloud/apps/api/tests/services/circumplex/aggregation.test.ts
+++ b/cloud/apps/api/tests/services/circumplex/aggregation.test.ts
@@ -61,6 +61,30 @@ function buildTranscripts(fixture: TranscriptFixture[]): Array<Record<string, un
   }));
 }
 
+function installRunMock(): void {
+  // Mirror what Prisma does with the `where` clause: aggregation.ts now filters
+  // status / deletedAt / definitionId in SQL, so the mock must honor those
+  // instead of returning every run unconditionally.
+  mockDb.run.findMany.mockImplementation((args: {
+    where?: {
+      status?: string;
+      deletedAt?: null;
+      definitionId?: { in?: string[] };
+    };
+  }) => {
+    const where = args.where ?? {};
+    return Promise.resolve(
+      buildRuns().filter((run) => {
+        if (where.status != null && run.status !== where.status) return false;
+        if (where.deletedAt === null && run.deletedAt != null) return false;
+        const inList = where.definitionId?.in;
+        if (inList != null && !inList.includes(run.definitionId)) return false;
+        return true;
+      }),
+    );
+  });
+}
+
 function installDecisionMock(): void {
   resolveTranscriptDecisionModelMock.mockImplementation((input: {
     decisionMetadata: unknown;
@@ -93,12 +117,12 @@ function installDecisionMock(): void {
 beforeEach(() => {
   vi.clearAllMocks();
   runMatchesSignatureMock.mockImplementation((config: { signature?: string }, signature: string) => config.signature === signature);
+  installRunMock();
   installDecisionMock();
 });
 
 describe('aggregatePairwiseWinRates', () => {
   it('canonicalizes flipped transcripts to the same pairwise counts as unflipped ones', async () => {
-    mockDb.run.findMany.mockResolvedValue(buildRuns());
 
     const unflipped = buildTranscripts([
       { runId: 'run-good-a', modelId: 'model-1', orientationFlipped: false, direction: 'favor_first', scenarioId: 'sc-1' },
@@ -144,7 +168,6 @@ describe('aggregatePairwiseWinRates', () => {
   });
 
   it('returns an empty matrix for models with no matching transcripts', async () => {
-    mockDb.run.findMany.mockResolvedValue(buildRuns());
     mockDb.transcript.findMany.mockResolvedValue([]);
 
     const result = await aggregatePairwiseWinRates({
@@ -160,7 +183,6 @@ describe('aggregatePairwiseWinRates', () => {
   });
 
   it('averages win rates per vignette rather than pooling raw counts', async () => {
-    mockDb.run.findMany.mockResolvedValue(buildRuns());
 
     // Vignette sc-A: 3 wins for Self_Direction (favor_first), 0 losses → rate = 1.0
     // Vignette sc-B: 1 win for Self_Direction, 3 losses → rate = 0.25
@@ -192,7 +214,6 @@ describe('aggregatePairwiseWinRates', () => {
   });
 
   it('filters transcripts to runs belonging to the specified domain', async () => {
-    mockDb.run.findMany.mockResolvedValue(buildRuns());
 
     // run-good-a and run-good-b belong to def-1; run-other-domain belongs to def-other
     const transcripts = buildTranscripts([


### PR DESCRIPTION
## Summary
- The circumplex aggregation behind the win rate page loaded **every** COMPLETED run's `config` JSONB system-wide, then filtered `status` / `deletedAt` / `definitionId` in JS.
- This pushes those filters into the Prisma `WHERE` clause so a domain-scoped win rate page uses the existing `Run.definitionId` index instead of scanning all runs.
- Dropped the now-redundant `status` / `deletedAt` JS re-check and trimmed the `RunRow` type.
- Updated the aggregation unit test so the `db.run.findMany` mock honors the `where` clause — the old mock returned all runs unconditionally and was really testing the JS filtering this PR moves to SQL.

## Test plan
- [x] Preflight passed (lint + build + test, @valuerank/api)
- [x] `turbo test --filter=@valuerank/api` — 2455 passed, 4 skipped, 216 files
- [ ] Production smoke test (pairwiseWinRates query) — see below

🤖 Generated with [Claude Code](https://claude.com/claude-code)