### PR TITLE
ff-review-reliability: tighten spec-stage Codex cap, fix dead invariant detector, add reconcile note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Canonical source: `docs/canonical-glossary.md`
 - Before building a new component, service, or utility that may already exist, check `docs/tech-debt/dedup-inventory.md` — the curated catalog of known duplicate-module clusters with severity × lift triage. New duplicates discovered during work should be added there as new `DEDUP-N` entries (in the same PR that finds them).
 - One feature per branch. Do not stack new work on top of an open feature PR unless the human asks.
 - Fix the root cause when CI fails. Do not retry blindly.
+- In Feature Factory, "reconcile the findings" means address them in the artifact (spec/plan/tasks), then move on — NOT re-run the review until it comes back clean. The review round is capped; re-running to chase a clean result wastes the cap and the wall clock.
 
 ## Read First
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_invariants.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_invariants.py
@@ -45,10 +45,17 @@ def _append_warning(state: dict, entry: dict) -> None:
 
 
 def _is_repair_action_for_stage(action: str, stage: str) -> bool:
-    """Return True if *action* is a repair action targeting *stage*."""
+    """Return True if *action* is a checkpoint action targeting *stage*.
+
+    recommended_next_action (factory_next_action.py) emits ``run_<stage>_checkpoint``
+    (e.g. ``run_plan_checkpoint``) — NOT ``repair_<stage>_checkpoint``.  The old
+    ``repair_`` prefix was a dead string that never matched, so FR-010 had never
+    fired for the most common failure mode (runner argues with itself).  Corrected
+    to match the strings that recommended_next_action actually emits.
+    """
     if not isinstance(action, str) or not action:
         return False
