### PR TITLE
perf(db): add AssumptionAnalysisSnapshot index for modelsAnalysis filter

### DIFF
--- a/cloud/packages/db/prisma/migrations/20260514000000_add_snapshot_models_analysis_index/migration.sql
+++ b/cloud/packages/db/prisma/migrations/20260514000000_add_snapshot_models_analysis_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "assumption_snapshots_models_analysis_idx" ON "assumption_analysis_snapshots"("assumption_key", "analysis_type", "status", "deleted_at", "config_signature");

--- a/cloud/packages/db/prisma/schema.prisma
+++ b/cloud/packages/db/prisma/schema.prisma
@@ -789,6 +789,7 @@ model AssumptionAnalysisSnapshot {
   @@index([status])
   @@index([deletedAt])
   @@index([assumptionKey, analysisType, inputHash, status])
+  @@index([assumptionKey, analysisType, status, deletedAt, configSignature], map: "assumption_snapshots_models_analysis_idx")
   @@map("assumption_analysis_snapshots")
 }
 


### PR DESCRIPTION
## Summary

The `modelsAnalysis` resolver ([models-analysis.ts:97](cloud/apps/api/src/graphql/queries/models-analysis.ts)) filters `AssumptionAnalysisSnapshot` by `(assumptionKey, analysisType, status, deletedAt)` plus an optional `configSignature`. The table's existing composite index leads with `inputHash` — a column that query never touches — so Postgres can't use it effectively and falls back to a broad scan.

Adds a composite index matching the resolver's actual filter. Speeds up the Model Groups page, which calls `modelsAnalysis` on every load.

## Test plan

- [x] `npm run lint --workspace @valuerank/db` (0 errors)
- [x] `npm run build --workspace @valuerank/db` (Prisma client regenerated)
- [x] `npm run lint --workspace @valuerank/api` (0 errors)
- [x] `npm run build --workspace @valuerank/api` (compiles)
- [ ] Migration applies cleanly in CI
- [ ] Post-deploy: confirm `assumption_snapshots_models_analysis_idx` exists via `\d assumption_analysis_snapshots`

## Validation

```
npm run lint --workspace @valuerank/db   ✓
npm run build --workspace @valuerank/db  ✓
npm run lint --workspace @valuerank/api  ✓
npm run build --workspace @valuerank/api ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)