### PR TITLE
fix(pressure-sensitivity): nowrap model names in pressure-by-domain table

### DIFF
--- a/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.tsx
+++ b/cloud/apps/web/src/components/models/PressureDirectionalBreakdown.tsx
@@ -127,7 +127,7 @@ export function PressureDirectionalBreakdown({ models }: Props) {
         <TableBody>
           {rows.map((row) => (
             <TableRow key={row.modelId}>
-              <TableCell className="font-medium text-gray-900">{row.label}</TableCell>
+              <TableCell className="whitespace-nowrap font-medium text-gray-900">{row.label}</TableCell>
               <TableCell
                 className={`text-right text-sm ${row.overallEffect < 0 ? 'text-red-700' : 'text-gray-900'}`}
               >


### PR DESCRIPTION
## Summary
- Adds `whitespace-nowrap` to the Model cell in the Pressure Sensitivity by Domain table (`PressureDirectionalBreakdown`)
- Each model name now renders on one full line instead of wrapping mid-word when the table is wide

## Test plan
- [ ] UI-only change — no data layer impact
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)