-    return action == f"repair_{stage}_checkpoint"
+    return action == f"run_{stage}_checkpoint"
 
 
 def check_judge_advance_vs_recommended(

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review.py
@@ -266,8 +266,12 @@ def fallback_review_command(spec: dict, artifact_path: Path, checkpoint: dict, w
         cmd.extend(["--max-artifact-chars", str(checkpoint["max_artifact_chars"])])
     if checkpoint.get("max_context_chars"):
         cmd.extend(["--max-context-chars", str(checkpoint["max_context_chars"])])
-    if checkpoint.get("max_total_chars"):
-        cmd.extend(["--max-total-chars", str(checkpoint["max_total_chars"])])
+    # Per-review spec cap takes precedence over the manifest-level cap when set.
+    # This allows stage-specific overrides (e.g. spec-stage 50k cap) without
+    # changing the checkpoint manifest structure used by the rest of the pipeline.
+    effective_max_total_chars = spec.get("max_total_chars") or checkpoint.get("max_total_chars")
+    if effective_max_total_chars:
+        cmd.extend(["--max-total-chars", str(effective_max_total_chars)])
     if workspace_dir:
         cmd.extend(["--workspace-dir", str(workspace_dir)])
     if spec.get("reviewer") == "gemini":

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review_specs.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review_specs.py
@@ -240,6 +240,15 @@ def required_reviews(
     if small_task_set and stage in ("tasks", "closeout") and not extra_gemini:
         return []
 
+    # Per-review prompt cap for the spec-stage Codex review.
+    # feasibility-adversarial produces structurally large prompts (avg 58k chars,
+    # up to 200k+). At the old 250k cap, 33% of spec-stage Codex reviews timed
+    # out against the 120s subprocess ceiling. At 50k the p50 latency drops from
+    # ~80s to ~40-50s, doubling the headroom. A review that sees a narrowed
+    # artifact beats a 33%-of-the-time review on the full artifact.
+    # Other stages (plan avg ~10k) never time out and keep the manifest-level cap.
+    _SPEC_CODEX_MAX_TOTAL_CHARS = 50000
+
     reviews: list[dict[str, str]] = []
     for reviewer, lens, model in (
         ("codex", codex_primary, DEFAULT_CODEX_MODEL),
@@ -248,11 +257,14 @@ def required_reviews(
     ):
         if not lens:
             continue
-        reviews.append({
+        entry: dict[str, str] = {
             "reviewer": reviewer,
             "lens": lens,
             "model": model,
-        })
+        }
+        if reviewer == "codex" and stage == "spec":
+            entry["max_total_chars"] = str(_SPEC_CODEX_MAX_TOTAL_CHARS)
+        reviews.append(entry)
     seen_gemini_lenses = {review["lens"] for review in reviews if review["reviewer"] == "gemini"}
     for lens in extra_gemini:
         candidate = lens.strip()

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/run_factory.py
@@ -232,7 +232,11 @@ def build_parser() -> argparse.ArgumentParser:
     checkpoint_parser.add_argument("--allow-dirty-path", action="append", default=[])
     checkpoint_parser.add_argument("--max-artifact-chars", type=int, default=50000)
     checkpoint_parser.add_argument("--max-context-chars", type=int, default=60000)
-    checkpoint_parser.add_argument("--max-total-chars", type=int, default=250000)
+    # Reconciled from 250000 to match run_codex_review.py's own default of 200000.
+    # Both values were wider than the 120s Codex timeout can reliably process (avg
+    # spec-stage prompts: 58k chars, up to 200k+; 33% timeout rate at 250k cap).
+    # Spec-stage reviews get a tighter 50k per-review cap via factory_review_specs.py.
+    checkpoint_parser.add_argument("--max-total-chars", type=int, default=200000)
     checkpoint_parser.add_argument("--gemini-timeout-seconds", type=int, default=120)
     checkpoint_parser.add_argument("--gemini-retries", type=int, default=1)
     checkpoint_parser.add_argument("--repair-timeout-seconds", type=int, default=300)

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_char_budget_defaults.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_char_budget_defaults.py
@@ -38,9 +38,9 @@ class CharBudgetDefaultsTests(unittest.TestCase):
         args = self._parse(["checkpoint", "--slug", "x", "--stage", "spec"])
         self.assertEqual(args.max_context_chars, 60000)
 
-    def test_default_max_total_chars_is_250000(self) -> None:
+    def test_default_max_total_chars_is_200000(self) -> None:
         args = self._parse(["checkpoint", "--slug", "x", "--stage", "spec"])
-        self.assertEqual(args.max_total_chars, 250000)
+        self.assertEqual(args.max_total_chars, 200000)
 
     def test_explicit_value_overrides_default(self) -> None:
         args = self._parse([

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_invariants.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_invariants.py
@@ -42,7 +42,8 @@ class RunInvariantChecksTests(unittest.TestCase):
 
     def test_contradiction_appends_warning_and_prints_to_stderr(self) -> None:
         state = _state_with_advance("spec")
-        appended = FI.run_invariant_checks(state, "auto-reconcile", "repair_spec_checkpoint")
+        # recommended_next_action emits run_<stage>_checkpoint (not repair_).
+        appended = FI.run_invariant_checks(state, "auto-reconcile", "run_spec_checkpoint")
 
         self.assertEqual(len(appended), 1)
         self.assertEqual(appended[0]["stage"], "spec")
@@ -58,7 +59,7 @@ class RunInvariantChecksTests(unittest.TestCase):
         state = _state_with_advance("spec")
         FI.set_json_mode(True)
         try:
-            FI.run_invariant_checks(state, "checkpoint", "repair_spec_checkpoint")
+            FI.run_invariant_checks(state, "checkpoint", "run_spec_checkpoint")
         finally:
             FI.set_json_mode(False)
 
@@ -86,8 +87,9 @@ class RunInvariantChecksTests(unittest.TestCase):
             },
             "invariant_warnings": [],
         }
-        appended = FI.run_invariant_checks(state, "auto-reconcile", "repair_spec_checkpoint")
-        # Only the spec stage's advance contradicts repair_spec_checkpoint.
+        # run_spec_checkpoint contradicts spec's advance but not plan's.
+        appended = FI.run_invariant_checks(state, "auto-reconcile", "run_spec_checkpoint")
+        # Only the spec stage's advance contradicts run_spec_checkpoint.
         self.assertEqual(len(appended), 1)
         self.assertEqual(appended[0]["stage"], "spec")
 
@@ -99,7 +101,7 @@ class RunInvariantChecksTests(unittest.TestCase):
         appended = FI.run_invariant_checks(
             state,
             "auto-reconcile",
-            "repair_spec_checkpoint",
+            "run_spec_checkpoint",
             invariants=(raising_check,),
         )
         self.assertEqual(len(appended), 1)
@@ -111,7 +113,7 @@ class RunInvariantChecksTests(unittest.TestCase):
             "invariant_warnings": [],
         }
         for _ in range(FI._INVARIANT_WARNINGS_CAP + 10):
-            FI.run_invariant_checks(state, "auto-reconcile", "repair_spec_checkpoint")
+            FI.run_invariant_checks(state, "auto-reconcile", "run_spec_checkpoint")
         self.assertEqual(len(state["invariant_warnings"]), FI._INVARIANT_WARNINGS_CAP)
 
     def test_non_dict_state_is_no_op(self) -> None:
@@ -128,21 +130,57 @@ class CheckJudgeAdvanceFunctionTests(unittest.TestCase):
                 "tasks": {"judge_next_action": ""},
             }
         }
-        findings = FI.check_judge_advance_vs_recommended(state, "repair_plan_checkpoint")
+        # recommended_next_action emits run_plan_checkpoint (not repair_plan_checkpoint).
+        findings = FI.check_judge_advance_vs_recommended(state, "run_plan_checkpoint")
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0]["stage"], "plan")
 
