### PR TITLE
perf(api): snapshot-cache modelAgreementClusterAnalysis

### DIFF
--- a/cloud/apps/api/src/graphql/queries/domain/types.ts
+++ b/cloud/apps/api/src/graphql/queries/domain/types.ts
@@ -47,6 +47,11 @@ export type KappaPair = {
 export type KappaClusterPayload = {
   clusterAnalysis: ClusterAnalysis;
   kappaPairs: KappaPair[];
+  // Freshness fields populated when the kappa matrix came from the
+  // model-agreement snapshot cache. null on live (non-canonical) selections
+  // and on empty/skipped payloads.
+  snapshotComputedAt: Date | null;
+  snapshotSource: 'CACHE_HIT' | 'CACHE_HIT_STALE' | 'LIVE_NON_CANONICAL' | 'BUILDING' | null;
 };
 
 export type PairwiseWinRateModel = {
@@ -240,6 +245,16 @@ builder.objectType(KappaClusterPayloadRef, {
     kappaPairs: t.field({
       type: [KappaPairRef],
       resolve: (parent) => parent.kappaPairs,
+    }),
+    snapshotComputedAt: t.field({
+      type: 'DateTime',
+      nullable: true,
+      resolve: (parent) => parent.snapshotComputedAt,
+    }),
+    snapshotSource: t.field({
+      type: 'String',
+      nullable: true,
+      resolve: (parent) => parent.snapshotSource,
     }),
   }),
 });

--- a/cloud/apps/api/src/graphql/queries/model-agreement-cluster-analysis.ts
+++ b/cloud/apps/api/src/graphql/queries/model-agreement-cluster-analysis.ts
@@ -1,4 +1,5 @@
 import { ValidationError } from '@valuerank/shared';
+import { db } from '@valuerank/db';
 import { builder } from '../builder.js';
 import { getModelsFromDatabase } from '../../config/models.js';
 import { KappaClusterPayloadRef } from './domain/types.js';
@@ -22,6 +23,9 @@ import {
   queueDomainAnalysisRefresh,
 } from '../../services/analysis/domain-analysis-cache.js';
 import { readModelAgreementSnapshotStateFromSnapshot } from '../../services/analysis/domain-analysis-snapshot-readers.js';
