### PR TITLE
fix(feature-factory): make the engine cross-repo portable

### DIFF
--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_dispatch.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_dispatch.py
@@ -29,7 +29,9 @@ import factory_state  # noqa: E402
 from factory_mutating import mutates_state  # noqa: E402
 from factory_io import read_text, write_text  # noqa: E402
 
-_REVIEW_LENS_DIR = factory_state.REPO_ROOT / "docs/workflow/operations/codex-skills/review-lens/scripts"
+# Review-lens scripts ship with the engine, so locate them relative to this
+# file — NOT relative to REPO_ROOT (the target repo, which may be elsewhere).
+_REVIEW_LENS_DIR = _SCRIPT_DIR.parents[1] / "review-lens" / "scripts"
 if str(_REVIEW_LENS_DIR) not in sys.path:
     sys.path.insert(0, str(_REVIEW_LENS_DIR))
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_status.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_cmd_status.py
@@ -377,7 +377,6 @@ def command_doctor(args: argparse.Namespace) -> int:
     )
 
     for label, path in {
-        "sync-script": SYNC_SCRIPT,
         "feature-runner": Path(__file__).resolve(),
         "write-diff": WRITE_DIFF,
         "repair": REPAIR,
@@ -391,8 +390,16 @@ def command_doctor(args: argparse.Namespace) -> int:
         level = "ok" if found else ("warn" if tool_name == "gh" else "fail")
         add(f"tool:{tool_name}", level, found or "not installed")
 
-    sync_check = subprocess.run([sys.executable, str(SYNC_SCRIPT), "--check"], text=True, capture_output=True)
-    add("skill-sync", "ok" if sync_check.returncode == 0 else "warn", "in sync" if sync_check.returncode == 0 else "needs sync")
+    # The sync script is an optional per-target-repo helper. Repos other than
+    # the engine's own ship none, and that is expected — report it as not
+    # applicable rather than a failure (mirrors factory_git.ensure_sync()).
+    if SYNC_SCRIPT.exists():
+        add("sync-script", "ok", str(SYNC_SCRIPT))
+        sync_check = subprocess.run([sys.executable, str(SYNC_SCRIPT), "--check"], text=True, capture_output=True)
+        add("skill-sync", "ok" if sync_check.returncode == 0 else "warn", "in sync" if sync_check.returncode == 0 else "needs sync")
+    else:
+        add("sync-script", "ok", f"not present — skipped ({SYNC_SCRIPT})")
+        add("skill-sync", "ok", "n/a (target repo ships no sync script)")
 
     branch = current_branch_name()
     add("git-branch", "ok" if branch else "warn", branch or "detached HEAD")

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_deliver.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_deliver.py
@@ -21,7 +21,9 @@ from factory_state import (  # noqa: E402
     update_workflow_state,
 )
 
-REVIEW_SCRIPTS = REPO_ROOT / "docs" / "workflow" / "operations" / "codex-skills" / "review-lens" / "scripts"
+# Review-lens scripts ship with the engine, so locate them relative to this
+# file — NOT relative to REPO_ROOT (the target repo, which may be elsewhere).
+REVIEW_SCRIPTS = _SCRIPT_DIR.parents[1] / "review-lens" / "scripts"
 if str(REVIEW_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(REVIEW_SCRIPTS))
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_git.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_git.py
@@ -119,6 +119,13 @@ def command_path(name: str) -> str | None:
 
 
 def ensure_sync() -> None:
+    # The sync script is a per-target-repo helper (it lives at the target's
+    # scripts/sync-codex-skills.py). When the factory runs against a repo that
+    # does not ship one — i.e. any repo other than the engine's own — there is
+    # nothing to sync, so skip gracefully instead of forcing every target repo
+    # to carry a stub.
+    if not SYNC_SCRIPT.exists():
+        return
     run([sys.executable, str(SYNC_SCRIPT), "--sync-if-needed"])
 
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_pr_body.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_pr_body.py
@@ -59,10 +59,14 @@ def _deferred_reviews(slug: str | None) -> list[dict]:
     if not slug:
         return []
     try:
-        from pathlib import Path as _Path
         import re as _re
-        repo_root = _Path(__file__).resolve().parents[5]
-        reviews_dir = repo_root / "docs" / "workflow" / "feature-runs" / slug / "reviews"
+        # Use the canonical, target-aware runs root rather than re-deriving a
+        # path from this file's location. The old `parents[5]` resolved to the
+        # engine's docs/ dir (then appended "docs/workflow/..." -> a doubled
+        # "docs/docs" that never existed), so this silently returned [] even
+        # in-repo. FACTORY_RUNS_ROOT points at the *target* repo's feature-runs.
+        from factory_state import FACTORY_RUNS_ROOT, REPO_ROOT
+        reviews_dir = FACTORY_RUNS_ROOT / slug / "reviews"
         if not reviews_dir.exists():
             return []
     except Exception:
@@ -88,7 +92,7 @@ def _deferred_reviews(slug: str | None) -> list[dict]:
         stage_match = _re.search(r'stage:\s*"([^"]+)"', frontmatter)
         deferred.append(
             {
-                "path": str(review_path.relative_to(repo_root)),
+                "path": str(review_path.relative_to(REPO_ROOT)),
                 "stage": stage_match.group(1) if stage_match else "?",
                 "reviewer": reviewer_match.group(1) if reviewer_match else "?",
                 "lens": lens_match.group(1) if lens_match else "?",

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_review.py
@@ -32,7 +32,9 @@ from factory_state import (  # noqa: E402
 )
 from factory_io import read_text  # noqa: E402
 
-REVIEW_SCRIPTS = REPO_ROOT / "docs" / "workflow" / "operations" / "codex-skills" / "review-lens" / "scripts"
+# Review-lens scripts ship with the engine, so locate them relative to this
+# file — NOT relative to REPO_ROOT (the target repo, which may be elsewhere).
+REVIEW_SCRIPTS = _SCRIPT_DIR.parents[1] / "review-lens" / "scripts"
 if str(REVIEW_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(REVIEW_SCRIPTS))
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_stages.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_stages.py
@@ -29,7 +29,9 @@ from factory_state import (  # noqa: E402
 )
 from factory_io import read_text  # noqa: E402
 
-REVIEW_SCRIPTS = REPO_ROOT / "docs" / "workflow" / "operations" / "codex-skills" / "review-lens" / "scripts"
+# Review-lens scripts ship with the engine, so locate them relative to this
+# file — NOT relative to REPO_ROOT (the target repo, which may be elsewhere).
+REVIEW_SCRIPTS = _SCRIPT_DIR.parents[1] / "review-lens" / "scripts"
 if str(REVIEW_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(REVIEW_SCRIPTS))
 

--- a/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_state.py
+++ b/docs/workflow/operations/codex-skills/feature-factory/scripts/factory_state.py
@@ -25,41 +25,22 @@ if str(_REVIEW_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_REVIEW_SCRIPTS))
 
 from factory_io import atomic_write_text, read_text
-from workflow_utils import normalized_artifact_hash, normalized_artifact_text
+from workflow_utils import normalized_artifact_hash, normalized_artifact_text, resolve_repo_root
 
 
 # ---------------------------------------------------------------------------
 # Repository root + canonical subdirectory roots
 # ---------------------------------------------------------------------------
 
-_DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[6]
-
-
 def _resolve_repo_root() -> Path:
-    """Resolve the repository root, preferring the current git worktree.
+    """Resolve the target repository root the factory is operating on.
 
-    This keeps the runner pointed at the active worktree when the operator is
-    running from a nested git worktree instead of the main checkout. If the
-    current directory is not inside a git repository, fall back to the
-    historical path derived from this file so installs and tests still work.
+    Thin wrapper over the shared :func:`workflow_utils.resolve_repo_root` so the
+    engine and the review-lens scripts answer "which repo are we acting on" the
+    same way (``$FF_REPO_ROOT`` -> recorded repo root -> current git worktree ->
+    install-location fallback). Kept as a named helper for callers and tests.
     """
-    override = os.environ.get("FF_REPO_ROOT")
-    if override:
-        return Path(override).expanduser().resolve()
-
-    git_result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        cwd=Path.cwd(),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    if git_result.returncode == 0:
-        git_root = git_result.stdout.strip()
-        if git_root:
-            return Path(git_root).expanduser().resolve()
-
-    return _DEFAULT_REPO_ROOT
+    return resolve_repo_root()
 
 
 REPO_ROOT: Path = _resolve_repo_root()

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/repair_review_checkpoint.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/repair_review_checkpoint.py
@@ -14,9 +14,16 @@ VERIFY = SCRIPT_DIR / "verify_review_checkpoint.py"
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from workflow_utils import artifact_hash_matches, normalized_artifact_text, resolve_stored_path
+from workflow_utils import (
+    artifact_hash_matches,
+    normalized_artifact_text,
+    resolve_repo_root,
+    resolve_stored_path,
+)
 
-REPO_ROOT = SCRIPT_DIR.parents[5]
+# The target repo being operated on — may differ from where these scripts live
+# (cross-repo use). Resolved the same way the engine resolves it.
+REPO_ROOT = resolve_repo_root()
 REPAIR_LIMIT_BUFFER_CHARS = 1000
 REPAIR_MIN_TOTAL_BUFFER_CHARS = 10000
 

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/verify_review_checkpoint.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/verify_review_checkpoint.py
@@ -6,11 +6,19 @@ import sys
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-REPO_ROOT = SCRIPT_DIR.parents[5]
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from workflow_utils import artifact_hash_matches, normalized_artifact_hash, resolve_stored_path
+from workflow_utils import (
+    artifact_hash_matches,
+    normalized_artifact_hash,
+    resolve_repo_root,
+    resolve_stored_path,
+)
+
+# The target repo being operated on — may differ from where these scripts live
+# (cross-repo use). Resolved the same way the engine resolves it.
+REPO_ROOT = resolve_repo_root()
 
 
 REQUIRED_KEYS = {

--- a/docs/workflow/operations/codex-skills/review-lens/scripts/workflow_utils.py
+++ b/docs/workflow/operations/codex-skills/review-lens/scripts/workflow_utils.py
@@ -1,7 +1,62 @@
 #!/usr/bin/env python3
 import hashlib
+import os
 import re
+import subprocess
 from pathlib import Path
+
+
+def _toolchain_repo_root() -> Path:
+    """Return the repo root derived from this file's install location.
+
+    This is the factory's *own* checkout — used only as a last-resort fallback
+    when no target repo can be determined from the environment, recorded data,
+    or the current git worktree. workflow_utils.py lives six directories below
+    the repo root (docs/workflow/operations/codex-skills/review-lens/scripts/).
+    """
+    return Path(__file__).resolve().parents[6]
+
+
+def resolve_repo_root(stored_repo_root: str = "") -> Path:
+    """Resolve the TARGET repository root the factory is operating on.
+
+    This is the single source of truth for "which repo are we acting on" shared
+    by the feature-factory engine and the review-lens scripts. The factory's own
+    scripts may live in a different repo than the one under work (cross-repo
+    use), so tool location and target repo must be resolved separately — tool
+    paths stay engine-relative, while every artifact / review / feature-run path
+    resolves against the root this function returns.
+
+    Resolution order, highest priority first:
+      1. ``$FF_REPO_ROOT`` — explicit operator override.
+      2. ``stored_repo_root`` — an absolute repo root recorded in checkpoint or
+         review data. Skipped when blank, relative (e.g. the historical ``"."``),
+         or not an existing directory.
+      3. The current git worktree (``git rev-parse --show-toplevel`` from cwd).
+      4. The factory's own install location (in-repo fallback for installs/tests).
+    """
+    override = os.environ.get("FF_REPO_ROOT")
+    if override:
+        return Path(override).expanduser().resolve()
+
+    if stored_repo_root:
+        candidate = Path(stored_repo_root).expanduser()
+        if candidate.is_absolute() and candidate.is_dir():
+            return candidate.resolve()
+
+    git_result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if git_result.returncode == 0:
+        git_root = git_result.stdout.strip()
+        if git_root:
+            return Path(git_root).expanduser().resolve()
+
+    return _toolchain_repo_root()
 
 
 def repo_relative_path(path: Path, repo_root: Path) -> str:


### PR DESCRIPTION
## Summary

One copy of the Feature Factory engine (which lives in valuerank) can now run against **any** target repo, not just valuerank. Today it works only when the target *is* its own home repo; pointed at another repo via `FF_REPO_ROOT` or the current git worktree, the review layer read/wrote under valuerank and checkpoints failed with `artifact does not exist: <valuerank>/docs/workflow/feature-runs/<slug>/spec.md`.

The root cause: the engine conflated two ideas that only coincide inside valuerank — **where the tool's own code lives** vs. **which repo is under work**. This PR separates them.

## What changed

| Concern | Fix |
|---|---|
| Single source of truth for the target repo | New `resolve_repo_root()` in `review-lens/scripts/workflow_utils.py` (`$FF_REPO_ROOT` → recorded repo root → cwd git worktree → install-location fallback). `factory_state._resolve_repo_root` now delegates to it, so engine and review-lens agree. |
| Review layer was not target-aware | `verify_review_checkpoint.py` / `repair_review_checkpoint.py` resolve the **target** repo via the shared resolver instead of hardcoding `SCRIPT_DIR.parents[5]`. All artifact/review/feature-run path resolution + existence checks now target the right repo. |
| Tool location built from target repo | `factory_review`, `factory_stages`, `factory_deliver`, `factory_cmd_dispatch` now locate the review-lens **scripts** engine-relative (`_SCRIPT_DIR.parents[1] / "review-lens" / "scripts"`), mirroring `factory_cmd_quick` / `factory_state`. |
| Target repos forced to carry a sync stub | `ensure_sync()` and the `doctor` command skip gracefully when the target ships no `scripts/sync-codex-skills.py`. |
| Latent bug found during the sweep | `factory_pr_body._deferred_reviews` used `parents[5]` (the engine's `docs/` dir) then appended `docs/workflow/...`, producing a doubled `docs/docs` path that never existed — so it silently returned `[]` even in-repo. Now uses the canonical target-aware `FACTORY_RUNS_ROOT` + `REPO_ROOT`. |

**In-repo behavior is unchanged:** with `FF_REPO_ROOT` unset and run inside valuerank, cwd git toplevel resolves to the same root as the old code.

## Validation

All commands run from a clean worktree off `origin/main`.

**A. In-repo (valuerank), `FF_REPO_ROOT` unset — must behave exactly as before**
- `python3 -m unittest discover .../feature-factory/scripts/tests` → **316 passed (OK)**
- `python3 -m unittest discover .../review-lens/scripts/tests` → **5 passed (OK)**
- CI gate `check_workflow_isolation.py --capture-baseline` → tests → `--check` → **isolation check exit 0**
- `.../feature-factory/tests/test_run_factory_repair.py` → 8 failures + 2 errors, **identical set with and without my changes** (pre-existing on `origin/main`; this directory is not run by CI). Diff of failing-test names = empty.
- `run_factory.py status --slug 030-remove-legacy-decision-code` → runs, reports stage health correctly.
- `ruff --select F` on the 11 changed files → only the **9 pre-existing** unused-import warnings (identical to `origin/main`); **0 introduced** (one F821 I briefly introduced in `factory_pr_body` was caught and fixed before commit).

**B. Cross-repo smoke (target = `/Users/chrislaw/hoard-hurt-help`, engine = this branch, no sync stub present)**
- `init` → run dir created under **hoard-hurt-help** (not valuerank); `ensure_sync` skipped gracefully with no stub.
- `discover` → recorded under hoard.
- Seeded `spec.md`, then `checkpoint --stage spec` → **Codex + Gemini reviews ran**, wrote all review files under hoard, verification **passed**, `status` reports `spec: healthy`. Checkpoint manifest `artifact_path` is repo-relative and resolved against hoard. **Zero** `ff-portability-probe` files anywhere under valuerank.

**C. Cross-repo multi-stage**
- `plan` checkpoint → passed (one transient Codex runner failure that retried green; the review file correctly recorded **hoard's** git HEAD SHA, confirming repo resolution).
- `tasks` checkpoint → passed (after the normal `parallel` gate).
- Implement-stage modules (`factory_cmd_implement`, `factory_cmd_dispatch`) smoke-tested under `FF_REPO_ROOT=hoard`: target = hoard, every review-lens tool path resolves into the **engine** (not hoard) and exists, `ensure_sync()` returns cleanly. A live Codex code-generation `implement` run was intentionally **not** fired — the probe's spec/plan/tasks describe the valuerank engine fix, so there is no coherent code for Codex to write into hoard; the implement stage's review path is the identical, already-proven one. Probe was cleaned up (hoard left in its original state).

## Notes
- The global slash-command wrappers (`~/.claude/commands/feature-{spec,plan,tasks,implement}.md`) were already updated to `cd "$(git rev-parse --show-toplevel)"` + absolute engine path; this PR is the engine/review back half and does not undo them.
- 9 pre-existing `ruff F401/F841` warnings in the touched files are left as-is (out of scope; not linted by CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)