-    def test_non_repair_action_is_fine(self) -> None:
+    def test_non_checkpoint_action_is_fine(self) -> None:
         state = {"stages": {"spec": {"judge_next_action": "advance"}}}
         findings = FI.check_judge_advance_vs_recommended(state, "author_plan")
         self.assertEqual(findings, [])
 
-    def test_repair_for_different_stage_is_not_a_contradiction_for_this_stage(
+    def test_checkpoint_for_different_stage_is_not_a_contradiction_for_this_stage(
         self,
     ) -> None:
         state = {"stages": {"spec": {"judge_next_action": "advance"}}}
-        findings = FI.check_judge_advance_vs_recommended(state, "repair_plan_checkpoint")
+        # run_plan_checkpoint only contradicts a plan advance, not a spec advance.
+        findings = FI.check_judge_advance_vs_recommended(state, "run_plan_checkpoint")
         self.assertEqual(findings, [])
+
+    def test_run_checkpoint_action_fires_for_all_checkpoint_stages(self) -> None:
+        """FR-010 regression: recommended_next_action emits run_<stage>_checkpoint.
+
+        This test proves the invariant fires for every stage's checkpoint action
+        string as actually emitted by recommended_next_action — not the old dead
+        'repair_<stage>_checkpoint' strings that never matched.
+        """
+        checkpoint_stages = ("spec", "plan", "tasks", "diff", "closeout")
+        for stage in checkpoint_stages:
+            with self.subTest(stage=stage):
+                state = {"stages": {stage: {"judge_next_action": "advance"}}}
+                action = f"run_{stage}_checkpoint"
+                findings = FI.check_judge_advance_vs_recommended(state, action)
+                self.assertEqual(
+                    len(findings),
+                    1,
+                    f"expected 1 contradiction for stage={stage} action={action}, got {findings}",
+                )
+                self.assertEqual(findings[0]["stage"], stage)
+
+    def test_old_repair_prefix_does_not_fire(self) -> None:
+        """Confirm the old dead string 'repair_<stage>_checkpoint' no longer triggers.
+
+        recommended_next_action never emitted this prefix; matching it was a bug.
+        After the fix the invariant correctly ignores it (it is not a real action).
+        """
+        state = {"stages": {"spec": {"judge_next_action": "advance"}}}
+        findings = FI.check_judge_advance_vs_recommended(state, "repair_spec_checkpoint")
+        self.assertEqual(
+            findings,
+            [],
+            "repair_ prefix is not a real recommended_next_action output; should not fire",
+        )
 
 
 if __name__ == "__main__":

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_review_specs.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/tests/test_factory_review_specs.py
@@ -290,6 +290,44 @@ class RequiredReviewSelectionTests(unittest.TestCase):
             ],
         )
 