+import { getModelAgreementSnapshot } from '../../services/analysis/model-agreement-snapshot/snapshot-cache.js';
+import type { ModelAgreementSnapshotPayload } from '../../services/analysis/model-agreement-snapshot/snapshot-types.js';
+import { getBoss } from '../../queue/boss.js';
 import {
   normalizeDomainIds,
   resolveDomainAnalysisSelection,
@@ -31,7 +35,14 @@ import type { Context } from '../context.js';
 
 const REFRESH_REASON = 'model-agreement-cluster-analysis-page-load-missing';
 
-function emptyPayload(reason: string): KappaClusterPayload {
+type KappaSnapshotFreshness = Pick<KappaClusterPayload, 'snapshotComputedAt' | 'snapshotSource'>;
+
+const EMPTY_FRESHNESS: KappaSnapshotFreshness = {
+  snapshotComputedAt: null,
+  snapshotSource: null,
+};
+
+function emptyPayload(reason: string, freshness: KappaSnapshotFreshness = EMPTY_FRESHNESS): KappaClusterPayload {
   return {
     clusterAnalysis: {
       clusters: [],
@@ -41,7 +52,15 @@ function emptyPayload(reason: string): KappaClusterPayload {
       skipReason: reason,
     },
     kappaPairs: [],
+    ...freshness,
   };
+}
+
+function sameModelSelection(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((value, index) => value === right[index]);
 }
 
 async function resolveScope(params: {
@@ -170,6 +189,67 @@ export async function resolveModelAgreementClusterAnalysis(
   const selectedModels = buildSelectedModels(selectedModelIds, labelByModelId);
   const selectedModelIdSet = new Set(selectedModels.map((model) => model.modelId));
 
+  // ----- Cache fast-path -----------------------------------------------------
+  // Reuse the model-agreement snapshot cache from PR #1100 for canonical
+  // selections. The clustering math is cheap once we have the kappa matrix;
+  // the live path's expensive step is computing the matrix. If the cache has
+  // it, skip straight to clustering.
+  const defaultModelIds = normalizeModelIds(activeModels.filter((model) => model.isDefault).map((model) => model.modelId));
+  const isCanonical = sameModelSelection(selectedModelIds, defaultModelIds);
+
+  if (isCanonical) {
+    const snapshotQueue = {
+      send: async (
+        name: string,
+        data: Parameters<ReturnType<typeof getBoss>['send']>[1],
+        options?: Parameters<ReturnType<typeof getBoss>['send']>[2],
+      ) => getBoss().send(name, data, options),
+    };
+    const snapshotResult = await getModelAgreementSnapshot(
+      db,
+      snapshotQueue,
+      {
+        scope,
+        domainId: selection.domainId,
+        domainIds: selection.domainIds,
+        signature,
+        modelIds: selectedModelIds,
+        isCanonical: true,
+      },
+    );
+
+    if (snapshotResult != null) {
+      if (snapshotResult.payload == null) {
+        // BUILDING — the cache reader has already queued a refresh.
+        return emptyPayload(
+          'Kappa cluster analysis is rebuilding — try again in a moment.',
+          { snapshotComputedAt: null, snapshotSource: 'BUILDING' },
+        );
+      }
+      // CACHE_HIT or CACHE_HIT_STALE — build cluster analysis from the cached matrix.
+      return await buildClusterAnalysisFromSnapshot({
+        payload: snapshotResult.payload,
+        method,
+        scope,
+        selection,
+        signature,
+        freshness: {
+          snapshotComputedAt: snapshotResult.snapshotComputedAt,
+          snapshotSource: snapshotResult.source,
+        },
+      });
+    }
+  }
+
+  // ----- Live fall-through path ---------------------------------------------
+  // Non-canonical selections (and any case where the canonical cache returned
+  // null) run the existing live computation. Carry LIVE_NON_CANONICAL through
+  // the freshness fields so the UI can suppress the "Cached as of" chip.
+  const LIVE_FRESHNESS: KappaSnapshotFreshness = {
+    snapshotComputedAt: null,
+    snapshotSource: 'LIVE_NON_CANONICAL',
+  };
+
   await resolveScope({
     scope,
     domainId: selection.domainId,
@@ -185,17 +265,17 @@ export async function resolveModelAgreementClusterAnalysis(
     ctx,
   });
   if (snapshotState == null) {
-    return emptyPayload('Kappa cluster analysis is rebuilding — try again in a moment.');
+    return emptyPayload('Kappa cluster analysis is rebuilding — try again in a moment.', LIVE_FRESHNESS);
   }
 
   const cellLevelOutcomes = snapshotState.cellLevelOutcomes;
   if (cellLevelOutcomes == null) {
-    return emptyPayload('Kappa cluster analysis is rebuilding — try again in a moment.');
+    return emptyPayload('Kappa cluster analysis is rebuilding — try again in a moment.', LIVE_FRESHNESS);
   }
   const { positionCells, cellsObservedByModelId } = buildPositionCells(cellLevelOutcomes, selectedModelIdSet);
   const availableModels = selectedModels.filter((model) => (cellsObservedByModelId.get(model.modelId) ?? 0) > 0);
   if (availableModels.length < 3) {
-    return emptyPayload('Kappa clustering requires at least 3 models with cell-level data in the selected scope.');
+    return emptyPayload('Kappa clustering requires at least 3 models with cell-level data in the selected scope.', LIVE_FRESHNESS);
   }
 
   // Pull log-odds scores from the domain-analysis result so the cluster centroids
@@ -216,7 +296,7 @@ export async function resolveModelAgreementClusterAnalysis(
   // has the same set of values, so pull from the first model that has data.
   const sampleValueScores = scoresByModelId.values().next().value;
   if (sampleValueScores == null) {
-    return emptyPayload('Kappa cluster analysis could not be computed because the domain-analysis snapshot has no model scores.');
+    return emptyPayload('Kappa cluster analysis could not be computed because the domain-analysis snapshot has no model scores.', LIVE_FRESHNESS);
   }
   const valueKeys = Object.keys(sampleValueScores);
   const zeroScores: Record<string, number> = Object.fromEntries(valueKeys.map((vk) => [vk, 0]));
@@ -245,7 +325,96 @@ export async function resolveModelAgreementClusterAnalysis(
     }
   }
 
-  return { clusterAnalysis, kappaPairs };
+  return { clusterAnalysis, kappaPairs, ...LIVE_FRESHNESS };
+}
+
+// Build cluster analysis from a cached snapshot. Skips the per-pair kappa
+// computation (which the live path runs in `buildKappaMatrix`) and instead
+// pulls the already-computed pair kappas out of the snapshot payload.
+async function buildClusterAnalysisFromSnapshot(params: {
+  payload: ModelAgreementSnapshotPayload;
+  method: ClusteringMethod;
+  scope: DomainAnalysisScope;
+  selection: { domainId: string; domainIds: string[] };
+  signature: string;
+  freshness: KappaSnapshotFreshness;
+}): Promise<KappaClusterPayload> {
+  const { payload, method, scope, selection, signature, freshness } = params;
+
+  if (payload.models.length < 3) {
+    return emptyPayload(
+      'Kappa clustering requires at least 3 models with cell-level data in the selected scope.',
+      freshness,
+    );
+  }
+
+  // Pull log-odds scores from the domain-analysis result so the cluster
+  // centroids and fault-lines are labeled the same way the live path labels
+  // them.
+  const domainAnalysis = await getDomainAnalysisResult({
+    scope,
+    domainId: selection.domainId,
+    domainIds: selection.domainIds,
+    requestedSignature: signature,
+  });
+  const scoresByModelId = new Map<string, Record<string, number>>();
+  for (const model of domainAnalysis.models) {
+    const scoreEntries = model.values.map((entry) => [entry.valueKey, entry.score] as const);
+    scoresByModelId.set(model.model, Object.fromEntries(scoreEntries));
+  }
+  const sampleValueScores = scoresByModelId.values().next().value;
+  if (sampleValueScores == null) {
+    return emptyPayload(
+      'Kappa cluster analysis could not be computed because the domain-analysis snapshot has no model scores.',
+      freshness,
+    );
+  }
+  const valueKeys = Object.keys(sampleValueScores);
+  const zeroScores: Record<string, number> = Object.fromEntries(valueKeys.map((vk) => [vk, 0]));
+
+  const clusterInputs: ClusterModelInput[] = payload.models.map((model) => ({
+    model: model.modelId,
+    label: model.label,
+    scores: scoresByModelId.get(model.modelId) ?? zeroScores,
+  }));
+
+  // Build a symmetric N×N kappa matrix indexed by `orderedModelIds`, sourced
+  // from the snapshot's flat pairwise list.
+  const orderedModelIds = clusterInputs.map((entry) => entry.model);
+  const n = orderedModelIds.length;
+  const kappaByPair = new Map<string, number | null>();
+  for (const row of payload.pairwiseAgreementMatrix) {
+    const keyAB = `${row.modelAId} ${row.modelBId}`;
+    const keyBA = `${row.modelBId} ${row.modelAId}`;
+    kappaByPair.set(keyAB, row.cohensKappa);
+    kappaByPair.set(keyBA, row.cohensKappa);
+  }
+
+  const kappaMatrix: Array<Array<number | null>> = Array.from({ length: n }, () => new Array<number | null>(n).fill(null));
+  for (let i = 0; i < n; i += 1) {
+    kappaMatrix[i]![i] = 1;
+    for (let j = i + 1; j < n; j += 1) {
+      const key = `${orderedModelIds[i]} ${orderedModelIds[j]}`;
+      const value = kappaByPair.get(key) ?? null;
+      kappaMatrix[i]![j] = value;
+      kappaMatrix[j]![i] = value;
+    }
+  }
+
+  const clusterAnalysis = computeKappaClusterAnalysis(clusterInputs, kappaMatrix, method);
+
+  const kappaPairs: KappaPair[] = [];
+  for (let i = 0; i < n; i += 1) {
+    for (let j = i + 1; j < n; j += 1) {
+      kappaPairs.push({
+        modelAId: orderedModelIds[i]!,
+        modelBId: orderedModelIds[j]!,
+        kappa: kappaMatrix[i]![j] ?? null,
+      });
+    }
+  }
+
+  return { clusterAnalysis, kappaPairs, ...freshness };
 }
 
 builder.queryField('modelAgreementClusterAnalysis', (t) =>

--- a/cloud/apps/web/schema.graphql
+++ b/cloud/apps/web/schema.graphql
@@ -1476,6 +1476,8 @@ type JobTypeStatus {
 type KappaClusterPayload {
   clusterAnalysis: ClusterAnalysis!
   kappaPairs: [KappaPair!]!
+  snapshotComputedAt: DateTime
+  snapshotSource: String
 }
 
 type KappaPair {

--- a/cloud/apps/web/src/api/operations/modelAgreementClusterAnalysis.graphql
+++ b/cloud/apps/web/src/api/operations/modelAgreementClusterAnalysis.graphql
@@ -41,5 +41,7 @@ query ModelAgreementClusterAnalysis(
       leafOrder
       clusterIdByModelId
     }
+    snapshotComputedAt
+    snapshotSource
   }
 }

--- a/cloud/apps/web/src/generated/graphql.ts
+++ b/cloud/apps/web/src/generated/graphql.ts
@@ -1421,6 +1421,8 @@ export type KappaClusterPayload = {
   __typename?: 'KappaClusterPayload';
   clusterAnalysis: ClusterAnalysis;
   kappaPairs: Array<KappaPair>;
+  snapshotComputedAt?: Maybe<Scalars['DateTime']['output']>;
+  snapshotSource?: Maybe<Scalars['String']['output']>;
 };
 
 export type KappaPair = {
@@ -5067,7 +5069,7 @@ export type ModelAgreementClusterAnalysisQueryVariables = Exact<{
 }>;
 
 
-export type ModelAgreementClusterAnalysisQuery = { __typename?: 'Query', modelAgreementClusterAnalysis: { __typename?: 'KappaClusterPayload', clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, leafOrder?: Array<string> | null, clusterIdByModelId?: unknown | null, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }>, dendrogram?: Array<{ __typename?: 'DendrogramMerge', leftMemberIds: Array<string>, rightMemberIds: Array<string>, height: number }> | null } } };
+export type ModelAgreementClusterAnalysisQuery = { __typename?: 'Query', modelAgreementClusterAnalysis: { __typename?: 'KappaClusterPayload', snapshotComputedAt?: string | null, snapshotSource?: string | null, clusterAnalysis: { __typename?: 'ClusterAnalysis', skipped: boolean, skipReason?: string | null, defaultPair?: Array<string> | null, faultLinesByPair: unknown, leafOrder?: Array<string> | null, clusterIdByModelId?: unknown | null, clusters: Array<{ __typename?: 'DomainCluster', id: string, name: string, definingValues: Array<string>, centroid: unknown, members: Array<{ __typename?: 'ClusterMember', model: string, label: string, silhouetteScore: number, isOutlier: boolean, nearestClusterIds?: Array<string> | null, distancesToNearestClusters?: Array<number> | null }> }>, dendrogram?: Array<{ __typename?: 'DendrogramMerge', leftMemberIds: Array<string>, rightMemberIds: Array<string>, height: number }> | null } } };
 
 export type ModelAgreementOnTradeoffsQueryVariables = Exact<{
   modelIds: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
@@ -7762,6 +7764,8 @@ export const ModelAgreementClusterAnalysisDocument = gql`
       leafOrder
       clusterIdByModelId
     }
+    snapshotComputedAt
+    snapshotSource
   }
 }
     `;


### PR DESCRIPTION
## Summary
- Wires the kappa-clustering resolver (`modelAgreementClusterAnalysis`) to the snapshot cache shipped in #1100 — the expensive pairwise Cohen's kappa matrix is already cached for canonical model selections, so reuse it instead of rebuilding live on every page load.
- Adds `snapshotComputedAt` and `snapshotSource` to `KappaClusterPayload` so the UI can show the same "Cached as of…" freshness chip as the Model Agreement section.
- Non-canonical model selections fall through to the existing live path unchanged.

## Behavior
- **Canonical selection + CACHE_HIT / CACHE_HIT_STALE**: derive NxN kappa matrix from `payload.pairwiseAgreementMatrix`, run the (cheap) `computeKappaClusterAnalysis` on it. Instant.
- **Canonical selection + BUILDING**: return empty payload with `snapshotSource: 'BUILDING'` — the snapshot reader has already queued a refresh.
- **Non-canonical selection**: existing live computation, `snapshotSource: 'LIVE_NON_CANONICAL'`.

## Scope
- No new tables, no new builder, no new queue handler — reuses `model_agreement_snapshots`.
- `modelAgreementOnTradeoffs` resolver untouched.
- Live-fallback path unchanged.

## Validation
- [x] `npm run lint --workspace @valuerank/api` (0 errors)
- [x] `npm run build --workspace @valuerank/api`
- [x] `npm run codegen --workspace @valuerank/web`
- [x] `npm run build --workspace @valuerank/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)