### PR TITLE
fix(model-agreement): treat neutral as its own option in trial consistency

### DIFF
--- a/cloud/apps/api/src/services/model-agreement/aggregation.ts
+++ b/cloud/apps/api/src/services/model-agreement/aggregation.ts
@@ -384,18 +384,14 @@ export function summarizeTrialConsistency(params: {
       continue;
     }
 
-    const totalTrials = outcome.aChoices + outcome.bChoices;
+    const totalTrials = outcome.aChoices + outcome.bChoices + outcome.neutrals;
     if (totalTrials < MIN_TRIALS_FOR_CONSISTENCY) {
       continue;
     }
 
-    const proportionA = computeProportionA(outcome);
-    if (proportionA == null) {
-      continue;
-    }
-
+    const modal = Math.max(outcome.aChoices, outcome.bChoices, outcome.neutrals);
     const valuePairKey = `${position.canonicalA}::${position.canonicalB}`;
-    pushNested(consistency, valuePairKey, position.definitionId, Math.max(proportionA, 1 - proportionA));
+    pushNested(consistency, valuePairKey, position.definitionId, modal / totalTrials);
     cellsObserved += 1;
   }
 


### PR DESCRIPTION
## Summary
- Trial consistency in the Model Agreement section was splitting neutral choices 50/50 between A and B via `computeProportionA`, so a model that always picked neutral scored 0.5 instead of 1.0
- Fixed to use `max(aChoices, bChoices, neutrals) / total` — neutral is now its own option, consistent with how Exact Agreement works on the win rate page
- Also corrected the minimum-trials gate to count neutrals toward the threshold (was `aChoices + bChoices` only)

## Validation
- `npm run lint --workspace @valuerank/api` — 0 errors, 38 warnings (all pre-existing)
- `npm run build --workspace @valuerank/api` — clean
- `npx vitest run apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts` — 11/11 passed

## Test plan
- [x] Preflight passed (lint + build)
- [x] All 11 model-agreement integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)