+    def test_spec_stage_codex_review_has_50k_max_total_chars_cap(self) -> None:
+        """Fix 1: spec-stage feasibility-adversarial Codex review must carry a 50k cap.
+
+        At the old 250k cap, 33% of spec-stage Codex reviews timed out against the
+        120s subprocess ceiling.  The per-review max_total_chars field lets
+        repair_review_checkpoint.py and factory_review.py apply the tighter cap
+        without touching the checkpoint manifest structure.
+        """
+        reviews = FRS.required_reviews("spec", False, False, False, [])
+        codex_reviews = [r for r in reviews if r["reviewer"] == "codex"]
+        self.assertEqual(len(codex_reviews), 1, "expected exactly 1 Codex review for spec stage")
+        codex_review = codex_reviews[0]
+        self.assertIn(
+            "max_total_chars",
+            codex_review,
+            "spec-stage Codex review must carry a max_total_chars cap",
+        )
+        self.assertEqual(
+            int(codex_review["max_total_chars"]),
+            50000,
+            "spec-stage Codex cap must be 50000",
+        )
+
+    def test_non_spec_stages_do_not_carry_per_review_max_total_chars(self) -> None:
+        """Fix 1: non-spec Codex reviews must NOT carry a per-review cap.
+
+        Plan-stage implementation reviews average ~10k chars and never time out;
+        forcing a 50k cap on them adds no value and could confuse operators.
+        """
+        plan_reviews = FRS.required_reviews("plan", False, False, False, [])
+        for review in plan_reviews:
+            if review["reviewer"] == "codex":
+                self.assertNotIn(
+                    "max_total_chars",
+                    review,
+                    f"plan-stage Codex review {review['lens']} must not carry max_total_chars",
+                )
+
 
 class ActionableFindingShapesManifestTests(unittest.TestCase):
     def test_shapes_manifest_present(self) -> None:

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/repair_review_checkpoint.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/repair_review_checkpoint.py
@@ -172,8 +172,12 @@ def run_codex(
         cmd.extend(["--max-artifact-chars", str(checkpoint["max_artifact_chars"])])
     if checkpoint.get("max_context_chars"):
         cmd.extend(["--max-context-chars", str(checkpoint["max_context_chars"])])
-    if checkpoint.get("max_total_chars"):
-        cmd.extend(["--max-total-chars", str(checkpoint["max_total_chars"])])
+    # Per-review spec cap takes precedence over the manifest-level cap when set.
+    # This allows stage-specific overrides (e.g. spec-stage 50k cap) without
+    # changing the checkpoint manifest structure used by the rest of the pipeline.
+    effective_max_total_chars = spec.get("max_total_chars") or checkpoint.get("max_total_chars")
+    if effective_max_total_chars:
+        cmd.extend(["--max-total-chars", str(effective_max_total_chars)])
     if workspace_dir:
         cmd.extend(["--workspace-dir", str(workspace_dir)])
     subprocess.run(cmd, check=True, text=True, timeout=210)


### PR DESCRIPTION
## Summary

Three fixes from the Codex-timeout investigation and the state-consistency investigation.

### Fix 1 — spec-stage Codex prompt cap

`feasibility-adversarial` (the spec-stage Codex review) had a **33% timeout rate**. Structurally-large prompts (avg 58k chars, up to 200k+) take 80-113s even on healthy infra — near-zero margin against the 120s subprocess timeout.

- Spec-stage Codex review capped at **50k chars** (`_SPEC_CODEX_MAX_TOTAL_CHARS`). Prior data: p50 latency drops ~80s → ~40-50s, doubling headroom before the ceiling. Other stages keep their caps — they don't time out.
- Reconciled a cap mismatch: `run_factory.py` passed **250k** to the checkpoint subcommand while `run_codex_review.py` defaulted to 200k — both wider than 120s can process. Lowered the `run_factory.py` default to 200k.

Tradeoff (intentional): a 50k cap means the spec Codex review sees a truncated artifact when spec+context exceeds 50k. A reliable 50k review beats a 33%-failing 100k review. The existing `write_narrowed_artifact()` truncation handles the narrowing.

### Fix 2 — dead invariant detector

`factory_invariants.py`'s FR-010 contradiction detector watched for the action string `repair_<stage>_checkpoint`. But `recommended_next_action` emits `run_<stage>_checkpoint`. The strings never matched — so the detector built to catch "the runner argues with itself" **had never fired**. Corrected the matched strings.

Confirmed actual emitted strings: `run_spec_checkpoint`, `run_plan_checkpoint`, `run_tasks_checkpoint`, `run_diff_checkpoint`, `run_closeout_checkpoint`.

### Fix 3 — AGENTS.md reconcile note

Added: "reconcile = address findings in the artifact, not re-run the review until clean." Operators were burning the review-round cap re-running reviews instead of acting on findings.

## Test plan
- [x] 311 tests pass
- [x] Test: spec-stage Codex review carries the 50k cap; non-spec stages don't
- [x] Test: invariant detector fires for `run_*_checkpoint`, not the dead `repair_*` prefix
- [x] `test_char_budget_defaults` updated for the 200k reconciliation
- [x] Zero state.json pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)