### PR TITLE
perf(api): extend snapshot fast-path TTL from 90min to 6h

### DIFF
--- a/cloud/apps/api/src/services/analysis/snapshot-fast-path.ts
+++ b/cloud/apps/api/src/services/analysis/snapshot-fast-path.ts
@@ -10,13 +10,16 @@
 // entirely. The tradeoff: a data change is served stale (as FRESH) until the
 // next warm rebuilds the snapshot — bounded by the TTL below.
 
-// 90 minutes: the warming crons run hourly, so this leaves a 30-minute buffer
-// for a late cron run before the fast path falls back to full validation.
+// 6 hours: the warming crons run hourly and the slow-path FRESH branch also
+// stamps lastValidatedAt, so any visit (or hourly warm) re-stamps the snapshot.
+// A wide TTL lets infrequent visitors (e.g. once per workday) still fast-path
+// across long idle periods. Worst-case staleness is still bounded by the
+// hourly warm — the TTL only matters if the cron stops running entirely.
 //
 // Disabled (0) under NODE_ENV=test so integration tests keep exercising the
 // full validation path — otherwise a test that mutates data and re-queries
 // would be served the stale cached snapshot.
-export const SNAPSHOT_FAST_PATH_TTL_MS = process.env.NODE_ENV === 'test' ? 0 : 90 * 60 * 1000;
+export const SNAPSHOT_FAST_PATH_TTL_MS = process.env.NODE_ENV === 'test' ? 0 : 6 * 60 * 60 * 1000;
 
 export function canFastPathSnapshot(
   snapshot: { lastValidatedAt: Date | null; codeVersion: string },


### PR DESCRIPTION
## Summary
- The fast-path TTL was 90 min — a snapshot stamped at one cron tick was fast for 90 min, then needed re-stamping.
- Hourly warm + the slow-path FRESH stamping in PR #1097 mean every read or cron tick re-stamps. The 90-min limit was unnecessarily tight for an analytics page.
- Bump to 6 hours so infrequent visitors (e.g. once per workday) still fast-path across long idle periods, instead of paying the slow-path validation cost on each return visit.

## Staleness window unchanged in practice
Worst-case staleness is bounded by the **hourly warming cron**, not the TTL — when the data changes, the next warm rebuilds the snapshot and stamps a fresh `lastValidatedAt`. The TTL only matters if the cron stops running entirely; in that scenario the system gracefully degrades over 6h instead of 90 min before falling back to full validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)