### PR TITLE
perf(api): warm per-domain + minus-Motivation snapshots at 6 AM PT

### DIFF
--- a/cloud/apps/api/src/services/run/scheduler.ts
+++ b/cloud/apps/api/src/services/run/scheduler.ts
@@ -29,6 +29,7 @@ import { enqueueTopUpProbesSingleton } from '../../queue/handlers/top-up-probes.
 import { DEFAULT_JOB_OPTIONS } from '../../queue/types.js';
 import { getBoss } from '../../queue/boss.js';
 import { getQueueNameForModel } from '../parallelism/index.js';
+import { buildDomainAnalysisDomainSetId } from '../analysis/domain-analysis-scope.js';
 
 const log = createLogger('services:run:scheduler');
 
@@ -447,6 +448,128 @@ async function registerWinRateStabilityWarmingSchedule(): Promise<void> {
   }
 }
 
+// Cron format for the named (per-domain + minus-invasion) warming targets:
+// minute is per-target, hours are 6 AM / noon / 6 PM / midnight Pacific.
+// Anchored at 6 AM PT so the morning visit always lands on a fresh snapshot.
+const NAMED_WARM_CRON_HOURS = '0,6,12,18';
+const NAMED_WARM_TZ = 'America/Los_Angeles';
+// "Motivation for Invasion Choice" is the production name; match by fragment
+// so a minor rename (e.g. dropping the suffix) does not silently break warming.
+const MOTIVATION_INVASION_NAME_FRAGMENT = 'motivation for invasion';
+// Stability schedules offset from domain-analysis schedules by 30 min so the
+// two rebuilds for the same target do not run simultaneously.
+const NAMED_WARM_STABILITY_MINUTE_OFFSET = 30;
+
+type NamedWarmTarget = {
+  key: string;
+  scope: 'DOMAIN' | 'DOMAIN_SET';
+  domainId: string;          // canonical scope id (real domain id, or domain-set:<hash>)
+  domainIds: string[];       // per-domain: [domainId]; DOMAIN_SET: full list
+  minute: number;            // 0..59 stagger
+  label: string;             // human-readable for logs
+};
+
+async function registerNamedWarmingSchedules(): Promise<void> {
+  try {
+    const boss = getBoss();
+    const domains = await db.domain.findMany({
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
+    });
+    if (domains.length === 0) {
+      log.info({}, 'No domains found — skipping named warming schedule registration');
+      return;
+    }
+
+    const targets: NamedWarmTarget[] = [];
+
+    domains.forEach((domain, idx) => {
+      targets.push({
+        key: `warm:domain:${domain.id}`,
+        scope: 'DOMAIN',
+        domainId: domain.id,
+        domainIds: [domain.id],
+        minute: idx,
+        label: `domain:${domain.name}`,
+      });
+    });
+
+    const invasionDomain = domains.find((domain) =>
+      domain.name.toLowerCase().includes(MOTIVATION_INVASION_NAME_FRAGMENT),
+    );
+    if (invasionDomain != null) {
+      const otherIds = domains
+        .filter((domain) => domain.id !== invasionDomain.id)
+        .map((domain) => domain.id);
+      if (otherIds.length >= 2) {
+        targets.push({
+          key: 'warm:minus-motivation-for-invasion',
+          scope: 'DOMAIN_SET',
+          domainId: buildDomainAnalysisDomainSetId(otherIds),
+          domainIds: otherIds,
+          // Park after all per-domain minutes (which span 0..N-1). With ~14
+          // domains today this gives a comfortable gap; clamp at 59 to be safe.
+          minute: Math.min(domains.length, 59),
+          label: 'minus-motivation-for-invasion',
+        });
+      }
+    } else {
+      log.warn(
+        { fragment: MOTIVATION_INVASION_NAME_FRAGMENT },
+        'No domain matched the motivation-for-invasion fragment — skipping minus-invasion warm',
+      );
+    }
+
+    for (const target of targets) {
+      const daCron = `${target.minute} ${NAMED_WARM_CRON_HOURS} * * *`;
+      const stabilityMinute = (target.minute + NAMED_WARM_STABILITY_MINUTE_OFFSET) % 60;
+      const stabilityCron = `${stabilityMinute} ${NAMED_WARM_CRON_HOURS} * * *`;
+
+      await boss
+        .unschedule('refresh_domain_analysis_snapshot', target.key)
+        .catch(() => undefined);
+      await boss.schedule(
+        'refresh_domain_analysis_snapshot',
+        daCron,
+        {
+          scope: target.scope,
+          domainId: target.domainId,
+          domainIds: target.domainIds,
+          signature: null,
+          reason: 'scheduled_warm',
+        },
+        { key: target.key, singletonKey: target.key, tz: NAMED_WARM_TZ },
+      );
+
+      await boss
+        .unschedule('refresh_win_rate_stability_snapshot', target.key)
+        .catch(() => undefined);
+      await boss.schedule(
+        'refresh_win_rate_stability_snapshot',
+        stabilityCron,
+        {
+          domainId: target.scope === 'DOMAIN' ? target.domainId : null,
+          domainIds: target.scope === 'DOMAIN_SET' ? target.domainIds : null,
+          signature: null,
+          reason: 'scheduled_warm',
+        },
+        { key: target.key, singletonKey: target.key, tz: NAMED_WARM_TZ },
+      );
+    }
+
+    log.info(
+      {
+        targetCount: targets.length,
+        cron: `_ ${NAMED_WARM_CRON_HOURS} * * *`,
+        tz: NAMED_WARM_TZ,
+      },
+      'Registered named (per-domain + minus-invasion) warming schedules',
+    );
+  } catch (error) {
+    log.error({ error }, 'Failed to register named warming schedules');
+  }
+}
+
 /**
  * Stops only the recovery interval (not the activity tracking).
  */
