### PR TITLE
perf(api): stamp lastValidatedAt when slow-path re-confirms snapshot

### DIFF
--- a/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
+++ b/cloud/apps/api/src/services/analysis/domain-analysis-cache.ts
@@ -581,6 +581,14 @@ export async function getDomainAnalysisResult(params: {
   const parsedCurrent = currentSnapshot != null ? parseSnapshotOutput(currentSnapshot.output) : null;
 
   if (currentSnapshot != null && parsedCurrent != null && currentSnapshot.inputHash === state.inputHash) {
+    // The slow path just confirmed the snapshot's input hash still matches —
+    // that's the same validation the warming cron does. Stamp lastValidatedAt
+    // so subsequent reads within the TTL can fast-path. Self-heals per-domain
+    // snapshots (which the warming cron only covers for ALL_DOMAINS).
+    await db.assumptionAnalysisSnapshot.update({
+      where: { id: currentSnapshot.id },
+      data: { lastValidatedAt: new Date() },
+    });
     return buildDomainAnalysisResultFromSnapshot({
       snapshot: parsedCurrent,
       activeModels,

--- a/cloud/apps/api/src/services/analysis/win-rate-stability/snapshot-cache.ts
+++ b/cloud/apps/api/src/services/analysis/win-rate-stability/snapshot-cache.ts
@@ -156,6 +156,14 @@ export async function getWinRateStabilityResult(
     const parsed = parseWinRateStabilitySnapshotOutput(currentSnapshot.output);
     if (parsed != null) {
       if (currentSnapshot.inputHash === state.inputHash) {
+        // The slow path just confirmed the snapshot is still valid — same
+        // check the warming cron does. Stamp lastValidatedAt so subsequent
+        // reads within the TTL can fast-path. Self-heals per-domain
+        // snapshots that the warming cron does not cover.
+        await db.assumptionAnalysisSnapshot.update({
+          where: { id: currentSnapshot.id },
+          data: { lastValidatedAt: new Date() },
+        });
         return withReadMetadata(parsed, 'FRESH', currentSnapshot.createdAt);
       }
       const queued = await queueWinRateStabilityRefresh({ request, reason: 'page-load-stale' });


### PR DESCRIPTION
## Summary
- The warming crons only cover **ALL_DOMAINS** — per-domain snapshots (Job Choice, Partner Choice, etc., what the win rate page hits) never get `lastValidatedAt` stamped by cron. Combined with PR #1095's fast-path gate requiring a recent `lastValidatedAt`, the fast path could never engage for per-domain reads on existing snapshots.
- The slow path's FRESH branch already does the same input-hash comparison the warming cron's skip-if-fresh branch does. Stamp `lastValidatedAt` there before returning.
- Applies symmetrically to `getDomainAnalysisResult` and `getWinRateStabilityResult`.

## Effect
- First per-domain page load after deploy: same speed as before (slow path, ~2s) but now stamps the snapshot.
- Every subsequent load within 90 min: fast-path. ~0.3-1s.
- Self-heals — no "Refresh now" click or data change required to unlock the fast path.

## Test plan
- [x] `turbo lint build test --filter=@valuerank/api` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)