### PR TITLE
perf(web): use cache-and-network for Model Groups page-load queries

### DIFF
--- a/cloud/apps/web/src/pages/ModelsGroups.tsx
+++ b/cloud/apps/web/src/pages/ModelsGroups.tsx
@@ -147,7 +147,7 @@ export function ModelsGroups() {
       scope: getDomainAnalysisScopeParam(effectiveScope),
     },
     pause: domainsLoading,
-    requestPolicy: 'network-only',
+    requestPolicy: 'cache-and-network',
   });
 
   const signatureOptions = useMemo<DomainAvailableSignature[]>(() => {
@@ -208,7 +208,7 @@ export function ModelsGroups() {
       signature: selectedSignature === '' ? undefined : selectedSignature,
     },
     pause: domainsLoading || activeUseLegacyQuery,
-    requestPolicy: 'network-only',
+    requestPolicy: 'cache-and-network',
   });
   const [{ data: modelsAnalysisData, fetching: modelsAnalysisFetching, error: modelsAnalysisError }] = useQuery<
     ModelsAnalysisQueryResult,
@@ -221,18 +221,18 @@ export function ModelsGroups() {
       ...(selectedSignature !== '' ? { signature: selectedSignature } : {}),
     },
     pause: domainsLoading,
-    requestPolicy: 'network-only',
+    requestPolicy: 'cache-and-network',
   });
   const [{ data: llmModelsData, error: llmModelsError }] = useQuery<LlmModelsQueryResult>({
     query: LLM_MODELS_QUERY,
     variables: { status: 'ACTIVE' },
-    requestPolicy: 'network-only',
+    requestPolicy: 'cache-and-network',
   });
   const [{ data: legacyData, fetching: legacyFetching, error: legacyError }] = useQuery<DomainAnalysisQueryResult, { domainId: string }>({
     query: DOMAIN_ANALYSIS_QUERY_LEGACY,
     variables: { domainId: effectiveDomainId },
     pause: effectiveDomainId === '' || !activeUseLegacyQuery,
-    requestPolicy: 'network-only',
+    requestPolicy: 'cache-and-network',
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

The Model Groups page ([ModelsGroups.tsx](cloud/apps/web/src/pages/ModelsGroups.tsx)) fired its five page-load queries (signatures, domain analysis, models analysis, LLM models, legacy) with `requestPolicy: 'network-only'`. That means every visit and every filter toggle does a full refetch with no client cache — even when the data hasn't changed.

Switches those five to `cache-and-network`, which is already the established pattern in this same file (lines 292, 425). Repeat loads and filter toggles now render cached data instantly while still revalidating from the network in the background. The 20-second polling re-execute on line 339 stays `network-only` — that's an intentional fresh poll.

No change to rendered output — `cache-and-network` produces the same final state as `network-only`, just faster on repeat views.

## Test plan

- [x] `npm run lint --workspace @valuerank/web` (0 errors)
- [x] `npm run test --workspace @valuerank/web` (1450 passed, 8 skipped)
- [x] `npm run build --workspace @valuerank/web` (built clean)
- [ ] Post-deploy: load Model Groups, toggle filters, confirm data renders correctly and repeat loads feel instant

## Validation

```
npm run lint --workspace @valuerank/web   ✓
npm run test --workspace @valuerank/web   ✓ 1450 passed
npm run build --workspace @valuerank/web  ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)