@@ -504,6 +627,7 @@ export async function startRecoveryScheduler(): Promise<void> {
   await registerAnalysisResultJanitorSchedule();
   await registerDomainAnalysisWarmingSchedule();
   await registerWinRateStabilityWarmingSchedule();
+  await registerNamedWarmingSchedules();
 
   // Run startup recovery first
   let hasActiveRuns = false;

--- a/cloud/apps/api/tests/services/run/scheduler.test.ts
+++ b/cloud/apps/api/tests/services/run/scheduler.test.ts
@@ -5,6 +5,7 @@ const mockDbRunFindMany = vi.hoisted(() => vi.fn());
 const mockDbTranscriptFindFirst = vi.hoisted(() => vi.fn());
 const mockDbRunAnomalyFindFirst = vi.hoisted(() => vi.fn());
 const mockDbQueryRaw = vi.hoisted(() => vi.fn());
+const mockDbDomainFindMany = vi.hoisted(() => vi.fn());
 const mockBossSchedule = vi.hoisted(() => vi.fn());
 const mockBossUnschedule = vi.hoisted(() => vi.fn());
 const mockLogDebug = vi.hoisted(() => vi.fn());
@@ -23,6 +24,9 @@ vi.mock('@valuerank/db', () => ({
     },
     runAnomaly: {
       findFirst: mockDbRunAnomalyFindFirst,
+    },
+    domain: {
+      findMany: mockDbDomainFindMany,
     },
     $queryRaw: mockDbQueryRaw,
   },
@@ -99,6 +103,7 @@ describe('getReconcileWindowDays', () => {
     mockDbRunFindMany.mockResolvedValue([]);
     mockDbTranscriptFindFirst.mockResolvedValue(null);
     mockDbQueryRaw.mockResolvedValue([]);
+    mockDbDomainFindMany.mockResolvedValue([]);
     mockBossSchedule.mockResolvedValue(undefined);
     mockBossUnschedule.mockResolvedValue(undefined);
   });
@@ -184,6 +189,58 @@ describe('getReconcileWindowDays', () => {
       }),
       'Registered win-rate-stability warming schedule'
     );
+  });
+
+  it('registers per-domain and minus-invasion warming schedules anchored at 6 AM PT', async () => {
+    mockDbDomainFindMany.mockResolvedValue([
+      { id: 'dom-jobs', name: 'Job Choice' },
+      { id: 'dom-invasion', name: 'Motivation for Invasion Choice' },
+      { id: 'dom-product', name: 'Product Choice' },
+    ]);
+
+    const { startRecoveryScheduler } = await loadScheduler();
+    await startRecoveryScheduler();
+
+    // Find a per-domain DA schedule and assert its shape — cron at 6/12/18/0 PT,
+    // tz Los_Angeles, scoped to the single domain.
+    const perDomainDaCall = mockBossSchedule.mock.calls.find(
+      ([jobName, _cron, payload]) =>
+        jobName === 'refresh_domain_analysis_snapshot'
+        && (payload as { scope?: string }).scope === 'DOMAIN'
+        && (payload as { domainId?: string }).domainId === 'dom-jobs',
+    );
+    expect(perDomainDaCall).toBeDefined();
+    expect(perDomainDaCall?.[1]).toMatch(/^\d+ 0,6,12,18 \* \* \*$/);
+    expect(perDomainDaCall?.[3]).toMatchObject({
+      key: 'warm:domain:dom-jobs',
+      tz: 'America/Los_Angeles',
+    });
+
+    // The minus-invasion schedule should be DOMAIN_SET with all non-invasion ids.
+    const minusInvasionDaCall = mockBossSchedule.mock.calls.find(
+      ([jobName, _cron, _payload, options]) =>
+        jobName === 'refresh_domain_analysis_snapshot'
+        && (options as { key?: string }).key === 'warm:minus-motivation-for-invasion',
+    );
+    expect(minusInvasionDaCall).toBeDefined();
+    expect((minusInvasionDaCall?.[2] as { scope?: string }).scope).toBe('DOMAIN_SET');
+    expect((minusInvasionDaCall?.[2] as { domainIds?: string[] }).domainIds?.sort()).toEqual([
+      'dom-jobs',
+      'dom-product',
+    ]);
+    expect(minusInvasionDaCall?.[3]).toMatchObject({ tz: 'America/Los_Angeles' });
+
+    // And a stability schedule for the same minus-invasion target should exist.
+    const minusInvasionStabilityCall = mockBossSchedule.mock.calls.find(
+      ([jobName, _cron, _payload, options]) =>
+        jobName === 'refresh_win_rate_stability_snapshot'
+        && (options as { key?: string }).key === 'warm:minus-motivation-for-invasion',
+    );
+    expect(minusInvasionStabilityCall).toBeDefined();
+    expect((minusInvasionStabilityCall?.[2] as { domainIds?: string[] }).domainIds?.sort()).toEqual([
+      'dom-jobs',
+      'dom-product',
+    ]);
   });
 
   it('falls back to the default and warns when the env var is invalid', async () => {


### PR DESCRIPTION
## Summary
- The win rate page hits one of three scope variants: All Domains, a single domain, or "all except an outlier". All Domains is already warmed hourly. This adds named warming schedules for the other two.
- For every non-deleted domain register a DOMAIN-scope warm; if a domain whose name contains "motivation for invasion" exists, also register a DOMAIN_SET warm over all the others.
- Each target gets both a `refresh_domain_analysis_snapshot` warm and a `refresh_win_rate_stability_snapshot` warm, with a 30-minute offset between the pair so a single target's rebuilds never run simultaneously. Minute is staggered per target to spread DB load.
- Cron is **6h anchored at 6 AM PT** (timezone-aware, DST-handled via `tz: 'America/Los_Angeles'`) — fires at 6 AM, 12 PM, 6 PM, 12 AM Pacific. With the 6h fast-path TTL the morning visit always finds a freshly-stamped snapshot.
- Existing All Domains hourly warms (`:15` and `:25`) stay as-is — cheap and the extra freshness costs nothing.

## Test plan
- [x] New unit test covers per-domain and minus-invasion schedule registration shape (cron, tz, payload).
- [x] `turbo lint build test --filter=@valuerank/api` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)