### PR TITLE
perf(api): strip cellLevelOutcomes server-side in modelsAnalysis

### DIFF
--- a/cloud/apps/api/src/graphql/queries/models-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/models-analysis.ts
@@ -1,4 +1,4 @@
-import { db } from '@valuerank/db';
+import { db, Prisma } from '@valuerank/db';
 import { getModelsFromDatabase } from '../../config/models.js';
 import { buildAssumptionKey, parseSnapshotOutput } from '../../services/analysis/domain-analysis-snapshot-builder.js';
 import { DOMAIN_ANALYSIS_ASSUMPTION_PREFIX, DOMAIN_ANALYSIS_SNAPSHOT_TYPE } from '../../services/analysis/domain-analysis-cache-types.js';
@@ -94,32 +94,35 @@ builder.queryField('modelsAnalysis', (t) =>
         availableOnly: false,
       });
 
-      const snapshots = await db.assumptionAnalysisSnapshot.findMany({
-        where: {
-          assumptionKey: selection.scope === 'ALL_DOMAINS'
-            ? {
-                startsWith: `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:`,
-              }
-            : selectionAssumptionKey,
-          analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
-          ...(signature != null ? { configSignature: signature } : {}),
-          status: 'CURRENT',
-          deletedAt: null,
-        },
-        select: {
-          id: true,
-          assumptionKey: true,
-          configSignature: true,
-          output: true,
-        },
-        orderBy: [
-          { createdAt: 'desc' },
-          { id: 'desc' },
-        ],
-      });
+      // Strip the per-cell `cellLevelOutcomes` field server-side via the JSONB
+      // minus-key operator. For ALL_DOMAINS this query fans across every
+      // domain's snapshot (~14 rows of multi-MB output JSONB), and the resolver
+      // only reads model.counts / valueWinRates / vignetteCount / valueWinRatesExcNeutral
+      // and the top-level domain id/name — it never touches cellLevelOutcomes.
+      // Sending that field over the wire was the ~22-27s cost at ALL_DOMAINS scope.
+      const assumptionKeyClause = selection.scope === 'ALL_DOMAINS'
+        ? Prisma.sql`assumption_key LIKE ${`${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:%`}`
+        : Prisma.sql`assumption_key = ${selectionAssumptionKey}`;
+      const signatureClause = signature != null
+        ? Prisma.sql`AND config_signature = ${signature}`
+        : Prisma.sql``;
+      const snapshots = await db.$queryRaw<ModelsAnalysisSnapshotRow[]>`
+        SELECT
+          id,
+          assumption_key AS "assumptionKey",
+          config_signature AS "configSignature",
+          (output - 'cellLevelOutcomes') AS output
+        FROM assumption_analysis_snapshots
+        WHERE ${assumptionKeyClause}
+          AND analysis_type = ${DOMAIN_ANALYSIS_SNAPSHOT_TYPE}
+          AND status = 'CURRENT'
+          AND deleted_at IS NULL
+          ${signatureClause}
+        ORDER BY created_at DESC, id DESC
+      `;
 
       const selectedSnapshots = selectModelsAnalysisSnapshots(
-        snapshots as ModelsAnalysisSnapshotRow[],
+        snapshots,
         signature,
         {
           scope: selection.scope,

--- a/cloud/apps/api/tests/graphql/queries/models-analysis-snapshot-query.test.ts
+++ b/cloud/apps/api/tests/graphql/queries/models-analysis-snapshot-query.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { db } from '@valuerank/db';
+import {
+  DOMAIN_ANALYSIS_ASSUMPTION_PREFIX,
+  DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
+} from '../../../src/services/analysis/domain-analysis-cache-types.js';
+
+// Guards the JSONB minus-key projection in models-analysis.ts. The resolver
+// fetches `(output - 'cellLevelOutcomes') AS output` so the heaviest field
+// never crosses the wire at ALL_DOMAINS scope. SQL template literals are not
+// type-checked, so this test catches syntax / operator / mapping regressions.
+
+const TS = Date.now();
+const ASSUMPTION_KEY = `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:mq-test-${TS}`;
+const CONFIG_SIGNATURE = `mq-test-sig-${TS}`;
+
+const SAMPLE_OUTPUT = {
+  scope: 'DOMAIN',
+  domainId: 'mq-test-domain',
+  domainName: 'MQ Test Domain',
+  totalDefinitions: 1,
+  targetedDefinitions: 1,
+  coveredDefinitions: 1,
+  definitionsWithAnalysis: 1,
+  missingDefinitions: [],
+  contributionSummary: [],
+  excludedDataSummary: [],
+  models: [
+    {
+      model: 'mq-test-model',
+      counts: { Achievement: { prioritized: 1, deprioritized: 0, neutral: 0 } },
+      valueWinRates: { Achievement: 100 },
+      vignetteCount: { Achievement: 1 },
+    },
+  ],
+  cellLevelOutcomes: {
+    'def-1::mq-test-model::Achievement::Hedonism::0::0': { aChoices: 1, bChoices: 0, neutrals: 0 },
+    'def-1::mq-test-model::Achievement::Tradition::0::0': { aChoices: 1, bChoices: 0, neutrals: 0 },
+  },
+};
+
+describe('models-analysis snapshot query (cellLevelOutcomes stripped server-side)', () => {
+  let snapshotId: string;
+
+  beforeAll(async () => {
+    const created = await db.assumptionAnalysisSnapshot.create({
+      data: {
+        assumptionKey: ASSUMPTION_KEY,
+        analysisType: DOMAIN_ANALYSIS_SNAPSHOT_TYPE,
+        inputHash: `mq-test-hash-${TS}`,
+        codeVersion: 'mq-test',
+        configSignature: CONFIG_SIGNATURE,
+        config: {},
+        output: SAMPLE_OUTPUT,
+        status: 'CURRENT',
+      },
+    });
+    snapshotId = created.id;
+  });
+
+  afterAll(async () => {
+    await db.assumptionAnalysisSnapshot.deleteMany({ where: { id: snapshotId } });
+  });
+
+  it('returns the snapshot output with cellLevelOutcomes stripped but other fields intact', async () => {
+    const rows = await db.$queryRaw<Array<{ id: string; assumptionKey: string; configSignature: string; output: Record<string, unknown> }>>`
+      SELECT
+        id,
+        assumption_key AS "assumptionKey",
+        config_signature AS "configSignature",
+        (output - 'cellLevelOutcomes') AS output
+      FROM assumption_analysis_snapshots
+      WHERE assumption_key = ${ASSUMPTION_KEY}
+        AND analysis_type = ${DOMAIN_ANALYSIS_SNAPSHOT_TYPE}
+        AND config_signature = ${CONFIG_SIGNATURE}
+        AND status = 'CURRENT'
+        AND deleted_at IS NULL
+    `;
+
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.assumptionKey).toBe(ASSUMPTION_KEY);
+    expect(row.configSignature).toBe(CONFIG_SIGNATURE);
+    expect(row.output).not.toHaveProperty('cellLevelOutcomes');
+    // The fields modelsAnalysis actually reads must survive the projection:
+    expect(row.output.domainId).toBe('mq-test-domain');
+    expect(row.output.domainName).toBe('MQ Test Domain');
+    expect(Array.isArray(row.output.models)).toBe(true);
+    expect((row.output.models as Array<{ model: string }>)[0]?.model).toBe('mq-test-model');
+  });
+
+  it('matches the ALL_DOMAINS startsWith pattern used by the resolver', async () => {
+    const prefix = `${DOMAIN_ANALYSIS_ASSUMPTION_PREFIX}:%`;
+    const rows = await db.$queryRaw<Array<{ id: string }>>`
+      SELECT id FROM assumption_analysis_snapshots
+      WHERE assumption_key LIKE ${prefix}
+        AND assumption_key = ${ASSUMPTION_KEY}
+        AND analysis_type = ${DOMAIN_ANALYSIS_SNAPSHOT_TYPE}
+        AND status = 'CURRENT'
+        AND deleted_at IS NULL
+    `;
+    expect(rows.some((r) => r.id === snapshotId)).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- `modelsAnalysis` at ALL_DOMAINS scope took **22-27s** while a single domain took <1s. The resolver fetched the **full `output` JSONB of every domain's `domain_overview` snapshot** (~29 MB across ~14 domains per prod profiling) but only ever read `model.counts` / `valueWinRates` / `vignetteCount` / `valueWinRatesExcNeutral` plus top-level `domainId` / `domainName`. The heaviest field — `cellLevelOutcomes`, a per-cell map keyed by `definitionId::modelId::canonicalA::canonicalB::ownLevel::opponentLevel` — was transferred and JSON-parsed on every request and never touched.
- Switch the snapshot fetch to a raw query that strips `cellLevelOutcomes` server-side via Postgres' JSONB minus-key operator (`output - 'cellLevelOutcomes'`). `parseSnapshotOutput` and the rest of the resolver are unchanged because they never read that field.
- Add a focused integration test that creates a fixture snapshot with `cellLevelOutcomes` populated and verifies the raw query returns the output with that key removed and other top-level fields intact. SQL template literals aren't type-checked, so this guards against syntax / operator / column-mapping regressions.

## Expected effect
`modelsAnalysis` at ALL_DOMAINS scope: ~22-27s → expected sub-second. Single-domain is already fast.

## Test plan
- [x] `turbo lint build --filter=@valuerank/api` — 0 errors
- [x] `turbo test --filter=@valuerank/api` — all passed (218 files)
- [x] Raw SQL verified directly against test DB (returns valid JSONB without `cellLevelOutcomes`)
- [ ] Post-deploy: re-time `modelsAnalysis` at all-domains scope; should drop from ~25s to <1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)