### PR TITLE
perf(api): fast-path snapshot reads when recently validated

### DIFF
--- a/cloud/apps/api/src/graphql/queries/model-agreement-cluster-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-cluster-analysis.ts
@@ -20,8 +20,8 @@ import { resolveSignatureRuns } from './domain/shared.js';
 import {
   getDomainAnalysisResult,
   queueDomainAnalysisRefresh,
-  readModelAgreementSnapshotStateFromSnapshot,
 } from '../../services/analysis/domain-analysis-cache.js';
+import { readModelAgreementSnapshotStateFromSnapshot } from '../../services/analysis/domain-analysis-snapshot-readers.js';
 import {
   normalizeDomainIds,
   resolveDomainAnalysisSelection,

--- a/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-on-tradeoffs.ts
@@ -33,10 +33,8 @@ import {
 } from '../../services/model-agreement/math.js';
 import { resolveDomainAnalysisScopeDefinitions } from '../../services/analysis/domain-analysis-scope-loader.js';
 import { resolveSignatureRuns } from '../queries/domain/shared.js';
-import {
-  queueDomainAnalysisRefresh,
-  readModelAgreementSnapshotStateFromSnapshot,
-} from '../../services/analysis/domain-analysis-cache.js';
+import { queueDomainAnalysisRefresh } from '../../services/analysis/domain-analysis-cache.js';
+import { readModelAgreementSnapshotStateFromSnapshot } from '../../services/analysis/domain-analysis-snapshot-readers.js';
 import {
   normalizeDomainIds,
   resolveDomainAnalysisSelection,

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -62,7 +62,7 @@ export async function getCurrentSnapshot(
 // with a new synchronous rebuild — that creates a thundering-herd loop.
 const DOMAIN_ANALYSIS_BUILD_PROGRESS_FRESH_MS = 5 * 60 * 1000;
 
-function parseBuildProgress(raw: unknown): DomainAnalysisBuildProgress | null {
+export function parseBuildProgress(raw: unknown): DomainAnalysisBuildProgress | null {
   if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) {
     return null;
   }
@@ -684,51 +684,3 @@ export async function getDomainAnalysisResult(params: {
 }
 
 
-/**
- * Read the pre-computed per-(definitionId::modelId::canonicalA::canonicalB::ownLevel::opponentLevel)
- * cell-level outcomes from the current domain-analysis snapshot. Returns null if no CURRENT
- * snapshot exists or if the snapshot pre-dates v1.12.0 (i.e. does not include `cellLevelOutcomes`).
- *
- * Used by the modelAgreementOnTradeoffs resolver to compute Cohen's kappa, percent
- * agreement, and divergence metrics with equal-weight aggregation.
- */
-export async function readCellLevelOutcomesFromSnapshot(
-  scope: DomainAnalysisScope,
-  domainId: string,
-  configSignature: string,
-): Promise<Record<string, { aChoices: number; bChoices: number; neutrals: number }> | null> {
-  const snapshot = await getCurrentSnapshot(db, scope, domainId, configSignature);
-  if (snapshot == null) return null;
-  const parsed = parseSnapshotOutput(snapshot.output);
-  return parsed?.cellLevelOutcomes ?? null;
-}
-
-export async function readModelAgreementSnapshotStateFromSnapshot(
-  scope: DomainAnalysisScope,
-  domainId: string,
-  configSignature: string,
-): Promise<{
-  cellLevelOutcomes: Record<string, { aChoices: number; bChoices: number; neutrals: number }> | null;
-  buildProgress: DomainAnalysisBuildProgress | null;
-  inputHash: string | null;
-} | null> {
-  const snapshot = await getCurrentSnapshot(db, scope, domainId, configSignature);
-  if (snapshot == null) {
-    return null;
-  }
-
-  const parsed = parseSnapshotOutput(snapshot.output);
-  if (parsed?.cellLevelOutcomes != null) {
-    return {
-      cellLevelOutcomes: parsed.cellLevelOutcomes,
-      buildProgress: null,
-      inputHash: snapshot.inputHash,
-    };
-  }
-
-  return {
-    cellLevelOutcomes: null,
-    buildProgress: parseBuildProgress(snapshot.output),
-    inputHash: snapshot.inputHash,
-  };
-}

--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -34,6 +34,7 @@ import {
 } from './domain-analysis-snapshot-builder.js';
 import type { DomainAnalysisScope } from './domain-analysis-scope.js';
 import { DOMAIN_ANALYSIS_ALL_DOMAINS_SCOPE } from './domain-analysis-scope.js';
+import { canFastPathSnapshot } from './snapshot-fast-path.js';
 
 const log = createLogger('analysis:domain-cache');
 
@@ -347,6 +348,13 @@ export async function refreshDomainAnalysisSnapshot(params: {
     },
   });
   if (existingFresh != null && parseSnapshotOutput(existingFresh.output) != null) {
+    // Stamp lastValidatedAt: the input hash still matches, so this snapshot is
+    // confirmed fresh as of now. This is what lets cache reads fast-path past
+    // prepareDomainAnalysisState until the next warm.
+    const revalidated = await db.assumptionAnalysisSnapshot.update({
+      where: { id: existingFresh.id },
+      data: { lastValidatedAt: new Date() },
+    });
     log.info({
       scope: params.scope,
       domainId: params.domainId,
@@ -355,7 +363,7 @@ export async function refreshDomainAnalysisSnapshot(params: {
       totalRefreshDurationMs: Date.now() - refreshStartedAt,
     }, 'refreshDomainAnalysisSnapshot: skipped — fresh snapshot already exists');
     return {
-      snapshot: existingFresh,
+      snapshot: revalidated,
       selectedSignature: state.selectedSignature,
       configSignature: state.configSignature,
     } as const;
@@ -455,6 +463,7 @@ export async function refreshDomainAnalysisSnapshot(params: {
       where: { id: progressSnapshot.id },
       data: {
         output,
+        lastValidatedAt: new Date(),
       },
     });
 
@@ -502,12 +511,50 @@ export async function refreshDomainAnalysisSnapshot(params: {
   }
 }
 
+/**
+ * Fast path: when the request pins a signature and the CURRENT snapshot for
+ * this scope was confirmed valid recently (by an hourly warm), serve straight
+ * from the snapshot and skip `prepareDomainAnalysisState` — which is several DB
+ * round-trips. Returns null when the fast path does not apply, so the caller
+ * falls through to full validation.
+ */
+async function tryDomainAnalysisFastPath(params: {
+  scope: DomainAnalysisScope;
+  domainId: string;
+  requestedSignature: string | null;
+}): Promise<DomainAnalysisResult | null> {
+  if (params.requestedSignature == null) return null;
+  const configSignature = normalizeSignature(params.requestedSignature);
+  const snapshot = await getCurrentSnapshot(db, params.scope, params.domainId, configSignature);
+  if (snapshot == null || !canFastPathSnapshot(snapshot, DOMAIN_ANALYSIS_SNAPSHOT_CODE_VERSION)) {
+    return null;
+  }
+  const parsed = parseSnapshotOutput(snapshot.output);
+  if (parsed == null) return null;
+
+  const activeModels = await db.llmModel.findMany({
+    where: { status: 'ACTIVE' },
+    select: { modelId: true, displayName: true, isDefault: true },
+  });
+  return buildDomainAnalysisResultFromSnapshot({
+    snapshot: parsed,
+    activeModels,
+    generatedAt: snapshot.createdAt,
+    cacheStatus: DOMAIN_ANALYSIS_CACHE_STATUS.FRESH,
+  });
+}
+
 export async function getDomainAnalysisResult(params: {
   scope: DomainAnalysisScope;
   domainId: string;
   domainIds?: string[];
   requestedSignature: string | null;
 }): Promise<DomainAnalysisResult> {
+  const fastResult = await tryDomainAnalysisFastPath(params);
+  if (fastResult != null) {
+    return fastResult;
+  }
+
   const state = await prepareDomainAnalysisState({
     scope: params.scope,
     domainId: params.domainId,

--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-builder.ts
@@ -469,6 +469,7 @@ export async function writeSnapshot(params: {
       },
       output: params.output,
       status: 'CURRENT',
+      lastValidatedAt: new Date(),
     },
   });
 }

--- a/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-readers.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-snapshot-readers.ts
@@ -1,0 +1,48 @@
+// Read accessors over the persisted domain-analysis snapshot, used by
+// resolvers that consume snapshot output without participating in the cache
+// orchestration (refresh/queue/validation) that lives in domain-analysis-cache.
+
+import { db } from '@valuerank/db';
+import {
+  getCurrentSnapshot,
+  parseBuildProgress,
+} from './domain-analysis-cache.js';
+import { parseSnapshotOutput } from './domain-analysis-snapshot-builder.js';
+import type { DomainAnalysisScope } from './domain-analysis-scope.js';
+import type { DomainAnalysisBuildProgress } from './domain-analysis-cache-types.js';
+
+/**
+ * Read snapshot state for the modelAgreementOnTradeoffs / clustering paths:
+ * the per-cell outcomes if the snapshot has them, otherwise the buildProgress
+ * placeholder so the caller can surface an UPDATING state. Returns null when
+ * no CURRENT snapshot exists.
+ */
+export async function readModelAgreementSnapshotStateFromSnapshot(
+  scope: DomainAnalysisScope,
+  domainId: string,
+  configSignature: string,
+): Promise<{
+  cellLevelOutcomes: Record<string, { aChoices: number; bChoices: number; neutrals: number }> | null;
+  buildProgress: DomainAnalysisBuildProgress | null;
+  inputHash: string | null;
+} | null> {
+  const snapshot = await getCurrentSnapshot(db, scope, domainId, configSignature);
+  if (snapshot == null) {
+    return null;
+  }
+
+  const parsed = parseSnapshotOutput(snapshot.output);
+  if (parsed?.cellLevelOutcomes != null) {
+    return {
+      cellLevelOutcomes: parsed.cellLevelOutcomes,
+      buildProgress: null,
+      inputHash: snapshot.inputHash,
+    };
+  }
+
+  return {
+    cellLevelOutcomes: null,
+    buildProgress: parseBuildProgress(snapshot.output),
+    inputHash: snapshot.inputHash,
+  };
+}

--- a/cloud/apps/api/src/services/analysis/snapshot-fast-path.ts
+++ b/cloud/apps/api/src/services/analysis/snapshot-fast-path.ts
@@ -1,0 +1,32 @@
+// Shared fast-path gate for assumption-analysis snapshot reads.
+//
+// The snapshot caches skip the expensive aggregation compute, but every read
+// still re-derives the input hash to confirm the snapshot is still valid — and
+// that re-derivation (`prepare*`) is itself several DB round-trips (~2-5s).
+//
+// The warming crons re-validate every snapshot hourly and stamp
+// `lastValidatedAt`. When a snapshot was confirmed valid recently AND was built
+// by the current code version, a read can trust it and skip re-validation
+// entirely. The tradeoff: a data change is served stale (as FRESH) until the
+// next warm rebuilds the snapshot — bounded by the TTL below.
+
+// 90 minutes: the warming crons run hourly, so this leaves a 30-minute buffer
+// for a late cron run before the fast path falls back to full validation.
+//
+// Disabled (0) under NODE_ENV=test so integration tests keep exercising the
+// full validation path — otherwise a test that mutates data and re-queries
+// would be served the stale cached snapshot.
+export const SNAPSHOT_FAST_PATH_TTL_MS = process.env.NODE_ENV === 'test' ? 0 : 90 * 60 * 1000;
+
+export function canFastPathSnapshot(
+  snapshot: { lastValidatedAt: Date | null; codeVersion: string },
+  expectedCodeVersion: string,
+  ttlMs: number = SNAPSHOT_FAST_PATH_TTL_MS,
+): boolean {
+  if (ttlMs <= 0) return false;
+  // A code-version bump changes the input hash for every scope; the old
+  // snapshot is stale by definition until the warm cron rebuilds it.
+  if (snapshot.codeVersion !== expectedCodeVersion) return false;
+  if (snapshot.lastValidatedAt == null) return false;
+  return Date.now() - snapshot.lastValidatedAt.getTime() < ttlMs;
+}

--- a/cloud/apps/api/src/services/analysis/win-rate-stability/snapshot-builder.ts
+++ b/cloud/apps/api/src/services/analysis/win-rate-stability/snapshot-builder.ts
@@ -349,6 +349,7 @@ export async function writeWinRateStabilitySnapshot(params: {
       config: { scopeId: params.scopeId, signature: params.configSignature },
       output: params.output as object,
       status: 'CURRENT',
+      lastValidatedAt: new Date(),
     },
   });
 }

--- a/cloud/apps/api/src/services/analysis/win-rate-stability/snapshot-cache.ts
+++ b/cloud/apps/api/src/services/analysis/win-rate-stability/snapshot-cache.ts
@@ -8,6 +8,7 @@ import {
   type DomainAnalysisSelection,
 } from '../domain-analysis-scope.js';
 import {
+  WIN_RATE_STABILITY_SNAPSHOT_CODE_VERSION,
   WIN_RATE_STABILITY_SNAPSHOT_TYPE,
   type WinRateStabilitySnapshotOutput,
 } from './snapshot-types.js';
@@ -18,6 +19,7 @@ import {
   prepareWinRateStabilityState,
   writeWinRateStabilitySnapshot,
 } from './snapshot-builder.js';
+import { canFastPathSnapshot } from '../snapshot-fast-path.js';
 
 const log = createLogger('win-rate-stability:cache');
 
@@ -74,6 +76,29 @@ export async function queueWinRateStabilityRefresh(params: {
 export async function refreshWinRateStabilitySnapshot(request: WinRateStabilityRequest): Promise<void> {
   const selection = resolveSelection(request);
   const state = await prepareWinRateStabilityState({ selection, signature: request.signature });
+  const assumptionKey = buildWinRateStabilityAssumptionKey(selection.domainId);
+
+  // If a CURRENT snapshot already matches the freshly-derived input hash, the
+  // underlying data has not changed — just stamp lastValidatedAt so cache reads
+  // keep fast-pathing, and skip the rebuild.
+  const existing = await db.assumptionAnalysisSnapshot.findFirst({
+    where: {
+      assumptionKey,
+      analysisType: WIN_RATE_STABILITY_SNAPSHOT_TYPE,
+      configSignature: state.configSignature,
+      inputHash: state.inputHash,
+      status: 'CURRENT',
+      deletedAt: null,
+    },
+  });
+  if (existing != null && parseWinRateStabilitySnapshotOutput(existing.output) != null) {
+    await db.assumptionAnalysisSnapshot.update({
+      where: { id: existing.id },
+      data: { lastValidatedAt: new Date() },
+    });
+    return;
+  }
+
   const output = await buildWinRateStabilityOutput(state);
   await writeWinRateStabilitySnapshot({
     scopeId: selection.domainId,
@@ -100,19 +125,32 @@ export async function getWinRateStabilityResult(
   request: WinRateStabilityRequest,
 ): Promise<ModelsStabilityResultShape> {
   const selection = resolveSelection(request);
-  const state = await prepareWinRateStabilityState({ selection, signature: request.signature });
+  const configSignature = normalizeWinRateStabilitySignature(request.signature);
   const assumptionKey = buildWinRateStabilityAssumptionKey(selection.domainId);
 
   const currentSnapshot = await db.assumptionAnalysisSnapshot.findFirst({
     where: {
       assumptionKey,
       analysisType: WIN_RATE_STABILITY_SNAPSHOT_TYPE,
-      configSignature: state.configSignature,
+      configSignature,
       status: 'CURRENT',
       deletedAt: null,
     },
     orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
   });
+
+  // Fast path: a snapshot confirmed valid recently (by an hourly warm) is
+  // trusted without re-deriving the input hash, which costs several DB
+  // round-trips in prepareWinRateStabilityState.
+  if (currentSnapshot != null && canFastPathSnapshot(currentSnapshot, WIN_RATE_STABILITY_SNAPSHOT_CODE_VERSION)) {
+    const parsed = parseWinRateStabilitySnapshotOutput(currentSnapshot.output);
+    if (parsed != null) {
+      return withReadMetadata(parsed, 'FRESH', currentSnapshot.createdAt);
+    }
+  }
+
+  // Slow path: re-derive the input hash and compare against the snapshot.
+  const state = await prepareWinRateStabilityState({ selection, signature: request.signature });
 
   if (currentSnapshot != null) {
     const parsed = parseWinRateStabilitySnapshotOutput(currentSnapshot.output);

--- a/cloud/apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/model-agreement-on-tradeoffs.test.ts
@@ -36,8 +36,11 @@ vi.mock('../../../src/graphql/queries/domain/shared.js', () => ({
 }));
 
 vi.mock('../../../src/services/analysis/domain-analysis-cache.js', () => ({
-  readModelAgreementSnapshotStateFromSnapshot: mocks.readModelAgreementSnapshotStateFromSnapshot,
   queueDomainAnalysisRefresh: mocks.queueDomainAnalysisRefresh,
+}));
+
+vi.mock('../../../src/services/analysis/domain-analysis-snapshot-readers.js', () => ({
+  readModelAgreementSnapshotStateFromSnapshot: mocks.readModelAgreementSnapshotStateFromSnapshot,
 }));
 
 const log = createLogger('test:model-agreement');

--- a/cloud/apps/api/tests/services/analysis/snapshot-fast-path.test.ts
+++ b/cloud/apps/api/tests/services/analysis/snapshot-fast-path.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { canFastPathSnapshot } from '../../../src/services/analysis/snapshot-fast-path.js';
+
+const TTL_MS = 90 * 60 * 1000;
+const CODE_VERSION = '1.0.0';
+
+function snapshotValidatedAgo(ms: number) {
+  return { lastValidatedAt: new Date(Date.now() - ms), codeVersion: CODE_VERSION };
+}
+
+describe('canFastPathSnapshot', () => {
+  it('returns true for a recently-validated snapshot on the current code version', () => {
+    expect(canFastPathSnapshot(snapshotValidatedAgo(60_000), CODE_VERSION, TTL_MS)).toBe(true);
+  });
+
+  it('returns false once the snapshot is older than the TTL', () => {
+    expect(canFastPathSnapshot(snapshotValidatedAgo(TTL_MS + 1_000), CODE_VERSION, TTL_MS)).toBe(false);
+  });
+
+  it('returns false when lastValidatedAt is null (never validated by warm)', () => {
+    expect(canFastPathSnapshot({ lastValidatedAt: null, codeVersion: CODE_VERSION }, CODE_VERSION, TTL_MS)).toBe(false);
+  });
+
+  it('returns false when the snapshot was built by a different code version', () => {
+    expect(canFastPathSnapshot(snapshotValidatedAgo(60_000), '2.0.0', TTL_MS)).toBe(false);
+  });
+
+  it('returns false when the TTL is zero (fast path disabled, e.g. test env)', () => {
+    expect(canFastPathSnapshot(snapshotValidatedAgo(60_000), CODE_VERSION, 0)).toBe(false);
+  });
+});

--- a/cloud/packages/db/prisma/migrations/20260514120000_add_snapshot_last_validated_at/migration.sql
+++ b/cloud/packages/db/prisma/migrations/20260514120000_add_snapshot_last_validated_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "assumption_analysis_snapshots" ADD COLUMN "last_validated_at" TIMESTAMP(3);

--- a/cloud/packages/db/prisma/schema.prisma
+++ b/cloud/packages/db/prisma/schema.prisma
@@ -780,6 +780,11 @@ model AssumptionAnalysisSnapshot {
   output        Json                     @db.JsonB
   status        AssumptionAnalysisStatus @default(CURRENT)
   createdAt     DateTime                 @default(now()) @map("created_at")
+  // Last time a warm/refresh confirmed this snapshot's input hash still matches
+  // the underlying data. Lets cache reads skip the expensive per-request
+  // validation when the snapshot was confirmed fresh recently. Null on rows
+  // written before this column existed — treated as "never validated".
+  lastValidatedAt DateTime?              @map("last_validated_at")
   deletedAt     DateTime?                @map("deleted_at")
 
   @@index([assumptionKey])


### PR DESCRIPTION
## Summary
- The analysis snapshot caches (`domain_overview`, `win_rate_stability`) skip the heavy aggregation compute on cache hits, but every request still re-derives the input hash to validate the snapshot — and that validation is 2-5s of DB round-trips per request. Per prod logs: `totalPrepareDurationMs` ~1.9s for a single domain, ~4.6s for ALL_DOMAINS. Cached queries on the Win Rate page were measuring 2-6 seconds despite `cacheStatus: FRESH`.
- Add a `lastValidatedAt` timestamp on `assumption_analysis_snapshots`. The hourly warm cron stamps it whenever it confirms a snapshot still matches the underlying data — including the "skip rebuild, data unchanged" path, so stable scopes stay stamped.
- `getDomainAnalysisResult` and `getWinRateStabilityResult` now check first: if a CURRENT snapshot exists, was validated within 90 min, and matches the current code version → serve it straight from the snapshot and skip `prepare*` entirely. Otherwise fall through to the existing full validation.
- Shared helper in `services/analysis/snapshot-fast-path.ts`. Disabled (TTL 0) under `NODE_ENV=test` so integration tests keep exercising the full validation path.

## Tradeoff
A data change is served as FRESH for up to ~90 min until the next hourly warm rebuilds. The `domainAnalysis` "Refresh now" mutation still rebuilds and re-stamps immediately, so users with a stale view can force the rebuild.

## Expected effect
- `domainAnalysis` single-domain: ~2.9s → ~1s (skips the 1.9s prepare; the remaining ~1s is post-prepare cluster compute, separate concern)
- `modelsWinRateStability` single-domain: ~2.4s → ~0.3s
- `domainAnalysis` ALL_DOMAINS: drops the ~4.6s prepare

## Test plan
- [x] `turbo lint build --filter=@valuerank/db --filter=@valuerank/api` — 0 errors
- [x] `turbo test --filter=@valuerank/api` — 2469 passed, 4 skipped, 218 files (includes new `snapshot-fast-path.test.ts`)
- [ ] Production smoke test post-deploy: re-time `domainAnalysis` and `modelsWinRateStability` and confirm the drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)